### PR TITLE
sensor/stmemsc: Introduce STMEMS Standard C Drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,6 @@ if(CONFIG_HAS_STLIB)
     zephyr_sources(audio/microphone/OpenPDMFilter.c)
   endif()
 endif()
+
+# STMEMSC - Hardware Abstraction Layer for ST sensor
+add_subdirectory_ifdef(CONFIG_HAS_STMEMSC sensor/stmemsc)

--- a/sensor/stmemsc/CMakeLists.txt
+++ b/sensor/stmemsc/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Makefile - STMems_Standard_C_drivers
+#
+# Copyright (c) 2019 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(stmems_pids
+  a3g4250d
+  ais328dq
+  ais3624dq
+  h3lis331dl
+  hts221
+  i3g4250d
+  iis2dh
+  iis2dlpc
+  iis2mdc
+  iis328dq
+  iis3dhhc
+  ism303dac
+  ism330dlc
+  l20g20is
+  lis2de12
+  lis2dh12
+  lis2ds12
+  lis2dw12
+  lis2hh12
+  lis2mdl
+  lis331dlh
+  lis3de
+  lis3dhh
+  lis3dh
+  lis3mdl
+  lps22hb
+  lps22hh
+  lps25hb
+  lps33hw
+  lsm303agr
+  lsm303ah
+  lsm6ds3
+  lsm6dsl
+  lsm6dsm
+  lsm6dso
+  lsm6dsox
+  lsm9ds1
+  stts751
+  )
+
+foreach(stmems_pid ${stmems_pids})
+  string(TOUPPER ${stmems_pid} pid_to_upper)
+  if(CONFIG_USE_STDC_${pid_to_upper})
+    zephyr_include_directories(
+        ${stmems_pid}_STdC/driver/
+        )
+    zephyr_sources(
+        ${stmems_pid}_STdC/driver/${stmems_pid}_reg.c
+        )
+  endif()
+endforeach()

--- a/sensor/stmemsc/LICENSE
+++ b/sensor/stmemsc/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, STMicroelectronics
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/sensor/stmemsc/README
+++ b/sensor/stmemsc/README
@@ -1,0 +1,58 @@
+C-Driver-MEMS
+#############
+
+Origin:
+   ST Microelectronics
+   https://www.st.com/en/embedded-software/c-driver-mems.html
+
+Status:
+   version v1.00
+
+Purpose:
+   ST Microelectronics standard C platform-independent drivers for MEMS
+   motion and environmental sensors.
+
+Description:
+   This package is an extract (examples have not been retained) of official
+   C-Driver-MEMS package written by ST Microelectronics.
+   It contains standard drivers for STMicroelectronics MEMS sensors to
+   provide a common and stable interface to access sensor registers.
+   For each supported sensor following files are provided:
+
+       - xyz_reg.c: contains the function to read/write 'xyz' sensor registers
+       - xyz_reg.h: contains structures and defines to describe in details
+                    the 'xyz' sensor registers.
+
+   The driver is platform-independent, you only need to define the two
+   functions for read and write transactions from the sensor hardware bus
+   (ie. SPI or I2C).
+
+   Define in your 'xyz' driver code the read and write functions that use the
+   I2C or SPI platform driver like the following:
+
+   /** Please note that is MANDATORY: return 0 -> no Error.**/
+   int platform_wr(void *handle, u8_t reg, u8_t *bufp, u16_t len);
+   int platform_rd(void *handle, u8_t reg, u8_t *bufp, u16_t len);
+
+   xyz_ctx_t xyz_ctx = {
+       .read_reg = (xyz_read_ptr) platform_rd,
+       .write_reg = (xyz_write_ptr) platform_wr,
+   };
+
+Dependencies:
+    None.
+
+URL:
+   https://www.st.com/en/embedded-software/c-driver-mems.html
+
+commit:
+   version v1.00
+
+Maintained-by:
+   ST Microelectronics
+
+License:
+   BSD-3-Clause
+
+License Link:
+   https://opensource.org/licenses/BSD-3-Clause

--- a/sensor/stmemsc/a3g4250d_STdC/driver/a3g4250d_reg.c
+++ b/sensor/stmemsc/a3g4250d_STdC/driver/a3g4250d_reg.c
@@ -1,0 +1,1722 @@
+/*
+ ******************************************************************************
+ * @file    a3g4250d_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   A3G4250D driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "a3g4250d_reg.h"
+
+/**
+  * @defgroup    A3G4250D
+  * @brief       This file provides a set of functions needed to drive the
+  *              a3g4250d enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    A3G4250D_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t a3g4250d_read_reg(a3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t a3g4250d_write_reg(a3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    A3G4250D_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t a3g4250d_from_fs245dps_to_mdps(int16_t lsb)
+{
+  return ( (float_t)lsb * 8.75f );
+}
+
+float_t a3g4250d_from_lsb_to_celsius(int16_t lsb)
+{
+  return ( (float_t)lsb + 25.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   A3G4250D_data_generation
+  * @brief      This section groups all the functions concerning
+  *             data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_data_rate_set(a3g4250d_ctx_t *ctx, a3g4250d_dr_t val)
+{
+  a3g4250d_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.dr = ((uint8_t)val & 0x30U) >> 4;
+    ctrl_reg1.pd = ((uint8_t)val & 0x0FU);
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dr in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_data_rate_get(a3g4250d_ctx_t *ctx, a3g4250d_dr_t *val)
+{
+  a3g4250d_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+
+  switch ( ( ctrl_reg1.dr  << 4 ) + ctrl_reg1.pd ){
+    case A3G4250D_ODR_OFF:
+      *val = A3G4250D_ODR_OFF;
+      break;
+    case A3G4250D_ODR_SLEEP:
+      *val = A3G4250D_ODR_SLEEP;
+      break;
+    case A3G4250D_ODR_100Hz:
+      *val = A3G4250D_ODR_100Hz;
+      break;
+    case A3G4250D_ODR_200Hz:
+      *val = A3G4250D_ODR_200Hz;
+      break;
+    case A3G4250D_ODR_400Hz:
+      *val = A3G4250D_ODR_400Hz;
+      break;
+    case A3G4250D_ODR_800Hz:
+      *val = A3G4250D_ODR_800Hz;
+      break;
+    default:
+      *val = A3G4250D_ODR_OFF;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    registers STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_status_reg_get(a3g4250d_ctx_t *ctx,
+                                a3g4250d_status_reg_t *val)
+{
+  int32_t ret;
+  ret = a3g4250d_read_reg(ctx, A3G4250D_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "zyxda" in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_flag_data_ready_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_STATUS_REG,(uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   A3G4250D_Dataoutput
+  * @brief      This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_temperature_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = a3g4250d_read_reg(ctx, A3G4250D_OUT_TEMP, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_angular_rate_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  a3g4250d_read_reg(ctx, A3G4250D_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   A3G4250D_common
+  * @brief      This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who amI.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  buff     Buffer that stores the data read.(ptr)
+  * @retval          Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_device_id_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = a3g4250d_read_reg(ctx, A3G4250D_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable. [set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    change the values of st in reg CTRL_REG4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_self_test_set(a3g4250d_ctx_t *ctx, a3g4250d_st_t val)
+{
+  a3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.st = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable. [get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_self_test_get(a3g4250d_ctx_t *ctx, a3g4250d_st_t *val)
+{
+  a3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.st){
+    case A3G4250D_GY_ST_DISABLE:
+      *val = A3G4250D_GY_ST_DISABLE;
+      break;
+    case A3G4250D_GY_ST_POSITIVE:
+      *val = A3G4250D_GY_ST_POSITIVE;
+      break;
+    case A3G4250D_GY_ST_NEGATIVE:
+      *val = A3G4250D_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = A3G4250D_GY_ST_DISABLE;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "ble" in reg CTRL_REG4.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_data_format_set(a3g4250d_ctx_t *ctx, a3g4250d_ble_t val)
+{
+  a3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of "ble" in reg CTRL_REG4.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_data_format_get(a3g4250d_ctx_t *ctx, a3g4250d_ble_t *val)
+{
+  a3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.ble){
+    case A3G4250D_AUX_LSB_AT_LOW_ADD:
+      *val = A3G4250D_AUX_LSB_AT_LOW_ADD;
+      break;
+    case A3G4250D_AUX_MSB_AT_LOW_ADD:
+      *val = A3G4250D_AUX_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = A3G4250D_AUX_LSB_AT_LOW_ADD;
+    break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of boot in reg CTRL_REG5.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_boot_set(a3g4250d_ctx_t *ctx, uint8_t val)
+{
+  a3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.boot = val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of boot in reg CTRL_REG5.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_boot_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.boot;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   A3G4250D_filters
+  * @brief      This section group all the functions concerning the
+  *             filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Lowpass filter bandwidth selection.[set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "bw" in reg CTRL_REG1.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_lp_bandwidth_set(a3g4250d_ctx_t *ctx, a3g4250d_bw_t val)
+{
+  a3g4250d_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG1,(uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.bw = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG1,(uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Lowpass filter bandwidth selection.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of "bw" in reg CTRL_REG1.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_lp_bandwidth_get(a3g4250d_ctx_t *ctx, a3g4250d_bw_t *val)
+{
+  a3g4250d_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG1,(uint8_t*)&ctrl_reg1, 1);
+
+  switch (ctrl_reg1.bw){
+  case A3G4250D_CUT_OFF_LOW:
+      *val = A3G4250D_CUT_OFF_LOW;
+      break;
+    case A3G4250D_CUT_OFF_MEDIUM:
+      *val = A3G4250D_CUT_OFF_MEDIUM;
+      break;
+    case A3G4250D_CUT_OFF_HIGH:
+      *val = A3G4250D_CUT_OFF_HIGH;
+      break;
+    case A3G4250D_CUT_OFF_VERY_HIGH:
+      *val = A3G4250D_CUT_OFF_VERY_HIGH;
+      break;
+    default:
+      *val = A3G4250D_CUT_OFF_LOW;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter bandwidth selection.[set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "hpcf" in reg CTRL_REG2.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_hp_bandwidth_set(a3g4250d_ctx_t *ctx, a3g4250d_hpcf_t val)
+{
+  a3g4250d_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter bandwidth selection.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of hpcf in reg CTRL_REG2.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_hp_bandwidth_get(a3g4250d_ctx_t *ctx, a3g4250d_hpcf_t *val)
+{
+  a3g4250d_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpcf){
+    case A3G4250D_HP_LEVEL_0:
+      *val = A3G4250D_HP_LEVEL_0;
+      break;
+    case A3G4250D_HP_LEVEL_1:
+      *val = A3G4250D_HP_LEVEL_1;
+      break;
+    case A3G4250D_HP_LEVEL_2:
+      *val = A3G4250D_HP_LEVEL_2;
+      break;
+    case A3G4250D_HP_LEVEL_3:
+      *val = A3G4250D_HP_LEVEL_3;
+      break;
+    case A3G4250D_HP_LEVEL_4:
+      *val = A3G4250D_HP_LEVEL_4;
+      break;
+    case A3G4250D_HP_LEVEL_5:
+      *val = A3G4250D_HP_LEVEL_5;
+      break;
+    case A3G4250D_HP_LEVEL_6:
+      *val = A3G4250D_HP_LEVEL_6;
+      break;
+    case A3G4250D_HP_LEVEL_7:
+      *val = A3G4250D_HP_LEVEL_7;
+      break;
+    case A3G4250D_HP_LEVEL_8:
+      *val = A3G4250D_HP_LEVEL_8;
+      break;
+    case A3G4250D_HP_LEVEL_9:
+      *val = A3G4250D_HP_LEVEL_9;
+      break;
+    default:
+      *val = A3G4250D_HP_LEVEL_0;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection. [set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "hpm" in reg CTRL_REG2.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_hp_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t val)
+{
+  a3g4250d_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection. [get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of hpm in reg CTRL_REG2.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_hp_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t *val)
+{
+  a3g4250d_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpm){
+    case A3G4250D_HP_NORMAL_MODE_WITH_RST:
+      *val = A3G4250D_HP_NORMAL_MODE_WITH_RST;
+      break;
+    case A3G4250D_HP_REFERENCE_SIGNAL:
+      *val = A3G4250D_HP_REFERENCE_SIGNAL;
+      break;
+    case A3G4250D_HP_NORMAL_MODE:
+      *val = A3G4250D_HP_NORMAL_MODE;
+      break;
+    case A3G4250D_HP_AUTO_RESET_ON_INT:
+      *val = A3G4250D_HP_AUTO_RESET_ON_INT;
+      break;
+    default:
+      *val = A3G4250D_HP_NORMAL_MODE_WITH_RST;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Out/FIFO selection path. [set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "out_sel" in reg CTRL_REG5.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_filter_path_set(a3g4250d_ctx_t *ctx, a3g4250d_out_sel_t val)
+{
+  a3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.out_sel = (uint8_t)val & 0x03U;
+    ctrl_reg5.hpen = ( (uint8_t)val & 0x04U ) >> 2;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Out/FIFO selection path. [get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of out_sel in reg CTRL_REG5.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_filter_path_get(a3g4250d_ctx_t *ctx, a3g4250d_out_sel_t *val)
+{
+  a3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+
+  switch ( ( ctrl_reg5.hpen << 2 ) + ctrl_reg5.out_sel ){
+    case A3G4250D_ONLY_LPF1_ON_OUT:
+      *val = A3G4250D_ONLY_LPF1_ON_OUT;
+      break;
+    case A3G4250D_LPF1_HP_ON_OUT:
+      *val = A3G4250D_LPF1_HP_ON_OUT;
+      break;
+    case A3G4250D_LPF1_LPF2_ON_OUT:
+      *val = A3G4250D_LPF1_LPF2_ON_OUT;
+      break;
+    case A3G4250D_LPF1_HP_LPF2_ON_OUT:
+      *val = A3G4250D_LPF1_HP_LPF2_ON_OUT;
+      break;
+    default:
+      *val = A3G4250D_ONLY_LPF1_ON_OUT;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator selection path.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_sel in reg CTRL_REG5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_filter_path_internal_set(a3g4250d_ctx_t *ctx,
+                                          a3g4250d_int1_sel_t val)
+{
+  a3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.int1_sel = (uint8_t)val & 0x03U;
+    ctrl_reg5.hpen = ( (uint8_t)val & 0x04U ) >> 2;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator selection path.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_sel in reg CTRL_REG5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_filter_path_internal_get(a3g4250d_ctx_t *ctx,
+                                          a3g4250d_int1_sel_t *val)
+{
+  a3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+
+  switch ( ( ctrl_reg5.hpen << 2 ) + ctrl_reg5.int1_sel ){
+    case A3G4250D_ONLY_LPF1_ON_INT:
+      *val = A3G4250D_ONLY_LPF1_ON_INT;
+      break;
+    case A3G4250D_LPF1_HP_ON_INT:
+      *val = A3G4250D_LPF1_HP_ON_INT;
+      break;
+    case A3G4250D_LPF1_LPF2_ON_INT:
+      *val = A3G4250D_LPF1_LPF2_ON_INT;
+      break;
+    case A3G4250D_LPF1_HP_LPF2_ON_INT:
+      *val = A3G4250D_LPF1_HP_LPF2_ON_INT;
+      break;
+    default:
+      *val = A3G4250D_ONLY_LPF1_ON_INT;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ref in reg REFERENCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_hp_reference_value_set(a3g4250d_ctx_t *ctx, uint8_t val)
+{
+  a3g4250d_reference_t reference;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_REFERENCE,(uint8_t*)&reference, 1);
+  if(ret == 0){
+    reference.ref = val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_REFERENCE,(uint8_t*)&reference, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ref in reg REFERENCE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_hp_reference_value_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_reference_t reference;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_REFERENCE,(uint8_t*)&reference, 1);
+  *val = reference.ref;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   A3G4250D_serial_interface
+  * @brief   This section groups all the functions concerning main serial
+  *          interface management.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_spi_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_sim_t val)
+{
+  a3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_spi_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_sim_t *val)
+{
+  a3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.sim){
+    case A3G4250D_SPI_4_WIRE:
+      *val = A3G4250D_SPI_4_WIRE;
+      break;
+    case A3G4250D_SPI_3_WIRE:
+      *val = A3G4250D_SPI_3_WIRE;
+      break;
+    default:
+      *val = A3G4250D_SPI_4_WIRE;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   A3G4250D_interrupt_pins
+  * @brief      This section groups all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Configure CTRL_REG3 int1 pad
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_pin_int1_route_set(a3g4250d_ctx_t *ctx,
+                                    a3g4250d_int1_route_t val)
+{
+  a3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.i1_int1         = val.i1_int1;
+    ctrl_reg3.i1_boot         = val.i1_boot;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read CTRL_REG3 int1 pad.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+
+int32_t a3g4250d_pin_int1_route_get(a3g4250d_ctx_t *ctx,
+                                    a3g4250d_int1_route_t *val)
+{
+  a3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  val->i1_int1       = ctrl_reg3.i1_int1;
+  val->i1_boot       = ctrl_reg3.i1_boot;
+
+  return ret;
+}
+/**
+  * @brief  Select the signal that need to route on int2 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Configure CTRL_REG3 int2 pad
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_pin_int2_route_set(a3g4250d_ctx_t *ctx,
+                                    a3g4250d_int2_route_t val)
+{
+  a3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.i2_empty         = val.i2_empty;
+    ctrl_reg3.i2_orun          = val.i2_orun;
+    ctrl_reg3.i2_wtm           = val.i2_wtm;
+    ctrl_reg3.i2_drdy          = val.i2_drdy;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read CTRL_REG3 int2 pad.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_pin_int2_route_get(a3g4250d_ctx_t *ctx,
+                                    a3g4250d_int2_route_t *val)
+{
+  a3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  val->i2_empty       = ctrl_reg3.i2_empty;
+  val->i2_orun        = ctrl_reg3.i2_orun;
+  val->i2_wtm         = ctrl_reg3.i2_wtm;
+  val->i2_drdy        = ctrl_reg3.i2_drdy;
+
+  return ret;
+}
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+
+int32_t a3g4250d_pin_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t val)
+{
+  a3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL_REG3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_pin_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t *val)
+{
+  a3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+
+  switch (ctrl_reg3.pp_od ){
+    case A3G4250D_PUSH_PULL:
+      *val = A3G4250D_PUSH_PULL;
+      break;
+    case A3G4250D_OPEN_DRAIN:
+      *val = A3G4250D_OPEN_DRAIN;
+      break;
+    default:
+      *val = A3G4250D_PUSH_PULL;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pin active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of h_lactive in reg CTRL_REG3.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_pin_polarity_set(a3g4250d_ctx_t *ctx,
+                                  a3g4250d_h_lactive_t val)
+{
+  a3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.h_lactive = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pin active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL_REG3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_pin_polarity_get(a3g4250d_ctx_t *ctx,
+                                  a3g4250d_h_lactive_t *val)
+{
+  a3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+
+  switch (ctrl_reg3.h_lactive){
+    case A3G4250D_ACTIVE_HIGH:
+      *val = A3G4250D_ACTIVE_HIGH;
+      break;
+    case A3G4250D_ACTIVE_LOW:
+      *val = A3G4250D_ACTIVE_LOW;
+      break;
+    default:
+      *val = A3G4250D_ACTIVE_HIGH;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir in reg INT1_CFG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_notification_set(a3g4250d_ctx_t *ctx,
+                                      a3g4250d_lir_t val)
+{
+  a3g4250d_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  if(ret == 0){
+    int1_cfg.lir = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg INT1_CFG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_notification_get(a3g4250d_ctx_t *ctx,
+                                      a3g4250d_lir_t *val)
+{
+  a3g4250d_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+
+  switch (int1_cfg.lir){
+    case A3G4250D_INT_PULSED:
+      *val = A3G4250D_INT_PULSED;
+      break;
+    case A3G4250D_INT_LATCHED:
+      *val = A3G4250D_INT_LATCHED;
+      break;
+    default:
+      *val = A3G4250D_INT_PULSED;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   A3G4250D_ interrupt_on_threshold
+  * @brief      This section groups all the functions that manage the event
+  *             generation on threshold.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the interrupt threshold sign.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Struct of registers INT1_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_on_threshold_conf_set(a3g4250d_ctx_t *ctx,
+                                           a3g4250d_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt threshold sign.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Struct of registers from INT1_CFG to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_on_threshold_conf_get(a3g4250d_ctx_t *ctx,
+                                           a3g4250d_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  AND/OR combination of interrupt events.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of and_or in reg INT1_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_on_threshold_mode_set(a3g4250d_ctx_t *ctx,
+                                           a3g4250d_and_or_t val)
+{
+  a3g4250d_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  if(ret == 0){
+    int1_cfg.and_or = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of interrupt events.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of and_or in reg INT1_CFG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_on_threshold_mode_get(a3g4250d_ctx_t *ctx,
+                                           a3g4250d_and_or_t *val)
+{
+  a3g4250d_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  switch (int1_cfg.and_or){
+    case A3G4250D_INT1_ON_TH_OR:
+      *val = A3G4250D_INT1_ON_TH_OR;
+      break;
+    case A3G4250D_INT1_ON_TH_AND:
+      *val = A3G4250D_INT1_ON_TH_AND;
+      break;
+    default:
+      *val = A3G4250D_INT1_ON_TH_OR;
+    break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   int_on_threshold_src: [get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Union of registers from INT1_SRC to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_on_threshold_src_get(a3g4250d_ctx_t *ctx,
+                                          a3g4250d_int1_src_t *val)
+{
+  int32_t ret;
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on X.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsx in reg INT1_TSH_XH
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_x_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
+{
+  a3g4250d_int1_tsh_xh_t int1_tsh_xh;
+  a3g4250d_int1_tsh_xl_t int1_tsh_xl;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_XH,
+                               (uint8_t*)&int1_tsh_xh, 1);
+  if(ret == 0){
+    int1_tsh_xh.thsx = (uint8_t)((uint16_t)val & 0x7F00U)>>8;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_TSH_XH,
+                             (uint8_t*)&int1_tsh_xh, 1);
+  }
+  if(ret == 0){
+    ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_XL,
+                            (uint8_t*)&int1_tsh_xl, 1);
+  }
+  if(ret == 0){
+    int1_tsh_xl.thsx = (uint8_t)((uint16_t)val & 0x00FFU);
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_TSH_XL,
+                             (uint8_t*)&int1_tsh_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on X.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsx in reg INT1_TSH_XH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_x_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
+{
+  a3g4250d_int1_tsh_xh_t int1_tsh_xh;
+  a3g4250d_int1_tsh_xl_t int1_tsh_xl;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_XH,
+                               (uint8_t*)&int1_tsh_xh, 1);
+  if(ret == 0){
+    ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_XL,
+                               (uint8_t*)&int1_tsh_xl, 1);
+
+    *val = int1_tsh_xh.thsx;
+    *val = *val << 8;
+    *val +=  int1_tsh_xl.thsx;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on Y.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsy in reg INT1_TSH_YH
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_y_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
+{
+  a3g4250d_int1_tsh_yh_t int1_tsh_yh;
+  a3g4250d_int1_tsh_yl_t int1_tsh_yl;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_YH,
+                               (uint8_t*)&int1_tsh_yh, 1);
+  int1_tsh_yh.thsy = (uint8_t)((uint16_t)val & 0x7F00U)>>8;
+  if(ret == 0){
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_TSH_YH,
+                                (uint8_t*)&int1_tsh_yh, 1);
+  }
+  if(ret == 0){
+    ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_YL,
+                               (uint8_t*)&int1_tsh_yl, 1);
+    int1_tsh_yl.thsy = (uint8_t)((uint16_t)val & 0x00FFU);
+  }
+  if(ret == 0){
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_TSH_YL,
+                                (uint8_t*)&int1_tsh_yl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on Y.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsy in reg INT1_TSH_YH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_y_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
+{
+  a3g4250d_int1_tsh_yh_t int1_tsh_yh;
+  a3g4250d_int1_tsh_yl_t int1_tsh_yl;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_YH,
+                               (uint8_t*)&int1_tsh_yh, 1);
+  if(ret == 0){
+    ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_YL,
+                               (uint8_t*)&int1_tsh_yl, 1);
+
+    *val = int1_tsh_yh.thsy;
+    *val = *val << 8;
+    *val += int1_tsh_yl.thsy;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on Z.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsz in reg INT1_TSH_ZH.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_z_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
+{
+  a3g4250d_int1_tsh_zh_t int1_tsh_zh;
+  a3g4250d_int1_tsh_zl_t int1_tsh_zl;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_ZH,
+                               (uint8_t*)&int1_tsh_zh, 1);
+  int1_tsh_zh.thsz = (uint8_t)((uint16_t)val & 0x7F00U)>>8;
+  if(ret == 0){
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_TSH_ZH,
+                                (uint8_t*)&int1_tsh_zh, 1);
+  }
+  if(ret == 0){
+    ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_ZL,
+                               (uint8_t*)&int1_tsh_zl, 1);
+    int1_tsh_zl.thsz = (uint8_t)((uint8_t)val & 0x00FFU);
+  }
+  if(ret == 0){
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_TSH_ZL,
+                                (uint8_t*)&int1_tsh_zl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on Z.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsz in reg INT1_TSH_ZH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_z_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
+{
+  a3g4250d_int1_tsh_zh_t int1_tsh_zh;
+  a3g4250d_int1_tsh_zl_t int1_tsh_zl;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_ZH,
+                               (uint8_t*)&int1_tsh_zh, 1);
+  if(ret == 0){
+    ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_TSH_ZL,
+                               (uint8_t*)&int1_tsh_zl, 1);
+
+    *val = int1_tsh_zh.thsz;
+    *val = *val << 8;
+    *val += int1_tsh_zl.thsz;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Durationvalue.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d in reg INT1_DURATION
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_on_threshold_dur_set(a3g4250d_ctx_t *ctx, uint8_t val)
+{
+  a3g4250d_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_DURATION, 
+                          (uint8_t*)&int1_duration, 1);
+  if(ret == 0){
+    int1_duration.d = val;
+    if (val != PROPERTY_DISABLE){
+      int1_duration.wait = PROPERTY_ENABLE;
+    }
+    else{
+      int1_duration.wait = PROPERTY_DISABLE;
+    }
+    ret = a3g4250d_write_reg(ctx, A3G4250D_INT1_DURATION,
+                             (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Durationvalue.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of d in reg INT1_DURATION.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_int_on_threshold_dur_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_INT1_DURATION,
+                          (uint8_t*)&int1_duration, 1);
+  *val = int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   A3G4250D_fifo
+  * @brief   This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFOenable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_en in reg CTRL_REG5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_enable_set(a3g4250d_ctx_t *ctx, uint8_t val)
+{
+  a3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.fifo_en = val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFOenable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL_REG5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_enable_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_watermark_set(a3g4250d_ctx_t *ctx, uint8_t val)
+{
+  a3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_FIFO_CTRL_REG,
+                          (uint8_t*)&fifo_ctrl_reg, 1);
+  if(ret == 0){
+    fifo_ctrl_reg.wtm = val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_FIFO_CTRL_REG,
+                             (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wtm in reg FIFO_CTRL_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_watermark_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_FIFO_CTRL_REG,
+                          (uint8_t*)&fifo_ctrl_reg, 1);
+  *val = fifo_ctrl_reg.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fm in reg FIFO_CTRL_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t val)
+{
+  a3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_FIFO_CTRL_REG,
+                          (uint8_t*)&fifo_ctrl_reg, 1);
+  if(ret == 0){
+    fifo_ctrl_reg.fm = (uint8_t)val;
+    ret = a3g4250d_write_reg(ctx, A3G4250D_FIFO_CTRL_REG,
+                             (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fm in reg FIFO_CTRL_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t *val)
+{
+  a3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_FIFO_CTRL_REG,
+                          (uint8_t*)&fifo_ctrl_reg, 1);
+
+  switch (fifo_ctrl_reg.fm){
+    case A3G4250D_FIFO_BYPASS_MODE:
+      *val = A3G4250D_FIFO_BYPASS_MODE;
+      break;
+    case A3G4250D_FIFO_MODE:
+      *val = A3G4250D_FIFO_MODE;
+      break;
+    case A3G4250D_FIFO_STREAM_MODE:
+      *val = A3G4250D_FIFO_STREAM_MODE;
+      break;
+    default:
+      *val = A3G4250D_FIFO_BYPASS_MODE;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fss in reg FIFO_SRC_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_data_level_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_FIFO_SRC_REG,
+                          (uint8_t*)&fifo_src_reg, 1);
+  *val = fifo_src_reg.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFOemptybit.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of empty in reg FIFO_SRC_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_empty_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_FIFO_SRC_REG,
+                          (uint8_t*)&fifo_src_reg, 1);
+  *val = fifo_src_reg.empty;
+
+  return ret;
+}
+
+/**
+  * @brief  Overrun bit status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ovrn in reg FIFO_SRC_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t a3g4250d_fifo_ovr_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_FIFO_SRC_REG,
+                          (uint8_t*)&fifo_src_reg, 1);
+  *val = fifo_src_reg.ovrn;
+
+  return ret;
+}
+
+/**
+  * @brief  Watermark status:[get]
+  *                0: FIFO filling is lower than WTM level;
+  *                1: FIFO filling is equal or higher than WTM level)
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wtm in reg FIFO_SRC_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+
+int32_t a3g4250d_fifo_wtm_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  a3g4250d_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = a3g4250d_read_reg(ctx, A3G4250D_FIFO_SRC_REG,
+                          (uint8_t*)&fifo_src_reg, 1);
+  *val = fifo_src_reg.wtm;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/a3g4250d_STdC/driver/a3g4250d_reg.h
+++ b/sensor/stmemsc/a3g4250d_STdC/driver/a3g4250d_reg.h
@@ -1,0 +1,580 @@
+/*
+ ******************************************************************************
+ * @file    a3g4250d_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          a3g4250d_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef A3G4250D_REGS_H
+#define A3G4250D_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup A3G4250D
+  * @{
+  *
+  */
+
+/** @defgroup A3G4250D_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup a3g4250d_interface
+  * @{
+  *
+  */
+
+typedef int32_t (*a3g4250d_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*a3g4250d_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  a3g4250d_write_ptr  write_reg;
+  a3g4250d_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} a3g4250d_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+
+/**
+  * @defgroup a3g4250d_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0xD1 if SA0=1 -> 0xD3 **/
+#define A3G4250D_I2C_ADD_L               0xD1U
+#define A3G4250D_I2C_ADD_H               0xD3U
+
+/** Device Identification (Who am I) **/
+#define A3G4250D_ID                      0xD3U
+
+/**
+  * @}
+  *
+  */
+
+#define A3G4250D_WHO_AM_I                0x0FU
+#define A3G4250D_CTRL_REG1               0x20U
+typedef struct {
+  uint8_t pd                        : 4; /* xen yen zen pd */
+  uint8_t bw                        : 2;
+  uint8_t dr                        : 2;
+} a3g4250d_ctrl_reg1_t;
+
+#define A3G4250D_CTRL_REG2               0x21U
+typedef struct {
+  uint8_t hpcf                      : 4;
+  uint8_t hpm                       : 2;
+  uint8_t not_used_01               : 2;
+} a3g4250d_ctrl_reg2_t;
+
+#define A3G4250D_CTRL_REG3               0x22U
+typedef struct {
+  uint8_t i2_empty                  : 1;
+  uint8_t i2_orun                   : 1;
+  uint8_t i2_wtm                    : 1;
+  uint8_t i2_drdy                   : 1;
+  uint8_t pp_od                     : 1;
+  uint8_t h_lactive                 : 1;
+  uint8_t i1_boot                   : 1;
+  uint8_t i1_int1                   : 1;
+} a3g4250d_ctrl_reg3_t;
+
+#define A3G4250D_CTRL_REG4               0x23U
+typedef struct {
+  uint8_t sim                       : 1;
+  uint8_t st                        : 2;
+  uint8_t not_used_01               : 3;
+  uint8_t ble                       : 1;
+  uint8_t not_used_02               : 1;
+} a3g4250d_ctrl_reg4_t;
+
+#define A3G4250D_CTRL_REG5               0x24U
+typedef struct {
+  uint8_t out_sel                   : 2;
+  uint8_t int1_sel                  : 2;
+  uint8_t hpen                      : 1;
+  uint8_t not_used_01               : 1;
+  uint8_t fifo_en                   : 1;
+  uint8_t boot                      : 1;
+} a3g4250d_ctrl_reg5_t;
+
+#define A3G4250D_REFERENCE               0x25U
+typedef struct {
+  uint8_t ref                       : 8;
+} a3g4250d_reference_t;
+
+#define A3G4250D_OUT_TEMP                0x26U
+#define A3G4250D_STATUS_REG              0x27U
+typedef struct {
+  uint8_t xda                       : 1;
+  uint8_t yda                       : 1;
+  uint8_t zda                       : 1;
+  uint8_t zyxda                     : 1;
+  uint8_t _xor                      : 1;
+  uint8_t yor                       : 1;
+  uint8_t zor                       : 1;
+  uint8_t zyxor                     : 1;
+} a3g4250d_status_reg_t;
+
+#define A3G4250D_OUT_X_L                 0x28U
+#define A3G4250D_OUT_X_H                 0x29U
+#define A3G4250D_OUT_Y_L                 0x2AU
+#define A3G4250D_OUT_Y_H                 0x2BU
+#define A3G4250D_OUT_Z_L                 0x2CU
+#define A3G4250D_OUT_Z_H                 0x2DU
+#define A3G4250D_FIFO_CTRL_REG           0x2EU
+typedef struct {
+  uint8_t wtm                       : 5;
+  uint8_t fm                        : 3;
+} a3g4250d_fifo_ctrl_reg_t;
+
+#define A3G4250D_FIFO_SRC_REG            0x2FU
+typedef struct {
+  uint8_t fss                       : 5;
+  uint8_t empty                     : 1;
+  uint8_t ovrn                      : 1;
+  uint8_t wtm                       : 1;
+} a3g4250d_fifo_src_reg_t;
+
+#define A3G4250D_INT1_CFG                0x30U
+typedef struct {
+  uint8_t xlie                      : 1;
+  uint8_t xhie                      : 1;
+  uint8_t ylie                      : 1;
+  uint8_t yhie                      : 1;
+  uint8_t zlie                      : 1;
+  uint8_t zhie                      : 1;
+  uint8_t lir                       : 1;
+  uint8_t and_or                    : 1;
+} a3g4250d_int1_cfg_t;
+
+#define A3G4250D_INT1_SRC                0x31U
+typedef struct {
+  uint8_t xl                        : 1;
+  uint8_t xh                        : 1;
+  uint8_t yl                        : 1;
+  uint8_t yh                        : 1;
+  uint8_t zl                        : 1;
+  uint8_t zh                        : 1;
+  uint8_t ia                        : 1;
+  uint8_t not_used_01               : 1;
+} a3g4250d_int1_src_t;
+
+#define A3G4250D_INT1_TSH_XH             0x32U
+typedef struct {
+  uint8_t thsx                      : 7;
+  uint8_t not_used_01               : 1;
+} a3g4250d_int1_tsh_xh_t;
+
+#define A3G4250D_INT1_TSH_XL             0x33U
+typedef struct {
+  uint8_t thsx                      : 8;
+} a3g4250d_int1_tsh_xl_t;
+
+#define A3G4250D_INT1_TSH_YH             0x34U
+typedef struct {
+  uint8_t thsy                      : 7;
+  uint8_t not_used_01               : 1;
+} a3g4250d_int1_tsh_yh_t;
+
+#define A3G4250D_INT1_TSH_YL             0x35U
+typedef struct {
+  uint8_t thsy                      : 8;
+} a3g4250d_int1_tsh_yl_t;
+
+#define A3G4250D_INT1_TSH_ZH             0x36U
+typedef struct {
+  uint8_t thsz                      : 7;
+  uint8_t not_used_01               : 1;
+} a3g4250d_int1_tsh_zh_t;
+
+#define A3G4250D_INT1_TSH_ZL             0x37U
+typedef struct {
+  uint8_t thsz                      : 8;
+} a3g4250d_int1_tsh_zl_t;
+
+#define A3G4250D_INT1_DURATION           0x38U
+typedef struct {
+  uint8_t d                         : 7;
+  uint8_t wait                      : 1;
+} a3g4250d_int1_duration_t;
+
+/**
+  * @defgroup LSM9DS1_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  a3g4250d_ctrl_reg1_t        ctrl_reg1;
+  a3g4250d_ctrl_reg2_t        ctrl_reg2;
+  a3g4250d_ctrl_reg3_t        ctrl_reg3;
+  a3g4250d_ctrl_reg4_t        ctrl_reg4;
+  a3g4250d_ctrl_reg5_t        ctrl_reg5;
+  a3g4250d_reference_t        reference;
+  a3g4250d_status_reg_t       status_reg;
+  a3g4250d_fifo_ctrl_reg_t    fifo_ctrl_reg;
+  a3g4250d_fifo_src_reg_t     fifo_src_reg;
+  a3g4250d_int1_cfg_t         int1_cfg;
+  a3g4250d_int1_src_t         int1_src;
+  a3g4250d_int1_tsh_xh_t      int1_tsh_xh;
+  a3g4250d_int1_tsh_xl_t      int1_tsh_xl;
+  a3g4250d_int1_tsh_yh_t      int1_tsh_yh;
+  a3g4250d_int1_tsh_yl_t      int1_tsh_yl;
+  a3g4250d_int1_tsh_zh_t      int1_tsh_zh;
+  a3g4250d_int1_tsh_zl_t      int1_tsh_zl;
+  a3g4250d_int1_duration_t    int1_duration;
+  bitwise_t                   bitwise;
+  uint8_t                     byte;
+} a3g4250d_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t a3g4250d_read_reg(a3g4250d_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t a3g4250d_write_reg(a3g4250d_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t a3g4250d_from_fs245dps_to_mdps(int16_t lsb);
+extern float_t a3g4250d_from_lsb_to_celsius(int16_t lsb);
+
+int32_t a3g4250d_axis_x_data_set(a3g4250d_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_axis_x_data_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t a3g4250d_axis_y_data_set(a3g4250d_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_axis_y_data_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t a3g4250d_axis_z_data_set(a3g4250d_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_axis_z_data_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  A3G4250D_ODR_OFF     = 0x00,
+  A3G4250D_ODR_SLEEP   = 0x08,
+  A3G4250D_ODR_100Hz   = 0x0F,
+  A3G4250D_ODR_200Hz   = 0x1F,
+  A3G4250D_ODR_400Hz   = 0x2F,
+  A3G4250D_ODR_800Hz   = 0x3F,
+} a3g4250d_dr_t;
+int32_t a3g4250d_data_rate_set(a3g4250d_ctx_t *ctx, a3g4250d_dr_t val);
+int32_t a3g4250d_data_rate_get(a3g4250d_ctx_t *ctx, a3g4250d_dr_t *val);
+
+int32_t a3g4250d_status_reg_get(a3g4250d_ctx_t *ctx,
+                                a3g4250d_status_reg_t *val);
+
+int32_t a3g4250d_flag_data_ready_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t a3g4250d_temperature_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff);
+
+int32_t a3g4250d_angular_rate_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff);
+
+int32_t a3g4250d_device_id_get(a3g4250d_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  A3G4250D_GY_ST_DISABLE    = 0,
+  A3G4250D_GY_ST_POSITIVE   = 1,
+  A3G4250D_GY_ST_NEGATIVE   = 3,
+} a3g4250d_st_t;
+int32_t a3g4250d_self_test_set(a3g4250d_ctx_t *ctx, a3g4250d_st_t val);
+int32_t a3g4250d_self_test_get(a3g4250d_ctx_t *ctx, a3g4250d_st_t *val);
+
+typedef enum {
+  A3G4250D_AUX_LSB_AT_LOW_ADD   = 0,
+  A3G4250D_AUX_MSB_AT_LOW_ADD   = 1,
+} a3g4250d_ble_t;
+int32_t a3g4250d_data_format_set(a3g4250d_ctx_t *ctx, a3g4250d_ble_t val);
+int32_t a3g4250d_data_format_get(a3g4250d_ctx_t *ctx, a3g4250d_ble_t *val);
+
+int32_t a3g4250d_boot_set(a3g4250d_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_boot_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  A3G4250D_CUT_OFF_LOW        = 0,
+  A3G4250D_CUT_OFF_MEDIUM     = 1,
+  A3G4250D_CUT_OFF_HIGH       = 2,
+  A3G4250D_CUT_OFF_VERY_HIGH  = 3,
+} a3g4250d_bw_t;
+int32_t a3g4250d_lp_bandwidth_set(a3g4250d_ctx_t *ctx, a3g4250d_bw_t val);
+int32_t a3g4250d_lp_bandwidth_get(a3g4250d_ctx_t *ctx, a3g4250d_bw_t *val);
+
+typedef enum {
+  A3G4250D_HP_LEVEL_0   = 0,
+  A3G4250D_HP_LEVEL_1   = 1,
+  A3G4250D_HP_LEVEL_2   = 2,
+  A3G4250D_HP_LEVEL_3   = 3,
+  A3G4250D_HP_LEVEL_4   = 4,
+  A3G4250D_HP_LEVEL_5   = 5,
+  A3G4250D_HP_LEVEL_6   = 6,
+  A3G4250D_HP_LEVEL_7   = 7,
+  A3G4250D_HP_LEVEL_8   = 8,
+  A3G4250D_HP_LEVEL_9   = 9,
+} a3g4250d_hpcf_t;
+int32_t a3g4250d_hp_bandwidth_set(a3g4250d_ctx_t *ctx,
+                                  a3g4250d_hpcf_t val);
+int32_t a3g4250d_hp_bandwidth_get(a3g4250d_ctx_t *ctx,
+                                  a3g4250d_hpcf_t *val);
+
+typedef enum {
+  A3G4250D_HP_NORMAL_MODE_WITH_RST  = 0,
+  A3G4250D_HP_REFERENCE_SIGNAL      = 1,
+  A3G4250D_HP_NORMAL_MODE           = 2,
+  A3G4250D_HP_AUTO_RESET_ON_INT     = 3,
+} a3g4250d_hpm_t;
+int32_t a3g4250d_hp_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t val);
+int32_t a3g4250d_hp_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t *val);
+
+typedef enum {
+  A3G4250D_ONLY_LPF1_ON_OUT     = 0,
+  A3G4250D_LPF1_HP_ON_OUT       = 1,
+  A3G4250D_LPF1_LPF2_ON_OUT     = 2,
+  A3G4250D_LPF1_HP_LPF2_ON_OUT  = 6,
+} a3g4250d_out_sel_t;
+int32_t a3g4250d_filter_path_set(a3g4250d_ctx_t *ctx,
+                                 a3g4250d_out_sel_t val);
+int32_t a3g4250d_filter_path_get(a3g4250d_ctx_t *ctx,
+                                 a3g4250d_out_sel_t *val);
+
+typedef enum {
+  A3G4250D_ONLY_LPF1_ON_INT     = 0,
+  A3G4250D_LPF1_HP_ON_INT       = 1,
+  A3G4250D_LPF1_LPF2_ON_INT     = 2,
+  A3G4250D_LPF1_HP_LPF2_ON_INT  = 6,
+} a3g4250d_int1_sel_t;
+int32_t a3g4250d_filter_path_internal_set(a3g4250d_ctx_t *ctx,
+                                          a3g4250d_int1_sel_t val);
+int32_t a3g4250d_filter_path_internal_get(a3g4250d_ctx_t *ctx,
+                                          a3g4250d_int1_sel_t *val);
+
+int32_t a3g4250d_hp_reference_value_set(a3g4250d_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_hp_reference_value_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  A3G4250D_SPI_4_WIRE  = 0,
+  A3G4250D_SPI_3_WIRE  = 1,
+} a3g4250d_sim_t;
+int32_t a3g4250d_spi_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_sim_t val);
+int32_t a3g4250d_spi_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_sim_t *val);
+
+typedef struct {
+  uint8_t i1_int1             : 1;
+  uint8_t i1_boot             : 1;
+} a3g4250d_int1_route_t;
+int32_t a3g4250d_pin_int1_route_set(a3g4250d_ctx_t *ctx,
+                                    a3g4250d_int1_route_t val);
+int32_t a3g4250d_pin_int1_route_get(a3g4250d_ctx_t *ctx,
+                                    a3g4250d_int1_route_t *val);
+
+typedef struct {
+  uint8_t i2_empty             : 1;
+  uint8_t i2_orun              : 1;
+  uint8_t i2_wtm               : 1;
+  uint8_t i2_drdy              : 1;
+} a3g4250d_int2_route_t;
+int32_t a3g4250d_pin_int2_route_set(a3g4250d_ctx_t *ctx,
+                                    a3g4250d_int2_route_t val);
+int32_t a3g4250d_pin_int2_route_get(a3g4250d_ctx_t *ctx,
+                                    a3g4250d_int2_route_t *val);
+
+typedef enum {
+  A3G4250D_PUSH_PULL   = 0,
+  A3G4250D_OPEN_DRAIN  = 1,
+} a3g4250d_pp_od_t;
+int32_t a3g4250d_pin_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t val);
+int32_t a3g4250d_pin_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t *val);
+
+typedef enum {
+  A3G4250D_ACTIVE_HIGH  = 0,
+  A3G4250D_ACTIVE_LOW   = 1,
+} a3g4250d_h_lactive_t;
+int32_t a3g4250d_pin_polarity_set(a3g4250d_ctx_t *ctx,
+                                  a3g4250d_h_lactive_t val);
+int32_t a3g4250d_pin_polarity_get(a3g4250d_ctx_t *ctx,
+                                  a3g4250d_h_lactive_t *val);
+
+typedef enum {
+  A3G4250D_INT_PULSED   = 0,
+  A3G4250D_INT_LATCHED  = 1,
+} a3g4250d_lir_t;
+int32_t a3g4250d_int_notification_set(a3g4250d_ctx_t *ctx,
+                                      a3g4250d_lir_t val);
+int32_t a3g4250d_int_notification_get(a3g4250d_ctx_t *ctx,
+                                      a3g4250d_lir_t *val);
+
+int32_t a3g4250d_int_on_threshold_conf_set(a3g4250d_ctx_t *ctx,
+                                           a3g4250d_int1_cfg_t *val);
+int32_t a3g4250d_int_on_threshold_conf_get(a3g4250d_ctx_t *ctx,
+                                           a3g4250d_int1_cfg_t *val);
+
+typedef enum {
+  A3G4250D_INT1_ON_TH_AND  = 1,
+  A3G4250D_INT1_ON_TH_OR   = 0,
+} a3g4250d_and_or_t;
+int32_t a3g4250d_int_on_threshold_mode_set(a3g4250d_ctx_t *ctx,
+                                           a3g4250d_and_or_t val);
+int32_t a3g4250d_int_on_threshold_mode_get(a3g4250d_ctx_t *ctx,
+                                           a3g4250d_and_or_t *val);
+
+int32_t a3g4250d_int_on_threshold_src_get(a3g4250d_ctx_t *ctx,
+                                          a3g4250d_int1_src_t *val);
+
+int32_t a3g4250d_int_x_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val);
+int32_t a3g4250d_int_x_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val);
+
+int32_t a3g4250d_int_y_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val);
+int32_t a3g4250d_int_y_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val);
+
+int32_t a3g4250d_int_z_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val);
+int32_t a3g4250d_int_z_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val);
+
+int32_t a3g4250d_int_on_threshold_dur_set(a3g4250d_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_int_on_threshold_dur_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t a3g4250d_fifo_enable_set(a3g4250d_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_fifo_enable_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t a3g4250d_fifo_watermark_set(a3g4250d_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_fifo_watermark_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  A3G4250D_FIFO_BYPASS_MODE     = 0x00,
+  A3G4250D_FIFO_MODE            = 0x01,
+  A3G4250D_FIFO_STREAM_MODE     = 0x02,
+} a3g4250d_fifo_mode_t;
+int32_t a3g4250d_fifo_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t val);
+int32_t a3g4250d_fifo_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t *val);
+
+int32_t a3g4250d_fifo_data_level_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t a3g4250d_fifo_empty_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t a3g4250d_fifo_ovr_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t a3g4250d_fifo_wtm_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* A3G4250D_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ais328dq_STdC/driver/ais328dq_reg.c
+++ b/sensor/stmemsc/ais328dq_STdC/driver/ais328dq_reg.c
@@ -1,0 +1,2001 @@
+/*
+ ******************************************************************************
+ * @file    ais328dq_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   AIS328DQ driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "ais328dq_reg.h"
+
+/**
+  * @defgroup    AIS328DQ
+  * @brief       This file provides a set of functions needed to drive the
+  *              ais328dq enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais328dq_read_reg(ais328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais328dq_write_reg(ais328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    AIS328DQ_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float ais328dq_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 0.98f / 16.0f);
+}
+
+float ais328dq_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 1.95f / 16.0f);
+}
+
+float ais328dq_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 3.91f / 16.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Data_Generation
+  * @brief       This section group all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  X axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t ais328dq_axis_x_data_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.xen = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t ais328dq_axis_x_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.xen;
+
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t ais328dq_axis_y_data_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.yen = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t ais328dq_axis_y_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.yen;
+
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t ais328dq_axis_z_data_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.zen = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t ais328dq_axis_z_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.zen;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t ais328dq_data_rate_set(ais328dq_ctx_t *ctx, ais328dq_dr_t val)
+{
+  ais328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.pm = (uint8_t)val & 0x07U;
+    ctrl_reg1.dr = ( (uint8_t)val & 0x30U ) >> 4;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t ais328dq_data_rate_get(ais328dq_ctx_t *ctx, ais328dq_dr_t *val)
+{
+  ais328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+
+  switch ((ctrl_reg1.dr << 4) + ctrl_reg1.pm)
+  {
+    case AIS328DQ_ODR_OFF:
+      *val = AIS328DQ_ODR_OFF;
+      break;
+    case AIS328DQ_ODR_Hz5:
+      *val = AIS328DQ_ODR_Hz5;
+      break;
+    case AIS328DQ_ODR_1Hz:
+      *val = AIS328DQ_ODR_1Hz;
+      break;
+    case AIS328DQ_ODR_5Hz2:
+      *val = AIS328DQ_ODR_5Hz2;
+      break;
+    case AIS328DQ_ODR_5Hz:
+      *val = AIS328DQ_ODR_5Hz;
+      break;
+    case AIS328DQ_ODR_10Hz:
+      *val = AIS328DQ_ODR_10Hz;
+      break;
+    case AIS328DQ_ODR_50Hz:
+      *val = AIS328DQ_ODR_50Hz;
+      break;
+    case AIS328DQ_ODR_100Hz:
+      *val = AIS328DQ_ODR_100Hz;
+      break;
+    case AIS328DQ_ODR_400Hz:
+      *val = AIS328DQ_ODR_400Hz;
+      break;
+    case AIS328DQ_ODR_1kHz:
+      *val = AIS328DQ_ODR_1kHz;
+      break;
+    default:
+      *val = AIS328DQ_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t ais328dq_reference_mode_set(ais328dq_ctx_t *ctx,
+                                     ais328dq_hpm_t val)
+{
+  ais328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t ais328dq_reference_mode_get(ais328dq_ctx_t *ctx,
+                                     ais328dq_hpm_t *val)
+{
+  ais328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG2,
+                           (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpm)
+  {
+    case AIS328DQ_NORMAL_MODE:
+      *val = AIS328DQ_NORMAL_MODE;
+      break;
+    case AIS328DQ_REF_MODE_ENABLE:
+      *val = AIS328DQ_REF_MODE_ENABLE;
+      break;
+    default:
+      *val = AIS328DQ_NORMAL_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_full_scale_set(ais328dq_ctx_t *ctx, ais328dq_fs_t val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_full_scale_get(ais328dq_ctx_t *ctx, ais328dq_fs_t *val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.fs)
+  {
+    case AIS328DQ_2g:
+      *val = AIS328DQ_2g;
+      break;
+    case AIS328DQ_4g:
+      *val = AIS328DQ_4g;
+      break;
+    case AIS328DQ_8g:
+      *val = AIS328DQ_8g;
+      break;
+    default:
+      *val = AIS328DQ_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_block_data_update_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_block_data_update_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers STATUS_REG
+  *
+  */
+int32_t ais328dq_status_reg_get(ais328dq_ctx_t *ctx,
+                                 ais328dq_status_reg_t *val)
+{
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zyxda in reg STATUS_REG
+  *
+  */
+int32_t ais328dq_flag_data_ready_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Data_Output
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t ais328dq_acceleration_raw_get(ais328dq_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Common
+  * @brief       This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t ais328dq_device_id_get(ais328dq_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t ais328dq_boot_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.boot = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t ais328dq_boot_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of st in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_self_test_set(ais328dq_ctx_t *ctx, ais328dq_st_t val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of st in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_self_test_get(ais328dq_ctx_t *ctx, ais328dq_st_t *val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.st)
+  {
+    case AIS328DQ_ST_DISABLE:
+      *val = AIS328DQ_ST_DISABLE;
+      break;
+    case AIS328DQ_ST_POSITIVE:
+      *val = AIS328DQ_ST_POSITIVE;
+      break;
+    case AIS328DQ_ST_NEGATIVE:
+      *val = AIS328DQ_ST_NEGATIVE;
+      break;
+    default:
+      *val = AIS328DQ_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_data_format_set(ais328dq_ctx_t *ctx, ais328dq_ble_t val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_data_format_get(ais328dq_ctx_t *ctx, ais328dq_ble_t *val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.ble)
+  {
+    case AIS328DQ_LSB_AT_LOW_ADD:
+      *val = AIS328DQ_LSB_AT_LOW_ADD;
+      break;
+    case AIS328DQ_MSB_AT_LOW_ADD:
+      *val = AIS328DQ_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = AIS328DQ_LSB_AT_LOW_ADD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Filters
+  * @brief       This section group all the functions concerning the
+  *              filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t ais328dq_hp_bandwidth_set(ais328dq_ctx_t *ctx, ais328dq_hpcf_t val)
+{
+  ais328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t ais328dq_hp_bandwidth_get(ais328dq_ctx_t *ctx,
+                                   ais328dq_hpcf_t *val)
+{
+  ais328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpcf)
+  {
+    case AIS328DQ_CUT_OFF_8Hz:
+      *val = AIS328DQ_CUT_OFF_8Hz;
+      break;
+    case AIS328DQ_CUT_OFF_16Hz:
+      *val = AIS328DQ_CUT_OFF_16Hz;
+      break;
+    case AIS328DQ_CUT_OFF_32Hz:
+      *val = AIS328DQ_CUT_OFF_32Hz;
+      break;
+    case AIS328DQ_CUT_OFF_64Hz:
+      *val = AIS328DQ_CUT_OFF_64Hz;
+      break;
+    default:
+      *val = AIS328DQ_CUT_OFF_8Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t ais328dq_hp_path_set(ais328dq_ctx_t *ctx, ais328dq_hpen_t val)
+{
+  ais328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpen = (uint8_t)val & 0x03U;
+    ctrl_reg2.fds = ((uint8_t)val & 0x04U) >> 2;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t ais328dq_hp_path_get(ais328dq_ctx_t *ctx, ais328dq_hpen_t *val)
+{
+  ais328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+
+  switch ( (ctrl_reg2.fds << 2) + ctrl_reg2.hpen )
+  {
+    case AIS328DQ_HP_DISABLE:
+      *val = AIS328DQ_HP_DISABLE;
+      break;
+    case AIS328DQ_HP_ON_OUT:
+      *val = AIS328DQ_HP_ON_OUT;
+      break;
+    case AIS328DQ_HP_ON_INT1:
+      *val = AIS328DQ_HP_ON_INT1;
+      break;
+    case AIS328DQ_HP_ON_INT2:
+      *val = AIS328DQ_HP_ON_INT2;
+      break;
+    case AIS328DQ_HP_ON_INT1_INT2:
+      *val = AIS328DQ_HP_ON_INT1_INT2;
+      break;
+    case AIS328DQ_HP_ON_INT1_INT2_OUT:
+      *val = AIS328DQ_HP_ON_INT1_INT2_OUT;
+      break;
+    case AIS328DQ_HP_ON_INT2_OUT:
+      *val = AIS328DQ_HP_ON_INT2_OUT;
+      break;
+    case AIS328DQ_HP_ON_INT1_OUT:
+      *val = AIS328DQ_HP_ON_INT1_OUT;
+      break;
+    default:
+      *val = AIS328DQ_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reading at this address zeroes instantaneously
+  *         the content of the internal high pass-filter.
+  *         If the high pass filter is enabled all three axes
+  *         are instantaneously set to 0g. This allows to
+  *         overcome the settling time of the high pass
+  *         filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  *
+  */
+int32_t ais328dq_hp_reset_get(ais328dq_ctx_t *ctx)
+{
+  uint8_t dummy;
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_HP_FILTER_RESET,
+                           (uint8_t*)&dummy, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t ais328dq_hp_reference_value_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  ret = ais328dq_write_reg(ctx, AIS328DQ_REFERENCE, (uint8_t*)&val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t ais328dq_hp_reference_value_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_REFERENCE, val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Serial_Interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_spi_mode_set(ais328dq_ctx_t *ctx, ais328dq_sim_t val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t ais328dq_spi_mode_get(ais328dq_ctx_t *ctx, ais328dq_sim_t *val)
+{
+  ais328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch ( ctrl_reg4.sim )
+  {
+    case AIS328DQ_SPI_4_WIRE:
+      *val = AIS328DQ_SPI_4_WIRE;
+      break;
+    case AIS328DQ_SPI_3_WIRE:
+      *val = AIS328DQ_SPI_3_WIRE;
+      break;
+    default:
+      *val = AIS328DQ_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Interrupt_Pins
+  * @brief       This section groups all the functions that manage
+  *              interrupt pins.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_pin_int1_route_set(ais328dq_ctx_t *ctx,
+                                     ais328dq_i1_cfg_t val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i1_cfg = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_pin_int1_route_get(ais328dq_ctx_t *ctx,
+                                     ais328dq_i1_cfg_t *val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i1_cfg )
+  {
+    case AIS328DQ_PAD1_INT1_SRC:
+      *val = AIS328DQ_PAD1_INT1_SRC;
+      break;
+    case AIS328DQ_PAD1_INT1_OR_INT2_SRC:
+      *val = AIS328DQ_PAD1_INT1_OR_INT2_SRC;
+      break;
+    case AIS328DQ_PAD1_DRDY:
+      *val = AIS328DQ_PAD1_DRDY;
+      break;
+    case AIS328DQ_PAD1_BOOT:
+      *val = AIS328DQ_PAD1_BOOT;
+      break;
+    default:
+      *val = AIS328DQ_PAD1_INT1_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_int1_notification_set(ais328dq_ctx_t *ctx,
+                                        ais328dq_lir1_t val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir1 = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_int1_notification_get(ais328dq_ctx_t *ctx,
+                                        ais328dq_lir1_t *val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir1 )
+  {
+    case AIS328DQ_INT1_PULSED:
+      *val = AIS328DQ_INT1_PULSED;
+      break;
+    case AIS328DQ_INT1_LATCHED:
+      *val = AIS328DQ_INT1_LATCHED;
+      break;
+    default:
+      *val = AIS328DQ_INT1_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_pin_int2_route_set(ais328dq_ctx_t *ctx,
+                                     ais328dq_i2_cfg_t val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i2_cfg = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_pin_int2_route_get(ais328dq_ctx_t *ctx,
+                                     ais328dq_i2_cfg_t *val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i2_cfg )
+  {
+    case AIS328DQ_PAD2_INT2_SRC:
+      *val = AIS328DQ_PAD2_INT2_SRC;
+      break;
+    case AIS328DQ_PAD2_INT1_OR_INT2_SRC:
+      *val = AIS328DQ_PAD2_INT1_OR_INT2_SRC;
+      break;
+    case AIS328DQ_PAD2_DRDY:
+      *val = AIS328DQ_PAD2_DRDY;
+      break;
+    case AIS328DQ_PAD2_BOOT:
+      *val = AIS328DQ_PAD2_BOOT;
+      break;
+    default:
+      *val = AIS328DQ_PAD2_INT2_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_int2_notification_set(ais328dq_ctx_t *ctx,
+                                        ais328dq_lir2_t val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir2 = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_int2_notification_get(ais328dq_ctx_t *ctx,
+                                        ais328dq_lir2_t *val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir2 )
+  {
+    case AIS328DQ_INT2_PULSED:
+      *val = AIS328DQ_INT2_PULSED;
+      break;
+    case AIS328DQ_INT2_LATCHED:
+      *val = AIS328DQ_INT2_LATCHED;
+      break;
+    default:
+      *val = AIS328DQ_INT2_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_pin_mode_set(ais328dq_ctx_t *ctx, ais328dq_pp_od_t val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_pin_mode_get(ais328dq_ctx_t *ctx, ais328dq_pp_od_t *val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.pp_od )
+  {
+    case AIS328DQ_PUSH_PULL:
+      *val = AIS328DQ_PUSH_PULL;
+      break;
+    case AIS328DQ_OPEN_DRAIN:
+      *val = AIS328DQ_OPEN_DRAIN;
+      break;
+    default:
+      *val = AIS328DQ_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_pin_polarity_set(ais328dq_ctx_t *ctx, ais328dq_ihl_t val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.ihl = (uint8_t)val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t ais328dq_pin_polarity_get(ais328dq_ctx_t *ctx, ais328dq_ihl_t *val)
+{
+  ais328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.ihl )
+  {
+    case AIS328DQ_ACTIVE_HIGH:
+      *val = AIS328DQ_ACTIVE_HIGH;
+      break;
+    case AIS328DQ_ACTIVE_LOW:
+      *val = AIS328DQ_ACTIVE_LOW;
+      break;
+    default:
+      *val = AIS328DQ_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_interrupt_on_threshold
+  * @brief       This section groups all the functions that manage
+  *              the interrupt on threshold event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the interrupt 1 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t ais328dq_int1_on_threshold_conf_set(ais328dq_ctx_t *ctx,
+                                              int1_on_th_conf_t val)
+{
+  ais328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.xlie  = val.int1_xlie;
+    int1_cfg.xhie  = val.int1_xhie;
+    int1_cfg.ylie  = val.int1_ylie;
+    int1_cfg.yhie  = val.int1_yhie;
+    int1_cfg.zlie  = val.int1_zlie;
+    int1_cfg.zhie  = val.int1_zhie;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Configure the interrupt 1 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t ais328dq_int1_on_threshold_conf_get(ais328dq_ctx_t *ctx,
+                                             int1_on_th_conf_t *val)
+{
+  ais328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  val->int1_xlie = int1_cfg.xlie;
+  val->int1_xhie = int1_cfg.xhie;
+  val->int1_ylie = int1_cfg.ylie;
+  val->int1_yhie = int1_cfg.yhie;
+  val->int1_zlie = int1_cfg.zlie;
+  val->int1_zhie = int1_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 1 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t ais328dq_int1_on_threshold_mode_set(ais328dq_ctx_t *ctx,
+                                             ais328dq_int1_aoi_t val)
+{
+  ais328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.aoi = (uint8_t) val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 1 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t ais328dq_int1_on_threshold_mode_get(ais328dq_ctx_t *ctx,
+                                             ais328dq_int1_aoi_t *val)
+{
+  ais328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ( int1_cfg.aoi )
+  {
+    case AIS328DQ_INT1_ON_THRESHOLD_OR:
+      *val = AIS328DQ_INT1_ON_THRESHOLD_OR;
+      break;
+    case AIS328DQ_INT1_ON_THRESHOLD_AND:
+      *val = AIS328DQ_INT1_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = AIS328DQ_INT1_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t ais328dq_int1_src_get(ais328dq_ctx_t *ctx,
+                               ais328dq_int1_src_t *val)
+{
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t ais328dq_int1_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT1_THS,
+                              (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t ais328dq_int1_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t ais328dq_int1_dur_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  if(ret == 0) {
+    int1_duration.d = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT1_DURATION,
+                              (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t ais328dq_int1_dur_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  *val = int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t ais328dq_int2_on_threshold_conf_set(ais328dq_ctx_t *ctx,
+                                              int2_on_th_conf_t val)
+{
+  ais328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_CFG,
+                           (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.xlie  = val.int2_xlie;
+    int2_cfg.xhie  = val.int2_xhie;
+    int2_cfg.ylie  = val.int2_ylie;
+    int2_cfg.yhie  = val.int2_yhie;
+    int2_cfg.zlie  = val.int2_zlie;
+    int2_cfg.zhie  = val.int2_zhie;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t ais328dq_int2_on_threshold_conf_get(ais328dq_ctx_t *ctx,
+                                              int2_on_th_conf_t *val)
+{
+  ais328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  val->int2_xlie = int2_cfg.xlie;
+  val->int2_xhie = int2_cfg.xhie;
+  val->int2_ylie = int2_cfg.ylie;
+  val->int2_yhie = int2_cfg.yhie;
+  val->int2_zlie = int2_cfg.zlie;
+  val->int2_zhie = int2_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 2 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t ais328dq_int2_on_threshold_mode_set(ais328dq_ctx_t *ctx,
+                                             ais328dq_int2_aoi_t val)
+{
+  ais328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.aoi = (uint8_t) val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 2 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t ais328dq_int2_on_threshold_mode_get(ais328dq_ctx_t *ctx,
+                                             ais328dq_int2_aoi_t *val)
+{
+  ais328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ( int2_cfg.aoi )
+  {
+    case AIS328DQ_INT2_ON_THRESHOLD_OR:
+      *val = AIS328DQ_INT2_ON_THRESHOLD_OR;
+      break;
+    case AIS328DQ_INT2_ON_THRESHOLD_AND:
+      *val = AIS328DQ_INT2_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = AIS328DQ_INT2_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t ais328dq_int2_src_get(ais328dq_ctx_t *ctx,
+                               ais328dq_int2_src_t *val)
+{
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t ais328dq_int2_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t ais328dq_int2_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t ais328dq_int2_dur_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  if(ret == 0) {
+    int2_duration.d = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT2_DURATION,
+                              (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Duration value for interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t ais328dq_int2_dur_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  *val = int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Wake_Up_Event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t ais328dq_wkup_to_sleep_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0) {
+    ctrl_reg5.turnon = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_CTRL_REG5,
+                              (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t ais328dq_wkup_to_sleep_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.turnon;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS328DQ_Six_Position_Detection
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the 6d on interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of 6d in reg INT1_CFG
+  *
+  */
+int32_t ais328dq_int1_6d_mode_set(ais328dq_ctx_t *ctx,
+                                   ais328dq_int1_6d_t val)
+{
+  ais328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg._6d = (uint8_t)val & 0x01U;
+    int1_cfg.aoi = ((uint8_t)val & 0x02U) >> 1;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of 6d in reg INT1_CFG
+  *
+  */
+int32_t ais328dq_int1_6d_mode_get(ais328dq_ctx_t *ctx,
+                                   ais328dq_int1_6d_t *val)
+{
+  ais328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ((int1_cfg.aoi << 1) + int1_cfg._6d)
+  {
+    case AIS328DQ_6D_INT1_DISABLE:
+      *val = AIS328DQ_6D_INT1_DISABLE;
+      break;
+    case AIS328DQ_6D_INT1_MOVEMENT:
+      *val = AIS328DQ_6D_INT1_MOVEMENT;
+      break;
+     case AIS328DQ_6D_INT1_POSITION:
+      *val = AIS328DQ_6D_INT1_POSITION;
+      break;
+    default:
+      *val = AIS328DQ_6D_INT1_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  6D on interrupt generator 1 source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t ais328dq_int1_6d_src_get(ais328dq_ctx_t *ctx,
+                                  ais328dq_int1_src_t *val)
+{
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t ais328dq_int1_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t ais328dq_int1_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of 6d in reg INT2_CFG
+  *
+  */
+int32_t ais328dq_int2_6d_mode_set(ais328dq_ctx_t *ctx,
+                                   ais328dq_int2_6d_t val)
+{
+  ais328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg._6d = (uint8_t)val & 0x01U;
+    int2_cfg.aoi = ((uint8_t)val & 0x02U) >> 1;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of 6d in reg INT2_CFG
+  *
+  */
+int32_t ais328dq_int2_6d_mode_get(ais328dq_ctx_t *ctx,
+                                   ais328dq_int2_6d_t *val)
+{
+  ais328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ((int2_cfg.aoi << 1) + int2_cfg._6d)
+  {
+    case AIS328DQ_6D_INT2_DISABLE:
+      *val = AIS328DQ_6D_INT2_DISABLE;
+      break;
+    case AIS328DQ_6D_INT2_MOVEMENT:
+      *val = AIS328DQ_6D_INT2_MOVEMENT;
+      break;
+     case AIS328DQ_6D_INT2_POSITION:
+      *val = AIS328DQ_6D_INT2_POSITION;
+      break;
+    default:
+      *val = AIS328DQ_6D_INT2_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  6D on interrupt generator 2 source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t ais328dq_int2_6d_src_get(ais328dq_ctx_t *ctx,
+                                  ais328dq_int2_src_t *val)
+{
+  int32_t ret;
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t ais328dq_int2_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
+{
+  ais328dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = ais328dq_write_reg(ctx, AIS328DQ_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t ais328dq_int2_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
+{
+  ais328dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = ais328dq_read_reg(ctx, AIS328DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ais328dq_STdC/driver/ais328dq_reg.h
+++ b/sensor/stmemsc/ais328dq_STdC/driver/ais328dq_reg.h
@@ -1,0 +1,640 @@
+/*
+ ******************************************************************************
+ * @file    ais328dq_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          ais328dq_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef AIS328DQ_REGS_H
+#define AIS328DQ_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup AIS328DQ
+  * @{
+  *
+  */
+
+/** @defgroup AIS328DQ_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  AIS328DQ_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*ais328dq_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*ais328dq_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  ais328dq_write_ptr  write_reg;
+  ais328dq_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} ais328dq_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+
+/** @defgroup AIS328DQ_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0x31 if SA0=1 -> 0x33 **/
+#define AIS328DQ_I2C_ADD_L     0x31
+#define AIS328DQ_I2C_ADD_H     0x33
+
+/** Device Identification (Who am I) **/
+#define AIS328DQ_ID            0x32
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  AIS328DQ_Sensitivity
+  * @brief       These macro are maintained for back compatibility.
+  *              in order to convert data into engineering units please
+  *              use functions:
+  *                -> _from_fs2_to_mg(int16_t lsb);
+  *                -> _from_fs4_to_mg(int16_t lsb);
+  *                -> _from_fs8_to_mg(int16_t lsb);
+  *
+  *              REMOVING the MACRO you are compliant with:
+  *              MISRA-C 2012 [Dir 4.9] -> " avoid function-like macros "
+  * @{
+  *
+  */
+
+#define AIS328DQ_FROM_FS_2g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 0.98f )
+#define AIS328DQ_FROM_FS_4g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 1.95f )
+#define AIS328DQ_FROM_FS_8g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 3.91f )
+
+/**
+  * @}
+  *
+  */
+
+#define AIS328DQ_WHO_AM_I                  0x0FU
+#define AIS328DQ_CTRL_REG1                 0x20U
+typedef struct {
+  uint8_t xen                      : 1;
+  uint8_t yen                      : 1;
+  uint8_t zen                      : 1;
+  uint8_t dr                       : 2;
+  uint8_t pm                       : 3;
+} ais328dq_ctrl_reg1_t;
+
+#define AIS328DQ_CTRL_REG2                 0x21U
+typedef struct {
+  uint8_t hpcf                     : 2;
+  uint8_t hpen                     : 2;
+  uint8_t fds                      : 1;
+  uint8_t hpm                      : 2;
+  uint8_t boot                     : 1;
+} ais328dq_ctrl_reg2_t;
+
+#define AIS328DQ_CTRL_REG3                 0x22U
+typedef struct {
+  uint8_t i1_cfg                   : 2;
+  uint8_t lir1                     : 1;
+  uint8_t i2_cfg                   : 2;
+  uint8_t lir2                     : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t ihl                      : 1;
+} ais328dq_ctrl_reg3_t;
+
+#define AIS328DQ_CTRL_REG4                 0x23U
+typedef struct {
+  uint8_t sim                      : 1;
+  uint8_t st                       : 3; /* STsign + ST */
+  uint8_t fs                       : 2;
+  uint8_t ble                      : 1;
+  uint8_t bdu                      : 1;
+} ais328dq_ctrl_reg4_t;
+
+#define AIS328DQ_CTRL_REG5                 0x24U
+typedef struct {
+  uint8_t turnon                   : 2;
+  uint8_t not_used_01              : 6;
+} ais328dq_ctrl_reg5_t;
+
+#define AIS328DQ_HP_FILTER_RESET           0x25U
+#define AIS328DQ_REFERENCE                 0x26U
+#define AIS328DQ_STATUS_REG                0x27U
+typedef struct {
+  uint8_t xda                      : 1;
+  uint8_t yda                      : 1;
+  uint8_t zda                      : 1;
+  uint8_t zyxda                    : 1;
+  uint8_t _xor                     : 1;
+  uint8_t yor                      : 1;
+  uint8_t zor                      : 1;
+  uint8_t zyxor                    : 1;
+} ais328dq_status_reg_t;
+
+#define AIS328DQ_OUT_X_L                   0x28U
+#define AIS328DQ_OUT_X_H                   0x29U
+#define AIS328DQ_OUT_Y_L                   0x2AU
+#define AIS328DQ_OUT_Y_H                   0x2BU
+#define AIS328DQ_OUT_Z_L                   0x2CU
+#define AIS328DQ_OUT_Z_H                   0x2DU
+#define AIS328DQ_INT1_CFG                  0x30U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi                      : 1;
+} ais328dq_int1_cfg_t;
+
+#define AIS328DQ_INT1_SRC                  0x31U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} ais328dq_int1_src_t;
+
+#define AIS328DQ_INT1_THS                  0x32U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} ais328dq_int1_ths_t;
+
+#define AIS328DQ_INT1_DURATION             0x33U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} ais328dq_int1_duration_t;
+
+#define AIS328DQ_INT2_CFG                  0x34U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi                      : 1;
+} ais328dq_int2_cfg_t;
+
+#define AIS328DQ_INT2_SRC                  0x35U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} ais328dq_int2_src_t;
+
+#define AIS328DQ_INT2_THS                  0x36U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} ais328dq_int2_ths_t;
+
+#define AIS328DQ_INT2_DURATION             0x37U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} ais328dq_int2_duration_t;
+
+/**
+  * @defgroup AIS328DQ_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  ais328dq_ctrl_reg1_t                     ctrl_reg1;
+  ais328dq_ctrl_reg2_t                     ctrl_reg2;
+  ais328dq_ctrl_reg3_t                     ctrl_reg3;
+  ais328dq_ctrl_reg4_t                     ctrl_reg4;
+  ais328dq_ctrl_reg5_t                     ctrl_reg5;
+  ais328dq_status_reg_t                    status_reg;
+  ais328dq_int1_cfg_t                      int1_cfg;
+  ais328dq_int1_src_t                      int1_src;
+  ais328dq_int1_ths_t                      int1_ths;
+  ais328dq_int1_duration_t                 int1_duration;
+  ais328dq_int2_cfg_t                      int2_cfg;
+  ais328dq_int2_src_t                      int2_src;
+  ais328dq_int2_ths_t                      int2_ths;
+  ais328dq_int2_duration_t                 int2_duration;
+  bitwise_t                                 bitwise;
+  uint8_t                                   byte;
+} ais328dq_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t ais328dq_read_reg(ais328dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+int32_t ais328dq_write_reg(ais328dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len);
+
+extern float ais328dq_from_fs2_to_mg(int16_t lsb);
+extern float ais328dq_from_fs4_to_mg(int16_t lsb);
+extern float ais328dq_from_fs8_to_mg(int16_t lsb);
+
+int32_t ais328dq_axis_x_data_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_axis_x_data_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais328dq_axis_y_data_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_axis_y_data_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais328dq_axis_z_data_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_axis_z_data_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS328DQ_ODR_OFF   = 0x00,
+  AIS328DQ_ODR_Hz5   = 0x02,
+  AIS328DQ_ODR_1Hz   = 0x03,
+  AIS328DQ_ODR_5Hz2  = 0x04,
+  AIS328DQ_ODR_5Hz   = 0x05,
+  AIS328DQ_ODR_10Hz  = 0x06,
+  AIS328DQ_ODR_50Hz  = 0x01,
+  AIS328DQ_ODR_100Hz = 0x11,
+  AIS328DQ_ODR_400Hz = 0x21,
+  AIS328DQ_ODR_1kHz  = 0x31,
+} ais328dq_dr_t;
+int32_t ais328dq_data_rate_set(ais328dq_ctx_t *ctx, ais328dq_dr_t val);
+int32_t ais328dq_data_rate_get(ais328dq_ctx_t *ctx, ais328dq_dr_t *val);
+
+typedef enum {
+  AIS328DQ_NORMAL_MODE      = 0,
+  AIS328DQ_REF_MODE_ENABLE  = 1,
+} ais328dq_hpm_t;
+int32_t ais328dq_reference_mode_set(ais328dq_ctx_t *ctx,
+                                     ais328dq_hpm_t val);
+int32_t ais328dq_reference_mode_get(ais328dq_ctx_t *ctx,
+                                     ais328dq_hpm_t *val);
+
+typedef enum {
+  AIS328DQ_2g  = 0,
+  AIS328DQ_4g  = 1,
+  AIS328DQ_8g  = 3,
+} ais328dq_fs_t;
+int32_t ais328dq_full_scale_set(ais328dq_ctx_t *ctx, ais328dq_fs_t val);
+int32_t ais328dq_full_scale_get(ais328dq_ctx_t *ctx, ais328dq_fs_t *val);
+
+int32_t ais328dq_block_data_update_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_block_data_update_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais328dq_status_reg_get(ais328dq_ctx_t *ctx,
+                                 ais328dq_status_reg_t *val);
+
+int32_t ais328dq_flag_data_ready_get(ais328dq_ctx_t *ctx,
+                                      uint8_t *val);
+
+int32_t ais328dq_acceleration_raw_get(ais328dq_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais328dq_device_id_get(ais328dq_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais328dq_boot_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_boot_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS328DQ_ST_DISABLE   = 0,
+  AIS328DQ_ST_POSITIVE  = 1,
+  AIS328DQ_ST_NEGATIVE  = 5,
+} ais328dq_st_t;
+int32_t ais328dq_self_test_set(ais328dq_ctx_t *ctx, ais328dq_st_t val);
+int32_t ais328dq_self_test_get(ais328dq_ctx_t *ctx, ais328dq_st_t *val);
+
+typedef enum {
+  AIS328DQ_LSB_AT_LOW_ADD  = 0,
+  AIS328DQ_MSB_AT_LOW_ADD  = 1,
+} ais328dq_ble_t;
+int32_t ais328dq_data_format_set(ais328dq_ctx_t *ctx, ais328dq_ble_t val);
+int32_t ais328dq_data_format_get(ais328dq_ctx_t *ctx, ais328dq_ble_t *val);
+
+typedef enum {
+  AIS328DQ_CUT_OFF_8Hz   = 0,
+  AIS328DQ_CUT_OFF_16Hz  = 1,
+  AIS328DQ_CUT_OFF_32Hz  = 2,
+  AIS328DQ_CUT_OFF_64Hz  = 3,
+} ais328dq_hpcf_t;
+int32_t ais328dq_hp_bandwidth_set(ais328dq_ctx_t *ctx,
+                                   ais328dq_hpcf_t val);
+int32_t ais328dq_hp_bandwidth_get(ais328dq_ctx_t *ctx,
+                                   ais328dq_hpcf_t *val);
+
+typedef enum {
+  AIS328DQ_HP_DISABLE            = 0,
+  AIS328DQ_HP_ON_OUT             = 4,
+  AIS328DQ_HP_ON_INT1            = 1,
+  AIS328DQ_HP_ON_INT2            = 2,
+  AIS328DQ_HP_ON_INT1_INT2       = 3,
+  AIS328DQ_HP_ON_INT1_INT2_OUT   = 7,
+  AIS328DQ_HP_ON_INT2_OUT        = 6,
+  AIS328DQ_HP_ON_INT1_OUT        = 5,
+} ais328dq_hpen_t;
+int32_t ais328dq_hp_path_set(ais328dq_ctx_t *ctx, ais328dq_hpen_t val);
+int32_t ais328dq_hp_path_get(ais328dq_ctx_t *ctx, ais328dq_hpen_t *val);
+
+int32_t ais328dq_hp_reset_get(ais328dq_ctx_t *ctx);
+
+int32_t ais328dq_hp_reference_value_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_hp_reference_value_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS328DQ_SPI_4_WIRE  = 0,
+  AIS328DQ_SPI_3_WIRE  = 1,
+} ais328dq_sim_t;
+int32_t ais328dq_spi_mode_set(ais328dq_ctx_t *ctx, ais328dq_sim_t val);
+int32_t ais328dq_spi_mode_get(ais328dq_ctx_t *ctx, ais328dq_sim_t *val);
+
+typedef enum {
+  AIS328DQ_PAD1_INT1_SRC           = 0,
+  AIS328DQ_PAD1_INT1_OR_INT2_SRC   = 1,
+  AIS328DQ_PAD1_DRDY               = 2,
+  AIS328DQ_PAD1_BOOT               = 3,
+} ais328dq_i1_cfg_t;
+int32_t ais328dq_pin_int1_route_set(ais328dq_ctx_t *ctx,
+                                     ais328dq_i1_cfg_t val);
+int32_t ais328dq_pin_int1_route_get(ais328dq_ctx_t *ctx,
+                                     ais328dq_i1_cfg_t *val);
+
+typedef enum {
+  AIS328DQ_INT1_PULSED   = 0,
+  AIS328DQ_INT1_LATCHED  = 1,
+} ais328dq_lir1_t;
+int32_t ais328dq_int1_notification_set(ais328dq_ctx_t *ctx,
+                                        ais328dq_lir1_t val);
+int32_t ais328dq_int1_notification_get(ais328dq_ctx_t *ctx,
+                                        ais328dq_lir1_t *val);
+
+typedef enum {
+  AIS328DQ_PAD2_INT2_SRC           = 0,
+  AIS328DQ_PAD2_INT1_OR_INT2_SRC   = 1,
+  AIS328DQ_PAD2_DRDY               = 2,
+  AIS328DQ_PAD2_BOOT               = 3,
+} ais328dq_i2_cfg_t;
+int32_t ais328dq_pin_int2_route_set(ais328dq_ctx_t *ctx,
+                                     ais328dq_i2_cfg_t val);
+int32_t ais328dq_pin_int2_route_get(ais328dq_ctx_t *ctx,
+                                     ais328dq_i2_cfg_t *val);
+
+typedef enum {
+  AIS328DQ_INT2_PULSED   = 0,
+  AIS328DQ_INT2_LATCHED  = 1,
+} ais328dq_lir2_t;
+int32_t ais328dq_int2_notification_set(ais328dq_ctx_t *ctx,
+                                        ais328dq_lir2_t val);
+int32_t ais328dq_int2_notification_get(ais328dq_ctx_t *ctx,
+                                        ais328dq_lir2_t *val);
+
+typedef enum {
+  AIS328DQ_PUSH_PULL   = 0,
+  AIS328DQ_OPEN_DRAIN  = 1,
+} ais328dq_pp_od_t;
+int32_t ais328dq_pin_mode_set(ais328dq_ctx_t *ctx, ais328dq_pp_od_t val);
+int32_t ais328dq_pin_mode_get(ais328dq_ctx_t *ctx, ais328dq_pp_od_t *val);
+
+typedef enum {
+  AIS328DQ_ACTIVE_HIGH  = 0,
+  AIS328DQ_ACTIVE_LOW   = 1,
+} ais328dq_ihl_t;
+int32_t ais328dq_pin_polarity_set(ais328dq_ctx_t *ctx,
+                                   ais328dq_ihl_t val);
+int32_t ais328dq_pin_polarity_get(ais328dq_ctx_t *ctx,
+                                   ais328dq_ihl_t *val);
+
+typedef struct {
+  uint8_t int1_xlie             : 1;
+  uint8_t int1_xhie             : 1;
+  uint8_t int1_ylie             : 1;
+  uint8_t int1_yhie             : 1;
+  uint8_t int1_zlie             : 1;
+  uint8_t int1_zhie             : 1;
+} int1_on_th_conf_t;
+int32_t ais328dq_int1_on_threshold_conf_set(ais328dq_ctx_t *ctx,
+                                             int1_on_th_conf_t val);
+int32_t ais328dq_int1_on_threshold_conf_get(ais328dq_ctx_t *ctx,
+                                             int1_on_th_conf_t *val);
+
+typedef enum {
+  AIS328DQ_INT1_ON_THRESHOLD_OR   = 0,
+  AIS328DQ_INT1_ON_THRESHOLD_AND  = 1,
+} ais328dq_int1_aoi_t;
+int32_t ais328dq_int1_on_threshold_mode_set(ais328dq_ctx_t *ctx,
+                                             ais328dq_int1_aoi_t val);
+int32_t ais328dq_int1_on_threshold_mode_get(ais328dq_ctx_t *ctx,
+                                             ais328dq_int1_aoi_t *val);
+
+int32_t ais328dq_int1_src_get(ais328dq_ctx_t *ctx,
+                               ais328dq_int1_src_t *val);
+
+int32_t ais328dq_int1_treshold_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int1_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais328dq_int1_dur_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int1_dur_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t int2_xlie             : 1;
+  uint8_t int2_xhie             : 1;
+  uint8_t int2_ylie             : 1;
+  uint8_t int2_yhie             : 1;
+  uint8_t int2_zlie             : 1;
+  uint8_t int2_zhie             : 1;
+} int2_on_th_conf_t;
+int32_t ais328dq_int2_on_threshold_conf_set(ais328dq_ctx_t *ctx,
+                                             int2_on_th_conf_t val);
+int32_t ais328dq_int2_on_threshold_conf_get(ais328dq_ctx_t *ctx,
+                                             int2_on_th_conf_t *val);
+
+typedef enum {
+  AIS328DQ_INT2_ON_THRESHOLD_OR   = 0,
+  AIS328DQ_INT2_ON_THRESHOLD_AND  = 1,
+} ais328dq_int2_aoi_t;
+int32_t ais328dq_int2_on_threshold_mode_set(ais328dq_ctx_t *ctx,
+                                             ais328dq_int2_aoi_t val);
+int32_t ais328dq_int2_on_threshold_mode_get(ais328dq_ctx_t *ctx,
+                                             ais328dq_int2_aoi_t *val);
+
+int32_t ais328dq_int2_src_get(ais328dq_ctx_t *ctx,
+                               ais328dq_int2_src_t *val);
+
+int32_t ais328dq_int2_treshold_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int2_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais328dq_int2_dur_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int2_dur_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais328dq_wkup_to_sleep_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_wkup_to_sleep_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS328DQ_6D_INT1_DISABLE   = 0,
+  AIS328DQ_6D_INT1_MOVEMENT  = 1,
+  AIS328DQ_6D_INT1_POSITION  = 3,
+} ais328dq_int1_6d_t;
+int32_t ais328dq_int1_6d_mode_set(ais328dq_ctx_t *ctx,
+                                   ais328dq_int1_6d_t val);
+int32_t ais328dq_int1_6d_mode_get(ais328dq_ctx_t *ctx,
+                                   ais328dq_int1_6d_t *val);
+
+int32_t ais328dq_int1_6d_src_get(ais328dq_ctx_t *ctx,
+                                  ais328dq_int1_src_t *val);
+
+int32_t ais328dq_int1_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int1_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS328DQ_6D_INT2_DISABLE   = 0,
+  AIS328DQ_6D_INT2_MOVEMENT  = 1,
+  AIS328DQ_6D_INT2_POSITION  = 3,
+} ais328dq_int2_6d_t;
+int32_t ais328dq_int2_6d_mode_set(ais328dq_ctx_t *ctx,
+                                   ais328dq_int2_6d_t val);
+int32_t ais328dq_int2_6d_mode_get(ais328dq_ctx_t *ctx,
+                                   ais328dq_int2_6d_t *val);
+
+int32_t ais328dq_int2_6d_src_get(ais328dq_ctx_t *ctx,
+                                  ais328dq_int2_src_t *val);
+
+int32_t ais328dq_int2_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int2_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AIS328DQ_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ais3624dq_STdC/driver/ais3624dq_reg.c
+++ b/sensor/stmemsc/ais3624dq_STdC/driver/ais3624dq_reg.c
@@ -1,0 +1,2001 @@
+/*
+ ******************************************************************************
+ * @file    ais3624dq_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   AIS3624DQ driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "ais3624dq_reg.h"
+
+/**
+  * @defgroup    AIS3624DQ
+  * @brief       This file provides a set of functions needed to drive the
+  *              ais3624dq enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais3624dq_read_reg(ais3624dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais3624dq_write_reg(ais3624dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    AIS3624DQ_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float ais3624dq_from_fs6_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 2.9f / 16.0f);
+}
+
+float ais3624dq_from_fs12_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 5.9f / 16.0f);
+}
+
+float ais3624dq_from_fs24_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 11.7f / 16.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Data_Generation
+  * @brief       This section group all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  X axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t ais3624dq_axis_x_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.xen = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t ais3624dq_axis_x_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.xen;
+
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t ais3624dq_axis_y_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.yen = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t ais3624dq_axis_y_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.yen;
+
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t ais3624dq_axis_z_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.zen = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t ais3624dq_axis_z_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.zen;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t ais3624dq_data_rate_set(ais3624dq_ctx_t *ctx, ais3624dq_dr_t val)
+{
+  ais3624dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.pm = (uint8_t)val & 0x07U;
+    ctrl_reg1.dr = ( (uint8_t)val & 0x30U ) >> 4;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t ais3624dq_data_rate_get(ais3624dq_ctx_t *ctx, ais3624dq_dr_t *val)
+{
+  ais3624dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+
+  switch ((ctrl_reg1.dr << 4) + ctrl_reg1.pm)
+  {
+    case AIS3624DQ_ODR_OFF:
+      *val = AIS3624DQ_ODR_OFF;
+      break;
+    case AIS3624DQ_ODR_Hz5:
+      *val = AIS3624DQ_ODR_Hz5;
+      break;
+    case AIS3624DQ_ODR_1Hz:
+      *val = AIS3624DQ_ODR_1Hz;
+      break;
+    case AIS3624DQ_ODR_5Hz2:
+      *val = AIS3624DQ_ODR_5Hz2;
+      break;
+    case AIS3624DQ_ODR_5Hz:
+      *val = AIS3624DQ_ODR_5Hz;
+      break;
+    case AIS3624DQ_ODR_10Hz:
+      *val = AIS3624DQ_ODR_10Hz;
+      break;
+    case AIS3624DQ_ODR_50Hz:
+      *val = AIS3624DQ_ODR_50Hz;
+      break;
+    case AIS3624DQ_ODR_100Hz:
+      *val = AIS3624DQ_ODR_100Hz;
+      break;
+    case AIS3624DQ_ODR_400Hz:
+      *val = AIS3624DQ_ODR_400Hz;
+      break;
+    case AIS3624DQ_ODR_1kHz:
+      *val = AIS3624DQ_ODR_1kHz;
+      break;
+    default:
+      *val = AIS3624DQ_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t ais3624dq_reference_mode_set(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_hpm_t val)
+{
+  ais3624dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t ais3624dq_reference_mode_get(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_hpm_t *val)
+{
+  ais3624dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG2,
+                           (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpm)
+  {
+    case AIS3624DQ_NORMAL_MODE:
+      *val = AIS3624DQ_NORMAL_MODE;
+      break;
+    case AIS3624DQ_REF_MODE_ENABLE:
+      *val = AIS3624DQ_REF_MODE_ENABLE;
+      break;
+    default:
+      *val = AIS3624DQ_NORMAL_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_full_scale_set(ais3624dq_ctx_t *ctx, ais3624dq_fs_t val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_full_scale_get(ais3624dq_ctx_t *ctx, ais3624dq_fs_t *val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.fs)
+  {
+    case AIS3624DQ_6g:
+      *val = AIS3624DQ_6g;
+      break;
+    case AIS3624DQ_12g:
+      *val = AIS3624DQ_12g;
+      break;
+    case AIS3624DQ_24g:
+      *val = AIS3624DQ_24g;
+      break;
+    default:
+      *val = AIS3624DQ_6g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_block_data_update_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_block_data_update_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers STATUS_REG
+  *
+  */
+int32_t ais3624dq_status_reg_get(ais3624dq_ctx_t *ctx,
+                                 ais3624dq_status_reg_t *val)
+{
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zyxda in reg STATUS_REG
+  *
+  */
+int32_t ais3624dq_flag_data_ready_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Data_Output
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t ais3624dq_acceleration_raw_get(ais3624dq_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Common
+  * @brief       This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t ais3624dq_device_id_get(ais3624dq_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t ais3624dq_boot_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.boot = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t ais3624dq_boot_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of st in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_self_test_set(ais3624dq_ctx_t *ctx, ais3624dq_st_t val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of st in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_self_test_get(ais3624dq_ctx_t *ctx, ais3624dq_st_t *val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.st)
+  {
+    case AIS3624DQ_ST_DISABLE:
+      *val = AIS3624DQ_ST_DISABLE;
+      break;
+    case AIS3624DQ_ST_POSITIVE:
+      *val = AIS3624DQ_ST_POSITIVE;
+      break;
+    case AIS3624DQ_ST_NEGATIVE:
+      *val = AIS3624DQ_ST_NEGATIVE;
+      break;
+    default:
+      *val = AIS3624DQ_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_data_format_set(ais3624dq_ctx_t *ctx, ais3624dq_ble_t val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_data_format_get(ais3624dq_ctx_t *ctx, ais3624dq_ble_t *val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.ble)
+  {
+    case AIS3624DQ_LSB_AT_LOW_ADD:
+      *val = AIS3624DQ_LSB_AT_LOW_ADD;
+      break;
+    case AIS3624DQ_MSB_AT_LOW_ADD:
+      *val = AIS3624DQ_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = AIS3624DQ_LSB_AT_LOW_ADD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Filters
+  * @brief       This section group all the functions concerning the
+  *              filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t ais3624dq_hp_bandwidth_set(ais3624dq_ctx_t *ctx, ais3624dq_hpcf_t val)
+{
+  ais3624dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t ais3624dq_hp_bandwidth_get(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_hpcf_t *val)
+{
+  ais3624dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpcf)
+  {
+    case AIS3624DQ_CUT_OFF_8Hz:
+      *val = AIS3624DQ_CUT_OFF_8Hz;
+      break;
+    case AIS3624DQ_CUT_OFF_16Hz:
+      *val = AIS3624DQ_CUT_OFF_16Hz;
+      break;
+    case AIS3624DQ_CUT_OFF_32Hz:
+      *val = AIS3624DQ_CUT_OFF_32Hz;
+      break;
+    case AIS3624DQ_CUT_OFF_64Hz:
+      *val = AIS3624DQ_CUT_OFF_64Hz;
+      break;
+    default:
+      *val = AIS3624DQ_CUT_OFF_8Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t ais3624dq_hp_path_set(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t val)
+{
+  ais3624dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpen = (uint8_t)val & 0x03U;
+    ctrl_reg2.fds = ((uint8_t)val & 0x04U) >> 2;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t ais3624dq_hp_path_get(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t *val)
+{
+  ais3624dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+
+  switch ( (ctrl_reg2.fds << 2) + ctrl_reg2.hpen )
+  {
+    case AIS3624DQ_HP_DISABLE:
+      *val = AIS3624DQ_HP_DISABLE;
+      break;
+    case AIS3624DQ_HP_ON_OUT:
+      *val = AIS3624DQ_HP_ON_OUT;
+      break;
+    case AIS3624DQ_HP_ON_INT1:
+      *val = AIS3624DQ_HP_ON_INT1;
+      break;
+    case AIS3624DQ_HP_ON_INT2:
+      *val = AIS3624DQ_HP_ON_INT2;
+      break;
+    case AIS3624DQ_HP_ON_INT1_INT2:
+      *val = AIS3624DQ_HP_ON_INT1_INT2;
+      break;
+    case AIS3624DQ_HP_ON_INT1_INT2_OUT:
+      *val = AIS3624DQ_HP_ON_INT1_INT2_OUT;
+      break;
+    case AIS3624DQ_HP_ON_INT2_OUT:
+      *val = AIS3624DQ_HP_ON_INT2_OUT;
+      break;
+    case AIS3624DQ_HP_ON_INT1_OUT:
+      *val = AIS3624DQ_HP_ON_INT1_OUT;
+      break;
+    default:
+      *val = AIS3624DQ_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reading at this address zeroes instantaneously
+  *         the content of the internal high pass-filter.
+  *         If the high pass filter is enabled all three axes
+  *         are instantaneously set to 0g. This allows to
+  *         overcome the settling time of the high pass
+  *         filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  *
+  */
+int32_t ais3624dq_hp_reset_get(ais3624dq_ctx_t *ctx)
+{
+  uint8_t dummy;
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_HP_FILTER_RESET,
+                           (uint8_t*)&dummy, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t ais3624dq_hp_reference_value_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  ret = ais3624dq_write_reg(ctx, AIS3624DQ_REFERENCE, (uint8_t*)&val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t ais3624dq_hp_reference_value_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_REFERENCE, val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Serial_Interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_spi_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_sim_t val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t ais3624dq_spi_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_sim_t *val)
+{
+  ais3624dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch ( ctrl_reg4.sim )
+  {
+    case AIS3624DQ_SPI_4_WIRE:
+      *val = AIS3624DQ_SPI_4_WIRE;
+      break;
+    case AIS3624DQ_SPI_3_WIRE:
+      *val = AIS3624DQ_SPI_3_WIRE;
+      break;
+    default:
+      *val = AIS3624DQ_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Interrupt_Pins
+  * @brief       This section groups all the functions that manage
+  *              interrupt pins.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_pin_int1_route_set(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_i1_cfg_t val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i1_cfg = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_pin_int1_route_get(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_i1_cfg_t *val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i1_cfg )
+  {
+    case AIS3624DQ_PAD1_INT1_SRC:
+      *val = AIS3624DQ_PAD1_INT1_SRC;
+      break;
+    case AIS3624DQ_PAD1_INT1_OR_INT2_SRC:
+      *val = AIS3624DQ_PAD1_INT1_OR_INT2_SRC;
+      break;
+    case AIS3624DQ_PAD1_DRDY:
+      *val = AIS3624DQ_PAD1_DRDY;
+      break;
+    case AIS3624DQ_PAD1_BOOT:
+      *val = AIS3624DQ_PAD1_BOOT;
+      break;
+    default:
+      *val = AIS3624DQ_PAD1_INT1_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_int1_notification_set(ais3624dq_ctx_t *ctx,
+                                        ais3624dq_lir1_t val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir1 = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_int1_notification_get(ais3624dq_ctx_t *ctx,
+                                        ais3624dq_lir1_t *val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir1 )
+  {
+    case AIS3624DQ_INT1_PULSED:
+      *val = AIS3624DQ_INT1_PULSED;
+      break;
+    case AIS3624DQ_INT1_LATCHED:
+      *val = AIS3624DQ_INT1_LATCHED;
+      break;
+    default:
+      *val = AIS3624DQ_INT1_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_pin_int2_route_set(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_i2_cfg_t val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i2_cfg = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_pin_int2_route_get(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_i2_cfg_t *val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i2_cfg )
+  {
+    case AIS3624DQ_PAD2_INT2_SRC:
+      *val = AIS3624DQ_PAD2_INT2_SRC;
+      break;
+    case AIS3624DQ_PAD2_INT1_OR_INT2_SRC:
+      *val = AIS3624DQ_PAD2_INT1_OR_INT2_SRC;
+      break;
+    case AIS3624DQ_PAD2_DRDY:
+      *val = AIS3624DQ_PAD2_DRDY;
+      break;
+    case AIS3624DQ_PAD2_BOOT:
+      *val = AIS3624DQ_PAD2_BOOT;
+      break;
+    default:
+      *val = AIS3624DQ_PAD2_INT2_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_int2_notification_set(ais3624dq_ctx_t *ctx,
+                                        ais3624dq_lir2_t val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir2 = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_int2_notification_get(ais3624dq_ctx_t *ctx,
+                                        ais3624dq_lir2_t *val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir2 )
+  {
+    case AIS3624DQ_INT2_PULSED:
+      *val = AIS3624DQ_INT2_PULSED;
+      break;
+    case AIS3624DQ_INT2_LATCHED:
+      *val = AIS3624DQ_INT2_LATCHED;
+      break;
+    default:
+      *val = AIS3624DQ_INT2_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_pin_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_pin_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t *val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.pp_od )
+  {
+    case AIS3624DQ_PUSH_PULL:
+      *val = AIS3624DQ_PUSH_PULL;
+      break;
+    case AIS3624DQ_OPEN_DRAIN:
+      *val = AIS3624DQ_OPEN_DRAIN;
+      break;
+    default:
+      *val = AIS3624DQ_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_pin_polarity_set(ais3624dq_ctx_t *ctx, ais3624dq_ihl_t val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.ihl = (uint8_t)val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t ais3624dq_pin_polarity_get(ais3624dq_ctx_t *ctx, ais3624dq_ihl_t *val)
+{
+  ais3624dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.ihl )
+  {
+    case AIS3624DQ_ACTIVE_HIGH:
+      *val = AIS3624DQ_ACTIVE_HIGH;
+      break;
+    case AIS3624DQ_ACTIVE_LOW:
+      *val = AIS3624DQ_ACTIVE_LOW;
+      break;
+    default:
+      *val = AIS3624DQ_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_interrupt_on_threshold
+  * @brief       This section groups all the functions that manage
+  *              the interrupt on threshold event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the interrupt 1 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t ais3624dq_int1_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
+                                              int1_on_th_conf_t val)
+{
+  ais3624dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.xlie  = val.int1_xlie;
+    int1_cfg.xhie  = val.int1_xhie;
+    int1_cfg.ylie  = val.int1_ylie;
+    int1_cfg.yhie  = val.int1_yhie;
+    int1_cfg.zlie  = val.int1_zlie;
+    int1_cfg.zhie  = val.int1_zhie;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Configure the interrupt 1 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t ais3624dq_int1_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
+                                             int1_on_th_conf_t *val)
+{
+  ais3624dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  val->int1_xlie = int1_cfg.xlie;
+  val->int1_xhie = int1_cfg.xhie;
+  val->int1_ylie = int1_cfg.ylie;
+  val->int1_yhie = int1_cfg.yhie;
+  val->int1_zlie = int1_cfg.zlie;
+  val->int1_zhie = int1_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 1 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t ais3624dq_int1_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
+                                             ais3624dq_int1_aoi_t val)
+{
+  ais3624dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.aoi = (uint8_t) val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 1 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t ais3624dq_int1_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
+                                             ais3624dq_int1_aoi_t *val)
+{
+  ais3624dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ( int1_cfg.aoi )
+  {
+    case AIS3624DQ_INT1_ON_THRESHOLD_OR:
+      *val = AIS3624DQ_INT1_ON_THRESHOLD_OR;
+      break;
+    case AIS3624DQ_INT1_ON_THRESHOLD_AND:
+      *val = AIS3624DQ_INT1_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = AIS3624DQ_INT1_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t ais3624dq_int1_src_get(ais3624dq_ctx_t *ctx,
+                               ais3624dq_int1_src_t *val)
+{
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t ais3624dq_int1_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT1_THS,
+                              (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t ais3624dq_int1_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t ais3624dq_int1_dur_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  if(ret == 0) {
+    int1_duration.d = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT1_DURATION,
+                              (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t ais3624dq_int1_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  *val = int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t ais3624dq_int2_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
+                                              int2_on_th_conf_t val)
+{
+  ais3624dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_CFG,
+                           (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.xlie  = val.int2_xlie;
+    int2_cfg.xhie  = val.int2_xhie;
+    int2_cfg.ylie  = val.int2_ylie;
+    int2_cfg.yhie  = val.int2_yhie;
+    int2_cfg.zlie  = val.int2_zlie;
+    int2_cfg.zhie  = val.int2_zhie;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t ais3624dq_int2_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
+                                              int2_on_th_conf_t *val)
+{
+  ais3624dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  val->int2_xlie = int2_cfg.xlie;
+  val->int2_xhie = int2_cfg.xhie;
+  val->int2_ylie = int2_cfg.ylie;
+  val->int2_yhie = int2_cfg.yhie;
+  val->int2_zlie = int2_cfg.zlie;
+  val->int2_zhie = int2_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 2 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t ais3624dq_int2_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
+                                             ais3624dq_int2_aoi_t val)
+{
+  ais3624dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.aoi = (uint8_t) val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 2 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t ais3624dq_int2_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
+                                             ais3624dq_int2_aoi_t *val)
+{
+  ais3624dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ( int2_cfg.aoi )
+  {
+    case AIS3624DQ_INT2_ON_THRESHOLD_OR:
+      *val = AIS3624DQ_INT2_ON_THRESHOLD_OR;
+      break;
+    case AIS3624DQ_INT2_ON_THRESHOLD_AND:
+      *val = AIS3624DQ_INT2_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = AIS3624DQ_INT2_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t ais3624dq_int2_src_get(ais3624dq_ctx_t *ctx,
+                               ais3624dq_int2_src_t *val)
+{
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t ais3624dq_int2_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t ais3624dq_int2_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t ais3624dq_int2_dur_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  if(ret == 0) {
+    int2_duration.d = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT2_DURATION,
+                              (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Duration value for interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t ais3624dq_int2_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  *val = int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Wake_Up_Event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t ais3624dq_wkup_to_sleep_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0) {
+    ctrl_reg5.turnon = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_CTRL_REG5,
+                              (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t ais3624dq_wkup_to_sleep_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.turnon;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS3624DQ_Six_Position_Detection
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the 6d on interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of 6d in reg INT1_CFG
+  *
+  */
+int32_t ais3624dq_int1_6d_mode_set(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_int1_6d_t val)
+{
+  ais3624dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg._6d = (uint8_t)val & 0x01U;
+    int1_cfg.aoi = ((uint8_t)val & 0x02U) >> 1;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of 6d in reg INT1_CFG
+  *
+  */
+int32_t ais3624dq_int1_6d_mode_get(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_int1_6d_t *val)
+{
+  ais3624dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ((int1_cfg.aoi << 1) + int1_cfg._6d)
+  {
+    case AIS3624DQ_6D_INT1_DISABLE:
+      *val = AIS3624DQ_6D_INT1_DISABLE;
+      break;
+    case AIS3624DQ_6D_INT1_MOVEMENT:
+      *val = AIS3624DQ_6D_INT1_MOVEMENT;
+      break;
+     case AIS3624DQ_6D_INT1_POSITION:
+      *val = AIS3624DQ_6D_INT1_POSITION;
+      break;
+    default:
+      *val = AIS3624DQ_6D_INT1_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  6D on interrupt generator 1 source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t ais3624dq_int1_6d_src_get(ais3624dq_ctx_t *ctx,
+                                  ais3624dq_int1_src_t *val)
+{
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t ais3624dq_int1_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t ais3624dq_int1_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of 6d in reg INT2_CFG
+  *
+  */
+int32_t ais3624dq_int2_6d_mode_set(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_int2_6d_t val)
+{
+  ais3624dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg._6d = (uint8_t)val & 0x01U;
+    int2_cfg.aoi = ((uint8_t)val & 0x02U) >> 1;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of 6d in reg INT2_CFG
+  *
+  */
+int32_t ais3624dq_int2_6d_mode_get(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_int2_6d_t *val)
+{
+  ais3624dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ((int2_cfg.aoi << 1) + int2_cfg._6d)
+  {
+    case AIS3624DQ_6D_INT2_DISABLE:
+      *val = AIS3624DQ_6D_INT2_DISABLE;
+      break;
+    case AIS3624DQ_6D_INT2_MOVEMENT:
+      *val = AIS3624DQ_6D_INT2_MOVEMENT;
+      break;
+     case AIS3624DQ_6D_INT2_POSITION:
+      *val = AIS3624DQ_6D_INT2_POSITION;
+      break;
+    default:
+      *val = AIS3624DQ_6D_INT2_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  6D on interrupt generator 2 source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t ais3624dq_int2_6d_src_get(ais3624dq_ctx_t *ctx,
+                                  ais3624dq_int2_src_t *val)
+{
+  int32_t ret;
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t ais3624dq_int2_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
+{
+  ais3624dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = ais3624dq_write_reg(ctx, AIS3624DQ_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t ais3624dq_int2_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+{
+  ais3624dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = ais3624dq_read_reg(ctx, AIS3624DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ais3624dq_STdC/driver/ais3624dq_reg.h
+++ b/sensor/stmemsc/ais3624dq_STdC/driver/ais3624dq_reg.h
@@ -1,0 +1,639 @@
+/*
+ ******************************************************************************
+ * @file    ais3624dq_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          ais3624dq_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef AIS3624DQ_REGS_H
+#define AIS3624DQ_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup AIS3624DQ
+  * @{
+  *
+  */
+
+/** @defgroup AIS3624DQ_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  AIS3624DQ_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*ais3624dq_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*ais3624dq_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  ais3624dq_write_ptr  write_reg;
+  ais3624dq_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} ais3624dq_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup AIS3624DQ_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0x31 if SA0=1 -> 0x33 **/
+#define AIS3624DQ_I2C_ADD_L     0x31
+#define AIS3624DQ_I2C_ADD_H     0x33
+
+/** Device Identification (Who am I) **/
+#define AIS3624DQ_ID            0x32
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  AIS3624DQ_Sensitivity
+  * @brief       These macro are maintained for back compatibility.
+  *              in order to convert data into engineering units please
+  *              use functions:
+  *                -> _from_fs6_to_mg(int16_t lsb);
+  *                -> _from_fs12_to_mg(int16_t lsb);
+  *                -> _from_fs24_to_mg(int16_t lsb);
+  *
+  *              REMOVING the MACRO you are compliant with:
+  *              MISRA-C 2012 [Dir 4.9] -> " avoid function-like macros "
+  * @{
+  *
+  */
+
+#define AIS3624DQ_FROM_FS_6g_TO_mg(lsb)     (float)( (lsb >> 4 ) *  2.9f )
+#define AIS3624DQ_FROM_FS_12g_TO_mg(lsb)    (float)( (lsb >> 4 ) *  5.9f )
+#define AIS3624DQ_FROM_FS_24g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 11.7f )
+
+/**
+  * @}
+  *
+  */
+
+#define AIS3624DQ_WHO_AM_I                  0x0FU
+#define AIS3624DQ_CTRL_REG1                 0x20U
+typedef struct {
+  uint8_t xen                      : 1;
+  uint8_t yen                      : 1;
+  uint8_t zen                      : 1;
+  uint8_t dr                       : 2;
+  uint8_t pm                       : 3;
+} ais3624dq_ctrl_reg1_t;
+
+#define AIS3624DQ_CTRL_REG2                 0x21U
+typedef struct {
+  uint8_t hpcf                     : 2;
+  uint8_t hpen                     : 2;
+  uint8_t fds                      : 1;
+  uint8_t hpm                      : 2;
+  uint8_t boot                     : 1;
+} ais3624dq_ctrl_reg2_t;
+
+#define AIS3624DQ_CTRL_REG3                 0x22U
+typedef struct {
+  uint8_t i1_cfg                   : 2;
+  uint8_t lir1                     : 1;
+  uint8_t i2_cfg                   : 2;
+  uint8_t lir2                     : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t ihl                      : 1;
+} ais3624dq_ctrl_reg3_t;
+
+#define AIS3624DQ_CTRL_REG4                 0x23U
+typedef struct {
+  uint8_t sim                      : 1;
+  uint8_t st                       : 3; /* STsign + ST */
+  uint8_t fs                       : 2;
+  uint8_t ble                      : 1;
+  uint8_t bdu                      : 1;
+} ais3624dq_ctrl_reg4_t;
+
+#define AIS3624DQ_CTRL_REG5                 0x24U
+typedef struct {
+  uint8_t turnon                   : 2;
+  uint8_t not_used_01              : 6;
+} ais3624dq_ctrl_reg5_t;
+
+#define AIS3624DQ_HP_FILTER_RESET           0x25U
+#define AIS3624DQ_REFERENCE                 0x26U
+#define AIS3624DQ_STATUS_REG                0x27U
+typedef struct {
+  uint8_t xda                      : 1;
+  uint8_t yda                      : 1;
+  uint8_t zda                      : 1;
+  uint8_t zyxda                    : 1;
+  uint8_t _xor                     : 1;
+  uint8_t yor                      : 1;
+  uint8_t zor                      : 1;
+  uint8_t zyxor                    : 1;
+} ais3624dq_status_reg_t;
+
+#define AIS3624DQ_OUT_X_L                   0x28U
+#define AIS3624DQ_OUT_X_H                   0x29U
+#define AIS3624DQ_OUT_Y_L                   0x2AU
+#define AIS3624DQ_OUT_Y_H                   0x2BU
+#define AIS3624DQ_OUT_Z_L                   0x2CU
+#define AIS3624DQ_OUT_Z_H                   0x2DU
+#define AIS3624DQ_INT1_CFG                  0x30U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi                      : 1;
+} ais3624dq_int1_cfg_t;
+
+#define AIS3624DQ_INT1_SRC                  0x31U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} ais3624dq_int1_src_t;
+
+#define AIS3624DQ_INT1_THS                  0x32U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} ais3624dq_int1_ths_t;
+
+#define AIS3624DQ_INT1_DURATION             0x33U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} ais3624dq_int1_duration_t;
+
+#define AIS3624DQ_INT2_CFG                  0x34U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi                      : 1;
+} ais3624dq_int2_cfg_t;
+
+#define AIS3624DQ_INT2_SRC                  0x35U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} ais3624dq_int2_src_t;
+
+#define AIS3624DQ_INT2_THS                  0x36U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} ais3624dq_int2_ths_t;
+
+#define AIS3624DQ_INT2_DURATION             0x37U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} ais3624dq_int2_duration_t;
+
+/**
+  * @defgroup AIS3624DQ_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  ais3624dq_ctrl_reg1_t                     ctrl_reg1;
+  ais3624dq_ctrl_reg2_t                     ctrl_reg2;
+  ais3624dq_ctrl_reg3_t                     ctrl_reg3;
+  ais3624dq_ctrl_reg4_t                     ctrl_reg4;
+  ais3624dq_ctrl_reg5_t                     ctrl_reg5;
+  ais3624dq_status_reg_t                    status_reg;
+  ais3624dq_int1_cfg_t                      int1_cfg;
+  ais3624dq_int1_src_t                      int1_src;
+  ais3624dq_int1_ths_t                      int1_ths;
+  ais3624dq_int1_duration_t                 int1_duration;
+  ais3624dq_int2_cfg_t                      int2_cfg;
+  ais3624dq_int2_src_t                      int2_src;
+  ais3624dq_int2_ths_t                      int2_ths;
+  ais3624dq_int2_duration_t                 int2_duration;
+  bitwise_t                                 bitwise;
+  uint8_t                                   byte;
+} ais3624dq_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t ais3624dq_read_reg(ais3624dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+int32_t ais3624dq_write_reg(ais3624dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len);
+
+extern float ais3624dq_from_fs6_to_mg(int16_t lsb);
+extern float ais3624dq_from_fs12_to_mg(int16_t lsb);
+extern float ais3624dq_from_fs24_to_mg(int16_t lsb);
+
+int32_t ais3624dq_axis_x_data_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_axis_x_data_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais3624dq_axis_y_data_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_axis_y_data_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais3624dq_axis_z_data_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_axis_z_data_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS3624DQ_ODR_OFF   = 0x00,
+  AIS3624DQ_ODR_Hz5   = 0x02,
+  AIS3624DQ_ODR_1Hz   = 0x03,
+  AIS3624DQ_ODR_5Hz2  = 0x04,
+  AIS3624DQ_ODR_5Hz   = 0x05,
+  AIS3624DQ_ODR_10Hz  = 0x06,
+  AIS3624DQ_ODR_50Hz  = 0x01,
+  AIS3624DQ_ODR_100Hz = 0x11,
+  AIS3624DQ_ODR_400Hz = 0x21,
+  AIS3624DQ_ODR_1kHz  = 0x31,
+} ais3624dq_dr_t;
+int32_t ais3624dq_data_rate_set(ais3624dq_ctx_t *ctx, ais3624dq_dr_t val);
+int32_t ais3624dq_data_rate_get(ais3624dq_ctx_t *ctx, ais3624dq_dr_t *val);
+
+typedef enum {
+  AIS3624DQ_NORMAL_MODE      = 0,
+  AIS3624DQ_REF_MODE_ENABLE  = 1,
+} ais3624dq_hpm_t;
+int32_t ais3624dq_reference_mode_set(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_hpm_t val);
+int32_t ais3624dq_reference_mode_get(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_hpm_t *val);
+
+typedef enum {
+  AIS3624DQ_6g   = 0,
+  AIS3624DQ_12g  = 1,
+  AIS3624DQ_24g  = 3,
+} ais3624dq_fs_t;
+int32_t ais3624dq_full_scale_set(ais3624dq_ctx_t *ctx, ais3624dq_fs_t val);
+int32_t ais3624dq_full_scale_get(ais3624dq_ctx_t *ctx, ais3624dq_fs_t *val);
+
+int32_t ais3624dq_block_data_update_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_block_data_update_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais3624dq_status_reg_get(ais3624dq_ctx_t *ctx,
+                                 ais3624dq_status_reg_t *val);
+
+int32_t ais3624dq_flag_data_ready_get(ais3624dq_ctx_t *ctx,
+                                      uint8_t *val);
+
+int32_t ais3624dq_acceleration_raw_get(ais3624dq_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais3624dq_device_id_get(ais3624dq_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais3624dq_boot_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_boot_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS3624DQ_ST_DISABLE   = 0,
+  AIS3624DQ_ST_POSITIVE  = 1,
+  AIS3624DQ_ST_NEGATIVE  = 5,
+} ais3624dq_st_t;
+int32_t ais3624dq_self_test_set(ais3624dq_ctx_t *ctx, ais3624dq_st_t val);
+int32_t ais3624dq_self_test_get(ais3624dq_ctx_t *ctx, ais3624dq_st_t *val);
+
+typedef enum {
+  AIS3624DQ_LSB_AT_LOW_ADD  = 0,
+  AIS3624DQ_MSB_AT_LOW_ADD  = 1,
+} ais3624dq_ble_t;
+int32_t ais3624dq_data_format_set(ais3624dq_ctx_t *ctx, ais3624dq_ble_t val);
+int32_t ais3624dq_data_format_get(ais3624dq_ctx_t *ctx, ais3624dq_ble_t *val);
+
+typedef enum {
+  AIS3624DQ_CUT_OFF_8Hz   = 0,
+  AIS3624DQ_CUT_OFF_16Hz  = 1,
+  AIS3624DQ_CUT_OFF_32Hz  = 2,
+  AIS3624DQ_CUT_OFF_64Hz  = 3,
+} ais3624dq_hpcf_t;
+int32_t ais3624dq_hp_bandwidth_set(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_hpcf_t val);
+int32_t ais3624dq_hp_bandwidth_get(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_hpcf_t *val);
+
+typedef enum {
+  AIS3624DQ_HP_DISABLE            = 0,
+  AIS3624DQ_HP_ON_OUT             = 4,
+  AIS3624DQ_HP_ON_INT1            = 1,
+  AIS3624DQ_HP_ON_INT2            = 2,
+  AIS3624DQ_HP_ON_INT1_INT2       = 3,
+  AIS3624DQ_HP_ON_INT1_INT2_OUT   = 7,
+  AIS3624DQ_HP_ON_INT2_OUT        = 6,
+  AIS3624DQ_HP_ON_INT1_OUT        = 5,
+} ais3624dq_hpen_t;
+int32_t ais3624dq_hp_path_set(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t val);
+int32_t ais3624dq_hp_path_get(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t *val);
+
+int32_t ais3624dq_hp_reset_get(ais3624dq_ctx_t *ctx);
+
+int32_t ais3624dq_hp_reference_value_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_hp_reference_value_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS3624DQ_SPI_4_WIRE  = 0,
+  AIS3624DQ_SPI_3_WIRE  = 1,
+} ais3624dq_sim_t;
+int32_t ais3624dq_spi_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_sim_t val);
+int32_t ais3624dq_spi_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_sim_t *val);
+
+typedef enum {
+  AIS3624DQ_PAD1_INT1_SRC           = 0,
+  AIS3624DQ_PAD1_INT1_OR_INT2_SRC   = 1,
+  AIS3624DQ_PAD1_DRDY               = 2,
+  AIS3624DQ_PAD1_BOOT               = 3,
+} ais3624dq_i1_cfg_t;
+int32_t ais3624dq_pin_int1_route_set(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_i1_cfg_t val);
+int32_t ais3624dq_pin_int1_route_get(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_i1_cfg_t *val);
+
+typedef enum {
+  AIS3624DQ_INT1_PULSED   = 0,
+  AIS3624DQ_INT1_LATCHED  = 1,
+} ais3624dq_lir1_t;
+int32_t ais3624dq_int1_notification_set(ais3624dq_ctx_t *ctx,
+                                        ais3624dq_lir1_t val);
+int32_t ais3624dq_int1_notification_get(ais3624dq_ctx_t *ctx,
+                                        ais3624dq_lir1_t *val);
+
+typedef enum {
+  AIS3624DQ_PAD2_INT2_SRC           = 0,
+  AIS3624DQ_PAD2_INT1_OR_INT2_SRC   = 1,
+  AIS3624DQ_PAD2_DRDY               = 2,
+  AIS3624DQ_PAD2_BOOT               = 3,
+} ais3624dq_i2_cfg_t;
+int32_t ais3624dq_pin_int2_route_set(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_i2_cfg_t val);
+int32_t ais3624dq_pin_int2_route_get(ais3624dq_ctx_t *ctx,
+                                     ais3624dq_i2_cfg_t *val);
+
+typedef enum {
+  AIS3624DQ_INT2_PULSED   = 0,
+  AIS3624DQ_INT2_LATCHED  = 1,
+} ais3624dq_lir2_t;
+int32_t ais3624dq_int2_notification_set(ais3624dq_ctx_t *ctx,
+                                        ais3624dq_lir2_t val);
+int32_t ais3624dq_int2_notification_get(ais3624dq_ctx_t *ctx,
+                                        ais3624dq_lir2_t *val);
+
+typedef enum {
+  AIS3624DQ_PUSH_PULL   = 0,
+  AIS3624DQ_OPEN_DRAIN  = 1,
+} ais3624dq_pp_od_t;
+int32_t ais3624dq_pin_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t val);
+int32_t ais3624dq_pin_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t *val);
+
+typedef enum {
+  AIS3624DQ_ACTIVE_HIGH  = 0,
+  AIS3624DQ_ACTIVE_LOW   = 1,
+} ais3624dq_ihl_t;
+int32_t ais3624dq_pin_polarity_set(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_ihl_t val);
+int32_t ais3624dq_pin_polarity_get(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_ihl_t *val);
+
+typedef struct {
+  uint8_t int1_xlie             : 1;
+  uint8_t int1_xhie             : 1;
+  uint8_t int1_ylie             : 1;
+  uint8_t int1_yhie             : 1;
+  uint8_t int1_zlie             : 1;
+  uint8_t int1_zhie             : 1;
+} int1_on_th_conf_t;
+int32_t ais3624dq_int1_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
+                                             int1_on_th_conf_t val);
+int32_t ais3624dq_int1_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
+                                             int1_on_th_conf_t *val);
+
+typedef enum {
+  AIS3624DQ_INT1_ON_THRESHOLD_OR   = 0,
+  AIS3624DQ_INT1_ON_THRESHOLD_AND  = 1,
+} ais3624dq_int1_aoi_t;
+int32_t ais3624dq_int1_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
+                                             ais3624dq_int1_aoi_t val);
+int32_t ais3624dq_int1_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
+                                             ais3624dq_int1_aoi_t *val);
+
+int32_t ais3624dq_int1_src_get(ais3624dq_ctx_t *ctx,
+                               ais3624dq_int1_src_t *val);
+
+int32_t ais3624dq_int1_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int1_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais3624dq_int1_dur_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int1_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t int2_xlie             : 1;
+  uint8_t int2_xhie             : 1;
+  uint8_t int2_ylie             : 1;
+  uint8_t int2_yhie             : 1;
+  uint8_t int2_zlie             : 1;
+  uint8_t int2_zhie             : 1;
+} int2_on_th_conf_t;
+int32_t ais3624dq_int2_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
+                                             int2_on_th_conf_t val);
+int32_t ais3624dq_int2_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
+                                             int2_on_th_conf_t *val);
+
+typedef enum {
+  AIS3624DQ_INT2_ON_THRESHOLD_OR   = 0,
+  AIS3624DQ_INT2_ON_THRESHOLD_AND  = 1,
+} ais3624dq_int2_aoi_t;
+int32_t ais3624dq_int2_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
+                                             ais3624dq_int2_aoi_t val);
+int32_t ais3624dq_int2_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
+                                             ais3624dq_int2_aoi_t *val);
+
+int32_t ais3624dq_int2_src_get(ais3624dq_ctx_t *ctx,
+                               ais3624dq_int2_src_t *val);
+
+int32_t ais3624dq_int2_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int2_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais3624dq_int2_dur_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int2_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+int32_t ais3624dq_wkup_to_sleep_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_wkup_to_sleep_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS3624DQ_6D_INT1_DISABLE   = 0,
+  AIS3624DQ_6D_INT1_MOVEMENT  = 1,
+  AIS3624DQ_6D_INT1_POSITION  = 3,
+} ais3624dq_int1_6d_t;
+int32_t ais3624dq_int1_6d_mode_set(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_int1_6d_t val);
+int32_t ais3624dq_int1_6d_mode_get(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_int1_6d_t *val);
+
+int32_t ais3624dq_int1_6d_src_get(ais3624dq_ctx_t *ctx,
+                                  ais3624dq_int1_src_t *val);
+
+int32_t ais3624dq_int1_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int1_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS3624DQ_6D_INT2_DISABLE   = 0,
+  AIS3624DQ_6D_INT2_MOVEMENT  = 1,
+  AIS3624DQ_6D_INT2_POSITION  = 3,
+} ais3624dq_int2_6d_t;
+int32_t ais3624dq_int2_6d_mode_set(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_int2_6d_t val);
+int32_t ais3624dq_int2_6d_mode_get(ais3624dq_ctx_t *ctx,
+                                   ais3624dq_int2_6d_t *val);
+
+int32_t ais3624dq_int2_6d_src_get(ais3624dq_ctx_t *ctx,
+                                  ais3624dq_int2_src_t *val);
+
+int32_t ais3624dq_int2_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int2_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AIS3624DQ_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.c
+++ b/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.c
@@ -1,0 +1,4253 @@
+/*
+ ******************************************************************************
+ * @file    asm330lhh_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   ASM330LHH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "asm330lhh_reg.h"
+
+/**
+  * @defgroup    ASM330LHH
+  * @brief       This file provides a set of functions needed to drive the
+  *              asm330lhh enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    ASM330LHH_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t asm330lhh_read_reg(asm330lhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t asm330lhh_write_reg(asm330lhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ASM330LHH_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t asm330lhh_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t asm330lhh_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t asm330lhh_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t asm330lhh_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t asm330lhh_from_fs125dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 4.375f);
+}
+
+float_t asm330lhh_from_fs250dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 8.75f);
+}
+
+float_t asm330lhh_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 17.50f);
+}
+
+float_t asm330lhh_from_fs1000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 35.0f);
+}
+
+float_t asm330lhh_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t asm330lhh_from_fs4000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 140.0f);
+}
+
+float_t asm330lhh_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+float_t asm330lhh_from_lsb_to_nsec(int32_t lsb)
+{
+  return ((float_t)lsb * 25000.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM9DS1_Data_generation
+  * @brief      This section groups all the functions concerning data
+  *             generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer full-scale selection[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_full_scale_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_fs_xl_t val)
+{
+  asm330lhh_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_full_scale_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_fs_xl_t *val)
+{
+  asm330lhh_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.fs_xl){
+    case ASM330LHH_2g:
+      *val = ASM330LHH_2g;
+      break;
+    case ASM330LHH_16g:
+      *val = ASM330LHH_16g;
+      break;
+    case ASM330LHH_4g:
+      *val = ASM330LHH_4g;
+      break;
+    case ASM330LHH_8g:
+      *val = ASM330LHH_8g;
+      break;
+    default:
+      *val = ASM330LHH_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_data_rate_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_odr_xl_t val)
+{
+  asm330lhh_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.odr_xl= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_data_rate_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_odr_xl_t *val)
+{
+  asm330lhh_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.odr_xl){
+    case ASM330LHH_XL_ODR_OFF:
+      *val = ASM330LHH_XL_ODR_OFF;
+      break;
+    case ASM330LHH_XL_ODR_12Hz5:
+      *val = ASM330LHH_XL_ODR_12Hz5;
+      break;
+    case ASM330LHH_XL_ODR_26Hz:
+      *val = ASM330LHH_XL_ODR_26Hz;
+      break;
+    case ASM330LHH_XL_ODR_52Hz:
+      *val = ASM330LHH_XL_ODR_52Hz;
+      break;
+    case ASM330LHH_XL_ODR_104Hz:
+      *val = ASM330LHH_XL_ODR_104Hz;
+      break;
+    case ASM330LHH_XL_ODR_208Hz:
+      *val = ASM330LHH_XL_ODR_208Hz;
+      break;
+    case ASM330LHH_XL_ODR_417Hz:
+      *val = ASM330LHH_XL_ODR_417Hz;
+      break;
+    case ASM330LHH_XL_ODR_833Hz:
+      *val = ASM330LHH_XL_ODR_833Hz;
+      break;
+    case ASM330LHH_XL_ODR_1667Hz:
+      *val = ASM330LHH_XL_ODR_1667Hz;
+      break;
+    case ASM330LHH_XL_ODR_3333Hz:
+      *val = ASM330LHH_XL_ODR_3333Hz;
+      break;
+    case ASM330LHH_XL_ODR_6667Hz:
+      *val = ASM330LHH_XL_ODR_6667Hz;
+      break;
+    case ASM330LHH_XL_ODR_6Hz5:
+      *val = ASM330LHH_XL_ODR_6Hz5;
+      break;
+    default:
+      *val = ASM330LHH_XL_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_full_scale_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_fs_g_t val)
+{
+  asm330lhh_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.fs_g= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_full_scale_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_fs_g_t *val)
+{
+  asm330lhh_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.fs_g){
+    case ASM330LHH_125dps:
+      *val = ASM330LHH_125dps;
+      break;
+    case ASM330LHH_250dps:
+      *val = ASM330LHH_250dps;
+      break;
+    case ASM330LHH_500dps:
+      *val = ASM330LHH_500dps;
+      break;
+    case ASM330LHH_1000dps:
+      *val = ASM330LHH_1000dps;
+      break;
+    case ASM330LHH_2000dps:
+      *val = ASM330LHH_2000dps;
+      break;
+    case ASM330LHH_4000dps:
+      *val = ASM330LHH_4000dps;
+      break;
+    default:
+      *val = ASM330LHH_125dps;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_data_rate_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_odr_g_t val)
+{
+  asm330lhh_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+   ctrl2_g.odr_g= (uint8_t)val;
+   ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_data_rate_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_odr_g_t *val)
+{
+  asm330lhh_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.odr_g){
+    case ASM330LHH_GY_ODR_OFF:
+      *val = ASM330LHH_GY_ODR_OFF;
+      break;
+    case ASM330LHH_GY_ODR_12Hz5:
+      *val = ASM330LHH_GY_ODR_12Hz5;
+      break;
+    case ASM330LHH_GY_ODR_26Hz:
+      *val = ASM330LHH_GY_ODR_26Hz;
+      break;
+    case ASM330LHH_GY_ODR_52Hz:
+      *val = ASM330LHH_GY_ODR_52Hz;
+      break;
+    case ASM330LHH_GY_ODR_104Hz:
+      *val = ASM330LHH_GY_ODR_104Hz;
+      break;
+    case ASM330LHH_GY_ODR_208Hz:
+      *val = ASM330LHH_GY_ODR_208Hz;
+      break;
+    case ASM330LHH_GY_ODR_417Hz:
+      *val = ASM330LHH_GY_ODR_417Hz;
+      break;
+    case ASM330LHH_GY_ODR_833Hz:
+      *val = ASM330LHH_GY_ODR_833Hz;
+      break;
+    case ASM330LHH_GY_ODR_1667Hz:
+      *val = ASM330LHH_GY_ODR_1667Hz;
+      break;
+    case ASM330LHH_GY_ODR_3333Hz:
+      *val = ASM330LHH_GY_ODR_3333Hz;
+      break;
+    case ASM330LHH_GY_ODR_6667Hz:
+      *val = ASM330LHH_GY_ODR_6667Hz;
+      break;
+    default:
+      *val = ASM330LHH_GY_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_block_data_update_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_block_data_update_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_offset_weight_set(asm330lhh_ctx_t *ctx,
+                                     asm330lhh_usr_off_w_t val)
+{
+  asm330lhh_ctrl6_g_t ctrl6_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.usr_off_w= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_offset_weight_get(asm330lhh_ctx_t *ctx,
+                                       asm330lhh_usr_off_w_t *val)
+{
+  asm330lhh_ctrl6_g_t ctrl6_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.usr_off_w){
+    case ASM330LHH_LSb_1mg:
+      *val = ASM330LHH_LSb_1mg;
+      break;
+    case ASM330LHH_LSb_16mg:
+      *val = ASM330LHH_LSb_16mg;
+      break;
+    default:
+      *val = ASM330LHH_LSb_1mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt flag of the device.
+  *[get]
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers ALL_INT_SRC; WAKE_UP_SRC;
+  *                              TAP_SRC; D6D_SRC; STATUS_REG;
+  *                              EMB_FUNC_STATUS; FSM_STATUS_A/B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_all_sources_get(asm330lhh_ctx_t *ctx,
+                                  asm330lhh_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_ALL_INT_SRC,
+                           (uint8_t*)&val->all_int_src, 1);
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_SRC,
+                             (uint8_t*)&val->wake_up_src, 1);
+  }
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_TAP_SRC,
+                             (uint8_t*)&val->tap_src, 1);
+  }
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_D6D_SRC,
+                             (uint8_t*)&val->d6d_src, 1);
+  }
+  if(ret == 0){
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_STATUS_REG,
+                           (uint8_t*)&val->status_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get register STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_status_reg_get(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_status_reg_t *val)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_temp_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_x_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_write_reg(ctx, ASM330LHH_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_x_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_y_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_write_reg(ctx, ASM330LHH_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_y_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_z_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_write_reg(ctx, ASM330LHH_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_z_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enables user offset on out.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_out in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.usr_off_on_out= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Get user offset on out flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get values of usr_off_on_out in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  *val = ctrl7_g.usr_off_on_out;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_Timestamp
+  * @brief      This section groups all the functions that manage the
+  *             timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_timestamp_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.timestamp_en= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL10_C,
+                              (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_timestamp_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp first data output register (r).
+  *         The value is expressed as a 32-bit word and the bit resolution
+  *         is 25 μs.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_timestamp_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_TIMESTAMP0, buff, 4);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_Data output
+  * @brief      This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read of the output registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_rounding_mode_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_rounding_t val)
+{
+  asm330lhh_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_rounding_mode_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_rounding_t *val)
+{
+  asm330lhh_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.rounding){
+    case ASM330LHH_NO_ROUND:
+      *val = ASM330LHH_NO_ROUND;
+      break;
+    case ASM330LHH_ROUND_XL:
+      *val = ASM330LHH_ROUND_XL;
+      break;
+    case ASM330LHH_ROUND_GY:
+      *val = ASM330LHH_ROUND_GY;
+      break;
+    case ASM330LHH_ROUND_GY_XL:
+      *val = ASM330LHH_ROUND_GY_XL;
+      break;
+    default:
+      *val = ASM330LHH_NO_ROUND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r).
+  *         L and H registers together express a 16-bit word in two’s
+  *         complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_temperature_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit
+  *         word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_angular_rate_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as a
+  *         16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_acceleration_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_OUTX_L_A, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  FIFO data output.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_out_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_DATA_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_common
+  * @brief      This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate)
+  *         with respect to the typical.[set]
+  *         Step:  0.15%. 8-bit format, 2's complement.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_odr_cal_reg_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_internal_freq_fine_t internal_freq_fine;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INTERNAL_FREQ_FINE,
+                           (uint8_t*)&internal_freq_fine, 1);
+  if(ret == 0){
+    internal_freq_fine.freq_fine= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INTERNAL_FREQ_FINE,
+                              (uint8_t*)&internal_freq_fine, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate)
+  *         with respect to the typical.[get]
+  *         Step:  0.15%. 8-bit format, 2's complement.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_odr_cal_reg_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_internal_freq_fine_t internal_freq_fine;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INTERNAL_FREQ_FINE,
+                           (uint8_t*)&internal_freq_fine, 1);
+  *val = internal_freq_fine.freq_fine;
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dataready_pulsed in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_data_ready_mode_set(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_dataready_pulsed_t val)
+{
+  asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.dataready_pulsed= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dataready_pulsed in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_data_ready_mode_get(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_dataready_pulsed_t *val)
+{
+  asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  switch (counter_bdr_reg1.dataready_pulsed){
+    case ASM330LHH_DRDY_LATCHED:
+      *val = ASM330LHH_DRDY_LATCHED;
+      break;
+    case ASM330LHH_DRDY_PULSED:
+      *val = ASM330LHH_DRDY_PULSED;
+      break;
+    default:
+      *val = ASM330LHH_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_device_id_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_reset_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_reset_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_auto_increment_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_auto_increment_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_boot_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_boot_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.boot;
+
+  return ret;
+}
+
+
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_self_test_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_st_xl_t val)
+{
+  asm330lhh_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_self_test_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_st_xl_t *val)
+{
+  asm330lhh_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_xl){
+    case ASM330LHH_XL_ST_DISABLE:
+      *val = ASM330LHH_XL_ST_DISABLE;
+      break;
+    case ASM330LHH_XL_ST_POSITIVE:
+      *val = ASM330LHH_XL_ST_POSITIVE;
+      break;
+    case ASM330LHH_XL_ST_NEGATIVE:
+      *val = ASM330LHH_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = ASM330LHH_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_self_test_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_st_g_t val)
+{
+  asm330lhh_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_g= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_self_test_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_st_g_t *val)
+{
+  asm330lhh_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_g){
+    case ASM330LHH_GY_ST_DISABLE:
+      *val = ASM330LHH_GY_ST_DISABLE;
+      break;
+    case ASM330LHH_GY_ST_POSITIVE:
+      *val = ASM330LHH_GY_ST_POSITIVE;
+      break;
+    case ASM330LHH_GY_ST_NEGATIVE:
+      *val = ASM330LHH_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = ASM330LHH_GY_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_filters
+  * @brief      This section group all the functions concerning the
+  *             filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf2_xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_filter_lp2_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf2_xl_en= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf2_xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_filter_lp2_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  *val = ctrl1_xl.lpf2_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0] in CTRL6_C.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf1_sel_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_filter_lp1_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.lpf1_sel_g= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0] in CTRL6_C.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf1_sel_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_filter_lp1_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.lpf1_sel_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_filter_settling_mask_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_filter_settling_mask_get(asm330lhh_ctx_t *ctx,
+                                           uint8_t *val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass filter 1 bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ftype in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_lp1_bandwidth_set(asm330lhh_ctx_t *ctx,
+                                       asm330lhh_ftype_t val)
+{
+  asm330lhh_ctrl6_g_t ctrl6_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.ftype= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass filter 1 bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ftype in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_lp1_bandwidth_get(asm330lhh_ctx_t *ctx,
+                                       asm330lhh_ftype_t *val)
+{
+  asm330lhh_ctrl6_g_t ctrl6_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.ftype){
+    case ASM330LHH_ULTRA_LIGHT:
+      *val = ASM330LHH_ULTRA_LIGHT;
+      break;
+    case ASM330LHH_VERY_LIGHT:
+      *val = ASM330LHH_VERY_LIGHT;
+      break;
+    case ASM330LHH_LIGHT:
+      *val = ASM330LHH_LIGHT;
+      break;
+    case ASM330LHH_MEDIUM:
+      *val = ASM330LHH_MEDIUM;
+      break;
+    case ASM330LHH_STRONG:
+      *val = ASM330LHH_STRONG;
+      break;
+    case ASM330LHH_VERY_STRONG:
+      *val = ASM330LHH_VERY_STRONG;
+      break;
+    case ASM330LHH_AGGRESSIVE:
+      *val = ASM330LHH_AGGRESSIVE;
+      break;
+    case ASM330LHH_XTREME:
+      *val = ASM330LHH_XTREME;
+      break;
+    default:
+      *val = ASM330LHH_ULTRA_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_lp2_on_6d_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.low_pass_on_6d= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_lp2_on_6d_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.low_pass_on_6d;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection
+  *         on output.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_hp_path_on_out_set(asm330lhh_ctx_t *ctx,
+                                        asm330lhh_hp_slope_xl_en_t val)
+{
+  asm330lhh_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.hp_slope_xl_en = (((uint8_t)val & 0x10U) >> 4);
+    ctrl8_xl.hp_ref_mode_xl = (((uint8_t)val & 0x20U) >> 5);
+    ctrl8_xl.hpcf_xl = (uint8_t)val & 0x07U;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection on
+  *         output.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_hp_path_on_out_get(asm330lhh_ctx_t *ctx,
+                                        asm330lhh_hp_slope_xl_en_t *val)
+{
+  asm330lhh_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  switch (( (ctrl8_xl.hp_ref_mode_xl << 5) +(ctrl8_xl.hp_slope_xl_en << 4) +
+             ctrl8_xl.hpcf_xl )){
+    case ASM330LHH_HP_PATH_DISABLE_ON_OUT:
+      *val = ASM330LHH_HP_PATH_DISABLE_ON_OUT;
+      break;
+    case ASM330LHH_SLOPE_ODR_DIV_4:
+      *val = ASM330LHH_SLOPE_ODR_DIV_4;
+      break;
+    case ASM330LHH_HP_ODR_DIV_10:
+      *val = ASM330LHH_HP_ODR_DIV_10;
+      break;
+    case ASM330LHH_HP_ODR_DIV_20:
+      *val = ASM330LHH_HP_ODR_DIV_20;
+      break;
+    case ASM330LHH_HP_ODR_DIV_45:
+      *val = ASM330LHH_HP_ODR_DIV_45;
+      break;
+    case ASM330LHH_HP_ODR_DIV_100:
+      *val = ASM330LHH_HP_ODR_DIV_100;
+      break;
+    case ASM330LHH_HP_ODR_DIV_200:
+      *val = ASM330LHH_HP_ODR_DIV_200;
+      break;
+    case ASM330LHH_HP_ODR_DIV_400:
+      *val = ASM330LHH_HP_ODR_DIV_400;
+      break;
+    case ASM330LHH_HP_ODR_DIV_800:
+      *val = ASM330LHH_HP_ODR_DIV_800;
+      break;
+    case ASM330LHH_HP_REF_MD_ODR_DIV_10:
+      *val = ASM330LHH_HP_REF_MD_ODR_DIV_10;
+      break;
+    case ASM330LHH_HP_REF_MD_ODR_DIV_20:
+      *val = ASM330LHH_HP_REF_MD_ODR_DIV_20;
+      break;
+    case ASM330LHH_HP_REF_MD_ODR_DIV_45:
+      *val = ASM330LHH_HP_REF_MD_ODR_DIV_45;
+      break;
+    case ASM330LHH_HP_REF_MD_ODR_DIV_100:
+      *val = ASM330LHH_HP_REF_MD_ODR_DIV_100;
+      break;
+    case ASM330LHH_HP_REF_MD_ODR_DIV_200:
+      *val = ASM330LHH_HP_REF_MD_ODR_DIV_200;
+      break;
+    case ASM330LHH_HP_REF_MD_ODR_DIV_400:
+      *val = ASM330LHH_HP_REF_MD_ODR_DIV_400;
+      break;
+    case ASM330LHH_HP_REF_MD_ODR_DIV_800:
+      *val = ASM330LHH_HP_REF_MD_ODR_DIV_800;
+      break;
+    case ASM330LHH_LP_ODR_DIV_10:
+      *val = ASM330LHH_LP_ODR_DIV_10;
+      break;
+    case ASM330LHH_LP_ODR_DIV_20:
+      *val = ASM330LHH_LP_ODR_DIV_20;
+      break;
+    case ASM330LHH_LP_ODR_DIV_45:
+      *val = ASM330LHH_LP_ODR_DIV_45;
+      break;
+    case ASM330LHH_LP_ODR_DIV_100:
+      *val = ASM330LHH_LP_ODR_DIV_100;
+      break;
+    case ASM330LHH_LP_ODR_DIV_200:
+      *val = ASM330LHH_LP_ODR_DIV_200;
+      break;
+    case ASM330LHH_LP_ODR_DIV_400:
+      *val = ASM330LHH_LP_ODR_DIV_400;
+      break;
+    case ASM330LHH_LP_ODR_DIV_800:
+      *val = ASM330LHH_LP_ODR_DIV_800;
+      break;
+    default:
+      *val = ASM330LHH_HP_PATH_DISABLE_ON_OUT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing this bit.
+  *         Active only during device exit from powerdown mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fastsettl_mode_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_fast_settling_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.fastsettl_mode_xl= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing
+  *         this bit. Active only during device exit from powerdown mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fastsettl_mode_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_fast_settling_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.fastsettl_mode_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of slope_fds in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_hp_path_internal_set(asm330lhh_ctx_t *ctx,
+                                          asm330lhh_slope_fds_t val)
+{
+  asm330lhh_int_cfg0_t int_cfg0;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t*)&int_cfg0, 1);
+  if(ret == 0){
+    int_cfg0.slope_fds= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG0,
+                              (uint8_t*)&int_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of slope_fds in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_hp_path_internal_get(asm330lhh_ctx_t *ctx,
+                                          asm330lhh_slope_fds_t *val)
+{
+  asm330lhh_int_cfg0_t int_cfg0;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t*)&int_cfg0, 1);
+  switch (int_cfg0.slope_fds){
+    case ASM330LHH_USE_SLOPE:
+      *val = ASM330LHH_USE_SLOPE;
+      break;
+    case ASM330LHH_USE_HPF:
+      *val = ASM330LHH_USE_HPF;
+      break;
+    default:
+      *val = ASM330LHH_USE_SLOPE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital high-pass filter. The filter is enabled
+  *         only if the gyro is in HP mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_en_g and hp_en_g in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_hp_path_internal_set(asm330lhh_ctx_t *ctx,
+                                          asm330lhh_hpm_g_t val)
+{
+  asm330lhh_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hp_en_g = (((uint8_t)val & 0x80U) >> 7);
+    ctrl7_g.hpm_g = (uint8_t)val & 0x03U;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Enables gyroscope digital high-pass filter. The filter is
+  *           enabled only if the gyro is in HP mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_en_g and hp_en_g in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_hp_path_internal_get(asm330lhh_ctx_t *ctx,
+                                          asm330lhh_hpm_g_t *val)
+{
+  asm330lhh_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  switch ((ctrl7_g.hp_en_g << 7) + ctrl7_g.hpm_g){
+    case ASM330LHH_HP_FILTER_NONE:
+      *val = ASM330LHH_HP_FILTER_NONE;
+      break;
+    case ASM330LHH_HP_FILTER_16mHz:
+      *val = ASM330LHH_HP_FILTER_16mHz;
+      break;
+    case ASM330LHH_HP_FILTER_65mHz:
+      *val = ASM330LHH_HP_FILTER_65mHz;
+      break;
+    case ASM330LHH_HP_FILTER_260mHz:
+      *val = ASM330LHH_HP_FILTER_260mHz;
+      break;
+    case ASM330LHH_HP_FILTER_1Hz04:
+      *val = ASM330LHH_HP_FILTER_1Hz04;
+      break;
+    default:
+      *val = ASM330LHH_HP_FILTER_NONE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_ main_serial_interface
+  * @brief      This section groups all the functions concerning main
+  *             serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sdo_pu_en in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_sdo_sa0_mode_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_sdo_pu_en_t val)
+{
+  asm330lhh_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+  if(ret == 0){
+    pin_ctrl.sdo_pu_en= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sdo_pu_en in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_sdo_sa0_mode_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_sdo_pu_en_t *val)
+{
+  asm330lhh_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+
+  switch (pin_ctrl.sdo_pu_en){
+    case ASM330LHH_PULL_UP_DISC:
+      *val = ASM330LHH_PULL_UP_DISC;
+      break;
+    case ASM330LHH_PULL_UP_CONNECT:
+      *val = ASM330LHH_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = ASM330LHH_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_spi_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_sim_t val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_spi_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_sim_t *val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.sim){
+    case ASM330LHH_SPI_4_WIRE:
+      *val = ASM330LHH_SPI_4_WIRE;
+      break;
+    case ASM330LHH_SPI_3_WIRE:
+      *val = ASM330LHH_SPI_3_WIRE;
+      break;
+    default:
+      *val = ASM330LHH_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_i2c_interface_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_i2c_disable_t val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_i2c_interface_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_i2c_disable_t *val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+
+  switch (ctrl4_c.i2c_disable){
+    case ASM330LHH_I2C_ENABLE:
+      *val = ASM330LHH_I2C_ENABLE;
+      break;
+    case ASM330LHH_I2C_DISABLE:
+      *val = ASM330LHH_I2C_DISABLE;
+      break;
+    default:
+      *val = ASM330LHH_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_interrupt_pins
+  * @brief      This section groups all the functions that manage
+  *             interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief   Select the signal that need to route on int1 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL,MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_pin_int1_route_set(asm330lhh_ctx_t *ctx,
+                                     asm330lhh_pin_int1_route_t *val)
+{
+  asm330lhh_int_cfg1_t tap_cfg2;
+  int32_t ret;
+
+  ret = asm330lhh_write_reg(ctx, ASM330LHH_INT1_CTRL,
+                            (uint8_t*)&val->int1_ctrl, 1);
+
+  if(ret == 0){
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_MD1_CFG,
+                              (uint8_t*)&val->md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t*)&tap_cfg2, 1);
+    if ((val->int1_ctrl.den_drdy_flag |
+         val->int1_ctrl.int1_boot |
+         val->int1_ctrl.int1_cnt_bdr |
+         val->int1_ctrl.int1_drdy_g |
+         val->int1_ctrl.int1_drdy_xl |
+         val->int1_ctrl.int1_fifo_full |
+         val->int1_ctrl.int1_fifo_ovr |
+         val->int1_ctrl.int1_fifo_th |
+         val->md1_cfg.int1_6d |
+         val->md1_cfg.int1_ff |
+         val->md1_cfg.int1_wu |
+         val->md1_cfg.int1_sleep_change)!= PROPERTY_DISABLE){
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1,
+                              (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL, MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_pin_int1_route_get(asm330lhh_ctx_t *ctx,
+                                     asm330lhh_pin_int1_route_t *val)
+{
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT1_CTRL,
+                           (uint8_t*)&val->int1_ctrl, 1);
+
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_MD1_CFG,
+                             (uint8_t*)&val->md1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_pin_int2_route_set(asm330lhh_ctx_t *ctx,
+                                     asm330lhh_pin_int2_route_t *val)
+{
+  asm330lhh_int_cfg1_t tap_cfg2;
+  int32_t ret;
+
+
+  ret = asm330lhh_write_reg(ctx, ASM330LHH_INT2_CTRL,
+                            (uint8_t*)&val->int2_ctrl, 1);
+
+  if(ret == 0){
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_MD2_CFG,
+                              (uint8_t*)&val->md2_cfg, 1);
+  }
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1,
+                             (uint8_t*)&tap_cfg2, 1);
+  }
+  if(ret == 0){
+    if ((val->int2_ctrl.int2_drdy_xl |
+         val->int2_ctrl.int2_drdy_g |
+         val->int2_ctrl.int2_drdy_temp |
+         val->int2_ctrl.int2_fifo_th |
+         val->int2_ctrl.int2_fifo_ovr |
+         val->int2_ctrl.int2_fifo_full |
+         val->int2_ctrl.int2_cnt_bdr |
+         val->md2_cfg.int2_6d |
+         val->md2_cfg.int2_ff |
+         val->md2_cfg.int2_wu |
+         val->md2_cfg.int2_sleep_change) != PROPERTY_DISABLE){
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1,
+                              (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B.[get]
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_pin_int2_route_get(asm330lhh_ctx_t *ctx,
+                                     asm330lhh_pin_int2_route_t *val)
+{
+  int32_t ret;
+
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_INT2_CTRL,
+                             (uint8_t*)&val->int2_ctrl, 1);
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_MD2_CFG,
+                             (uint8_t*)&val->md2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_pin_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_pin_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t *val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.pp_od){
+    case ASM330LHH_PUSH_PULL:
+      *val = ASM330LHH_PUSH_PULL;
+      break;
+    case ASM330LHH_OPEN_DRAIN:
+      *val = ASM330LHH_OPEN_DRAIN;
+      break;
+    default:
+      *val = ASM330LHH_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_pin_polarity_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_h_lactive_t val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_pin_polarity_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_h_lactive_t *val)
+{
+  asm330lhh_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.h_lactive){
+    case ASM330LHH_ACTIVE_HIGH:
+      *val = ASM330LHH_ACTIVE_HIGH;
+      break;
+    case ASM330LHH_ACTIVE_LOW:
+      *val = ASM330LHH_ACTIVE_LOW;
+      break;
+    default:
+      *val = ASM330LHH_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_all_on_int1_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_all_on_int1_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals notification mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_int_notification_set(asm330lhh_ctx_t *ctx,
+                                       asm330lhh_lir_t val)
+{
+  asm330lhh_int_cfg0_t int_cfg0;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t*)&int_cfg0, 1);
+  if(ret == 0){
+    int_cfg0.lir = (uint8_t)val & 0x01U;
+    int_cfg0.int_clr_on_read = (uint8_t)val & 0x01U;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG0,
+                              (uint8_t*)&int_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals notification mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_int_notification_get(asm330lhh_ctx_t *ctx,
+                                       asm330lhh_lir_t *val)
+{
+  asm330lhh_int_cfg0_t int_cfg0;
+  int32_t ret;
+
+  *val = ASM330LHH_ALL_INT_PULSED;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t*)&int_cfg0, 1);
+
+  switch ((int_cfg0.lir << 1) + int_cfg0.int_clr_on_read){
+    case ASM330LHH_ALL_INT_PULSED:
+      *val = ASM330LHH_ALL_INT_PULSED;
+      break;
+    case ASM330LHH_ALL_INT_LATCHED:
+      *val = ASM330LHH_ALL_INT_LATCHED;
+      break;
+    default:
+      *val = ASM330LHH_ALL_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_Wake_Up_event
+  * @brief      This section groups all the functions that manage the
+  *             Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[set]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_ths_w in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_wkup_ths_weight_set(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_wake_ths_w_t val)
+{
+  asm330lhh_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_ths_w= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[get]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wake_ths_w in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_wkup_ths_weight_get(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_wake_ths_w_t *val)
+{
+  asm330lhh_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+
+  switch (wake_up_dur.wake_ths_w){
+    case ASM330LHH_LSb_FS_DIV_64:
+      *val = ASM330LHH_LSb_FS_DIV_64;
+      break;
+    case ASM330LHH_LSb_FS_DIV_256:
+      *val = ASM330LHH_LSb_FS_DIV_256;
+      break;
+    default:
+      *val = ASM330LHH_LSb_FS_DIV_64;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_wkup_threshold_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_wkup_threshold_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event( 1LSb = 1 / ODR ).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_wu in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_on_wkup_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.usr_off_on_wu= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event( 1LSb = 1 / ODR ).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_wu in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_xl_usr_offset_on_wkup_get(asm330lhh_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  asm330lhh_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.usr_off_on_wu;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_wkup_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_wkup_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_ Activity/Inactivity_detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_sleep_mode_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.sleep_g= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_gy_sleep_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.sleep_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of sleep change on INT pins
+  *         (only if INT1_SLEEP_CHANGE or INT2_SLEEP_CHANGE bits
+  *         are enabled).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_status_on_int in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_act_pin_notification_set(asm330lhh_ctx_t *ctx,
+                                           asm330lhh_sleep_status_on_int_t val)
+{
+  asm330lhh_int_cfg0_t int_cfg0;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t*)&int_cfg0, 1);
+  if(ret == 0){
+    int_cfg0. sleep_status_on_int= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG0,
+                              (uint8_t*)&int_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of sleep change on INT pins
+  *         (only if INT1_SLEEP_CHANGE or INT2_SLEEP_CHANGE bits
+  *         are enabled).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_status_on_int in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_act_pin_notification_get(asm330lhh_ctx_t *ctx,
+                                       asm330lhh_sleep_status_on_int_t *val)
+{
+  asm330lhh_int_cfg0_t int_cfg0;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG0, (uint8_t*)&int_cfg0, 1);
+  switch (int_cfg0. sleep_status_on_int){
+    case ASM330LHH_DRIVE_SLEEP_CHG_EVENT:
+      *val = ASM330LHH_DRIVE_SLEEP_CHG_EVENT;
+      break;
+    case ASM330LHH_DRIVE_SLEEP_STATUS:
+      *val = ASM330LHH_DRIVE_SLEEP_STATUS;
+      break;
+    default:
+      *val = ASM330LHH_DRIVE_SLEEP_CHG_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of inact_en in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_act_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_inact_en_t val)
+{
+  asm330lhh_int_cfg1_t tap_cfg2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t*)&tap_cfg2, 1);
+  if(ret == 0){
+    tap_cfg2.inact_en= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of inact_en in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_act_mode_get(asm330lhh_ctx_t *ctx,
+                               asm330lhh_inact_en_t *val)
+{
+  asm330lhh_int_cfg1_t tap_cfg2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_INT_CFG1, (uint8_t*)&tap_cfg2, 1);
+
+  switch (tap_cfg2.inact_en){
+    case ASM330LHH_XL_AND_GY_NOT_AFFECTED:
+      *val = ASM330LHH_XL_AND_GY_NOT_AFFECTED;
+      break;
+    case ASM330LHH_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = ASM330LHH_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case ASM330LHH_XL_12Hz5_GY_SLEEP:
+      *val = ASM330LHH_XL_12Hz5_GY_SLEEP;
+      break;
+    case ASM330LHH_XL_12Hz5_GY_PD:
+      *val = ASM330LHH_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = ASM330LHH_XL_AND_GY_NOT_AFFECTED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_act_sleep_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.(1 LSb = 512 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_act_sleep_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_ Six_position_detection(6D/4D)
+  * @brief      This section groups all the functions concerning six
+  *             position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_6d_threshold_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_sixd_ths_t val)
+{
+  asm330lhh_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.sixd_ths= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_6d_threshold_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_sixd_ths_t *val)
+{
+  asm330lhh_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+
+  switch (tap_ths_6d.sixd_ths){
+    case ASM330LHH_DEG_80:
+      *val = ASM330LHH_DEG_80;
+      break;
+    case ASM330LHH_DEG_70:
+      *val = ASM330LHH_DEG_70;
+      break;
+    case ASM330LHH_DEG_60:
+      *val = ASM330LHH_DEG_60;
+      break;
+    case ASM330LHH_DEG_50:
+      *val = ASM330LHH_DEG_50;
+      break;
+    default:
+      *val = ASM330LHH_DEG_80;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_4d_mode_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.d4d_en= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_4d_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_free_fall
+  * @brief      This section group all the functions concerning the free
+  *             fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_ff_threshold_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_ff_ths_t val)
+{
+  asm330lhh_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FREE_FALL,
+                              (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_ff_threshold_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_ff_ths_t *val)
+{
+  asm330lhh_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL, (uint8_t*)&free_fall, 1);
+
+  switch (free_fall.ff_ths){
+    case ASM330LHH_FF_TSH_156mg:
+      *val = ASM330LHH_FF_TSH_156mg;
+      break;
+    case ASM330LHH_FF_TSH_219mg:
+      *val = ASM330LHH_FF_TSH_219mg;
+      break;
+    case ASM330LHH_FF_TSH_250mg:
+      *val = ASM330LHH_FF_TSH_250mg;
+      break;
+    case ASM330LHH_FF_TSH_312mg:
+      *val = ASM330LHH_FF_TSH_312mg;
+      break;
+    case ASM330LHH_FF_TSH_344mg:
+      *val = ASM330LHH_FF_TSH_344mg;
+      break;
+    case ASM330LHH_FF_TSH_406mg:
+      *val = ASM330LHH_FF_TSH_406mg;
+      break;
+    case ASM330LHH_FF_TSH_469mg:
+      *val = ASM330LHH_FF_TSH_469mg;
+      break;
+    case ASM330LHH_FF_TSH_500mg:
+      *val = ASM330LHH_FF_TSH_500mg;
+      break;
+    default:
+      *val = ASM330LHH_FF_TSH_156mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_dur in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_ff_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_wake_up_dur_t wake_up_dur;
+  asm330lhh_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.ff_dur = (val & 0x20U) >> 5;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL,
+                             (uint8_t*)&free_fall, 1);
+  }
+  if(ret == 0){
+    free_fall.ff_dur = val & 0x1FU;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FREE_FALL,
+                              (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_dur in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_ff_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_wake_up_dur_t wake_up_dur;
+  asm330lhh_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_FREE_FALL,
+                             (uint8_t*)&free_fall, 1);
+  }
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_fifo
+  * @brief      This section group all the functions concerning
+  *             the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_watermark_set(asm330lhh_ctx_t *ctx, uint16_t val)
+{
+  asm330lhh_fifo_ctrl1_t fifo_ctrl1;
+  asm330lhh_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl1.wtm = (uint8_t)(0x00FFU & val);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL1,
+                              (uint8_t*)&fifo_ctrl1, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl2.wtm = (uint8_t)(( 0x0100U & val ) >> 8);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_watermark_get(asm330lhh_ctx_t *ctx, uint16_t *val)
+{
+  asm330lhh_fifo_ctrl1_t fifo_ctrl1;
+  asm330lhh_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL1,
+                             (uint8_t*)&fifo_ctrl1, 1);
+  }
+  *val = fifo_ctrl2.wtm;
+  *val = *val << 8;
+  *val += fifo_ctrl1.wtm;
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odrchg_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(asm330lhh_ctx_t *ctx,
+                                                uint8_t val)
+{
+  asm330lhh_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.odrchg_en= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odrchg_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_virtual_sens_odr_chg_get(asm330lhh_ctx_t *ctx,
+                                                uint8_t *val)
+{
+  asm330lhh_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.odrchg_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_wtm in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_stop_on_wtm_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.stop_on_wtm= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_wtm in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_stop_on_wtm_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdr_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_xl_batch_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_bdr_xl_t val)
+{
+  asm330lhh_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.bdr_xl= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdr_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_xl_batch_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_bdr_xl_t *val)
+{
+  asm330lhh_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.bdr_xl){
+    case ASM330LHH_XL_NOT_BATCHED:
+      *val = ASM330LHH_XL_NOT_BATCHED;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_12Hz5:
+      *val = ASM330LHH_XL_BATCHED_AT_12Hz5;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_26Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_26Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_52Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_52Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_104Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_104Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_208Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_208Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_417Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_417Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_833Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_833Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_1667Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_1667Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_3333Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_3333Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_6667Hz:
+      *val = ASM330LHH_XL_BATCHED_AT_6667Hz;
+      break;
+    case ASM330LHH_XL_BATCHED_AT_6Hz5:
+      *val = ASM330LHH_XL_BATCHED_AT_6Hz5;
+      break;
+    default:
+      *val = ASM330LHH_XL_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdr_gy in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_gy_batch_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_bdr_gy_t val)
+{
+  asm330lhh_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.bdr_gy= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdr_gy in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_gy_batch_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_bdr_gy_t *val)
+{
+  asm330lhh_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.bdr_gy){
+    case ASM330LHH_GY_NOT_BATCHED:
+      *val = ASM330LHH_GY_NOT_BATCHED;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_12Hz5:
+      *val = ASM330LHH_GY_BATCHED_AT_12Hz5;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_26Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_26Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_52Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_52Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_104Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_104Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_208Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_208Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_417Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_417Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_833Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_833Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_1667Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_1667Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_3333Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_3333Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_AT_6667Hz:
+      *val = ASM330LHH_GY_BATCHED_AT_6667Hz;
+      break;
+    case ASM330LHH_GY_BATCHED_6Hz5:
+      *val = ASM330LHH_GY_BATCHED_6Hz5;
+      break;
+    default:
+      *val = ASM330LHH_GY_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_mode in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_mode_set(asm330lhh_ctx_t *ctx,
+                                asm330lhh_fifo_mode_t val)
+{
+  asm330lhh_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.fifo_mode= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_mode in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_mode_get(asm330lhh_ctx_t *ctx,
+                                asm330lhh_fifo_mode_t *val)
+{
+  asm330lhh_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.fifo_mode){
+    case ASM330LHH_BYPASS_MODE:
+      *val = ASM330LHH_BYPASS_MODE;
+      break;
+    case ASM330LHH_FIFO_MODE:
+      *val = ASM330LHH_FIFO_MODE;
+      break;
+    case ASM330LHH_STREAM_TO_FIFO_MODE:
+      *val = ASM330LHH_STREAM_TO_FIFO_MODE;
+      break;
+    case ASM330LHH_BYPASS_TO_STREAM_MODE:
+      *val = ASM330LHH_BYPASS_TO_STREAM_MODE;
+      break;
+    case ASM330LHH_STREAM_MODE:
+      *val = ASM330LHH_STREAM_MODE;
+      break;
+    case ASM330LHH_BYPASS_TO_FIFO_MODE:
+      *val = ASM330LHH_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = ASM330LHH_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_t_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_temp_batch_set(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_odr_t_batch_t val)
+{
+  asm330lhh_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.odr_t_batch= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_t_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_temp_batch_get(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_odr_t_batch_t *val)
+{
+  asm330lhh_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.odr_t_batch){
+    case ASM330LHH_TEMP_NOT_BATCHED:
+      *val = ASM330LHH_TEMP_NOT_BATCHED;
+      break;
+    case ASM330LHH_TEMP_BATCHED_AT_52Hz:
+      *val = ASM330LHH_TEMP_BATCHED_AT_52Hz;
+      break;
+    case ASM330LHH_TEMP_BATCHED_AT_12Hz5:
+      *val = ASM330LHH_TEMP_BATCHED_AT_12Hz5;
+      break;
+    case ASM330LHH_TEMP_BATCHED_AT_1Hz6:
+      *val = ASM330LHH_TEMP_BATCHED_AT_1Hz6;
+      break;
+    default:
+      *val = ASM330LHH_TEMP_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_ts_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_timestamp_decimation_set(asm330lhh_ctx_t *ctx,
+                                                asm330lhh_odr_ts_batch_t val)
+{
+  asm330lhh_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.odr_ts_batch= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_ts_batch in reg
+  *                                 FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_timestamp_decimation_get(asm330lhh_ctx_t *ctx,
+                                                asm330lhh_odr_ts_batch_t *val)
+{
+  asm330lhh_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.odr_ts_batch){
+    case ASM330LHH_NO_DECIMATION:
+      *val = ASM330LHH_NO_DECIMATION;
+      break;
+    case ASM330LHH_DEC_1:
+      *val = ASM330LHH_DEC_1;
+      break;
+    case ASM330LHH_DEC_8:
+      *val = ASM330LHH_DEC_8;
+      break;
+    case ASM330LHH_DEC_32:
+      *val = ASM330LHH_DEC_32;
+      break;
+    default:
+      *val = ASM330LHH_NO_DECIMATION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *         between XL and gyro.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of trig_counter_bdr in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_cnt_event_batch_set(asm330lhh_ctx_t *ctx,
+                                           asm330lhh_trig_counter_bdr_t val)
+{
+  asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.trig_counter_bdr= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *          between XL and gyro.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of trig_counter_bdr
+  *                in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_cnt_event_batch_get(asm330lhh_ctx_t *ctx,
+                                           asm330lhh_trig_counter_bdr_t *val)
+{
+  asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+
+  switch (counter_bdr_reg1.trig_counter_bdr){
+    case ASM330LHH_XL_BATCH_EVENT:
+      *val = ASM330LHH_XL_BATCH_EVENT;
+      break;
+    case ASM330LHH_GYRO_BATCH_EVENT:
+      *val = ASM330LHH_GYRO_BATCH_EVENT;
+      break;
+    default:
+      *val = ASM330LHH_XL_BATCH_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_rst_batch_counter_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.rst_counter_bdr= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_rst_batch_counter_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  *val = counter_bdr_reg1.rst_counter_bdr;
+
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of cnt_bdr_th in reg COUNTER_BDR_REG2
+  *                and COUNTER_BDR_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_batch_counter_threshold_set(asm330lhh_ctx_t *ctx,
+                                              uint16_t val)
+{
+  asm330lhh_counter_bdr_reg2_t counter_bdr_reg1;
+  asm330lhh_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0){
+    counter_bdr_reg1.cnt_bdr_th = (uint8_t)((0x0700U & val) >> 8);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG1, (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  if (ret == 0){
+    counter_bdr_reg2.cnt_bdr_th = (uint8_t)(0x00FFU & val);
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_COUNTER_BDR_REG2,
+                              (uint8_t*)&counter_bdr_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of cnt_bdr_th in reg COUNTER_BDR_REG2
+  *                and COUNTER_BDR_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_batch_counter_threshold_get(asm330lhh_ctx_t *ctx,
+                                              uint16_t *val)
+{
+  asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
+  asm330lhh_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_COUNTER_BDR_REG2,
+                             (uint8_t*)&counter_bdr_reg2, 1);
+  }
+
+  *val = counter_bdr_reg1.cnt_bdr_th;
+  *val = *val << 8;
+  *val += counter_bdr_reg2.cnt_bdr_th;
+  return ret;
+}
+
+/**
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_data_level_get(asm330lhh_ctx_t *ctx, uint16_t *val)
+{
+  asm330lhh_fifo_status1_t fifo_status1;
+  asm330lhh_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS1,
+                           (uint8_t*)&fifo_status1, 1);
+  if (ret == 0){
+    ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2,
+                             (uint8_t*)&fifo_status2, 1);
+    *val = fifo_status2.diff_fifo;
+    *val = *val << 8;
+    *val += fifo_status1.diff_fifo;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Registers FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_status_get(asm330lhh_ctx_t *ctx,
+                                  asm330lhh_fifo_status2_t *val)
+{
+  int32_t ret;
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2, (uint8_t*)val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO full status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_full_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.fifo_full_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  fifo_over_run_latched in
+  *                reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_ovr_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2. fifo_ovr_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_wtm_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.fifo_wtm_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  Identifies the sensor in FIFO_DATA_OUT.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tag_sensor in reg FIFO_DATA_OUT_TAG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_fifo_sensor_tag_get(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_fifo_tag_t *val)
+{
+  asm330lhh_fifo_data_out_tag_t fifo_data_out_tag;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_DATA_OUT_TAG,
+                           (uint8_t*)&fifo_data_out_tag, 1);
+
+  switch (fifo_data_out_tag.tag_sensor){
+    case ASM330LHH_GYRO_NC_TAG:
+      *val = ASM330LHH_GYRO_NC_TAG;
+      break;
+    case ASM330LHH_XL_NC_TAG:
+      *val = ASM330LHH_XL_NC_TAG;
+      break;
+    case ASM330LHH_TEMPERATURE_TAG:
+      *val = ASM330LHH_TEMPERATURE_TAG;
+      break;
+    case ASM330LHH_TIMESTAMP_TAG:
+      *val = ASM330LHH_TIMESTAMP_TAG;
+      break;
+    case ASM330LHH_CFG_CHANGE_TAG:
+      *val = ASM330LHH_CFG_CHANGE_TAG;
+      break;
+    default:
+      *val = ASM330LHH_CFG_CHANGE_TAG;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ASM330LHH_DEN_functionality
+  * @brief      This section groups all the functions concerning
+  *             DEN functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DEN functionality marking mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_den_mode_t val)
+{
+  asm330lhh_ctrl6_g_t ctrl6_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.den_mode= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_mode_get(asm330lhh_ctx_t *ctx,
+                               asm330lhh_den_mode_t *val)
+{
+  asm330lhh_ctrl6_g_t ctrl6_c;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL6_G, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.den_mode){
+    case ASM330LHH_DEN_DISABLE:
+      *val = ASM330LHH_DEN_DISABLE;
+      break;
+    case ASM330LHH_LEVEL_FIFO:
+      *val = ASM330LHH_LEVEL_FIFO;
+      break;
+    case ASM330LHH_LEVEL_LETCHED:
+      *val = ASM330LHH_LEVEL_LETCHED;
+      break;
+    case ASM330LHH_LEVEL_TRIGGER:
+      *val = ASM330LHH_LEVEL_TRIGGER;
+      break;
+    case ASM330LHH_EDGE_TRIGGER:
+      *val = ASM330LHH_EDGE_TRIGGER;
+      break;
+    default:
+      *val = ASM330LHH_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_lh in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_polarity_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_den_lh_t val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_lh= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_lh in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_polarity_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_den_lh_t *val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+
+  switch (ctrl9_xl.den_lh){
+    case ASM330LHH_DEN_ACT_LOW:
+      *val = ASM330LHH_DEN_ACT_LOW;
+      break;
+    case ASM330LHH_DEN_ACT_HIGH:
+      *val = ASM330LHH_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = ASM330LHH_DEN_ACT_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_xl_g in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_enable_set(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_den_xl_g_t val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_xl_g= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_xl_g in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_enable_get(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_den_xl_g_t *val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+
+  switch (ctrl9_xl.den_xl_g){
+    case ASM330LHH_STAMP_IN_GY_DATA:
+      *val = ASM330LHH_STAMP_IN_GY_DATA;
+      break;
+    case ASM330LHH_STAMP_IN_XL_DATA:
+      *val = ASM330LHH_STAMP_IN_XL_DATA;
+      break;
+    case ASM330LHH_STAMP_IN_GY_XL_DATA:
+      *val = ASM330LHH_STAMP_IN_GY_XL_DATA;
+      break;
+    default:
+      *val = ASM330LHH_STAMP_IN_GY_DATA;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_mark_axis_x_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_z= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_mark_axis_x_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_mark_axis_y_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_y= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_mark_axis_y_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_mark_axis_z_set(asm330lhh_ctx_t *ctx, uint8_t val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_x= (uint8_t)val;
+    ret = asm330lhh_write_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t asm330lhh_den_mark_axis_z_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+{
+  asm330lhh_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = asm330lhh_read_reg(ctx, ASM330LHH_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.h
+++ b/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.h
@@ -1,0 +1,1140 @@
+/*
+ ******************************************************************************
+ * @file    asm330lhh_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          asm330lhh_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef ASM330LHH_REGS_H
+#define ASM330LHH_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup ASM330LHH
+  * @{
+  *
+  */
+
+/** @defgroup ASM330LHH_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  ASM330LHH Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*asm330lhh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*asm330lhh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  asm330lhh_write_ptr  write_reg;
+  asm330lhh_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} asm330lhh_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup ASM330LHH Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define ASM330LHH_I2C_ADD_L                    0xD5U
+#define ASM330LHH_I2C_ADD_H                    0xD7U
+
+/** Device Identification (Who am I) **/
+#define ASM330LHH_ID                           0x6BU
+
+/**
+  * @}
+  *
+  */
+
+#define ASM330LHH_PIN_CTRL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t sdo_pu_en                : 1;
+  uint8_t not_used_02              : 1;
+} asm330lhh_pin_ctrl_t;
+
+#define ASM330LHH_FIFO_CTRL1                   0x07U
+typedef struct {
+  uint8_t wtm                      : 8;
+} asm330lhh_fifo_ctrl1_t;
+
+#define ASM330LHH_FIFO_CTRL2                   0x08U
+typedef struct {
+  uint8_t wtm                      : 1;
+  uint8_t not_used_01              : 3;
+  uint8_t odrchg_en                : 1;
+  uint8_t not_used_02              : 2;
+  uint8_t stop_on_wtm              : 1;
+} asm330lhh_fifo_ctrl2_t;
+
+#define ASM330LHH_FIFO_CTRL3                   0x09U
+typedef struct {
+  uint8_t bdr_xl                   : 4;
+  uint8_t bdr_gy                   : 4;
+} asm330lhh_fifo_ctrl3_t;
+
+#define ASM330LHH_FIFO_CTRL4                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t odr_t_batch              : 2;
+  uint8_t odr_ts_batch             : 2;
+} asm330lhh_fifo_ctrl4_t;
+
+#define ASM330LHH_COUNTER_BDR_REG1             0x0BU
+typedef struct {
+  uint8_t cnt_bdr_th               : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t trig_counter_bdr         : 1;
+  uint8_t rst_counter_bdr          : 1;
+  uint8_t dataready_pulsed         : 1;
+} asm330lhh_counter_bdr_reg1_t;
+
+#define ASM330LHH_COUNTER_BDR_REG2             0x0CU
+typedef struct {
+  uint8_t cnt_bdr_th               : 8;
+} asm330lhh_counter_bdr_reg2_t;
+
+#define ASM330LHH_INT1_CTRL                    0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fifo_th             : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_fifo_full           : 1;
+  uint8_t int1_cnt_bdr             : 1;
+  uint8_t den_drdy_flag            : 1;
+} asm330lhh_int1_ctrl_t;
+
+#define ASM330LHH_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fifo_th             : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_fifo_full           : 1;
+  uint8_t int2_cnt_bdr             : 1;
+  uint8_t not_used_01              : 1;
+} asm330lhh_int2_ctrl_t;
+
+#define ASM330LHH_WHO_AM_I                     0x0FU
+#define ASM330LHH_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf2_xl_en               : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} asm330lhh_ctrl1_xl_t;
+
+#define ASM330LHH_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t fs_g                     : 4; /* fs_4000 + fs_125 + fs_g */
+  uint8_t odr_g                    : 4;
+} asm330lhh_ctrl2_g_t;
+
+#define ASM330LHH_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} asm330lhh_ctrl3_c_t;
+
+#define ASM330LHH_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep_g                  : 1;
+  uint8_t not_used_03              : 1;
+} asm330lhh_ctrl4_c_t;
+
+#define ASM330LHH_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t rounding                 : 2;
+  uint8_t not_used_02              : 1;
+} asm330lhh_ctrl5_c_t;
+
+#define ASM330LHH_CTRL6_G                      0x15U
+typedef struct {
+  uint8_t ftype                    : 3;
+  uint8_t usr_off_w                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t den_mode                 : 3;   /* trig_en + lvl1_en + lvl2_en */
+} asm330lhh_ctrl6_g_t;
+
+#define ASM330LHH_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t usr_off_on_out           : 1;
+  uint8_t not_used_02              : 2;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t not_used_03              : 1;
+} asm330lhh_ctrl7_g_t;
+
+#define ASM330LHH_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t fastsettl_mode_xl        : 1;
+  uint8_t hp_ref_mode_xl           : 1;
+  uint8_t hpcf_xl                  : 3;
+} asm330lhh_ctrl8_xl_t;
+
+#define ASM330LHH_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t den_lh                   : 1;
+  uint8_t den_xl_g                 : 2;   /* den_xl_en + den_xl_g */
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} asm330lhh_ctrl9_xl_t;
+
+#define ASM330LHH_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t timestamp_en             : 1;
+  uint8_t not_used_02              : 2;
+} asm330lhh_ctrl10_c_t;
+
+#define ASM330LHH_ALL_INT_SRC                  0x1AU
+typedef struct {
+  uint8_t ff_ia                    : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t d6d_ia                   : 1;
+  uint8_t sleep_change             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t timestamp_endcount       : 1;
+} asm330lhh_all_int_src_t;
+
+#define ASM330LHH_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_change             : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t not_used_01              : 2;
+} asm330lhh_wake_up_src_t;
+
+#define ASM330LHH_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_01              : 1;
+} asm330lhh_tap_src_t;
+
+#define ASM330LHH_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} asm330lhh_d6d_src_t;
+
+#define ASM330LHH_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} asm330lhh_status_reg_t;
+
+#define ASM330LHH_OUT_TEMP_L                   0x20U
+#define ASM330LHH_OUT_TEMP_H                   0x21U
+#define ASM330LHH_OUTX_L_G                     0x22U
+#define ASM330LHH_OUTX_H_G                     0x23U
+#define ASM330LHH_OUTY_L_G                     0x24U
+#define ASM330LHH_OUTY_H_G                     0x25U
+#define ASM330LHH_OUTZ_L_G                     0x26U
+#define ASM330LHH_OUTZ_H_G                     0x27U
+#define ASM330LHH_OUTX_L_A                     0x28U
+#define ASM330LHH_OUTX_H_A                     0x29U
+#define ASM330LHH_OUTY_L_A                     0x2AU
+#define ASM330LHH_OUTY_H_A                     0x2BU
+#define ASM330LHH_OUTZ_L_A                     0x2CU
+#define ASM330LHH_OUTZ_H_A                     0x2DU
+#define ASM330LHH_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;
+} asm330lhh_fifo_status1_t;
+
+#define ASM330LHH_FIFO_STATUS2                 0x3BU
+typedef struct {
+  uint8_t diff_fifo                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t over_run_latched         : 1;
+  uint8_t counter_bdr_ia           : 1;
+  uint8_t fifo_full_ia             : 1;
+  uint8_t fifo_ovr_ia              : 1;
+  uint8_t fifo_wtm_ia              : 1;
+} asm330lhh_fifo_status2_t;
+
+#define ASM330LHH_TIMESTAMP0                   0x40U
+#define ASM330LHH_TIMESTAMP1                   0x41U
+#define ASM330LHH_TIMESTAMP2                   0x42U
+#define ASM330LHH_TIMESTAMP3                   0x43U
+#define ASM330LHH_INT_CFG0                     0x56U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t not_used_01              : 3;
+  uint8_t slope_fds                : 1;
+  uint8_t sleep_status_on_int      : 1;
+  uint8_t int_clr_on_read          : 1;
+  uint8_t not_used_02              : 1;
+} asm330lhh_int_cfg0_t;
+
+#define ASM330LHH_INT_CFG1                     0x58U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} asm330lhh_int_cfg1_t;
+
+#define ASM330LHH_THS_6D                       0x59U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} asm330lhh_ths_6d_t;
+
+#define ASM330LHH_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} asm330lhh_int_dur2_t;
+
+#define ASM330LHH_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t usr_off_on_wu            : 1;
+  uint8_t not_used_01              : 1;
+} asm330lhh_wake_up_ths_t;
+
+#define ASM330LHH_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t wake_ths_w               : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} asm330lhh_wake_up_dur_t;
+
+#define ASM330LHH_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} asm330lhh_free_fall_t;
+
+#define ASM330LHH_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t int1_6d                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t not_used_03              : 1;
+  uint8_t int1_sleep_change        : 1;
+} asm330lhh_md1_cfg_t;
+
+#define ASM330LHH_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_timestamp           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t not_used_03              : 1;
+  uint8_t int2_sleep_change        : 1;
+} asm330lhh_md2_cfg_t;
+
+#define ASM330LHH_INTERNAL_FREQ_FINE           0x63U
+typedef struct {
+  uint8_t freq_fine                : 8;
+} asm330lhh_internal_freq_fine_t;
+
+#define ASM330LHH_X_OFS_USR                    0x73U
+#define ASM330LHH_Y_OFS_USR                    0x74U
+#define ASM330LHH_Z_OFS_USR                    0x75U
+#define ASM330LHH_FIFO_DATA_OUT_TAG            0x78U
+typedef struct {
+  uint8_t tag_parity               : 1;
+  uint8_t tag_cnt                  : 2;
+  uint8_t tag_sensor               : 5;
+} asm330lhh_fifo_data_out_tag_t;
+
+#define ASM330LHH_FIFO_DATA_OUT_X_L            0x79U
+#define ASM330LHH_FIFO_DATA_OUT_X_H            0x7AU
+#define ASM330LHH_FIFO_DATA_OUT_Y_L            0x7BU
+#define ASM330LHH_FIFO_DATA_OUT_Y_H            0x7CU
+#define ASM330LHH_FIFO_DATA_OUT_Z_L            0x7DU
+#define ASM330LHH_FIFO_DATA_OUT_Z_H            0x7EU
+
+/**
+  * @defgroup ASM330LHH_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  asm330lhh_pin_ctrl_t                      pin_ctrl;
+  asm330lhh_fifo_ctrl1_t                    fifo_ctrl1;
+  asm330lhh_fifo_ctrl2_t                    fifo_ctrl2;
+  asm330lhh_fifo_ctrl3_t                    fifo_ctrl3;
+  asm330lhh_fifo_ctrl4_t                    fifo_ctrl4;
+  asm330lhh_counter_bdr_reg1_t              counter_bdr_reg1;
+  asm330lhh_counter_bdr_reg2_t              counter_bdr_reg2;
+  asm330lhh_int1_ctrl_t                     int1_ctrl;
+  asm330lhh_int2_ctrl_t                     int2_ctrl;
+  asm330lhh_ctrl1_xl_t                      ctrl1_xl;
+  asm330lhh_ctrl2_g_t                       ctrl2_g;
+  asm330lhh_ctrl3_c_t                       ctrl3_c;
+  asm330lhh_ctrl4_c_t                       ctrl4_c;
+  asm330lhh_ctrl5_c_t                       ctrl5_c;
+  asm330lhh_ctrl6_g_t                       ctrl6_g;
+  asm330lhh_ctrl7_g_t                       ctrl7_g;
+  asm330lhh_ctrl8_xl_t                      ctrl8_xl;
+  asm330lhh_ctrl9_xl_t                      ctrl9_xl;
+  asm330lhh_ctrl10_c_t                      ctrl10_c;
+  asm330lhh_all_int_src_t                   all_int_src;
+  asm330lhh_wake_up_src_t                   wake_up_src;
+  asm330lhh_tap_src_t                       tap_src;
+  asm330lhh_d6d_src_t                       d6d_src;
+  asm330lhh_status_reg_t                    status_reg;
+  asm330lhh_fifo_status1_t                  fifo_status1;
+  asm330lhh_fifo_status2_t                  fifo_status2;
+  asm330lhh_int_cfg0_t                      tap_cfg0;
+  asm330lhh_int_cfg1_t                      int_cfg1;
+  asm330lhh_ths_6d_t                        ths_6d;
+  asm330lhh_int_dur2_t                      int_dur2;
+  asm330lhh_wake_up_ths_t                   wake_up_ths;
+  asm330lhh_wake_up_dur_t                   wake_up_dur;
+  asm330lhh_free_fall_t                     free_fall;
+  asm330lhh_md1_cfg_t                       md1_cfg;
+  asm330lhh_md2_cfg_t                       md2_cfg;
+  asm330lhh_internal_freq_fine_t            internal_freq_fine;
+  asm330lhh_fifo_data_out_tag_t             fifo_data_out_tag;
+  bitwise_t                                 bitwise;
+  uint8_t                                   byte;
+} asm330lhh_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t asm330lhh_read_reg(asm330lhh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t asm330lhh_write_reg(asm330lhh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t asm330lhh_from_fs2g_to_mg(int16_t lsb);
+extern float_t asm330lhh_from_fs4g_to_mg(int16_t lsb);
+extern float_t asm330lhh_from_fs8g_to_mg(int16_t lsb);
+extern float_t asm330lhh_from_fs16g_to_mg(int16_t lsb);
+extern float_t asm330lhh_from_fs125dps_to_mdps(int16_t lsb);
+extern float_t asm330lhh_from_fs250dps_to_mdps(int16_t lsb);
+extern float_t asm330lhh_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t asm330lhh_from_fs1000dps_to_mdps(int16_t lsb);
+extern float_t asm330lhh_from_fs2000dps_to_mdps(int16_t lsb);
+extern float_t asm330lhh_from_fs4000dps_to_mdps(int16_t lsb);
+extern float_t asm330lhh_from_lsb_to_celsius(int16_t lsb);
+extern float_t asm330lhh_from_lsb_to_nsec(int32_t lsb);
+
+typedef enum {
+  ASM330LHH_2g   = 0,
+  ASM330LHH_16g  = 1, /* if XL_FS_MODE = ‘1’ -> ASM330LHH_2g */
+  ASM330LHH_4g   = 2,
+  ASM330LHH_8g   = 3,
+} asm330lhh_fs_xl_t;
+int32_t asm330lhh_xl_full_scale_set(asm330lhh_ctx_t *ctx, asm330lhh_fs_xl_t val);
+int32_t asm330lhh_xl_full_scale_get(asm330lhh_ctx_t *ctx, asm330lhh_fs_xl_t *val);
+
+typedef enum {
+  ASM330LHH_XL_ODR_OFF    = 0,
+  ASM330LHH_XL_ODR_12Hz5  = 1,
+  ASM330LHH_XL_ODR_26Hz   = 2,
+  ASM330LHH_XL_ODR_52Hz   = 3,
+  ASM330LHH_XL_ODR_104Hz  = 4,
+  ASM330LHH_XL_ODR_208Hz  = 5,
+  ASM330LHH_XL_ODR_417Hz  = 6,
+  ASM330LHH_XL_ODR_833Hz  = 7,
+  ASM330LHH_XL_ODR_1667Hz = 8,
+  ASM330LHH_XL_ODR_3333Hz = 9,
+  ASM330LHH_XL_ODR_6667Hz = 10,
+  ASM330LHH_XL_ODR_6Hz5   = 11, /* (low power only) */
+} asm330lhh_odr_xl_t;
+int32_t asm330lhh_xl_data_rate_set(asm330lhh_ctx_t *ctx, asm330lhh_odr_xl_t val);
+int32_t asm330lhh_xl_data_rate_get(asm330lhh_ctx_t *ctx, asm330lhh_odr_xl_t *val);
+
+typedef enum {
+  ASM330LHH_125dps = 2,
+  ASM330LHH_250dps = 0,
+  ASM330LHH_500dps = 4,
+  ASM330LHH_1000dps = 8,
+  ASM330LHH_2000dps = 12,
+  ASM330LHH_4000dps = 1,
+} asm330lhh_fs_g_t;
+int32_t asm330lhh_gy_full_scale_set(asm330lhh_ctx_t *ctx, asm330lhh_fs_g_t val);
+int32_t asm330lhh_gy_full_scale_get(asm330lhh_ctx_t *ctx, asm330lhh_fs_g_t *val);
+
+typedef enum {
+  ASM330LHH_GY_ODR_OFF    = 0,
+  ASM330LHH_GY_ODR_12Hz5  = 1,
+  ASM330LHH_GY_ODR_26Hz   = 2,
+  ASM330LHH_GY_ODR_52Hz   = 3,
+  ASM330LHH_GY_ODR_104Hz  = 4,
+  ASM330LHH_GY_ODR_208Hz  = 5,
+  ASM330LHH_GY_ODR_417Hz  = 6,
+  ASM330LHH_GY_ODR_833Hz  = 7,
+  ASM330LHH_GY_ODR_1667Hz = 8,
+  ASM330LHH_GY_ODR_3333Hz = 9,
+  ASM330LHH_GY_ODR_6667Hz = 10,
+} asm330lhh_odr_g_t;
+int32_t asm330lhh_gy_data_rate_set(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_odr_g_t val);
+int32_t asm330lhh_gy_data_rate_get(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_odr_g_t *val);
+
+int32_t asm330lhh_block_data_update_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_block_data_update_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_LSb_1mg  = 0,
+  ASM330LHH_LSb_16mg = 1,
+} asm330lhh_usr_off_w_t;
+int32_t asm330lhh_xl_offset_weight_set(asm330lhh_ctx_t *ctx,
+                                     asm330lhh_usr_off_w_t val);
+int32_t asm330lhh_xl_offset_weight_get(asm330lhh_ctx_t *ctx,
+                                     asm330lhh_usr_off_w_t *val);
+
+typedef struct {
+  asm330lhh_all_int_src_t       all_int_src;
+  asm330lhh_wake_up_src_t       wake_up_src;
+  asm330lhh_tap_src_t           tap_src;
+  asm330lhh_d6d_src_t           d6d_src;
+  asm330lhh_status_reg_t        status_reg;
+  } asm330lhh_all_sources_t;
+int32_t asm330lhh_all_sources_get(asm330lhh_ctx_t *ctx,
+                                asm330lhh_all_sources_t *val);
+
+int32_t asm330lhh_status_reg_get(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_status_reg_t *val);
+
+int32_t asm330lhh_xl_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_gy_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_temp_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_xl_usr_offset_x_set(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_x_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t asm330lhh_xl_usr_offset_y_set(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_y_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t asm330lhh_xl_usr_offset_z_set(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_z_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t asm330lhh_xl_usr_offset_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_usr_offset_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_timestamp_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_timestamp_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_timestamp_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  ASM330LHH_NO_ROUND      = 0,
+  ASM330LHH_ROUND_XL      = 1,
+  ASM330LHH_ROUND_GY      = 2,
+  ASM330LHH_ROUND_GY_XL   = 3,
+} asm330lhh_rounding_t;
+int32_t asm330lhh_rounding_mode_set(asm330lhh_ctx_t *ctx,
+                                  asm330lhh_rounding_t val);
+int32_t asm330lhh_rounding_mode_get(asm330lhh_ctx_t *ctx,
+                                  asm330lhh_rounding_t *val);
+
+int32_t asm330lhh_temperature_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t asm330lhh_angular_rate_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t asm330lhh_acceleration_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t asm330lhh_fifo_out_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t asm330lhh_odr_cal_reg_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_odr_cal_reg_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_DRDY_LATCHED = 0,
+  ASM330LHH_DRDY_PULSED  = 1,
+} asm330lhh_dataready_pulsed_t;
+int32_t asm330lhh_data_ready_mode_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_dataready_pulsed_t val);
+int32_t asm330lhh_data_ready_mode_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_dataready_pulsed_t *val);
+
+int32_t asm330lhh_device_id_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t asm330lhh_reset_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_reset_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_auto_increment_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_auto_increment_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_boot_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_boot_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_XL_ST_DISABLE  = 0,
+  ASM330LHH_XL_ST_POSITIVE = 1,
+  ASM330LHH_XL_ST_NEGATIVE = 2,
+} asm330lhh_st_xl_t;
+int32_t asm330lhh_xl_self_test_set(asm330lhh_ctx_t *ctx, asm330lhh_st_xl_t val);
+int32_t asm330lhh_xl_self_test_get(asm330lhh_ctx_t *ctx, asm330lhh_st_xl_t *val);
+
+typedef enum {
+  ASM330LHH_GY_ST_DISABLE  = 0,
+  ASM330LHH_GY_ST_POSITIVE = 1,
+  ASM330LHH_GY_ST_NEGATIVE = 3,
+} asm330lhh_st_g_t;
+int32_t asm330lhh_gy_self_test_set(asm330lhh_ctx_t *ctx, asm330lhh_st_g_t val);
+int32_t asm330lhh_gy_self_test_get(asm330lhh_ctx_t *ctx, asm330lhh_st_g_t *val);
+
+int32_t asm330lhh_xl_filter_lp2_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_filter_lp2_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_gy_filter_lp1_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_gy_filter_lp1_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_filter_settling_mask_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_filter_settling_mask_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_ULTRA_LIGHT  = 0,
+  ASM330LHH_VERY_LIGHT   = 1,
+  ASM330LHH_LIGHT        = 2,
+  ASM330LHH_MEDIUM       = 3,
+  ASM330LHH_STRONG       = 4,
+  ASM330LHH_VERY_STRONG  = 5,
+  ASM330LHH_AGGRESSIVE   = 6,
+  ASM330LHH_XTREME       = 7,
+} asm330lhh_ftype_t;
+int32_t asm330lhh_gy_lp1_bandwidth_set(asm330lhh_ctx_t *ctx, asm330lhh_ftype_t val);
+int32_t asm330lhh_gy_lp1_bandwidth_get(asm330lhh_ctx_t *ctx, asm330lhh_ftype_t *val);
+
+int32_t asm330lhh_xl_lp2_on_6d_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_lp2_on_6d_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_HP_PATH_DISABLE_ON_OUT    = 0x00,
+  ASM330LHH_SLOPE_ODR_DIV_4           = 0x10,
+  ASM330LHH_HP_ODR_DIV_10             = 0x11,
+  ASM330LHH_HP_ODR_DIV_20             = 0x12,
+  ASM330LHH_HP_ODR_DIV_45             = 0x13,
+  ASM330LHH_HP_ODR_DIV_100            = 0x14,
+  ASM330LHH_HP_ODR_DIV_200            = 0x15,
+  ASM330LHH_HP_ODR_DIV_400            = 0x16,
+  ASM330LHH_HP_ODR_DIV_800            = 0x17,
+  ASM330LHH_HP_REF_MD_ODR_DIV_10      = 0x31,
+  ASM330LHH_HP_REF_MD_ODR_DIV_20      = 0x32,
+  ASM330LHH_HP_REF_MD_ODR_DIV_45      = 0x33,
+  ASM330LHH_HP_REF_MD_ODR_DIV_100     = 0x34,
+  ASM330LHH_HP_REF_MD_ODR_DIV_200     = 0x35,
+  ASM330LHH_HP_REF_MD_ODR_DIV_400     = 0x36,
+  ASM330LHH_HP_REF_MD_ODR_DIV_800     = 0x37,
+  ASM330LHH_LP_ODR_DIV_10             = 0x01,
+  ASM330LHH_LP_ODR_DIV_20             = 0x02,
+  ASM330LHH_LP_ODR_DIV_45             = 0x03,
+  ASM330LHH_LP_ODR_DIV_100            = 0x04,
+  ASM330LHH_LP_ODR_DIV_200            = 0x05,
+  ASM330LHH_LP_ODR_DIV_400            = 0x06,
+  ASM330LHH_LP_ODR_DIV_800            = 0x07,
+} asm330lhh_hp_slope_xl_en_t;
+int32_t asm330lhh_xl_hp_path_on_out_set(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_hp_slope_xl_en_t val);
+int32_t asm330lhh_xl_hp_path_on_out_get(asm330lhh_ctx_t *ctx,
+                                      asm330lhh_hp_slope_xl_en_t *val);
+
+int32_t asm330lhh_xl_fast_settling_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_fast_settling_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_USE_SLOPE = 0,
+  ASM330LHH_USE_HPF   = 1,
+} asm330lhh_slope_fds_t;
+int32_t asm330lhh_xl_hp_path_internal_set(asm330lhh_ctx_t *ctx,
+                                        asm330lhh_slope_fds_t val);
+int32_t asm330lhh_xl_hp_path_internal_get(asm330lhh_ctx_t *ctx,
+                                        asm330lhh_slope_fds_t *val);
+
+typedef enum {
+  ASM330LHH_HP_FILTER_NONE     = 0x00,
+  ASM330LHH_HP_FILTER_16mHz    = 0x80,
+  ASM330LHH_HP_FILTER_65mHz    = 0x81,
+  ASM330LHH_HP_FILTER_260mHz   = 0x82,
+  ASM330LHH_HP_FILTER_1Hz04    = 0x83,
+} asm330lhh_hpm_g_t;
+int32_t asm330lhh_gy_hp_path_internal_set(asm330lhh_ctx_t *ctx,
+                                        asm330lhh_hpm_g_t val);
+int32_t asm330lhh_gy_hp_path_internal_get(asm330lhh_ctx_t *ctx,
+                                        asm330lhh_hpm_g_t *val);
+
+typedef enum {
+  ASM330LHH_PULL_UP_DISC       = 0,
+  ASM330LHH_PULL_UP_CONNECT    = 1,
+} asm330lhh_sdo_pu_en_t;
+int32_t asm330lhh_sdo_sa0_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_sdo_pu_en_t val);
+int32_t asm330lhh_sdo_sa0_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_sdo_pu_en_t *val);
+
+typedef enum {
+  ASM330LHH_SPI_4_WIRE = 0,
+  ASM330LHH_SPI_3_WIRE = 1,
+} asm330lhh_sim_t;
+int32_t asm330lhh_spi_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_sim_t val);
+int32_t asm330lhh_spi_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_sim_t *val);
+
+typedef enum {
+  ASM330LHH_I2C_ENABLE  = 0,
+  ASM330LHH_I2C_DISABLE = 1,
+} asm330lhh_i2c_disable_t;
+int32_t asm330lhh_i2c_interface_set(asm330lhh_ctx_t *ctx,
+                                  asm330lhh_i2c_disable_t val);
+int32_t asm330lhh_i2c_interface_get(asm330lhh_ctx_t *ctx,
+                                  asm330lhh_i2c_disable_t *val);
+
+typedef struct {
+    asm330lhh_int1_ctrl_t          int1_ctrl;
+    asm330lhh_md1_cfg_t            md1_cfg;
+} asm330lhh_pin_int1_route_t;
+int32_t asm330lhh_pin_int1_route_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_pin_int1_route_t *val);
+int32_t asm330lhh_pin_int1_route_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_pin_int1_route_t *val);
+
+typedef struct {
+  asm330lhh_int2_ctrl_t          int2_ctrl;
+  asm330lhh_md2_cfg_t            md2_cfg;
+} asm330lhh_pin_int2_route_t;
+int32_t asm330lhh_pin_int2_route_set(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_pin_int2_route_t *val);
+int32_t asm330lhh_pin_int2_route_get(asm330lhh_ctx_t *ctx,
+                                   asm330lhh_pin_int2_route_t *val);
+
+typedef enum {
+  ASM330LHH_PUSH_PULL   = 0,
+  ASM330LHH_OPEN_DRAIN  = 1,
+} asm330lhh_pp_od_t;
+int32_t asm330lhh_pin_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t val);
+int32_t asm330lhh_pin_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t *val);
+
+typedef enum {
+  ASM330LHH_ACTIVE_HIGH = 0,
+  ASM330LHH_ACTIVE_LOW  = 1,
+} asm330lhh_h_lactive_t;
+int32_t asm330lhh_pin_polarity_set(asm330lhh_ctx_t *ctx, asm330lhh_h_lactive_t val);
+int32_t asm330lhh_pin_polarity_get(asm330lhh_ctx_t *ctx, asm330lhh_h_lactive_t *val);
+
+int32_t asm330lhh_all_on_int1_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_all_on_int1_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_ALL_INT_PULSED            = 0,
+  ASM330LHH_ALL_INT_LATCHED           = 3,
+} asm330lhh_lir_t;
+int32_t asm330lhh_int_notification_set(asm330lhh_ctx_t *ctx, asm330lhh_lir_t val);
+int32_t asm330lhh_int_notification_get(asm330lhh_ctx_t *ctx, asm330lhh_lir_t *val);
+
+typedef enum {
+  ASM330LHH_LSb_FS_DIV_64       = 0,
+  ASM330LHH_LSb_FS_DIV_256      = 1,
+} asm330lhh_wake_ths_w_t;
+int32_t asm330lhh_wkup_ths_weight_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_wake_ths_w_t val);
+int32_t asm330lhh_wkup_ths_weight_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_wake_ths_w_t *val);
+
+int32_t asm330lhh_wkup_threshold_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_wkup_threshold_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_xl_usr_offset_on_wkup_set(asm330lhh_ctx_t *ctx,
+                                          uint8_t val);
+int32_t asm330lhh_xl_usr_offset_on_wkup_get(asm330lhh_ctx_t *ctx,
+                                          uint8_t *val);
+
+int32_t asm330lhh_wkup_dur_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_wkup_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_gy_sleep_mode_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_gy_sleep_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_DRIVE_SLEEP_CHG_EVENT = 0,
+  ASM330LHH_DRIVE_SLEEP_STATUS    = 1,
+} asm330lhh_sleep_status_on_int_t;
+int32_t asm330lhh_act_pin_notification_set(asm330lhh_ctx_t *ctx,
+                                         asm330lhh_sleep_status_on_int_t val);
+int32_t asm330lhh_act_pin_notification_get(asm330lhh_ctx_t *ctx,
+                                         asm330lhh_sleep_status_on_int_t *val);
+
+typedef enum {
+  ASM330LHH_XL_AND_GY_NOT_AFFECTED      = 0,
+  ASM330LHH_XL_12Hz5_GY_NOT_AFFECTED    = 1,
+  ASM330LHH_XL_12Hz5_GY_SLEEP           = 2,
+  ASM330LHH_XL_12Hz5_GY_PD              = 3,
+} asm330lhh_inact_en_t;
+int32_t asm330lhh_act_mode_set(asm330lhh_ctx_t *ctx,
+                             asm330lhh_inact_en_t val);
+int32_t asm330lhh_act_mode_get(asm330lhh_ctx_t *ctx,
+                             asm330lhh_inact_en_t *val);
+
+int32_t asm330lhh_act_sleep_dur_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_act_sleep_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_DEG_80  = 0,
+  ASM330LHH_DEG_70  = 1,
+  ASM330LHH_DEG_60  = 2,
+  ASM330LHH_DEG_50  = 3,
+} asm330lhh_sixd_ths_t;
+int32_t asm330lhh_6d_threshold_set(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_sixd_ths_t val);
+int32_t asm330lhh_6d_threshold_get(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_sixd_ths_t *val);
+
+int32_t asm330lhh_4d_mode_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_4d_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_FF_TSH_156mg = 0,
+  ASM330LHH_FF_TSH_219mg = 1,
+  ASM330LHH_FF_TSH_250mg = 2,
+  ASM330LHH_FF_TSH_312mg = 3,
+  ASM330LHH_FF_TSH_344mg = 4,
+  ASM330LHH_FF_TSH_406mg = 5,
+  ASM330LHH_FF_TSH_469mg = 6,
+  ASM330LHH_FF_TSH_500mg = 7,
+} asm330lhh_ff_ths_t;
+int32_t asm330lhh_ff_threshold_set(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_ff_ths_t val);
+int32_t asm330lhh_ff_threshold_get(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_ff_ths_t *val);
+
+int32_t asm330lhh_ff_dur_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_ff_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_fifo_watermark_set(asm330lhh_ctx_t *ctx, uint16_t val);
+int32_t asm330lhh_fifo_watermark_get(asm330lhh_ctx_t *ctx, uint16_t *val);
+
+int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(asm330lhh_ctx_t *ctx,
+                                              uint8_t val);
+int32_t asm330lhh_fifo_virtual_sens_odr_chg_get(asm330lhh_ctx_t *ctx,
+                                              uint8_t *val);
+
+int32_t asm330lhh_fifo_stop_on_wtm_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_fifo_stop_on_wtm_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_XL_NOT_BATCHED        =  0,
+  ASM330LHH_XL_BATCHED_AT_12Hz5   =  1,
+  ASM330LHH_XL_BATCHED_AT_26Hz    =  2,
+  ASM330LHH_XL_BATCHED_AT_52Hz    =  3,
+  ASM330LHH_XL_BATCHED_AT_104Hz   =  4,
+  ASM330LHH_XL_BATCHED_AT_208Hz   =  5,
+  ASM330LHH_XL_BATCHED_AT_417Hz   =  6,
+  ASM330LHH_XL_BATCHED_AT_833Hz   =  7,
+  ASM330LHH_XL_BATCHED_AT_1667Hz  =  8,
+  ASM330LHH_XL_BATCHED_AT_3333Hz  =  9,
+  ASM330LHH_XL_BATCHED_AT_6667Hz  = 10,
+  ASM330LHH_XL_BATCHED_AT_6Hz5    = 11,
+} asm330lhh_bdr_xl_t;
+int32_t asm330lhh_fifo_xl_batch_set(asm330lhh_ctx_t *ctx, asm330lhh_bdr_xl_t val);
+int32_t asm330lhh_fifo_xl_batch_get(asm330lhh_ctx_t *ctx, asm330lhh_bdr_xl_t *val);
+
+typedef enum {
+  ASM330LHH_GY_NOT_BATCHED         = 0,
+  ASM330LHH_GY_BATCHED_AT_12Hz5    = 1,
+  ASM330LHH_GY_BATCHED_AT_26Hz     = 2,
+  ASM330LHH_GY_BATCHED_AT_52Hz     = 3,
+  ASM330LHH_GY_BATCHED_AT_104Hz    = 4,
+  ASM330LHH_GY_BATCHED_AT_208Hz    = 5,
+  ASM330LHH_GY_BATCHED_AT_417Hz    = 6,
+  ASM330LHH_GY_BATCHED_AT_833Hz    = 7,
+  ASM330LHH_GY_BATCHED_AT_1667Hz   = 8,
+  ASM330LHH_GY_BATCHED_AT_3333Hz   = 9,
+  ASM330LHH_GY_BATCHED_AT_6667Hz   = 10,
+  ASM330LHH_GY_BATCHED_6Hz5        = 11,
+} asm330lhh_bdr_gy_t;
+int32_t asm330lhh_fifo_gy_batch_set(asm330lhh_ctx_t *ctx, asm330lhh_bdr_gy_t val);
+int32_t asm330lhh_fifo_gy_batch_get(asm330lhh_ctx_t *ctx, asm330lhh_bdr_gy_t *val);
+
+typedef enum {
+  ASM330LHH_BYPASS_MODE             = 0,
+  ASM330LHH_FIFO_MODE               = 1,
+  ASM330LHH_STREAM_TO_FIFO_MODE     = 3,
+  ASM330LHH_BYPASS_TO_STREAM_MODE   = 4,
+  ASM330LHH_STREAM_MODE             = 6,
+  ASM330LHH_BYPASS_TO_FIFO_MODE     = 7,
+} asm330lhh_fifo_mode_t;
+int32_t asm330lhh_fifo_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_fifo_mode_t val);
+int32_t asm330lhh_fifo_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_fifo_mode_t *val);
+
+typedef enum {
+  ASM330LHH_TEMP_NOT_BATCHED        = 0,
+  ASM330LHH_TEMP_BATCHED_AT_52Hz    = 1,
+  ASM330LHH_TEMP_BATCHED_AT_12Hz5   = 2,
+  ASM330LHH_TEMP_BATCHED_AT_1Hz6    = 3,
+} asm330lhh_odr_t_batch_t;
+int32_t asm330lhh_fifo_temp_batch_set(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_odr_t_batch_t val);
+int32_t asm330lhh_fifo_temp_batch_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_odr_t_batch_t *val);
+
+typedef enum {
+  ASM330LHH_NO_DECIMATION = 0,
+  ASM330LHH_DEC_1         = 1,
+  ASM330LHH_DEC_8         = 2,
+  ASM330LHH_DEC_32        = 3,
+} asm330lhh_odr_ts_batch_t;
+int32_t asm330lhh_fifo_timestamp_decimation_set(asm330lhh_ctx_t *ctx,
+                                              asm330lhh_odr_ts_batch_t val);
+int32_t asm330lhh_fifo_timestamp_decimation_get(asm330lhh_ctx_t *ctx,
+                                              asm330lhh_odr_ts_batch_t *val);
+
+typedef enum {
+  ASM330LHH_XL_BATCH_EVENT   = 0,
+  ASM330LHH_GYRO_BATCH_EVENT = 1,
+} asm330lhh_trig_counter_bdr_t;
+int32_t asm330lhh_fifo_cnt_event_batch_set(asm330lhh_ctx_t *ctx,
+                                         asm330lhh_trig_counter_bdr_t val);
+int32_t asm330lhh_fifo_cnt_event_batch_get(asm330lhh_ctx_t *ctx,
+                                         asm330lhh_trig_counter_bdr_t *val);
+
+int32_t asm330lhh_rst_batch_counter_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_rst_batch_counter_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_batch_counter_threshold_set(asm330lhh_ctx_t *ctx,
+                                            uint16_t val);
+int32_t asm330lhh_batch_counter_threshold_get(asm330lhh_ctx_t *ctx,
+                                            uint16_t *val);
+
+int32_t asm330lhh_fifo_data_level_get(asm330lhh_ctx_t *ctx, uint16_t *val);
+
+int32_t asm330lhh_fifo_status_get(asm330lhh_ctx_t *ctx,
+                                asm330lhh_fifo_status2_t *val);
+
+int32_t asm330lhh_fifo_full_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_fifo_ovr_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_fifo_wtm_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ASM330LHH_GYRO_NC_TAG    = 1,
+  ASM330LHH_XL_NC_TAG,
+  ASM330LHH_TEMPERATURE_TAG,
+  ASM330LHH_TIMESTAMP_TAG,
+  ASM330LHH_CFG_CHANGE_TAG,
+} asm330lhh_fifo_tag_t;
+int32_t asm330lhh_fifo_sensor_tag_get(asm330lhh_ctx_t *ctx,
+                                    asm330lhh_fifo_tag_t *val);
+
+typedef enum {
+  ASM330LHH_DEN_DISABLE    = 0,
+  ASM330LHH_LEVEL_FIFO     = 6,
+  ASM330LHH_LEVEL_LETCHED  = 3,
+  ASM330LHH_LEVEL_TRIGGER  = 2,
+  ASM330LHH_EDGE_TRIGGER   = 4,
+} asm330lhh_den_mode_t;
+int32_t asm330lhh_den_mode_set(asm330lhh_ctx_t *ctx,
+                             asm330lhh_den_mode_t val);
+int32_t asm330lhh_den_mode_get(asm330lhh_ctx_t *ctx,
+                             asm330lhh_den_mode_t *val);
+
+typedef enum {
+  ASM330LHH_DEN_ACT_LOW  = 0,
+  ASM330LHH_DEN_ACT_HIGH = 1,
+} asm330lhh_den_lh_t;
+int32_t asm330lhh_den_polarity_set(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_den_lh_t val);
+int32_t asm330lhh_den_polarity_get(asm330lhh_ctx_t *ctx,
+                                 asm330lhh_den_lh_t *val);
+
+typedef enum {
+  ASM330LHH_STAMP_IN_GY_DATA     = 0,
+  ASM330LHH_STAMP_IN_XL_DATA     = 1,
+  ASM330LHH_STAMP_IN_GY_XL_DATA  = 2,
+} asm330lhh_den_xl_g_t;
+int32_t asm330lhh_den_enable_set(asm330lhh_ctx_t *ctx,
+                               asm330lhh_den_xl_g_t val);
+int32_t asm330lhh_den_enable_get(asm330lhh_ctx_t *ctx,
+                               asm330lhh_den_xl_g_t *val);
+
+int32_t asm330lhh_den_mark_axis_x_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_den_mark_axis_x_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_den_mark_axis_y_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_den_mark_axis_y_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+int32_t asm330lhh_den_mark_axis_z_set(asm330lhh_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_den_mark_axis_z_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASM330LHH_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/h3lis331dl_STdC/driver/h3lis331dl_reg.c
+++ b/sensor/stmemsc/h3lis331dl_STdC/driver/h3lis331dl_reg.c
@@ -1,0 +1,1755 @@
+/*
+ ******************************************************************************
+ * @file    h3lis331dl_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   H3LIS331DL driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "h3lis331dl_reg.h"
+
+/**
+  * @defgroup    H3LIS331DL
+  * @brief       This file provides a set of functions needed to drive the
+  *              h3lis331dl enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t h3lis331dl_read_reg(h3lis331dl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t h3lis331dl_write_reg(h3lis331dl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    H3LIS331DL_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float h3lis331dl_from_fs100_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 49.0f);
+}
+
+float h3lis331dl_from_fs200_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 98.0f);
+}
+
+float h3lis331dl_from_fs400_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 195.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_Data_Generation
+  * @brief       This section group all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  X axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t h3lis331dl_axis_x_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG1,
+                            (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.xen = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t h3lis331dl_axis_x_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG1,
+                            (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.xen;
+
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t h3lis331dl_axis_y_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG1,
+                            (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.yen = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t h3lis331dl_axis_y_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG1,
+                            (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.yen;
+
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t h3lis331dl_axis_z_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG1,
+                            (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.zen = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t h3lis331dl_axis_z_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG1,
+                            (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.zen;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t h3lis331dl_data_rate_set(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t val)
+{
+  h3lis331dl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.pm = (uint8_t)val & 0x07U;
+    ctrl_reg1.dr = ( (uint8_t)val & 0x30U ) >> 4;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t h3lis331dl_data_rate_get(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t *val)
+{
+  h3lis331dl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+
+  switch ((ctrl_reg1.dr << 4) + ctrl_reg1.pm)
+  {
+    case H3LIS331DL_ODR_OFF:
+      *val = H3LIS331DL_ODR_OFF;
+      break;
+    case H3LIS331DL_ODR_Hz5:
+      *val = H3LIS331DL_ODR_Hz5;
+      break;
+    case H3LIS331DL_ODR_1Hz:
+      *val = H3LIS331DL_ODR_1Hz;
+      break;
+    case H3LIS331DL_ODR_5Hz2:
+      *val = H3LIS331DL_ODR_5Hz2;
+      break;
+    case H3LIS331DL_ODR_5Hz:
+      *val = H3LIS331DL_ODR_5Hz;
+      break;
+    case H3LIS331DL_ODR_10Hz:
+      *val = H3LIS331DL_ODR_10Hz;
+      break;
+    case H3LIS331DL_ODR_50Hz:
+      *val = H3LIS331DL_ODR_50Hz;
+      break;
+    case H3LIS331DL_ODR_100Hz:
+      *val = H3LIS331DL_ODR_100Hz;
+      break;
+    case H3LIS331DL_ODR_400Hz:
+      *val = H3LIS331DL_ODR_400Hz;
+      break;
+    case H3LIS331DL_ODR_1kHz:
+      *val = H3LIS331DL_ODR_1kHz;
+      break;
+    default:
+      *val = H3LIS331DL_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t h3lis331dl_reference_mode_set(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_hpm_t val)
+{
+  h3lis331dl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG2,
+                            (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t h3lis331dl_reference_mode_get(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_hpm_t *val)
+{
+  h3lis331dl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG2,
+                           (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpm)
+  {
+    case H3LIS331DL_NORMAL_MODE:
+      *val = H3LIS331DL_NORMAL_MODE;
+      break;
+    case H3LIS331DL_REF_MODE_ENABLE:
+      *val = H3LIS331DL_REF_MODE_ENABLE;
+      break;
+    default:
+      *val = H3LIS331DL_NORMAL_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t h3lis331dl_full_scale_set(h3lis331dl_ctx_t *ctx, h3lis331dl_fs_t val)
+{
+  h3lis331dl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t h3lis331dl_full_scale_get(h3lis331dl_ctx_t *ctx, h3lis331dl_fs_t *val)
+{
+  h3lis331dl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.fs)
+  {
+    case H3LIS331DL_100g:
+      *val = H3LIS331DL_100g;
+      break;
+    case H3LIS331DL_200g:
+      *val = H3LIS331DL_200g;
+      break;
+    case H3LIS331DL_400g:
+      *val = H3LIS331DL_400g;
+      break;
+    default:
+      *val = H3LIS331DL_100g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t h3lis331dl_block_data_update_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t h3lis331dl_block_data_update_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers STATUS_REG
+  *
+  */
+int32_t h3lis331dl_status_reg_get(h3lis331dl_ctx_t *ctx,
+                                 h3lis331dl_status_reg_t *val)
+{
+  int32_t ret;
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_STATUS_REG,
+                            (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zyxda in reg STATUS_REG
+  *
+  */
+int32_t h3lis331dl_flag_data_ready_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_Data_Output
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t h3lis331dl_acceleration_raw_get(h3lis331dl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_Common
+  * @brief       This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t h3lis331dl_device_id_get(h3lis331dl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t h3lis331dl_boot_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG2,
+                            (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.boot = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t h3lis331dl_boot_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG2,
+                            (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t h3lis331dl_data_format_set(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_ble_t val)
+{
+  h3lis331dl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t h3lis331dl_data_format_get(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_ble_t *val)
+{
+  h3lis331dl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.ble)
+  {
+    case H3LIS331DL_LSB_AT_LOW_ADD:
+      *val = H3LIS331DL_LSB_AT_LOW_ADD;
+      break;
+    case H3LIS331DL_MSB_AT_LOW_ADD:
+      *val = H3LIS331DL_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = H3LIS331DL_LSB_AT_LOW_ADD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_Filters
+  * @brief       This section group all the functions concerning the
+  *              filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t h3lis331dl_hp_bandwidth_set(h3lis331dl_ctx_t *ctx,
+                                    h3lis331dl_hpcf_t val)
+{
+  h3lis331dl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG2,
+                            (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t h3lis331dl_hp_bandwidth_get(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_hpcf_t *val)
+{
+  h3lis331dl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG2,
+                            (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpcf)
+  {
+    case H3LIS331DL_CUT_OFF_8Hz:
+      *val = H3LIS331DL_CUT_OFF_8Hz;
+      break;
+    case H3LIS331DL_CUT_OFF_16Hz:
+      *val = H3LIS331DL_CUT_OFF_16Hz;
+      break;
+    case H3LIS331DL_CUT_OFF_32Hz:
+      *val = H3LIS331DL_CUT_OFF_32Hz;
+      break;
+    case H3LIS331DL_CUT_OFF_64Hz:
+      *val = H3LIS331DL_CUT_OFF_64Hz;
+      break;
+    default:
+      *val = H3LIS331DL_CUT_OFF_8Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t h3lis331dl_hp_path_set(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t val)
+{
+  h3lis331dl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG2,
+                            (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpen = (uint8_t)val & 0x03U;
+    ctrl_reg2.fds = ((uint8_t)val & 0x04U) >> 2;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t h3lis331dl_hp_path_get(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t *val)
+{
+  h3lis331dl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG2,
+                            (uint8_t*)&ctrl_reg2, 1);
+
+  switch ( (ctrl_reg2.fds << 2) + ctrl_reg2.hpen )
+  {
+    case H3LIS331DL_HP_DISABLE:
+      *val = H3LIS331DL_HP_DISABLE;
+      break;
+    case H3LIS331DL_HP_ON_OUT:
+      *val = H3LIS331DL_HP_ON_OUT;
+      break;
+    case H3LIS331DL_HP_ON_INT1:
+      *val = H3LIS331DL_HP_ON_INT1;
+      break;
+    case H3LIS331DL_HP_ON_INT2:
+      *val = H3LIS331DL_HP_ON_INT2;
+      break;
+    case H3LIS331DL_HP_ON_INT1_INT2:
+      *val = H3LIS331DL_HP_ON_INT1_INT2;
+      break;
+    case H3LIS331DL_HP_ON_INT1_INT2_OUT:
+      *val = H3LIS331DL_HP_ON_INT1_INT2_OUT;
+      break;
+    case H3LIS331DL_HP_ON_INT2_OUT:
+      *val = H3LIS331DL_HP_ON_INT2_OUT;
+      break;
+    case H3LIS331DL_HP_ON_INT1_OUT:
+      *val = H3LIS331DL_HP_ON_INT1_OUT;
+      break;
+    default:
+      *val = H3LIS331DL_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reading at this address zeroes instantaneously
+  *         the content of the internal high pass-filter.
+  *         If the high pass filter is enabled all three axes
+  *         are instantaneously set to 0g. This allows to
+  *         overcome the settling time of the high pass
+  *         filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  *
+  */
+int32_t h3lis331dl_hp_reset_get(h3lis331dl_ctx_t *ctx)
+{
+  uint8_t dummy;
+  int32_t ret;
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_HP_FILTER_RESET,
+                           (uint8_t*)&dummy, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t h3lis331dl_hp_reference_value_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  ret = h3lis331dl_write_reg(ctx, H3LIS331DL_REFERENCE, (uint8_t*)&val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t h3lis331dl_hp_reference_value_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_REFERENCE, val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_Serial_Interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t h3lis331dl_spi_mode_set(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t val)
+{
+  h3lis331dl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t h3lis331dl_spi_mode_get(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t *val)
+{
+  h3lis331dl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+
+  switch ( ctrl_reg4.sim )
+  {
+    case H3LIS331DL_SPI_4_WIRE:
+      *val = H3LIS331DL_SPI_4_WIRE;
+      break;
+    case H3LIS331DL_SPI_3_WIRE:
+      *val = H3LIS331DL_SPI_3_WIRE;
+      break;
+    default:
+      *val = H3LIS331DL_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_Interrupt_Pins
+  * @brief       This section groups all the functions that manage
+  *              interrupt pins.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_pin_int1_route_set(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_i1_cfg_t val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i1_cfg = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_pin_int1_route_get(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_i1_cfg_t *val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i1_cfg )
+  {
+    case H3LIS331DL_PAD1_INT1_SRC:
+      *val = H3LIS331DL_PAD1_INT1_SRC;
+      break;
+    case H3LIS331DL_PAD1_INT1_OR_INT2_SRC:
+      *val = H3LIS331DL_PAD1_INT1_OR_INT2_SRC;
+      break;
+    case H3LIS331DL_PAD1_DRDY:
+      *val = H3LIS331DL_PAD1_DRDY;
+      break;
+    case H3LIS331DL_PAD1_BOOT:
+      *val = H3LIS331DL_PAD1_BOOT;
+      break;
+    default:
+      *val = H3LIS331DL_PAD1_INT1_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_int1_notification_set(h3lis331dl_ctx_t *ctx,
+                                        h3lis331dl_lir1_t val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir1 = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_int1_notification_get(h3lis331dl_ctx_t *ctx,
+                                        h3lis331dl_lir1_t *val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir1 )
+  {
+    case H3LIS331DL_INT1_PULSED:
+      *val = H3LIS331DL_INT1_PULSED;
+      break;
+    case H3LIS331DL_INT1_LATCHED:
+      *val = H3LIS331DL_INT1_LATCHED;
+      break;
+    default:
+      *val = H3LIS331DL_INT1_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_pin_int2_route_set(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_i2_cfg_t val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i2_cfg = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_pin_int2_route_get(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_i2_cfg_t *val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i2_cfg )
+  {
+    case H3LIS331DL_PAD2_INT2_SRC:
+      *val = H3LIS331DL_PAD2_INT2_SRC;
+      break;
+    case H3LIS331DL_PAD2_INT1_OR_INT2_SRC:
+      *val = H3LIS331DL_PAD2_INT1_OR_INT2_SRC;
+      break;
+    case H3LIS331DL_PAD2_DRDY:
+      *val = H3LIS331DL_PAD2_DRDY;
+      break;
+    case H3LIS331DL_PAD2_BOOT:
+      *val = H3LIS331DL_PAD2_BOOT;
+      break;
+    default:
+      *val = H3LIS331DL_PAD2_INT2_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_int2_notification_set(h3lis331dl_ctx_t *ctx,
+                                        h3lis331dl_lir2_t val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir2 = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_int2_notification_get(h3lis331dl_ctx_t *ctx,
+                                        h3lis331dl_lir2_t *val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir2 )
+  {
+    case H3LIS331DL_INT2_PULSED:
+      *val = H3LIS331DL_INT2_PULSED;
+      break;
+    case H3LIS331DL_INT2_LATCHED:
+      *val = H3LIS331DL_INT2_LATCHED;
+      break;
+    default:
+      *val = H3LIS331DL_INT2_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_pin_mode_set(h3lis331dl_ctx_t *ctx, h3lis331dl_pp_od_t val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_pin_mode_get(h3lis331dl_ctx_t *ctx, h3lis331dl_pp_od_t *val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.pp_od )
+  {
+    case H3LIS331DL_PUSH_PULL:
+      *val = H3LIS331DL_PUSH_PULL;
+      break;
+    case H3LIS331DL_OPEN_DRAIN:
+      *val = H3LIS331DL_OPEN_DRAIN;
+      break;
+    default:
+      *val = H3LIS331DL_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_pin_polarity_set(h3lis331dl_ctx_t *ctx,
+                                    h3lis331dl_ihl_t val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.ihl = (uint8_t)val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t h3lis331dl_pin_polarity_get(h3lis331dl_ctx_t *ctx,
+                                    h3lis331dl_ihl_t *val)
+{
+  h3lis331dl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG3,
+                            (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.ihl )
+  {
+    case H3LIS331DL_ACTIVE_HIGH:
+      *val = H3LIS331DL_ACTIVE_HIGH;
+      break;
+    case H3LIS331DL_ACTIVE_LOW:
+      *val = H3LIS331DL_ACTIVE_LOW;
+      break;
+    default:
+      *val = H3LIS331DL_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_interrupt_on_threshold
+  * @brief       This section groups all the functions that manage
+  *              the interrupt on threshold event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the interrupt 1 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t h3lis331dl_int1_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
+                                              int1_on_th_conf_t val)
+{
+  h3lis331dl_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.xlie  = val.int1_xlie;
+    int1_cfg.xhie  = val.int1_xhie;
+    int1_cfg.ylie  = val.int1_ylie;
+    int1_cfg.yhie  = val.int1_yhie;
+    int1_cfg.zlie  = val.int1_zlie;
+    int1_cfg.zhie  = val.int1_zhie;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Configure the interrupt 1 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t h3lis331dl_int1_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
+                                             int1_on_th_conf_t *val)
+{
+  h3lis331dl_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  val->int1_xlie = int1_cfg.xlie;
+  val->int1_xhie = int1_cfg.xhie;
+  val->int1_ylie = int1_cfg.ylie;
+  val->int1_yhie = int1_cfg.yhie;
+  val->int1_zlie = int1_cfg.zlie;
+  val->int1_zhie = int1_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 1 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t h3lis331dl_int1_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
+                                             h3lis331dl_int1_aoi_t val)
+{
+  h3lis331dl_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.aoi = (uint8_t) val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 1 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t h3lis331dl_int1_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
+                                             h3lis331dl_int1_aoi_t *val)
+{
+  h3lis331dl_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ( int1_cfg.aoi )
+  {
+    case H3LIS331DL_INT1_ON_THRESHOLD_OR:
+      *val = H3LIS331DL_INT1_ON_THRESHOLD_OR;
+      break;
+    case H3LIS331DL_INT1_ON_THRESHOLD_AND:
+      *val = H3LIS331DL_INT1_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = H3LIS331DL_INT1_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t h3lis331dl_int1_src_get(h3lis331dl_ctx_t *ctx,
+                               h3lis331dl_int1_src_t *val)
+{
+  int32_t ret;
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t h3lis331dl_int1_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_INT1_THS,
+                              (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t h3lis331dl_int1_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t h3lis331dl_int1_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  if(ret == 0) {
+    int1_duration.d = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_INT1_DURATION,
+                              (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t h3lis331dl_int1_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  *val = int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t h3lis331dl_int2_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
+                                              int2_on_th_conf_t val)
+{
+  h3lis331dl_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_CFG,
+                           (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.xlie  = val.int2_xlie;
+    int2_cfg.xhie  = val.int2_xhie;
+    int2_cfg.ylie  = val.int2_ylie;
+    int2_cfg.yhie  = val.int2_yhie;
+    int2_cfg.zlie  = val.int2_zlie;
+    int2_cfg.zhie  = val.int2_zhie;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t h3lis331dl_int2_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
+                                              int2_on_th_conf_t *val)
+{
+  h3lis331dl_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  val->int2_xlie = int2_cfg.xlie;
+  val->int2_xhie = int2_cfg.xhie;
+  val->int2_ylie = int2_cfg.ylie;
+  val->int2_yhie = int2_cfg.yhie;
+  val->int2_zlie = int2_cfg.zlie;
+  val->int2_zhie = int2_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 2 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t h3lis331dl_int2_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
+                                             h3lis331dl_int2_aoi_t val)
+{
+  h3lis331dl_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.aoi = (uint8_t) val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 2 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t h3lis331dl_int2_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
+                                             h3lis331dl_int2_aoi_t *val)
+{
+  h3lis331dl_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ( int2_cfg.aoi )
+  {
+    case H3LIS331DL_INT2_ON_THRESHOLD_OR:
+      *val = H3LIS331DL_INT2_ON_THRESHOLD_OR;
+      break;
+    case H3LIS331DL_INT2_ON_THRESHOLD_AND:
+      *val = H3LIS331DL_INT2_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = H3LIS331DL_INT2_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 2 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t h3lis331dl_int2_src_get(h3lis331dl_ctx_t *ctx,
+                               h3lis331dl_int2_src_t *val)
+{
+  int32_t ret;
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t h3lis331dl_int2_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t h3lis331dl_int2_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t h3lis331dl_int2_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  if(ret == 0) {
+    int2_duration.d = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_INT2_DURATION,
+                              (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Duration value for interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t h3lis331dl_int2_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  *val = int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    H3LIS331DL_Wake_Up_Event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t h3lis331dl_wkup_to_sleep_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+{
+  h3lis331dl_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG5,
+                            (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0) {
+    ctrl_reg5.turnon = val;
+    ret = h3lis331dl_write_reg(ctx, H3LIS331DL_CTRL_REG5,
+                              (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t h3lis331dl_wkup_to_sleep_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+{
+  h3lis331dl_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = h3lis331dl_read_reg(ctx, H3LIS331DL_CTRL_REG5,
+                            (uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.turnon;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/h3lis331dl_STdC/driver/h3lis331dl_reg.h
+++ b/sensor/stmemsc/h3lis331dl_STdC/driver/h3lis331dl_reg.h
@@ -1,0 +1,605 @@
+/*
+ ******************************************************************************
+ * @file    h3lis331dl_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          h3lis331dl_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef H3LIS331DL_REGS_H
+#define H3LIS331DL_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup H3LIS331DL
+  * @{
+  *
+  */
+
+/** @defgroup H3LIS331DL_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  H3LIS331DL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*h3lis331dl_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*h3lis331dl_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  h3lis331dl_write_ptr  write_reg;
+  h3lis331dl_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} h3lis331dl_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup H3LIS331DL_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0x31 if SA0=1 -> 0x33 **/
+#define H3LIS331DL_I2C_ADD_L     0x31
+#define H3LIS331DL_I2C_ADD_H     0x33
+
+/** Device Identification (Who am I) **/
+#define H3LIS331DL_ID            0x32
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  H3LIS331DL_Sensitivity
+  * @brief       These macro are maintained for back compatibility.
+  *              in order to convert data into engineering units please
+  *              use functions:
+  *                -> _from_fs100_to_mg(int16_t lsb);
+  *                -> _from_fs200_to_mg(int16_t lsb);
+  *                -> _from_fs400_to_mg(int16_t lsb);
+  *
+  *              REMOVING the MACRO you are compliant with:
+  *              MISRA-C 2012 [Dir 4.9] -> " avoid function-like macros "
+  * @{
+  *
+  */
+
+#define H3LIS331DL_FROM_FS_100g_TO_mg(lsb)    (float)( lsb *  49.0f )
+#define H3LIS331DL_FROM_FS_200g_TO_mg(lsb)    (float)( lsb *  98.0f )
+#define H3LIS331DL_FROM_FS_400g_TO_mg(lsb)    (float)( lsb * 195.0f )
+
+/**
+  * @}
+  *
+  */
+
+#define H3LIS331DL_WHO_AM_I                  0x0FU
+#define H3LIS331DL_CTRL_REG1                 0x20U
+typedef struct {
+  uint8_t xen                      : 1;
+  uint8_t yen                      : 1;
+  uint8_t zen                      : 1;
+  uint8_t dr                       : 2;
+  uint8_t pm                       : 3;
+} h3lis331dl_ctrl_reg1_t;
+
+#define H3LIS331DL_CTRL_REG2                 0x21U
+typedef struct {
+  uint8_t hpcf                     : 2;
+  uint8_t hpen                     : 2;
+  uint8_t fds                      : 1;
+  uint8_t hpm                      : 2;
+  uint8_t boot                     : 1;
+} h3lis331dl_ctrl_reg2_t;
+
+#define H3LIS331DL_CTRL_REG3                 0x22U
+typedef struct {
+  uint8_t i1_cfg                   : 2;
+  uint8_t lir1                     : 1;
+  uint8_t i2_cfg                   : 2;
+  uint8_t lir2                     : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t ihl                      : 1;
+} h3lis331dl_ctrl_reg3_t;
+
+#define H3LIS331DL_CTRL_REG4                 0x23U
+typedef struct {
+  uint8_t sim                      : 1;
+  uint8_t not_used_01              : 3;
+  uint8_t fs                       : 2;
+  uint8_t ble                      : 1;
+  uint8_t bdu                      : 1;
+} h3lis331dl_ctrl_reg4_t;
+
+#define H3LIS331DL_CTRL_REG5                 0x24U
+typedef struct {
+  uint8_t turnon                   : 2;
+  uint8_t not_used_01              : 6;
+} h3lis331dl_ctrl_reg5_t;
+
+#define H3LIS331DL_HP_FILTER_RESET           0x25U
+#define H3LIS331DL_REFERENCE                 0x26U
+#define H3LIS331DL_STATUS_REG                0x27U
+typedef struct {
+  uint8_t xda                      : 1;
+  uint8_t yda                      : 1;
+  uint8_t zda                      : 1;
+  uint8_t zyxda                    : 1;
+  uint8_t _xor                     : 1;
+  uint8_t yor                      : 1;
+  uint8_t zor                      : 1;
+  uint8_t zyxor                    : 1;
+} h3lis331dl_status_reg_t;
+
+#define H3LIS331DL_OUT_X_L                   0x28U
+#define H3LIS331DL_OUT_X_H                   0x29U
+#define H3LIS331DL_OUT_Y_L                   0x2AU
+#define H3LIS331DL_OUT_Y_H                   0x2BU
+#define H3LIS331DL_OUT_Z_L                   0x2CU
+#define H3LIS331DL_OUT_Z_H                   0x2DU
+#define H3LIS331DL_INT1_CFG                  0x30U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t aoi                      : 1;
+} h3lis331dl_int1_cfg_t;
+
+#define H3LIS331DL_INT1_SRC                  0x31U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} h3lis331dl_int1_src_t;
+
+#define H3LIS331DL_INT1_THS                  0x32U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} h3lis331dl_int1_ths_t;
+
+#define H3LIS331DL_INT1_DURATION             0x33U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} h3lis331dl_int1_duration_t;
+
+#define H3LIS331DL_INT2_CFG                  0x34U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t aoi                      : 1;
+} h3lis331dl_int2_cfg_t;
+
+#define H3LIS331DL_INT2_SRC                  0x35U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} h3lis331dl_int2_src_t;
+
+#define H3LIS331DL_INT2_THS                  0x36U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} h3lis331dl_int2_ths_t;
+
+#define H3LIS331DL_INT2_DURATION             0x37U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} h3lis331dl_int2_duration_t;
+
+/**
+  * @defgroup H3LIS331DL_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  h3lis331dl_ctrl_reg1_t                     ctrl_reg1;
+  h3lis331dl_ctrl_reg2_t                     ctrl_reg2;
+  h3lis331dl_ctrl_reg3_t                     ctrl_reg3;
+  h3lis331dl_ctrl_reg4_t                     ctrl_reg4;
+  h3lis331dl_ctrl_reg5_t                     ctrl_reg5;
+  h3lis331dl_status_reg_t                    status_reg;
+  h3lis331dl_int1_cfg_t                      int1_cfg;
+  h3lis331dl_int1_src_t                      int1_src;
+  h3lis331dl_int1_ths_t                      int1_ths;
+  h3lis331dl_int1_duration_t                 int1_duration;
+  h3lis331dl_int2_cfg_t                      int2_cfg;
+  h3lis331dl_int2_src_t                      int2_src;
+  h3lis331dl_int2_ths_t                      int2_ths;
+  h3lis331dl_int2_duration_t                 int2_duration;
+  bitwise_t                                  bitwise;
+  uint8_t                                    byte;
+} h3lis331dl_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t h3lis331dl_read_reg(h3lis331dl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+int32_t h3lis331dl_write_reg(h3lis331dl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len);
+
+extern float h3lis331dl_from_fs100_to_mg(int16_t lsb);
+extern float h3lis331dl_from_fs200_to_mg(int16_t lsb);
+extern float h3lis331dl_from_fs400_to_mg(int16_t lsb);
+
+int32_t h3lis331dl_axis_x_data_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_axis_x_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+int32_t h3lis331dl_axis_y_data_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_axis_y_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+int32_t h3lis331dl_axis_z_data_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_axis_z_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  H3LIS331DL_ODR_OFF   = 0x00,
+  H3LIS331DL_ODR_Hz5   = 0x02,
+  H3LIS331DL_ODR_1Hz   = 0x03,
+  H3LIS331DL_ODR_5Hz2  = 0x04,
+  H3LIS331DL_ODR_5Hz   = 0x05,
+  H3LIS331DL_ODR_10Hz  = 0x06,
+  H3LIS331DL_ODR_50Hz  = 0x01,
+  H3LIS331DL_ODR_100Hz = 0x11,
+  H3LIS331DL_ODR_400Hz = 0x21,
+  H3LIS331DL_ODR_1kHz  = 0x31,
+} h3lis331dl_dr_t;
+int32_t h3lis331dl_data_rate_set(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t val);
+int32_t h3lis331dl_data_rate_get(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t *val);
+
+typedef enum {
+  H3LIS331DL_NORMAL_MODE      = 0,
+  H3LIS331DL_REF_MODE_ENABLE  = 1,
+} h3lis331dl_hpm_t;
+int32_t h3lis331dl_reference_mode_set(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_hpm_t val);
+int32_t h3lis331dl_reference_mode_get(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_hpm_t *val);
+
+typedef enum {
+  H3LIS331DL_100g  = 0,
+  H3LIS331DL_200g  = 1,
+  H3LIS331DL_400g  = 3,
+} h3lis331dl_fs_t;
+int32_t h3lis331dl_full_scale_set(h3lis331dl_ctx_t *ctx,
+                                  h3lis331dl_fs_t val);
+int32_t h3lis331dl_full_scale_get(h3lis331dl_ctx_t *ctx,
+                                  h3lis331dl_fs_t *val);
+
+int32_t h3lis331dl_block_data_update_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_block_data_update_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+int32_t h3lis331dl_status_reg_get(h3lis331dl_ctx_t *ctx,
+                                 h3lis331dl_status_reg_t *val);
+
+int32_t h3lis331dl_flag_data_ready_get(h3lis331dl_ctx_t *ctx,
+                                      uint8_t *val);
+
+int32_t h3lis331dl_acceleration_raw_get(h3lis331dl_ctx_t *ctx, uint8_t *buff);
+
+int32_t h3lis331dl_device_id_get(h3lis331dl_ctx_t *ctx, uint8_t *buff);
+
+int32_t h3lis331dl_boot_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_boot_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  H3LIS331DL_LSB_AT_LOW_ADD  = 0,
+  H3LIS331DL_MSB_AT_LOW_ADD  = 1,
+} h3lis331dl_ble_t;
+int32_t h3lis331dl_data_format_set(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_ble_t val);
+int32_t h3lis331dl_data_format_get(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_ble_t *val);
+
+typedef enum {
+  H3LIS331DL_CUT_OFF_8Hz   = 0,
+  H3LIS331DL_CUT_OFF_16Hz  = 1,
+  H3LIS331DL_CUT_OFF_32Hz  = 2,
+  H3LIS331DL_CUT_OFF_64Hz  = 3,
+} h3lis331dl_hpcf_t;
+int32_t h3lis331dl_hp_bandwidth_set(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_hpcf_t val);
+int32_t h3lis331dl_hp_bandwidth_get(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_hpcf_t *val);
+
+typedef enum {
+  H3LIS331DL_HP_DISABLE            = 0,
+  H3LIS331DL_HP_ON_OUT             = 4,
+  H3LIS331DL_HP_ON_INT1            = 1,
+  H3LIS331DL_HP_ON_INT2            = 2,
+  H3LIS331DL_HP_ON_INT1_INT2       = 3,
+  H3LIS331DL_HP_ON_INT1_INT2_OUT   = 7,
+  H3LIS331DL_HP_ON_INT2_OUT        = 6,
+  H3LIS331DL_HP_ON_INT1_OUT        = 5,
+} h3lis331dl_hpen_t;
+int32_t h3lis331dl_hp_path_set(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t val);
+int32_t h3lis331dl_hp_path_get(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t *val);
+
+int32_t h3lis331dl_hp_reset_get(h3lis331dl_ctx_t *ctx);
+
+int32_t h3lis331dl_hp_reference_value_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_hp_reference_value_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  H3LIS331DL_SPI_4_WIRE  = 0,
+  H3LIS331DL_SPI_3_WIRE  = 1,
+} h3lis331dl_sim_t;
+int32_t h3lis331dl_spi_mode_set(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t val);
+int32_t h3lis331dl_spi_mode_get(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t *val);
+
+typedef enum {
+  H3LIS331DL_PAD1_INT1_SRC           = 0,
+  H3LIS331DL_PAD1_INT1_OR_INT2_SRC   = 1,
+  H3LIS331DL_PAD1_DRDY               = 2,
+  H3LIS331DL_PAD1_BOOT               = 3,
+} h3lis331dl_i1_cfg_t;
+int32_t h3lis331dl_pin_int1_route_set(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_i1_cfg_t val);
+int32_t h3lis331dl_pin_int1_route_get(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_i1_cfg_t *val);
+
+typedef enum {
+  H3LIS331DL_INT1_PULSED   = 0,
+  H3LIS331DL_INT1_LATCHED  = 1,
+} h3lis331dl_lir1_t;
+int32_t h3lis331dl_int1_notification_set(h3lis331dl_ctx_t *ctx,
+                                        h3lis331dl_lir1_t val);
+int32_t h3lis331dl_int1_notification_get(h3lis331dl_ctx_t *ctx,
+                                        h3lis331dl_lir1_t *val);
+
+typedef enum {
+  H3LIS331DL_PAD2_INT2_SRC           = 0,
+  H3LIS331DL_PAD2_INT1_OR_INT2_SRC   = 1,
+  H3LIS331DL_PAD2_DRDY               = 2,
+  H3LIS331DL_PAD2_BOOT               = 3,
+} h3lis331dl_i2_cfg_t;
+int32_t h3lis331dl_pin_int2_route_set(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_i2_cfg_t val);
+int32_t h3lis331dl_pin_int2_route_get(h3lis331dl_ctx_t *ctx,
+                                     h3lis331dl_i2_cfg_t *val);
+
+typedef enum {
+  H3LIS331DL_INT2_PULSED   = 0,
+  H3LIS331DL_INT2_LATCHED  = 1,
+} h3lis331dl_lir2_t;
+int32_t h3lis331dl_int2_notification_set(h3lis331dl_ctx_t *ctx,
+                                        h3lis331dl_lir2_t val);
+int32_t h3lis331dl_int2_notification_get(h3lis331dl_ctx_t *ctx,
+                                        h3lis331dl_lir2_t *val);
+
+typedef enum {
+  H3LIS331DL_PUSH_PULL   = 0,
+  H3LIS331DL_OPEN_DRAIN  = 1,
+} h3lis331dl_pp_od_t;
+int32_t h3lis331dl_pin_mode_set(h3lis331dl_ctx_t *ctx,
+                                h3lis331dl_pp_od_t val);
+int32_t h3lis331dl_pin_mode_get(h3lis331dl_ctx_t *ctx,
+                                h3lis331dl_pp_od_t *val);
+
+typedef enum {
+  H3LIS331DL_ACTIVE_HIGH  = 0,
+  H3LIS331DL_ACTIVE_LOW   = 1,
+} h3lis331dl_ihl_t;
+int32_t h3lis331dl_pin_polarity_set(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_ihl_t val);
+int32_t h3lis331dl_pin_polarity_get(h3lis331dl_ctx_t *ctx,
+                                   h3lis331dl_ihl_t *val);
+
+typedef struct {
+  uint8_t int1_xlie             : 1;
+  uint8_t int1_xhie             : 1;
+  uint8_t int1_ylie             : 1;
+  uint8_t int1_yhie             : 1;
+  uint8_t int1_zlie             : 1;
+  uint8_t int1_zhie             : 1;
+} int1_on_th_conf_t;
+int32_t h3lis331dl_int1_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
+                                             int1_on_th_conf_t val);
+int32_t h3lis331dl_int1_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
+                                             int1_on_th_conf_t *val);
+
+typedef enum {
+  H3LIS331DL_INT1_ON_THRESHOLD_OR   = 0,
+  H3LIS331DL_INT1_ON_THRESHOLD_AND  = 1,
+} h3lis331dl_int1_aoi_t;
+int32_t h3lis331dl_int1_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
+                                             h3lis331dl_int1_aoi_t val);
+int32_t h3lis331dl_int1_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
+                                             h3lis331dl_int1_aoi_t *val);
+
+int32_t h3lis331dl_int1_src_get(h3lis331dl_ctx_t *ctx,
+                               h3lis331dl_int1_src_t *val);
+
+int32_t h3lis331dl_int1_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_int1_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+int32_t h3lis331dl_int1_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_int1_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t int2_xlie             : 1;
+  uint8_t int2_xhie             : 1;
+  uint8_t int2_ylie             : 1;
+  uint8_t int2_yhie             : 1;
+  uint8_t int2_zlie             : 1;
+  uint8_t int2_zhie             : 1;
+} int2_on_th_conf_t;
+int32_t h3lis331dl_int2_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
+                                             int2_on_th_conf_t val);
+int32_t h3lis331dl_int2_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
+                                             int2_on_th_conf_t *val);
+
+typedef enum {
+  H3LIS331DL_INT2_ON_THRESHOLD_OR   = 0,
+  H3LIS331DL_INT2_ON_THRESHOLD_AND  = 1,
+} h3lis331dl_int2_aoi_t;
+int32_t h3lis331dl_int2_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
+                                             h3lis331dl_int2_aoi_t val);
+int32_t h3lis331dl_int2_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
+                                             h3lis331dl_int2_aoi_t *val);
+
+int32_t h3lis331dl_int2_src_get(h3lis331dl_ctx_t *ctx,
+                               h3lis331dl_int2_src_t *val);
+
+int32_t h3lis331dl_int2_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_int2_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+int32_t h3lis331dl_int2_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_int2_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+int32_t h3lis331dl_wkup_to_sleep_set(h3lis331dl_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_wkup_to_sleep_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H3LIS331DL_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/hts221_STdC/driver/hts221_reg.c
+++ b/sensor/stmemsc/hts221_STdC/driver/hts221_reg.c
@@ -1,0 +1,946 @@
+/*
+ ******************************************************************************
+ * @file    hts221_reg.c
+ * @author  MEMS Software Solution Team
+ * @brief   HTS221 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+#include "hts221_reg.h"
+
+/**
+  * @defgroup  HTS221
+  * @brief     This file provides a set of functions needed to drive the
+  *            hts221 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  HTS221_interfaces_functions
+  * @brief     This section provide a set of functions used to read and write
+  *            a generic register of the device.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_read_reg(hts221_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                        uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_write_reg(hts221_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  HTS221_Data_Generation
+  * @brief     This section group all the functions concerning data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  The numbers of averaged humidity samples.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of avgh in reg AV_CONF
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_humidity_avg_set(hts221_ctx_t *ctx, hts221_avgh_t val)
+{
+  hts221_av_conf_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_AV_CONF, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.avgh = (uint8_t)val;
+    ret = hts221_write_reg(ctx, HTS221_AV_CONF, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The numbers of averaged humidity samples.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     Get the values of avgh in reg AV_CONF
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_humidity_avg_get(hts221_ctx_t *ctx, hts221_avgh_t *val)
+{
+  hts221_av_conf_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_AV_CONF, (uint8_t*) &reg, 1);
+
+  switch (reg.avgh) {
+    case HTS221_H_AVG_4:
+      *val = HTS221_H_AVG_4;
+      break;
+    case HTS221_H_AVG_8:
+      *val = HTS221_H_AVG_8;
+      break;
+    case HTS221_H_AVG_16:
+      *val = HTS221_H_AVG_16;
+      break;
+    case HTS221_H_AVG_32:
+      *val = HTS221_H_AVG_32;
+      break;
+    case HTS221_H_AVG_64:
+      *val = HTS221_H_AVG_64;
+      break;
+    case HTS221_H_AVG_128:
+      *val = HTS221_H_AVG_128;
+      break;
+    case HTS221_H_AVG_256:
+      *val = HTS221_H_AVG_256;
+      break;
+    case HTS221_H_AVG_512:
+      *val = HTS221_H_AVG_512;
+      break;
+    default:
+      *val = HTS221_H_AVG_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The numbers of averaged temperature samples.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of avgt in reg AV_CONF
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_temperature_avg_set(hts221_ctx_t *ctx, hts221_avgt_t val)
+{
+  hts221_av_conf_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_AV_CONF, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.avgt = (uint8_t)val;
+    ret = hts221_write_reg(ctx, HTS221_AV_CONF, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The numbers of averaged temperature samples.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     Get the values of avgt in reg AV_CONF
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_temperature_avg_get(hts221_ctx_t *ctx, hts221_avgt_t *val)
+{
+  hts221_av_conf_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_AV_CONF, (uint8_t*) &reg, 1);
+
+  switch (reg.avgh) {
+    case HTS221_T_AVG_2:
+      *val = HTS221_T_AVG_2;
+      break;
+    case HTS221_T_AVG_4:
+      *val = HTS221_T_AVG_4;
+      break;
+    case HTS221_T_AVG_8:
+      *val = HTS221_T_AVG_8;
+      break;
+    case HTS221_T_AVG_16:
+      *val = HTS221_T_AVG_16;
+      break;
+    case HTS221_T_AVG_32:
+      *val = HTS221_T_AVG_32;
+      break;
+    case HTS221_T_AVG_64:
+      *val = HTS221_T_AVG_64;
+      break;
+    case HTS221_T_AVG_128:
+      *val = HTS221_T_AVG_128;
+      break;
+    case HTS221_T_AVG_256:
+      *val = HTS221_T_AVG_256;
+      break;
+    default:
+      *val = HTS221_T_AVG_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of odr in reg CTRL_REG1
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_data_rate_set(hts221_ctx_t *ctx, hts221_odr_t val)
+{
+  hts221_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.odr = (uint8_t)val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     Get the values of odr in reg CTRL_REG1
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_data_rate_get(hts221_ctx_t *ctx, hts221_odr_t *val)
+{
+  hts221_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+
+  switch (reg.odr) {
+    case HTS221_ONE_SHOT:
+      *val = HTS221_ONE_SHOT;
+      break;
+    case HTS221_ODR_1Hz:
+      *val = HTS221_ODR_1Hz;
+      break;
+    case HTS221_ODR_7Hz:
+      *val = HTS221_ODR_7Hz;
+      break;
+    case HTS221_ODR_12Hz5:
+      *val = HTS221_ODR_12Hz5;
+      break;
+    default:
+      *val = HTS221_ODR_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of bdu in reg CTRL_REG1
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_block_data_update_set(hts221_ctx_t *ctx, uint8_t val)
+{
+  hts221_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.bdu = val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of bdu in reg CTRL_REG1
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_block_data_update_get(hts221_ctx_t *ctx, uint8_t *val)
+{
+  hts221_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of one_shot in reg CTRL_REG2
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_one_shoot_trigger_set(hts221_ctx_t *ctx, uint8_t val)
+{
+  hts221_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.one_shot = val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of one_shot in reg CTRL_REG2
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_one_shoot_trigger_get(hts221_ctx_t *ctx, uint8_t *val)
+{
+  hts221_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.one_shot;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of t_da in reg STATUS_REG
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_temp_data_ready_get(hts221_ctx_t *ctx, uint8_t *val)
+{
+  hts221_status_reg_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_STATUS_REG, (uint8_t*) &reg, 1);
+  *val = reg.t_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Humidity data available.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of h_da in reg STATUS_REG
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_hum_data_ready_get(hts221_ctx_t *ctx, uint8_t *val)
+{
+  hts221_status_reg_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_STATUS_REG, (uint8_t*) &reg, 1);
+  *val = reg.h_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Humidity output value[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_humidity_raw_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = hts221_read_reg(ctx, HTS221_HUMIDITY_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Temperature output value[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_temperature_raw_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = hts221_read_reg(ctx, HTS221_TEMP_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  HTS221_common
+  * @brief     This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who amI.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_device_id_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = hts221_read_reg(ctx, HTS221_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Switch device on/off.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of pd in reg CTRL_REG1
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_power_on_set(hts221_ctx_t *ctx, uint8_t val)
+{
+  hts221_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.pd = val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Switch device on/off.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of pd in reg CTRL_REG1
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_power_on_get(hts221_ctx_t *ctx, uint8_t *val)
+{
+  hts221_ctrl_reg1_t reg;
+  int32_t mm_error;
+
+  mm_error = hts221_read_reg(ctx, HTS221_CTRL_REG1, (uint8_t*) &reg, 1);
+  *val = reg.pd;
+
+  return mm_error;
+}
+
+/**
+  * @brief  Heater enable / disable.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of heater in reg CTRL_REG2
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_heater_set(hts221_ctx_t *ctx, uint8_t val)
+{
+  hts221_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.heater = val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Heater enable / disable.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of heater in reg CTRL_REG2
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_heater_get(hts221_ctx_t *ctx, uint8_t *val)
+{
+  hts221_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.heater;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of boot in reg CTRL_REG2
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_boot_set(hts221_ctx_t *ctx, uint8_t val)
+{
+  hts221_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.boot = val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of boot in reg CTRL_REG2
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_boot_get(hts221_ctx_t *ctx, uint8_t *val)
+{
+  hts221_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     Registers STATUS_REG
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_status_get(hts221_ctx_t *ctx, hts221_status_reg_t *val)
+{
+  int32_t ret;
+  ret = hts221_read_reg(ctx, HTS221_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  HTS221_interrupts
+  * @brief   This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of drdy in reg CTRL_REG3
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_drdy_on_int_set(hts221_ctx_t *ctx, uint8_t val)
+{
+  hts221_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.drdy = val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of drdy in reg CTRL_REG3
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_drdy_on_int_get(hts221_ctx_t *ctx, uint8_t *val)
+{
+  hts221_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+  *val = reg.drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t hts221_pin_mode_set(hts221_ctx_t *ctx, hts221_pp_od_t val)
+{
+  hts221_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.pp_od = (uint8_t)val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     Get the values of pp_od in reg CTRL_REG3
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_pin_mode_get(hts221_ctx_t *ctx, hts221_pp_od_t *val)
+{
+  hts221_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+
+  switch (reg.pp_od) {
+    case HTS221_PUSH_PULL:
+      *val = HTS221_PUSH_PULL;
+      break;
+    case HTS221_OPEN_DRAIN:
+      *val = HTS221_OPEN_DRAIN;
+      break;
+    default:
+      *val = HTS221_PIN_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     change the values of drdy_h_l in reg CTRL_REG3
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_int_polarity_set(hts221_ctx_t *ctx, hts221_drdy_h_l_t val)
+{
+  hts221_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+
+  if(ret == 0){
+    reg.drdy_h_l = (uint8_t)val;
+    ret = hts221_write_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  val     Get the values of drdy_h_l in reg CTRL_REG3
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_int_polarity_get(hts221_ctx_t *ctx, hts221_drdy_h_l_t *val)
+{
+  hts221_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_CTRL_REG3, (uint8_t*) &reg, 1);
+
+  switch (reg.drdy_h_l) {
+    case HTS221_ACTIVE_HIGH:
+      *val = HTS221_ACTIVE_HIGH;
+      break;
+    case HTS221_ACTIVE_LOW:
+      *val = HTS221_ACTIVE_LOW;
+      break;
+    default:
+      *val = HTS221_ACTIVE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  HTS221_calibration
+  * @brief     This section group all the calibration coefficients need
+  *            for reading data
+  * @{
+  *
+  */
+
+/**
+  * @brief  First calibration point for Rh Humidity.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_hum_rh_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_H0_RH_X2, buff, 1);
+  *buff = (uint8_t)(((uint16_t)(*buff) >> 1) & 0x7FFFu);
+
+  return ret;
+}
+
+/**
+  * @brief  Second calibration point for Rh Humidity.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_hum_rh_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_H1_RH_X2, buff, 1);
+  *buff = (uint8_t)(((uint16_t)(*buff) >> 1) & 0x7FFFu);
+
+  return ret;
+}
+
+/**
+  * @brief  First calibration point for degC temperature.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_temp_deg_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  hts221_t1_t0_msb_t reg;
+  uint8_t coeff_h, coeff_l;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_T0_DEGC_X8, &coeff_l, 1);
+
+  if(ret == 0){
+    ret = hts221_read_reg(ctx, HTS221_T1_T0_MSB, (uint8_t*) &reg, 1);
+    coeff_h = reg.t0_msb;
+    *(buff) = (uint8_t)(((coeff_h << 8) + coeff_l) >> 3);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Second calibration point for degC temperature.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_temp_deg_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  hts221_t1_t0_msb_t reg;
+  uint8_t coeff_h, coeff_l;
+  int32_t ret;
+
+  ret = hts221_read_reg(ctx, HTS221_T1_DEGC_X8, &coeff_l, 1);
+
+  if(ret == 0){
+    ret = hts221_read_reg(ctx, HTS221_T1_T0_MSB, (uint8_t*) &reg, 1);
+    coeff_h = reg.t1_msb;
+    *(buff) = (uint8_t)(((coeff_h << 8) + coeff_l) >> 3);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  First calibration point for humidity in LSB.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_hum_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = hts221_read_reg(ctx, HTS221_H0_T0_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Second calibration point for humidity in LSB.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_hum_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = hts221_read_reg(ctx, HTS221_H1_T0_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  First calibration point for temperature in LSB.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_temp_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = hts221_read_reg(ctx, HTS221_T0_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Second calibration point for temperature in LSB.[get]
+  *
+  * @param  ctx     read / write interface definitions
+  * @param  buff    buffer that stores data read
+  * @retval         interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t hts221_temp_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = hts221_read_reg(ctx, HTS221_T1_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/hts221_STdC/driver/hts221_reg.h
+++ b/sensor/stmemsc/hts221_STdC/driver/hts221_reg.h
@@ -1,0 +1,366 @@
+/*
+ ******************************************************************************
+ * @file    hts221_reg.h
+ * @author  MEMS Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          hts221_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef HTS221_REGS_H
+#define HTS221_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup HTS221
+  * @{
+  *
+  */
+
+/** @defgroup HTS221_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  HTS221_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*hts221_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*hts221_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  hts221_write_ptr  write_reg;
+  hts221_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} hts221_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup HTS221_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  **/
+#define HTS221_I2C_ADDRESS         0xBFU
+
+/** Device Identification (Who am I) **/
+#define HTS221_ID                  0xBCU
+
+/**
+  * @}
+  *
+  */
+
+#define HTS221_WHO_AM_I            0x0FU
+#define HTS221_AV_CONF             0x10U
+typedef struct {
+  uint8_t avgh                 : 3;
+  uint8_t avgt                 : 3;
+  uint8_t not_used_01          : 2;
+} hts221_av_conf_t;
+
+#define HTS221_CTRL_REG1           0x20U
+typedef struct {
+  uint8_t odr                  : 2;
+  uint8_t bdu                  : 1;
+  uint8_t not_used_01          : 4;
+  uint8_t pd                   : 1;
+} hts221_ctrl_reg1_t;
+
+#define HTS221_CTRL_REG2           0x21U
+typedef struct {
+  uint8_t one_shot             : 1;
+  uint8_t heater               : 1;
+  uint8_t not_used_01          : 5;
+  uint8_t boot                 : 1;
+} hts221_ctrl_reg2_t;
+
+#define HTS221_CTRL_REG3           0x22U
+typedef struct {
+  uint8_t not_used_01          : 2;
+  uint8_t drdy                 : 1;
+  uint8_t not_used_02          : 3;
+  uint8_t pp_od                : 1;
+  uint8_t drdy_h_l             : 1;
+} hts221_ctrl_reg3_t;
+
+#define HTS221_STATUS_REG          0x27U
+typedef struct {
+  uint8_t t_da                 : 1;
+  uint8_t h_da                 : 1;
+  uint8_t not_used_01          : 6;
+} hts221_status_reg_t;
+
+#define HTS221_HUMIDITY_OUT_L      0x28U
+#define HTS221_HUMIDITY_OUT_H      0x29U
+#define HTS221_TEMP_OUT_L          0x2AU
+#define HTS221_TEMP_OUT_H          0x2BU
+#define HTS221_H0_RH_X2            0x30U
+#define HTS221_H1_RH_X2            0x31U
+#define HTS221_T0_DEGC_X8          0x32U
+#define HTS221_T1_DEGC_X8          0x33U
+#define HTS221_T1_T0_MSB           0x35U
+typedef struct {
+  uint8_t t0_msb               : 2;
+  uint8_t t1_msb               : 2;
+  uint8_t not_used_01          : 4;
+} hts221_t1_t0_msb_t;
+
+#define HTS221_H0_T0_OUT_L         0x36U
+#define HTS221_H0_T0_OUT_H         0x37U
+#define HTS221_H1_T0_OUT_L         0x3AU
+#define HTS221_H1_T0_OUT_H         0x3BU
+#define HTS221_T0_OUT_L            0x3CU
+#define HTS221_T0_OUT_H            0x3DU
+#define HTS221_T1_OUT_L            0x3EU
+#define HTS221_T1_OUT_H            0x3FU
+
+/**
+  * @defgroup HTS221_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  hts221_av_conf_t        av_conf;
+  hts221_ctrl_reg1_t      ctrl_reg1;
+  hts221_ctrl_reg2_t      ctrl_reg2;
+  hts221_ctrl_reg3_t      ctrl_reg3;
+  hts221_status_reg_t     status_reg;
+  hts221_t1_t0_msb_t      t1_t0_msb;
+  bitwise_t               bitwise;
+  uint8_t                 byte;
+} hts221_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t hts221_read_reg(hts221_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                        uint16_t len);
+int32_t hts221_write_reg(hts221_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+
+typedef enum {
+  HTS221_H_AVG_4    = 0,
+  HTS221_H_AVG_8    = 1,
+  HTS221_H_AVG_16   = 2,
+  HTS221_H_AVG_32   = 3,
+  HTS221_H_AVG_64   = 4,
+  HTS221_H_AVG_128  = 5,
+  HTS221_H_AVG_256  = 6,
+  HTS221_H_AVG_512  = 7,
+  HTS221_H_AVG_ND   = 8,
+} hts221_avgh_t;
+int32_t hts221_humidity_avg_set(hts221_ctx_t *ctx, hts221_avgh_t val);
+int32_t hts221_humidity_avg_get(hts221_ctx_t *ctx, hts221_avgh_t *val);
+
+typedef enum {
+  HTS221_T_AVG_2   = 0,
+  HTS221_T_AVG_4   = 1,
+  HTS221_T_AVG_8   = 2,
+  HTS221_T_AVG_16  = 3,
+  HTS221_T_AVG_32  = 4,
+  HTS221_T_AVG_64  = 5,
+  HTS221_T_AVG_128 = 6,
+  HTS221_T_AVG_256 = 7,
+  HTS221_T_AVG_ND  = 8,
+} hts221_avgt_t;
+int32_t hts221_temperature_avg_set(hts221_ctx_t *ctx, hts221_avgt_t val);
+int32_t hts221_temperature_avg_get(hts221_ctx_t *ctx, hts221_avgt_t *val);
+
+typedef enum {
+  HTS221_ONE_SHOT  = 0,
+  HTS221_ODR_1Hz   = 1,
+  HTS221_ODR_7Hz   = 2,
+  HTS221_ODR_12Hz5 = 3,
+  HTS221_ODR_ND    = 4,
+} hts221_odr_t;
+int32_t hts221_data_rate_set(hts221_ctx_t *ctx, hts221_odr_t val);
+int32_t hts221_data_rate_get(hts221_ctx_t *ctx, hts221_odr_t *val);
+
+int32_t hts221_block_data_update_set(hts221_ctx_t *ctx, uint8_t val);
+int32_t hts221_block_data_update_get(hts221_ctx_t *ctx, uint8_t *val);
+
+int32_t hts221_one_shoot_trigger_set(hts221_ctx_t *ctx, uint8_t val);
+int32_t hts221_one_shoot_trigger_get(hts221_ctx_t *ctx, uint8_t *val);
+
+int32_t hts221_temp_data_ready_get(hts221_ctx_t *ctx, uint8_t *val);
+
+int32_t hts221_hum_data_ready_get(hts221_ctx_t *ctx, uint8_t *val);
+
+int32_t hts221_humidity_raw_get(hts221_ctx_t *ctx, uint8_t *buff);
+
+int32_t hts221_temperature_raw_get(hts221_ctx_t *ctx, uint8_t *buff);
+
+int32_t hts221_device_id_get(hts221_ctx_t *ctx, uint8_t *buff);
+
+int32_t hts221_power_on_set(hts221_ctx_t *ctx, uint8_t val);
+
+int32_t hts221_power_on_get(hts221_ctx_t *ctx, uint8_t *val);
+
+int32_t hts221_heater_set(hts221_ctx_t *ctx, uint8_t val);
+int32_t hts221_heater_get(hts221_ctx_t *ctx, uint8_t *val);
+
+int32_t hts221_boot_set(hts221_ctx_t *ctx, uint8_t val);
+int32_t hts221_boot_get(hts221_ctx_t *ctx, uint8_t *val);
+
+int32_t hts221_status_get(hts221_ctx_t *ctx, hts221_status_reg_t *val);
+
+int32_t hts221_drdy_on_int_set(hts221_ctx_t *ctx, uint8_t val);
+int32_t hts221_drdy_on_int_get(hts221_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  HTS221_PUSH_PULL   = 0,
+  HTS221_OPEN_DRAIN  = 1,
+  HTS221_PIN_MODE_ND = 2,
+} hts221_pp_od_t;
+int32_t hts221_pin_mode_set(hts221_ctx_t *ctx, hts221_pp_od_t val);
+int32_t hts221_pin_mode_get(hts221_ctx_t *ctx, hts221_pp_od_t *val);
+
+typedef enum {
+  HTS221_ACTIVE_HIGH = 0,
+  HTS221_ACTIVE_LOW  = 1,
+  HTS221_ACTIVE_ND   = 2,
+} hts221_drdy_h_l_t;
+int32_t hts221_int_polarity_set(hts221_ctx_t *ctx, hts221_drdy_h_l_t val);
+int32_t hts221_int_polarity_get(hts221_ctx_t *ctx, hts221_drdy_h_l_t *val);
+
+int32_t hts221_hum_rh_point_0_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_hum_rh_point_1_get(hts221_ctx_t *ctx, uint8_t *buff);
+
+int32_t hts221_temp_deg_point_0_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_temp_deg_point_1_get(hts221_ctx_t *ctx, uint8_t *buff);
+
+int32_t hts221_hum_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_hum_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff);
+
+int32_t hts221_temp_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_temp_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*HTS221_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/i3g4250d_STdC/driver/i3g4250d_reg.c
+++ b/sensor/stmemsc/i3g4250d_STdC/driver/i3g4250d_reg.c
@@ -1,0 +1,1722 @@
+/*
+ ******************************************************************************
+ * @file    i3g4250d_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   I3G4250D driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "i3g4250d_reg.h"
+
+/**
+  * @defgroup    I3G4250D
+  * @brief       This file provides a set of functions needed to drive the
+  *              i3g4250d enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    I3G4250D_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t i3g4250d_read_reg(i3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t i3g4250d_write_reg(i3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    I3G4250D_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t i3g4250d_from_fs245dps_to_mdps(int16_t lsb)
+{
+  return ( (float_t)lsb * 8.75f );
+}
+
+float_t i3g4250d_from_lsb_to_celsius(int16_t lsb)
+{
+  return ( (float_t)lsb + 25.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   I3G4250D_data_generation
+  * @brief      This section groups all the functions concerning
+  *             data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_data_rate_set(i3g4250d_ctx_t *ctx, i3g4250d_dr_t val)
+{
+  i3g4250d_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.dr = ((uint8_t)val & 0x30U) >> 4;
+    ctrl_reg1.pd = ((uint8_t)val & 0x0FU);
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dr in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_data_rate_get(i3g4250d_ctx_t *ctx, i3g4250d_dr_t *val)
+{
+  i3g4250d_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+
+  switch ( ( ctrl_reg1.dr  << 4 ) + ctrl_reg1.pd ){
+    case I3G4250D_ODR_OFF:
+      *val = I3G4250D_ODR_OFF;
+      break;
+    case I3G4250D_ODR_SLEEP:
+      *val = I3G4250D_ODR_SLEEP;
+      break;
+    case I3G4250D_ODR_100Hz:
+      *val = I3G4250D_ODR_100Hz;
+      break;
+    case I3G4250D_ODR_200Hz:
+      *val = I3G4250D_ODR_200Hz;
+      break;
+    case I3G4250D_ODR_400Hz:
+      *val = I3G4250D_ODR_400Hz;
+      break;
+    case I3G4250D_ODR_800Hz:
+      *val = I3G4250D_ODR_800Hz;
+      break;
+    default:
+      *val = I3G4250D_ODR_OFF;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    registers STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_status_reg_get(i3g4250d_ctx_t *ctx,
+                                i3g4250d_status_reg_t *val)
+{
+  int32_t ret;
+  ret = i3g4250d_read_reg(ctx, I3G4250D_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "zyxda" in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_flag_data_ready_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_STATUS_REG,(uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   I3G4250D_Dataoutput
+  * @brief      This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_temperature_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = i3g4250d_read_reg(ctx, I3G4250D_OUT_TEMP, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_angular_rate_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  i3g4250d_read_reg(ctx, I3G4250D_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   I3G4250D_common
+  * @brief      This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who amI.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  buff     Buffer that stores the data read.(ptr)
+  * @retval          Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_device_id_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = i3g4250d_read_reg(ctx, I3G4250D_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable. [set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    change the values of st in reg CTRL_REG4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_self_test_set(i3g4250d_ctx_t *ctx, i3g4250d_st_t val)
+{
+  i3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.st = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable. [get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_self_test_get(i3g4250d_ctx_t *ctx, i3g4250d_st_t *val)
+{
+  i3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.st){
+    case I3G4250D_GY_ST_DISABLE:
+      *val = I3G4250D_GY_ST_DISABLE;
+      break;
+    case I3G4250D_GY_ST_POSITIVE:
+      *val = I3G4250D_GY_ST_POSITIVE;
+      break;
+    case I3G4250D_GY_ST_NEGATIVE:
+      *val = I3G4250D_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = I3G4250D_GY_ST_DISABLE;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "ble" in reg CTRL_REG4.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_data_format_set(i3g4250d_ctx_t *ctx, i3g4250d_ble_t val)
+{
+  i3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of "ble" in reg CTRL_REG4.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_data_format_get(i3g4250d_ctx_t *ctx, i3g4250d_ble_t *val)
+{
+  i3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.ble){
+    case I3G4250D_AUX_LSB_AT_LOW_ADD:
+      *val = I3G4250D_AUX_LSB_AT_LOW_ADD;
+      break;
+    case I3G4250D_AUX_MSB_AT_LOW_ADD:
+      *val = I3G4250D_AUX_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = I3G4250D_AUX_LSB_AT_LOW_ADD;
+    break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of boot in reg CTRL_REG5.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_boot_set(i3g4250d_ctx_t *ctx, uint8_t val)
+{
+  i3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.boot = val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of boot in reg CTRL_REG5.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_boot_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.boot;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   I3G4250D_filters
+  * @brief      This section group all the functions concerning the
+  *             filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Lowpass filter bandwidth selection.[set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "bw" in reg CTRL_REG1.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_lp_bandwidth_set(i3g4250d_ctx_t *ctx, i3g4250d_bw_t val)
+{
+  i3g4250d_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG1,(uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.bw = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG1,(uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Lowpass filter bandwidth selection.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of "bw" in reg CTRL_REG1.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_lp_bandwidth_get(i3g4250d_ctx_t *ctx, i3g4250d_bw_t *val)
+{
+  i3g4250d_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG1,(uint8_t*)&ctrl_reg1, 1);
+
+  switch (ctrl_reg1.bw){
+  case I3G4250D_CUT_OFF_LOW:
+      *val = I3G4250D_CUT_OFF_LOW;
+      break;
+    case I3G4250D_CUT_OFF_MEDIUM:
+      *val = I3G4250D_CUT_OFF_MEDIUM;
+      break;
+    case I3G4250D_CUT_OFF_HIGH:
+      *val = I3G4250D_CUT_OFF_HIGH;
+      break;
+    case I3G4250D_CUT_OFF_VERY_HIGH:
+      *val = I3G4250D_CUT_OFF_VERY_HIGH;
+      break;
+    default:
+      *val = I3G4250D_CUT_OFF_LOW;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter bandwidth selection.[set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "hpcf" in reg CTRL_REG2.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_hp_bandwidth_set(i3g4250d_ctx_t *ctx, i3g4250d_hpcf_t val)
+{
+  i3g4250d_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter bandwidth selection.[get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of hpcf in reg CTRL_REG2.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_hp_bandwidth_get(i3g4250d_ctx_t *ctx, i3g4250d_hpcf_t *val)
+{
+  i3g4250d_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpcf){
+    case I3G4250D_HP_LEVEL_0:
+      *val = I3G4250D_HP_LEVEL_0;
+      break;
+    case I3G4250D_HP_LEVEL_1:
+      *val = I3G4250D_HP_LEVEL_1;
+      break;
+    case I3G4250D_HP_LEVEL_2:
+      *val = I3G4250D_HP_LEVEL_2;
+      break;
+    case I3G4250D_HP_LEVEL_3:
+      *val = I3G4250D_HP_LEVEL_3;
+      break;
+    case I3G4250D_HP_LEVEL_4:
+      *val = I3G4250D_HP_LEVEL_4;
+      break;
+    case I3G4250D_HP_LEVEL_5:
+      *val = I3G4250D_HP_LEVEL_5;
+      break;
+    case I3G4250D_HP_LEVEL_6:
+      *val = I3G4250D_HP_LEVEL_6;
+      break;
+    case I3G4250D_HP_LEVEL_7:
+      *val = I3G4250D_HP_LEVEL_7;
+      break;
+    case I3G4250D_HP_LEVEL_8:
+      *val = I3G4250D_HP_LEVEL_8;
+      break;
+    case I3G4250D_HP_LEVEL_9:
+      *val = I3G4250D_HP_LEVEL_9;
+      break;
+    default:
+      *val = I3G4250D_HP_LEVEL_0;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection. [set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "hpm" in reg CTRL_REG2.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_hp_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t val)
+{
+  i3g4250d_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection. [get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of hpm in reg CTRL_REG2.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_hp_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t *val)
+{
+  i3g4250d_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG2,(uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpm){
+    case I3G4250D_HP_NORMAL_MODE_WITH_RST:
+      *val = I3G4250D_HP_NORMAL_MODE_WITH_RST;
+      break;
+    case I3G4250D_HP_REFERENCE_SIGNAL:
+      *val = I3G4250D_HP_REFERENCE_SIGNAL;
+      break;
+    case I3G4250D_HP_NORMAL_MODE:
+      *val = I3G4250D_HP_NORMAL_MODE;
+      break;
+    case I3G4250D_HP_AUTO_RESET_ON_INT:
+      *val = I3G4250D_HP_AUTO_RESET_ON_INT;
+      break;
+    default:
+      *val = I3G4250D_HP_NORMAL_MODE_WITH_RST;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Out/FIFO selection path. [set]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Change the values of "out_sel" in reg CTRL_REG5.
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_filter_path_set(i3g4250d_ctx_t *ctx, i3g4250d_out_sel_t val)
+{
+  i3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.out_sel = (uint8_t)val & 0x03U;
+    ctrl_reg5.hpen = ( (uint8_t)val & 0x04U ) >> 2;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Out/FIFO selection path. [get]
+  *
+  * @param  ctx     Read / write interface definitions.(ptr)
+  * @param  val     Get the values of out_sel in reg CTRL_REG5.(ptr)
+  * @retval         Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_filter_path_get(i3g4250d_ctx_t *ctx, i3g4250d_out_sel_t *val)
+{
+  i3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+
+  switch ( ( ctrl_reg5.hpen << 2 ) + ctrl_reg5.out_sel ){
+    case I3G4250D_ONLY_LPF1_ON_OUT:
+      *val = I3G4250D_ONLY_LPF1_ON_OUT;
+      break;
+    case I3G4250D_LPF1_HP_ON_OUT:
+      *val = I3G4250D_LPF1_HP_ON_OUT;
+      break;
+    case I3G4250D_LPF1_LPF2_ON_OUT:
+      *val = I3G4250D_LPF1_LPF2_ON_OUT;
+      break;
+    case I3G4250D_LPF1_HP_LPF2_ON_OUT:
+      *val = I3G4250D_LPF1_HP_LPF2_ON_OUT;
+      break;
+    default:
+      *val = I3G4250D_ONLY_LPF1_ON_OUT;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator selection path.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_sel in reg CTRL_REG5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_filter_path_internal_set(i3g4250d_ctx_t *ctx,
+                                          i3g4250d_int1_sel_t val)
+{
+  i3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.int1_sel = (uint8_t)val & 0x03U;
+    ctrl_reg5.hpen = ( (uint8_t)val & 0x04U ) >> 2;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator selection path.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_sel in reg CTRL_REG5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_filter_path_internal_get(i3g4250d_ctx_t *ctx,
+                                          i3g4250d_int1_sel_t *val)
+{
+  i3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+
+  switch ( ( ctrl_reg5.hpen << 2 ) + ctrl_reg5.int1_sel ){
+    case I3G4250D_ONLY_LPF1_ON_INT:
+      *val = I3G4250D_ONLY_LPF1_ON_INT;
+      break;
+    case I3G4250D_LPF1_HP_ON_INT:
+      *val = I3G4250D_LPF1_HP_ON_INT;
+      break;
+    case I3G4250D_LPF1_LPF2_ON_INT:
+      *val = I3G4250D_LPF1_LPF2_ON_INT;
+      break;
+    case I3G4250D_LPF1_HP_LPF2_ON_INT:
+      *val = I3G4250D_LPF1_HP_LPF2_ON_INT;
+      break;
+    default:
+      *val = I3G4250D_ONLY_LPF1_ON_INT;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ref in reg REFERENCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_hp_reference_value_set(i3g4250d_ctx_t *ctx, uint8_t val)
+{
+  i3g4250d_reference_t reference;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_REFERENCE,(uint8_t*)&reference, 1);
+  if(ret == 0){
+    reference.ref = val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_REFERENCE,(uint8_t*)&reference, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ref in reg REFERENCE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_hp_reference_value_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_reference_t reference;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_REFERENCE,(uint8_t*)&reference, 1);
+  *val = reference.ref;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   I3G4250D_serial_interface
+  * @brief   This section groups all the functions concerning main serial
+  *          interface management.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_spi_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_sim_t val)
+{
+  i3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_spi_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_sim_t *val)
+{
+  i3g4250d_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG4,(uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.sim){
+    case I3G4250D_SPI_4_WIRE:
+      *val = I3G4250D_SPI_4_WIRE;
+      break;
+    case I3G4250D_SPI_3_WIRE:
+      *val = I3G4250D_SPI_3_WIRE;
+      break;
+    default:
+      *val = I3G4250D_SPI_4_WIRE;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   I3G4250D_interrupt_pins
+  * @brief      This section groups all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Configure CTRL_REG3 int1 pad
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_pin_int1_route_set(i3g4250d_ctx_t *ctx,
+                                    i3g4250d_int1_route_t val)
+{
+  i3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.i1_int1         = val.i1_int1;
+    ctrl_reg3.i1_boot         = val.i1_boot;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read CTRL_REG3 int1 pad.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+
+int32_t i3g4250d_pin_int1_route_get(i3g4250d_ctx_t *ctx,
+                                    i3g4250d_int1_route_t *val)
+{
+  i3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  val->i1_int1       = ctrl_reg3.i1_int1;
+  val->i1_boot       = ctrl_reg3.i1_boot;
+
+  return ret;
+}
+/**
+  * @brief  Select the signal that need to route on int2 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Configure CTRL_REG3 int2 pad
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_pin_int2_route_set(i3g4250d_ctx_t *ctx,
+                                    i3g4250d_int2_route_t val)
+{
+  i3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.i2_empty         = val.i2_empty;
+    ctrl_reg3.i2_orun          = val.i2_orun;
+    ctrl_reg3.i2_wtm           = val.i2_wtm;
+    ctrl_reg3.i2_drdy          = val.i2_drdy;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Read CTRL_REG3 int2 pad.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_pin_int2_route_get(i3g4250d_ctx_t *ctx,
+                                    i3g4250d_int2_route_t *val)
+{
+  i3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  val->i2_empty       = ctrl_reg3.i2_empty;
+  val->i2_orun        = ctrl_reg3.i2_orun;
+  val->i2_wtm         = ctrl_reg3.i2_wtm;
+  val->i2_drdy        = ctrl_reg3.i2_drdy;
+
+  return ret;
+}
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+
+int32_t i3g4250d_pin_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t val)
+{
+  i3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL_REG3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_pin_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t *val)
+{
+  i3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+
+  switch (ctrl_reg3.pp_od ){
+    case I3G4250D_PUSH_PULL:
+      *val = I3G4250D_PUSH_PULL;
+      break;
+    case I3G4250D_OPEN_DRAIN:
+      *val = I3G4250D_OPEN_DRAIN;
+      break;
+    default:
+      *val = I3G4250D_PUSH_PULL;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pin active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of h_lactive in reg CTRL_REG3.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_pin_polarity_set(i3g4250d_ctx_t *ctx,
+                                  i3g4250d_h_lactive_t val)
+{
+  i3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.h_lactive = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pin active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL_REG3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_pin_polarity_get(i3g4250d_ctx_t *ctx,
+                                  i3g4250d_h_lactive_t *val)
+{
+  i3g4250d_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG3,(uint8_t*)&ctrl_reg3, 1);
+
+  switch (ctrl_reg3.h_lactive){
+    case I3G4250D_ACTIVE_HIGH:
+      *val = I3G4250D_ACTIVE_HIGH;
+      break;
+    case I3G4250D_ACTIVE_LOW:
+      *val = I3G4250D_ACTIVE_LOW;
+      break;
+    default:
+      *val = I3G4250D_ACTIVE_HIGH;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir in reg INT1_CFG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_notification_set(i3g4250d_ctx_t *ctx,
+                                      i3g4250d_lir_t val)
+{
+  i3g4250d_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  if(ret == 0){
+    int1_cfg.lir = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg INT1_CFG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_notification_get(i3g4250d_ctx_t *ctx,
+                                      i3g4250d_lir_t *val)
+{
+  i3g4250d_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+
+  switch (int1_cfg.lir){
+    case I3G4250D_INT_PULSED:
+      *val = I3G4250D_INT_PULSED;
+      break;
+    case I3G4250D_INT_LATCHED:
+      *val = I3G4250D_INT_LATCHED;
+      break;
+    default:
+      *val = I3G4250D_INT_PULSED;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   I3G4250D_ interrupt_on_threshold
+  * @brief      This section groups all the functions that manage the event
+  *             generation on threshold.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the interrupt threshold sign.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Struct of registers INT1_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_on_threshold_conf_set(i3g4250d_ctx_t *ctx,
+                                           i3g4250d_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt threshold sign.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Struct of registers from INT1_CFG to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_on_threshold_conf_get(i3g4250d_ctx_t *ctx,
+                                           i3g4250d_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  AND/OR combination of interrupt events.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of and_or in reg INT1_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_on_threshold_mode_set(i3g4250d_ctx_t *ctx,
+                                           i3g4250d_and_or_t val)
+{
+  i3g4250d_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  if(ret == 0){
+    int1_cfg.and_or = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of interrupt events.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of and_or in reg INT1_CFG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_on_threshold_mode_get(i3g4250d_ctx_t *ctx,
+                                           i3g4250d_and_or_t *val)
+{
+  i3g4250d_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_CFG,(uint8_t*)&int1_cfg, 1);
+  switch (int1_cfg.and_or){
+    case I3G4250D_INT1_ON_TH_OR:
+      *val = I3G4250D_INT1_ON_TH_OR;
+      break;
+    case I3G4250D_INT1_ON_TH_AND:
+      *val = I3G4250D_INT1_ON_TH_AND;
+      break;
+    default:
+      *val = I3G4250D_INT1_ON_TH_OR;
+    break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   int_on_threshold_src: [get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Union of registers from INT1_SRC to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_on_threshold_src_get(i3g4250d_ctx_t *ctx,
+                                          i3g4250d_int1_src_t *val)
+{
+  int32_t ret;
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on X.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsx in reg INT1_TSH_XH
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_x_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
+{
+  i3g4250d_int1_tsh_xh_t int1_tsh_xh;
+  i3g4250d_int1_tsh_xl_t int1_tsh_xl;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_XH,
+                               (uint8_t*)&int1_tsh_xh, 1);
+  if(ret == 0){
+    int1_tsh_xh.thsx = (uint8_t)((uint16_t)val & 0x7F00U)>>8;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_TSH_XH,
+                             (uint8_t*)&int1_tsh_xh, 1);
+  }
+  if(ret == 0){
+    ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_XL,
+                            (uint8_t*)&int1_tsh_xl, 1);
+  }
+  if(ret == 0){
+    int1_tsh_xl.thsx = (uint8_t)((uint16_t)val & 0x00FFU);
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_TSH_XL,
+                             (uint8_t*)&int1_tsh_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on X.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsx in reg INT1_TSH_XH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_x_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
+{
+  i3g4250d_int1_tsh_xh_t int1_tsh_xh;
+  i3g4250d_int1_tsh_xl_t int1_tsh_xl;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_XH,
+                               (uint8_t*)&int1_tsh_xh, 1);
+  if(ret == 0){
+    ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_XL,
+                               (uint8_t*)&int1_tsh_xl, 1);
+
+    *val = int1_tsh_xh.thsx;
+    *val = *val << 8;
+    *val +=  int1_tsh_xl.thsx;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on Y.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsy in reg INT1_TSH_YH
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_y_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
+{
+  i3g4250d_int1_tsh_yh_t int1_tsh_yh;
+  i3g4250d_int1_tsh_yl_t int1_tsh_yl;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_YH,
+                               (uint8_t*)&int1_tsh_yh, 1);
+  int1_tsh_yh.thsy = (uint8_t)((uint16_t)val & 0x7F00U)>>8;
+  if(ret == 0){
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_TSH_YH,
+                                (uint8_t*)&int1_tsh_yh, 1);
+  }
+  if(ret == 0){
+    ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_YL,
+                               (uint8_t*)&int1_tsh_yl, 1);
+    int1_tsh_yl.thsy = (uint8_t)((uint16_t)val & 0x00FFU);
+  }
+  if(ret == 0){
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_TSH_YL,
+                                (uint8_t*)&int1_tsh_yl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on Y.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsy in reg INT1_TSH_YH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_y_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
+{
+  i3g4250d_int1_tsh_yh_t int1_tsh_yh;
+  i3g4250d_int1_tsh_yl_t int1_tsh_yl;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_YH,
+                               (uint8_t*)&int1_tsh_yh, 1);
+  if(ret == 0){
+    ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_YL,
+                               (uint8_t*)&int1_tsh_yl, 1);
+
+    *val = int1_tsh_yh.thsy;
+    *val = *val << 8;
+    *val += int1_tsh_yl.thsy;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on Z.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsz in reg INT1_TSH_ZH.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_z_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
+{
+  i3g4250d_int1_tsh_zh_t int1_tsh_zh;
+  i3g4250d_int1_tsh_zl_t int1_tsh_zl;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_ZH,
+                               (uint8_t*)&int1_tsh_zh, 1);
+  int1_tsh_zh.thsz = (uint8_t)((uint16_t)val & 0x7F00U)>>8;
+  if(ret == 0){
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_TSH_ZH,
+                                (uint8_t*)&int1_tsh_zh, 1);
+  }
+  if(ret == 0){
+    ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_ZL,
+                               (uint8_t*)&int1_tsh_zl, 1);
+    int1_tsh_zl.thsz = (uint8_t)((uint8_t)val & 0x00FFU);
+  }
+  if(ret == 0){
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_TSH_ZL,
+                                (uint8_t*)&int1_tsh_zl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt threshold on Z.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsz in reg INT1_TSH_ZH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_z_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
+{
+  i3g4250d_int1_tsh_zh_t int1_tsh_zh;
+  i3g4250d_int1_tsh_zl_t int1_tsh_zl;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_ZH,
+                               (uint8_t*)&int1_tsh_zh, 1);
+  if(ret == 0){
+    ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_TSH_ZL,
+                               (uint8_t*)&int1_tsh_zl, 1);
+
+    *val = int1_tsh_zh.thsz;
+    *val = *val << 8;
+    *val += int1_tsh_zl.thsz;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Durationvalue.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d in reg INT1_DURATION
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_on_threshold_dur_set(i3g4250d_ctx_t *ctx, uint8_t val)
+{
+  i3g4250d_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_DURATION,
+                          (uint8_t*)&int1_duration, 1);
+  if(ret == 0){
+    int1_duration.d = val;
+    if (val != PROPERTY_DISABLE){
+      int1_duration.wait = PROPERTY_ENABLE;
+    }
+    else{
+      int1_duration.wait = PROPERTY_DISABLE;
+    }
+    ret = i3g4250d_write_reg(ctx, I3G4250D_INT1_DURATION,
+                             (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Durationvalue.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of d in reg INT1_DURATION.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_int_on_threshold_dur_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_INT1_DURATION,
+                          (uint8_t*)&int1_duration, 1);
+  *val = int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   I3G4250D_fifo
+  * @brief   This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFOenable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_en in reg CTRL_REG5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_enable_set(i3g4250d_ctx_t *ctx, uint8_t val)
+{
+  i3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.fifo_en = val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFOenable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL_REG5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_enable_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_CTRL_REG5,(uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_watermark_set(i3g4250d_ctx_t *ctx, uint8_t val)
+{
+  i3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_FIFO_CTRL_REG,
+                          (uint8_t*)&fifo_ctrl_reg, 1);
+  if(ret == 0){
+    fifo_ctrl_reg.wtm = val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_FIFO_CTRL_REG,
+                             (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wtm in reg FIFO_CTRL_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_watermark_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_FIFO_CTRL_REG,
+                          (uint8_t*)&fifo_ctrl_reg, 1);
+  *val = fifo_ctrl_reg.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fm in reg FIFO_CTRL_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t val)
+{
+  i3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_FIFO_CTRL_REG,
+                          (uint8_t*)&fifo_ctrl_reg, 1);
+  if(ret == 0){
+    fifo_ctrl_reg.fm = (uint8_t)val;
+    ret = i3g4250d_write_reg(ctx, I3G4250D_FIFO_CTRL_REG,
+                             (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fm in reg FIFO_CTRL_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t *val)
+{
+  i3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_FIFO_CTRL_REG,
+                          (uint8_t*)&fifo_ctrl_reg, 1);
+
+  switch (fifo_ctrl_reg.fm){
+    case I3G4250D_FIFO_BYPASS_MODE:
+      *val = I3G4250D_FIFO_BYPASS_MODE;
+      break;
+    case I3G4250D_FIFO_MODE:
+      *val = I3G4250D_FIFO_MODE;
+      break;
+    case I3G4250D_FIFO_STREAM_MODE:
+      *val = I3G4250D_FIFO_STREAM_MODE;
+      break;
+    default:
+      *val = I3G4250D_FIFO_BYPASS_MODE;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fss in reg FIFO_SRC_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_data_level_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_FIFO_SRC_REG,
+                          (uint8_t*)&fifo_src_reg, 1);
+  *val = fifo_src_reg.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFOemptybit.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of empty in reg FIFO_SRC_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_empty_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_FIFO_SRC_REG,
+                          (uint8_t*)&fifo_src_reg, 1);
+  *val = fifo_src_reg.empty;
+
+  return ret;
+}
+
+/**
+  * @brief  Overrun bit status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ovrn in reg FIFO_SRC_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t i3g4250d_fifo_ovr_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_FIFO_SRC_REG,
+                          (uint8_t*)&fifo_src_reg, 1);
+  *val = fifo_src_reg.ovrn;
+
+  return ret;
+}
+
+/**
+  * @brief  Watermark status:[get]
+  *                0: FIFO filling is lower than WTM level;
+  *                1: FIFO filling is equal or higher than WTM level)
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wtm in reg FIFO_SRC_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+
+int32_t i3g4250d_fifo_wtm_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+{
+  i3g4250d_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = i3g4250d_read_reg(ctx, I3G4250D_FIFO_SRC_REG,
+                          (uint8_t*)&fifo_src_reg, 1);
+  *val = fifo_src_reg.wtm;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/i3g4250d_STdC/driver/i3g4250d_reg.h
+++ b/sensor/stmemsc/i3g4250d_STdC/driver/i3g4250d_reg.h
@@ -1,0 +1,580 @@
+/*
+ ******************************************************************************
+ * @file    i3g4250d_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          i3g4250d_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef I3G4250D_REGS_H
+#define I3G4250D_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup I3G4250D
+  * @{
+  *
+  */
+
+/** @defgroup I3G4250D_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup i3g4250d_interface
+  * @{
+  *
+  */
+
+typedef int32_t (*i3g4250d_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*i3g4250d_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  i3g4250d_write_ptr  write_reg;
+  i3g4250d_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} i3g4250d_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+
+/**
+  * @defgroup i3g4250d_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0xD1 if SA0=1 -> 0xD3 **/
+#define I3G4250D_I2C_ADD_L               0xD1U
+#define I3G4250D_I2C_ADD_H               0xD3U
+
+/** Device Identification (Who am I) **/
+#define I3G4250D_ID                      0xD3U
+
+/**
+  * @}
+  *
+  */
+
+#define I3G4250D_WHO_AM_I                0x0FU
+#define I3G4250D_CTRL_REG1               0x20U
+typedef struct {
+  uint8_t pd                        : 4; /* xen yen zen pd */
+  uint8_t bw                        : 2;
+  uint8_t dr                        : 2;
+} i3g4250d_ctrl_reg1_t;
+
+#define I3G4250D_CTRL_REG2               0x21U
+typedef struct {
+  uint8_t hpcf                      : 4;
+  uint8_t hpm                       : 2;
+  uint8_t not_used_01               : 2;
+} i3g4250d_ctrl_reg2_t;
+
+#define I3G4250D_CTRL_REG3               0x22U
+typedef struct {
+  uint8_t i2_empty                  : 1;
+  uint8_t i2_orun                   : 1;
+  uint8_t i2_wtm                    : 1;
+  uint8_t i2_drdy                   : 1;
+  uint8_t pp_od                     : 1;
+  uint8_t h_lactive                 : 1;
+  uint8_t i1_boot                   : 1;
+  uint8_t i1_int1                   : 1;
+} i3g4250d_ctrl_reg3_t;
+
+#define I3G4250D_CTRL_REG4               0x23U
+typedef struct {
+  uint8_t sim                       : 1;
+  uint8_t st                        : 2;
+  uint8_t not_used_01               : 3;
+  uint8_t ble                       : 1;
+  uint8_t not_used_02               : 1;
+} i3g4250d_ctrl_reg4_t;
+
+#define I3G4250D_CTRL_REG5               0x24U
+typedef struct {
+  uint8_t out_sel                   : 2;
+  uint8_t int1_sel                  : 2;
+  uint8_t hpen                      : 1;
+  uint8_t not_used_01               : 1;
+  uint8_t fifo_en                   : 1;
+  uint8_t boot                      : 1;
+} i3g4250d_ctrl_reg5_t;
+
+#define I3G4250D_REFERENCE               0x25U
+typedef struct {
+  uint8_t ref                       : 8;
+} i3g4250d_reference_t;
+
+#define I3G4250D_OUT_TEMP                0x26U
+#define I3G4250D_STATUS_REG              0x27U
+typedef struct {
+  uint8_t xda                       : 1;
+  uint8_t yda                       : 1;
+  uint8_t zda                       : 1;
+  uint8_t zyxda                     : 1;
+  uint8_t _xor                      : 1;
+  uint8_t yor                       : 1;
+  uint8_t zor                       : 1;
+  uint8_t zyxor                     : 1;
+} i3g4250d_status_reg_t;
+
+#define I3G4250D_OUT_X_L                 0x28U
+#define I3G4250D_OUT_X_H                 0x29U
+#define I3G4250D_OUT_Y_L                 0x2AU
+#define I3G4250D_OUT_Y_H                 0x2BU
+#define I3G4250D_OUT_Z_L                 0x2CU
+#define I3G4250D_OUT_Z_H                 0x2DU
+#define I3G4250D_FIFO_CTRL_REG           0x2EU
+typedef struct {
+  uint8_t wtm                       : 5;
+  uint8_t fm                        : 3;
+} i3g4250d_fifo_ctrl_reg_t;
+
+#define I3G4250D_FIFO_SRC_REG            0x2FU
+typedef struct {
+  uint8_t fss                       : 5;
+  uint8_t empty                     : 1;
+  uint8_t ovrn                      : 1;
+  uint8_t wtm                       : 1;
+} i3g4250d_fifo_src_reg_t;
+
+#define I3G4250D_INT1_CFG                0x30U
+typedef struct {
+  uint8_t xlie                      : 1;
+  uint8_t xhie                      : 1;
+  uint8_t ylie                      : 1;
+  uint8_t yhie                      : 1;
+  uint8_t zlie                      : 1;
+  uint8_t zhie                      : 1;
+  uint8_t lir                       : 1;
+  uint8_t and_or                    : 1;
+} i3g4250d_int1_cfg_t;
+
+#define I3G4250D_INT1_SRC                0x31U
+typedef struct {
+  uint8_t xl                        : 1;
+  uint8_t xh                        : 1;
+  uint8_t yl                        : 1;
+  uint8_t yh                        : 1;
+  uint8_t zl                        : 1;
+  uint8_t zh                        : 1;
+  uint8_t ia                        : 1;
+  uint8_t not_used_01               : 1;
+} i3g4250d_int1_src_t;
+
+#define I3G4250D_INT1_TSH_XH             0x32U
+typedef struct {
+  uint8_t thsx                      : 7;
+  uint8_t not_used_01               : 1;
+} i3g4250d_int1_tsh_xh_t;
+
+#define I3G4250D_INT1_TSH_XL             0x33U
+typedef struct {
+  uint8_t thsx                      : 8;
+} i3g4250d_int1_tsh_xl_t;
+
+#define I3G4250D_INT1_TSH_YH             0x34U
+typedef struct {
+  uint8_t thsy                      : 7;
+  uint8_t not_used_01               : 1;
+} i3g4250d_int1_tsh_yh_t;
+
+#define I3G4250D_INT1_TSH_YL             0x35U
+typedef struct {
+  uint8_t thsy                      : 8;
+} i3g4250d_int1_tsh_yl_t;
+
+#define I3G4250D_INT1_TSH_ZH             0x36U
+typedef struct {
+  uint8_t thsz                      : 7;
+  uint8_t not_used_01               : 1;
+} i3g4250d_int1_tsh_zh_t;
+
+#define I3G4250D_INT1_TSH_ZL             0x37U
+typedef struct {
+  uint8_t thsz                      : 8;
+} i3g4250d_int1_tsh_zl_t;
+
+#define I3G4250D_INT1_DURATION           0x38U
+typedef struct {
+  uint8_t d                         : 7;
+  uint8_t wait                      : 1;
+} i3g4250d_int1_duration_t;
+
+/**
+  * @defgroup LSM9DS1_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  i3g4250d_ctrl_reg1_t        ctrl_reg1;
+  i3g4250d_ctrl_reg2_t        ctrl_reg2;
+  i3g4250d_ctrl_reg3_t        ctrl_reg3;
+  i3g4250d_ctrl_reg4_t        ctrl_reg4;
+  i3g4250d_ctrl_reg5_t        ctrl_reg5;
+  i3g4250d_reference_t        reference;
+  i3g4250d_status_reg_t       status_reg;
+  i3g4250d_fifo_ctrl_reg_t    fifo_ctrl_reg;
+  i3g4250d_fifo_src_reg_t     fifo_src_reg;
+  i3g4250d_int1_cfg_t         int1_cfg;
+  i3g4250d_int1_src_t         int1_src;
+  i3g4250d_int1_tsh_xh_t      int1_tsh_xh;
+  i3g4250d_int1_tsh_xl_t      int1_tsh_xl;
+  i3g4250d_int1_tsh_yh_t      int1_tsh_yh;
+  i3g4250d_int1_tsh_yl_t      int1_tsh_yl;
+  i3g4250d_int1_tsh_zh_t      int1_tsh_zh;
+  i3g4250d_int1_tsh_zl_t      int1_tsh_zl;
+  i3g4250d_int1_duration_t    int1_duration;
+  bitwise_t                   bitwise;
+  uint8_t                     byte;
+} i3g4250d_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t i3g4250d_read_reg(i3g4250d_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t i3g4250d_write_reg(i3g4250d_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t i3g4250d_from_fs245dps_to_mdps(int16_t lsb);
+extern float_t i3g4250d_from_lsb_to_celsius(int16_t lsb);
+
+int32_t i3g4250d_axis_x_data_set(i3g4250d_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_axis_x_data_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t i3g4250d_axis_y_data_set(i3g4250d_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_axis_y_data_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t i3g4250d_axis_z_data_set(i3g4250d_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_axis_z_data_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  I3G4250D_ODR_OFF     = 0x00,
+  I3G4250D_ODR_SLEEP   = 0x08,
+  I3G4250D_ODR_100Hz   = 0x0F,
+  I3G4250D_ODR_200Hz   = 0x1F,
+  I3G4250D_ODR_400Hz   = 0x2F,
+  I3G4250D_ODR_800Hz   = 0x3F,
+} i3g4250d_dr_t;
+int32_t i3g4250d_data_rate_set(i3g4250d_ctx_t *ctx, i3g4250d_dr_t val);
+int32_t i3g4250d_data_rate_get(i3g4250d_ctx_t *ctx, i3g4250d_dr_t *val);
+
+int32_t i3g4250d_status_reg_get(i3g4250d_ctx_t *ctx,
+                                i3g4250d_status_reg_t *val);
+
+int32_t i3g4250d_flag_data_ready_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t i3g4250d_temperature_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff);
+
+int32_t i3g4250d_angular_rate_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff);
+
+int32_t i3g4250d_device_id_get(i3g4250d_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  I3G4250D_GY_ST_DISABLE    = 0,
+  I3G4250D_GY_ST_POSITIVE   = 1,
+  I3G4250D_GY_ST_NEGATIVE   = 3,
+} i3g4250d_st_t;
+int32_t i3g4250d_self_test_set(i3g4250d_ctx_t *ctx, i3g4250d_st_t val);
+int32_t i3g4250d_self_test_get(i3g4250d_ctx_t *ctx, i3g4250d_st_t *val);
+
+typedef enum {
+  I3G4250D_AUX_LSB_AT_LOW_ADD   = 0,
+  I3G4250D_AUX_MSB_AT_LOW_ADD   = 1,
+} i3g4250d_ble_t;
+int32_t i3g4250d_data_format_set(i3g4250d_ctx_t *ctx, i3g4250d_ble_t val);
+int32_t i3g4250d_data_format_get(i3g4250d_ctx_t *ctx, i3g4250d_ble_t *val);
+
+int32_t i3g4250d_boot_set(i3g4250d_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_boot_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  I3G4250D_CUT_OFF_LOW        = 0,
+  I3G4250D_CUT_OFF_MEDIUM     = 1,
+  I3G4250D_CUT_OFF_HIGH       = 2,
+  I3G4250D_CUT_OFF_VERY_HIGH  = 3,
+} i3g4250d_bw_t;
+int32_t i3g4250d_lp_bandwidth_set(i3g4250d_ctx_t *ctx, i3g4250d_bw_t val);
+int32_t i3g4250d_lp_bandwidth_get(i3g4250d_ctx_t *ctx, i3g4250d_bw_t *val);
+
+typedef enum {
+  I3G4250D_HP_LEVEL_0   = 0,
+  I3G4250D_HP_LEVEL_1   = 1,
+  I3G4250D_HP_LEVEL_2   = 2,
+  I3G4250D_HP_LEVEL_3   = 3,
+  I3G4250D_HP_LEVEL_4   = 4,
+  I3G4250D_HP_LEVEL_5   = 5,
+  I3G4250D_HP_LEVEL_6   = 6,
+  I3G4250D_HP_LEVEL_7   = 7,
+  I3G4250D_HP_LEVEL_8   = 8,
+  I3G4250D_HP_LEVEL_9   = 9,
+} i3g4250d_hpcf_t;
+int32_t i3g4250d_hp_bandwidth_set(i3g4250d_ctx_t *ctx,
+                                  i3g4250d_hpcf_t val);
+int32_t i3g4250d_hp_bandwidth_get(i3g4250d_ctx_t *ctx,
+                                  i3g4250d_hpcf_t *val);
+
+typedef enum {
+  I3G4250D_HP_NORMAL_MODE_WITH_RST  = 0,
+  I3G4250D_HP_REFERENCE_SIGNAL      = 1,
+  I3G4250D_HP_NORMAL_MODE           = 2,
+  I3G4250D_HP_AUTO_RESET_ON_INT     = 3,
+} i3g4250d_hpm_t;
+int32_t i3g4250d_hp_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t val);
+int32_t i3g4250d_hp_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t *val);
+
+typedef enum {
+  I3G4250D_ONLY_LPF1_ON_OUT     = 0,
+  I3G4250D_LPF1_HP_ON_OUT       = 1,
+  I3G4250D_LPF1_LPF2_ON_OUT     = 2,
+  I3G4250D_LPF1_HP_LPF2_ON_OUT  = 6,
+} i3g4250d_out_sel_t;
+int32_t i3g4250d_filter_path_set(i3g4250d_ctx_t *ctx,
+                                 i3g4250d_out_sel_t val);
+int32_t i3g4250d_filter_path_get(i3g4250d_ctx_t *ctx,
+                                 i3g4250d_out_sel_t *val);
+
+typedef enum {
+  I3G4250D_ONLY_LPF1_ON_INT     = 0,
+  I3G4250D_LPF1_HP_ON_INT       = 1,
+  I3G4250D_LPF1_LPF2_ON_INT     = 2,
+  I3G4250D_LPF1_HP_LPF2_ON_INT  = 6,
+} i3g4250d_int1_sel_t;
+int32_t i3g4250d_filter_path_internal_set(i3g4250d_ctx_t *ctx,
+                                          i3g4250d_int1_sel_t val);
+int32_t i3g4250d_filter_path_internal_get(i3g4250d_ctx_t *ctx,
+                                          i3g4250d_int1_sel_t *val);
+
+int32_t i3g4250d_hp_reference_value_set(i3g4250d_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_hp_reference_value_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  I3G4250D_SPI_4_WIRE  = 0,
+  I3G4250D_SPI_3_WIRE  = 1,
+} i3g4250d_sim_t;
+int32_t i3g4250d_spi_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_sim_t val);
+int32_t i3g4250d_spi_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_sim_t *val);
+
+typedef struct {
+  uint8_t i1_int1             : 1;
+  uint8_t i1_boot             : 1;
+} i3g4250d_int1_route_t;
+int32_t i3g4250d_pin_int1_route_set(i3g4250d_ctx_t *ctx,
+                                    i3g4250d_int1_route_t val);
+int32_t i3g4250d_pin_int1_route_get(i3g4250d_ctx_t *ctx,
+                                    i3g4250d_int1_route_t *val);
+
+typedef struct {
+  uint8_t i2_empty             : 1;
+  uint8_t i2_orun              : 1;
+  uint8_t i2_wtm               : 1;
+  uint8_t i2_drdy              : 1;
+} i3g4250d_int2_route_t;
+int32_t i3g4250d_pin_int2_route_set(i3g4250d_ctx_t *ctx,
+                                    i3g4250d_int2_route_t val);
+int32_t i3g4250d_pin_int2_route_get(i3g4250d_ctx_t *ctx,
+                                    i3g4250d_int2_route_t *val);
+
+typedef enum {
+  I3G4250D_PUSH_PULL   = 0,
+  I3G4250D_OPEN_DRAIN  = 1,
+} i3g4250d_pp_od_t;
+int32_t i3g4250d_pin_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t val);
+int32_t i3g4250d_pin_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t *val);
+
+typedef enum {
+  I3G4250D_ACTIVE_HIGH  = 0,
+  I3G4250D_ACTIVE_LOW   = 1,
+} i3g4250d_h_lactive_t;
+int32_t i3g4250d_pin_polarity_set(i3g4250d_ctx_t *ctx,
+                                  i3g4250d_h_lactive_t val);
+int32_t i3g4250d_pin_polarity_get(i3g4250d_ctx_t *ctx,
+                                  i3g4250d_h_lactive_t *val);
+
+typedef enum {
+  I3G4250D_INT_PULSED   = 0,
+  I3G4250D_INT_LATCHED  = 1,
+} i3g4250d_lir_t;
+int32_t i3g4250d_int_notification_set(i3g4250d_ctx_t *ctx,
+                                      i3g4250d_lir_t val);
+int32_t i3g4250d_int_notification_get(i3g4250d_ctx_t *ctx,
+                                      i3g4250d_lir_t *val);
+
+int32_t i3g4250d_int_on_threshold_conf_set(i3g4250d_ctx_t *ctx,
+                                           i3g4250d_int1_cfg_t *val);
+int32_t i3g4250d_int_on_threshold_conf_get(i3g4250d_ctx_t *ctx,
+                                           i3g4250d_int1_cfg_t *val);
+
+typedef enum {
+  I3G4250D_INT1_ON_TH_AND  = 1,
+  I3G4250D_INT1_ON_TH_OR   = 0,
+} i3g4250d_and_or_t;
+int32_t i3g4250d_int_on_threshold_mode_set(i3g4250d_ctx_t *ctx,
+                                           i3g4250d_and_or_t val);
+int32_t i3g4250d_int_on_threshold_mode_get(i3g4250d_ctx_t *ctx,
+                                           i3g4250d_and_or_t *val);
+
+int32_t i3g4250d_int_on_threshold_src_get(i3g4250d_ctx_t *ctx,
+                                          i3g4250d_int1_src_t *val);
+
+int32_t i3g4250d_int_x_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val);
+int32_t i3g4250d_int_x_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val);
+
+int32_t i3g4250d_int_y_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val);
+int32_t i3g4250d_int_y_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val);
+
+int32_t i3g4250d_int_z_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val);
+int32_t i3g4250d_int_z_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val);
+
+int32_t i3g4250d_int_on_threshold_dur_set(i3g4250d_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_int_on_threshold_dur_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t i3g4250d_fifo_enable_set(i3g4250d_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_fifo_enable_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t i3g4250d_fifo_watermark_set(i3g4250d_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_fifo_watermark_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  I3G4250D_FIFO_BYPASS_MODE     = 0x00,
+  I3G4250D_FIFO_MODE            = 0x01,
+  I3G4250D_FIFO_STREAM_MODE     = 0x02,
+} i3g4250d_fifo_mode_t;
+int32_t i3g4250d_fifo_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t val);
+int32_t i3g4250d_fifo_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t *val);
+
+int32_t i3g4250d_fifo_data_level_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t i3g4250d_fifo_empty_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t i3g4250d_fifo_ovr_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+int32_t i3g4250d_fifo_wtm_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* I3G4250D_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis2dh_STdC/driver/iis2dh_reg.c
+++ b/sensor/stmemsc/iis2dh_STdC/driver/iis2dh_reg.c
@@ -1,0 +1,2298 @@
+/*
+ ******************************************************************************
+ * @file    iis2dh_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   IIS2DH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "iis2dh_reg.h"
+
+/**
+  * @defgroup  IIS2DH
+  * @brief     This file provides a set of functions needed to drive the
+  *            iis2dh enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  IIS2DH_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_read_reg(iis2dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                        uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_write_reg(iis2dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    IIS2DH_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float iis2dh_from_fs2_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 1.0f;
+}
+
+float iis2dh_from_fs4_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) *  2.0f;
+}
+
+float iis2dh_from_fs8_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 4.0f;
+}
+
+float iis2dh_from_fs16_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 12.0f;
+}
+
+float iis2dh_from_lsb_hr_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 64.0f ) / 4.0f ) + 25.0f;
+}
+
+float iis2dh_from_fs2_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) *  4.0f;
+}
+
+float iis2dh_from_fs4_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) *  8.0f;
+}
+
+float iis2dh_from_fs8_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) * 16.0f;
+}
+
+float iis2dh_from_fs16_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) * 48.0f;
+}
+
+float iis2dh_from_lsb_nm_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 64.0f ) / 4.0f ) + 25.0f;
+}
+
+float iis2dh_from_fs2_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 16.0f;
+}
+
+float iis2dh_from_fs4_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 32.0f;
+}
+
+float iis2dh_from_fs8_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 64.0f;
+}
+
+float iis2dh_from_fs16_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 192.0f;
+}
+
+float iis2dh_from_lsb_lp_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 256.0f ) * 1.0f ) + 25.0f;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DH_Data_generation
+  * @brief     This section group all the functions concerning data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_temp_status_reg_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_STATUS_REG_AUX, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tda in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_temp_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_STATUS_REG_AUX,
+                        (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux.tda;
+
+  return ret;
+}
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tor in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_temp_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_STATUS_REG_AUX,
+                        (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux.tor;
+
+  return ret;
+}
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_temperature_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+/**
+  * @brief  Temperature sensor enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of temp_en in reg TEMP_CFG_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_temperature_meas_set(iis2dh_ctx_t *ctx, iis2dh_temp_en_t val)
+{
+  iis2dh_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  if (ret == 0) {
+    temp_cfg_reg.temp_en = (uint8_t) val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_TEMP_CFG_REG,
+                           (uint8_t*)&temp_cfg_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of temp_en in reg TEMP_CFG_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_temperature_meas_get(iis2dh_ctx_t *ctx, iis2dh_temp_en_t *val)
+{
+  iis2dh_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  switch (temp_cfg_reg.temp_en) {
+    case IIS2DH_TEMP_DISABLE:
+      *val = IIS2DH_TEMP_DISABLE;
+      break;
+    case IIS2DH_TEMP_ENABLE:
+      *val = IIS2DH_TEMP_ENABLE;
+      break;
+    default:
+      *val = IIS2DH_TEMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpen in reg CTRL_REG1
+  *                  and HR in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_operating_mode_set(iis2dh_ctx_t *ctx, iis2dh_op_md_t val)
+{
+  iis2dh_ctrl_reg1_t ctrl_reg1;
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  if (ret == 0) {
+    if ( val == IIS2DH_HR_12bit ) {
+      ctrl_reg1.lpen = 0;
+      ctrl_reg4.hr   = 1;
+    }
+    if (val == IIS2DH_NM_10bit) {
+      ctrl_reg1.lpen = 0;
+      ctrl_reg4.hr   = 0;
+    }
+    if (val == IIS2DH_LP_8bit) {
+      ctrl_reg1.lpen = 1;
+      ctrl_reg4.hr   = 0;
+    }
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  if (ret == 0) {
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpen in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_operating_mode_get(iis2dh_ctx_t *ctx, iis2dh_op_md_t *val)
+{
+  iis2dh_ctrl_reg1_t ctrl_reg1;
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+    if ( ctrl_reg1.lpen == PROPERTY_ENABLE ) {
+      *val = IIS2DH_LP_8bit;
+    } else if (ctrl_reg4.hr == PROPERTY_ENABLE ) {
+      *val = IIS2DH_HR_12bit;
+    } else {
+      *val = IIS2DH_NM_10bit;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_data_rate_set(iis2dh_ctx_t *ctx, iis2dh_odr_t val)
+{
+  iis2dh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ctrl_reg1.odr = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_data_rate_get(iis2dh_ctx_t *ctx, iis2dh_odr_t *val)
+{
+  iis2dh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.odr) {
+    case IIS2DH_POWER_DOWN:
+      *val = IIS2DH_POWER_DOWN;
+      break;
+    case IIS2DH_ODR_1Hz:
+      *val = IIS2DH_ODR_1Hz;
+      break;
+    case IIS2DH_ODR_10Hz:
+      *val = IIS2DH_ODR_10Hz;
+      break;
+    case IIS2DH_ODR_25Hz:
+      *val = IIS2DH_ODR_25Hz;
+      break;
+    case IIS2DH_ODR_50Hz:
+      *val = IIS2DH_ODR_50Hz;
+      break;
+    case IIS2DH_ODR_100Hz:
+      *val = IIS2DH_ODR_100Hz;
+      break;
+    case IIS2DH_ODR_200Hz:
+      *val = IIS2DH_ODR_200Hz;
+      break;
+    case IIS2DH_ODR_400Hz:
+      *val = IIS2DH_ODR_400Hz;
+      break;
+    case IIS2DH_ODR_1kHz620_LP:
+      *val = IIS2DH_ODR_1kHz620_LP;
+      break;
+    case IIS2DH_ODR_5kHz376_LP_1kHz344_NM_HP:
+      *val = IIS2DH_ODR_5kHz376_LP_1kHz344_NM_HP;
+      break;
+    default:
+      *val = IIS2DH_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_high_pass_on_outputs_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.fds = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_high_pass_on_outputs_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = (uint8_t)ctrl_reg2.fds;
+
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[set]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_high_pass_bandwidth_set(iis2dh_ctx_t *ctx, iis2dh_hpcf_t val)
+{
+  iis2dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[get]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_high_pass_bandwidth_get(iis2dh_ctx_t *ctx, iis2dh_hpcf_t *val)
+{
+  iis2dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpcf) {
+    case IIS2DH_AGGRESSIVE:
+      *val = IIS2DH_AGGRESSIVE;
+      break;
+    case IIS2DH_STRONG:
+      *val = IIS2DH_STRONG;
+      break;
+    case IIS2DH_MEDIUM:
+      *val = IIS2DH_MEDIUM;
+      break;
+    case IIS2DH_LIGHT:
+      *val = IIS2DH_LIGHT;
+      break;
+    default:
+      *val = IIS2DH_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_high_pass_mode_set(iis2dh_ctx_t *ctx, iis2dh_hpm_t val)
+{
+  iis2dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_high_pass_mode_get(iis2dh_ctx_t *ctx, iis2dh_hpm_t *val)
+{
+  iis2dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpm) {
+    case IIS2DH_NORMAL_WITH_RST:
+      *val = IIS2DH_NORMAL_WITH_RST;
+      break;
+    case IIS2DH_REFERENCE_MODE:
+      *val = IIS2DH_REFERENCE_MODE;
+      break;
+    case IIS2DH_NORMAL:
+      *val = IIS2DH_NORMAL;
+      break;
+    case IIS2DH_AUTORST_ON_INT:
+      *val = IIS2DH_AUTORST_ON_INT;
+      break;
+    default:
+      *val = IIS2DH_NORMAL_WITH_RST;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_full_scale_set(iis2dh_ctx_t *ctx, iis2dh_fs_t val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_full_scale_get(iis2dh_ctx_t *ctx, iis2dh_fs_t *val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.fs) {
+    case IIS2DH_2g:
+      *val = IIS2DH_2g;
+      break;
+    case IIS2DH_4g:
+      *val = IIS2DH_4g;
+      break;
+    case IIS2DH_8g:
+      *val = IIS2DH_8g;
+      break;
+    case IIS2DH_16g:
+      *val = IIS2DH_16g;
+      break;
+    default:
+      *val = IIS2DH_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_block_data_update_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_block_data_update_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = (uint8_t)ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[set]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_filter_reference_set(iis2dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dh_write_reg(ctx, IIS2DH_REFERENCE, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[get]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_filter_reference_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_REFERENCE, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_xl_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxor in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_xl_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxor;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_acceleration_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_OUT_X_L, buff, 6);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DH_Common
+  * @brief     This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI .[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_device_id_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_WHO_AM_I, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Self Test.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_self_test_set(iis2dh_ctx_t *ctx, iis2dh_st_t val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Self Test.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_self_test_get(iis2dh_ctx_t *ctx, iis2dh_st_t *val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.st) {
+    case IIS2DH_ST_DISABLE:
+      *val = IIS2DH_ST_DISABLE;
+      break;
+    case IIS2DH_ST_POSITIVE:
+      *val = IIS2DH_ST_POSITIVE;
+      break;
+    case IIS2DH_ST_NEGATIVE:
+      *val = IIS2DH_ST_NEGATIVE;
+      break;
+    default:
+      *val = IIS2DH_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ble in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_data_format_set(iis2dh_ctx_t *ctx, iis2dh_ble_t val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of ble in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_data_format_get(iis2dh_ctx_t *ctx, iis2dh_ble_t *val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.ble) {
+    case IIS2DH_LSB_AT_LOW_ADD:
+      *val = IIS2DH_LSB_AT_LOW_ADD;
+      break;
+    case IIS2DH_MSB_AT_LOW_ADD:
+      *val = IIS2DH_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = IIS2DH_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_boot_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.boot = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_boot_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  count the interrupt occurrencies.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT_COUNTER_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int_occurrencies_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT_COUNTER_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_status_get(iis2dh_ctx_t *ctx, iis2dh_status_reg_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2DH_Interrupts_generator_1
+  * @brief      This section group all the functions that manage the first
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_write_reg(ctx, IIS2DH_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Registers INT1_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int1_src_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[set]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if (ret == 0) {
+    int1_ths.ths = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = (uint8_t)int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT1_DURATION,
+                        (uint8_t*)&int1_duration, 1);
+  if (ret == 0) {
+    int1_duration.d = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT1_DURATION,
+                        (uint8_t*)&int1_duration, 1);
+  *val = (uint8_t)int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2DH_Interrupts_generator_2
+  * @brief      This section group all the functions that manage the second
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_write_reg(ctx, IIS2DH_INT2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Interrupt generator 2 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int2_src_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief   User-defined threshold value for xl interrupt event on
+  *          generator 2.[set]
+  *          LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if (ret == 0) {
+    int2_ths.ths = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 2.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = (uint8_t)int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized .[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT2_DURATION,
+                        (uint8_t*)&int2_duration, 1);
+  if (ret == 0) {
+    int2_duration.d = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_INT2_DURATION,
+                        (uint8_t*)&int2_duration, 1);
+  *val = (uint8_t)int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DH_Interrupt_pins
+  * @brief     This section group all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_high_pass_int_conf_set(iis2dh_ctx_t *ctx, iis2dh_hp_t val)
+{
+  iis2dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hp = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_high_pass_int_conf_get(iis2dh_ctx_t *ctx, iis2dh_hp_t *val)
+{
+  iis2dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hp) {
+    case IIS2DH_DISC_FROM_INT_GENERATOR:
+      *val = IIS2DH_DISC_FROM_INT_GENERATOR;
+      break;
+    case IIS2DH_ON_INT1_GEN:
+      *val = IIS2DH_ON_INT1_GEN;
+      break;
+    case IIS2DH_ON_INT2_GEN:
+      *val = IIS2DH_ON_INT2_GEN;
+      break;
+    case IIS2DH_ON_TAP_GEN:
+      *val = IIS2DH_ON_TAP_GEN;
+      break;
+    case IIS2DH_ON_INT1_INT2_GEN:
+      *val = IIS2DH_ON_INT1_INT2_GEN;
+      break;
+    case IIS2DH_ON_INT1_TAP_GEN:
+      *val = IIS2DH_ON_INT1_TAP_GEN;
+      break;
+    case IIS2DH_ON_INT2_TAP_GEN:
+      *val = IIS2DH_ON_INT2_TAP_GEN;
+      break;
+    case IIS2DH_ON_INT1_INT2_TAP_GEN:
+      *val = IIS2DH_ON_INT1_INT2_TAP_GEN;
+      break;
+    default:
+      *val = IIS2DH_DISC_FROM_INT_GENERATOR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_pin_int1_config_set(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_pin_int1_config_get(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  int2_pin_detect_4d: [set]  4D enable: 4D detection is enabled
+  *                                    on INT2 pin when 6D bit on
+  *                                    INT2_CFG (34h) is set to 1.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_int2 = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT2 pin when 6D bit on
+  *         INT2_CFG (34h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_int2;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_pin_notification_mode_set(iis2dh_ctx_t *ctx,
+                                              iis2dh_lir_int2_t val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_int2 = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int2_pin_notification_mode_get(iis2dh_ctx_t *ctx,
+                                              iis2dh_lir_int2_t *val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_int2) {
+    case IIS2DH_INT2_PULSED:
+      *val = IIS2DH_INT2_PULSED;
+      break;
+    case IIS2DH_INT2_LATCHED:
+      *val = IIS2DH_INT2_LATCHED;
+      break;
+    default:
+      *val = IIS2DH_INT2_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit
+  *                    on INT1_CFG(30h) is set to 1.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_int1 = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit on
+  *         INT1_CFG(30h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_int1;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_pin_notification_mode_set(iis2dh_ctx_t *ctx,
+                                              iis2dh_lir_int1_t val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_int1 = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_int1_pin_notification_mode_get(iis2dh_ctx_t *ctx,
+                                              iis2dh_lir_int1_t *val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_int1) {
+    case IIS2DH_INT1_PULSED:
+      *val = IIS2DH_INT1_PULSED;
+      break;
+    case IIS2DH_INT1_LATCHED:
+      *val = IIS2DH_INT1_LATCHED;
+      break;
+    default:
+      *val = IIS2DH_INT1_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_pin_int2_config_set(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_pin_int2_config_get(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DH_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.fifo_en = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_watermark_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                        (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fth = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                           (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_watermark_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                        (uint8_t*)&fifo_ctrl_reg, 1);
+  *val = (uint8_t)fifo_ctrl_reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_trigger_event_set(iis2dh_ctx_t *ctx, iis2dh_tr_t val)
+{
+  iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                        (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.tr = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                           (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_trigger_event_get(iis2dh_ctx_t *ctx, iis2dh_tr_t *val)
+{
+  iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                        (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.tr) {
+    case IIS2DH_INT1_GEN:
+      *val = IIS2DH_INT1_GEN;
+      break;
+    case IIS2DH_INT2_GEN:
+      *val = IIS2DH_INT2_GEN;
+      break;
+    default:
+      *val = IIS2DH_INT1_GEN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_mode_set(iis2dh_ctx_t *ctx, iis2dh_fm_t val)
+{
+  iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                        (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fm = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                           (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_mode_get(iis2dh_ctx_t *ctx, iis2dh_fm_t *val)
+{
+  iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_CTRL_REG,
+                        (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.fm) {
+    case IIS2DH_BYPASS_MODE:
+      *val = IIS2DH_BYPASS_MODE;
+      break;
+    case IIS2DH_FIFO_MODE:
+      *val = IIS2DH_FIFO_MODE;
+      break;
+    case IIS2DH_DYNAMIC_STREAM_MODE:
+      *val = IIS2DH_DYNAMIC_STREAM_MODE;
+      break;
+    case IIS2DH_STREAM_TO_FIFO_MODE:
+      *val = IIS2DH_STREAM_TO_FIFO_MODE;
+      break;
+    default:
+      *val = IIS2DH_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_status_get(iis2dh_ctx_t *ctx, iis2dh_fifo_src_reg_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_SRC_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fss in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_data_level_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.fss;
+
+  return ret;
+}
+/**
+  * @brief  Empty FIFO status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of empty in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_empty_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.empty;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ovrn_fifo in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_ovr_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.ovrn_fifo;
+
+  return ret;
+}
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_fifo_fth_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.wtm;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DH_Tap_generator
+  * @brief     This section group all the functions that manage the tap and
+  *            double tap event generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_tap_conf_set(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_write_reg(ctx, IIS2DH_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_tap_conf_get(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Tap/Double Tap generator source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_tap_source_get(iis2dh_ctx_t *ctx, iis2dh_click_src_t *val)
+{
+  int32_t ret;
+  ret = iis2dh_read_reg(ctx, IIS2DH_CLICK_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[set]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_tap_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.ths = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[get]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_tap_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  *val = (uint8_t)click_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse
+  *         between the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_shock_dur_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  if (ret == 0) {
+    time_limit.tli = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse between
+  *         the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_shock_dur_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  *val = (uint8_t)time_limit.tli;
+
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_quiet_dur_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  if (ret == 0) {
+    time_latency.tla = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_TIME_LATENCY,
+                           (uint8_t*)&time_latency, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_quiet_dur_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  *val = (uint8_t)time_latency.tla;
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the click-detection
+  *         procedure can start, in cases where the device is configured
+  *         for double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_double_tap_timeout_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_time_window_t time_window;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  if (ret == 0) {
+    time_window.tw = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the
+  *         click-detection procedure can start, in cases where the device
+  *         is configured for double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_double_tap_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_time_window_t time_window;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  *val = (uint8_t)time_window.tw;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DH_Activity_inactivity
+  * @brief     This section group all the functions concerning activity
+  *            inactivity functionality
+  * @{
+  *
+  */
+
+/**
+  * @brief    Sleep-to-wake, return-to-sleep activation threshold in
+  *           low-power mode.[set]
+  *           1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_act_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_ACT_THS, (uint8_t*)&act_ths, 1);
+  if (ret == 0) {
+    act_ths.acth = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_ACT_THS, (uint8_t*)&act_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep activation threshold in low-power
+  *         mode.[get]
+  *         1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_act_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_ACT_THS, (uint8_t*)&act_ths, 1);
+  *val = (uint8_t)act_ths.acth;
+
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[set]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_act_timeout_set(iis2dh_ctx_t *ctx, uint8_t val)
+{
+  iis2dh_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_ACT_DUR, (uint8_t*)&act_dur, 1);
+  if (ret == 0) {
+    act_dur.actd = val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_ACT_DUR, (uint8_t*)&act_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[get]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_act_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val)
+{
+  iis2dh_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_ACT_DUR, (uint8_t*)&act_dur, 1);
+  *val = (uint8_t)act_dur.actd;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DH_Serial_interface
+  * @brief     This section group all the functions concerning serial
+  *            interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_spi_mode_set(iis2dh_ctx_t *ctx, iis2dh_sim_t val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dh_spi_mode_get(iis2dh_ctx_t *ctx, iis2dh_sim_t *val)
+{
+  iis2dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.sim) {
+    case IIS2DH_SPI_4_WIRE:
+      *val = IIS2DH_SPI_4_WIRE;
+      break;
+    case IIS2DH_SPI_3_WIRE:
+      *val = IIS2DH_SPI_3_WIRE;
+      break;
+    default:
+      *val = IIS2DH_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis2dh_STdC/driver/iis2dh_reg.h
+++ b/sensor/stmemsc/iis2dh_STdC/driver/iis2dh_reg.h
@@ -1,0 +1,741 @@
+/*
+ ******************************************************************************
+ * @file    iis2dh_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          iis2dh_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef IIS2DH_REGS_H
+#define IIS2DH_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup IIS2DH
+  * @{
+  *
+  */
+
+/** @defgroup IIS2DH_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup LIS3MDL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*iis2dh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*iis2dh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  iis2dh_write_ptr  write_reg;
+  iis2dh_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} iis2dh_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup IIS2DH_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define IIS2DH_I2C_ADD_L   0x31U
+#define IIS2DH_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define IIS2DH_ID          0x33U
+
+/**
+  * @}
+  *
+  */
+
+#define IIS2DH_STATUS_REG_AUX        0x07U
+typedef struct {
+  uint8_t not_used_01       : 2;
+  uint8_t tda               : 1;
+  uint8_t not_used_02       : 3;
+  uint8_t tor               : 1;
+  uint8_t not_used_03       : 1;
+} iis2dh_status_reg_aux_t;
+
+#define IIS2DH_OUT_TEMP_L            0x0CU
+#define IIS2DH_OUT_TEMP_H            0x0DU
+#define IIS2DH_INT_COUNTER_REG       0x0EU
+#define IIS2DH_WHO_AM_I              0x0FU
+
+#define IIS2DH_TEMP_CFG_REG          0x1FU
+typedef struct {
+  uint8_t not_used_01       : 6;
+  uint8_t temp_en           : 2;
+} iis2dh_temp_cfg_reg_t;
+
+#define IIS2DH_CTRL_REG1             0x20U
+typedef struct {
+  uint8_t xen               : 1;
+  uint8_t yen               : 1;
+  uint8_t zen               : 1;
+  uint8_t lpen              : 1;
+  uint8_t odr               : 4;
+} iis2dh_ctrl_reg1_t;
+
+#define IIS2DH_CTRL_REG2             0x21U
+typedef struct {
+  uint8_t hp                : 3; /* HPCLICK + HPIS2 + HPIS1 -> HP */
+  uint8_t fds               : 1;
+  uint8_t hpcf              : 2;
+  uint8_t hpm               : 2;
+} iis2dh_ctrl_reg2_t;
+
+#define IIS2DH_CTRL_REG3             0x22U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t i1_overrun        : 1;
+  uint8_t i1_wtm            : 1;
+  uint8_t i1_drdy2          : 1;
+  uint8_t i1_drdy1          : 1;
+  uint8_t i1_aoi2           : 1;
+  uint8_t i1_aoi1           : 1;
+  uint8_t i1_click          : 1;
+} iis2dh_ctrl_reg3_t;
+
+#define IIS2DH_CTRL_REG4             0x23U
+typedef struct {
+  uint8_t sim               : 1;
+  uint8_t st                : 2;
+  uint8_t hr                : 1;
+  uint8_t fs                : 2;
+  uint8_t ble               : 1;
+  uint8_t bdu               : 1;
+} iis2dh_ctrl_reg4_t;
+
+#define IIS2DH_CTRL_REG5             0x24U
+typedef struct {
+  uint8_t d4d_int2          : 1;
+  uint8_t lir_int2          : 1;
+  uint8_t d4d_int1          : 1;
+  uint8_t lir_int1          : 1;
+  uint8_t not_used_01       : 2;
+  uint8_t fifo_en           : 1;
+  uint8_t boot              : 1;
+} iis2dh_ctrl_reg5_t;
+
+#define IIS2DH_CTRL_REG6            0x25U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t h_lactive         : 1;
+  uint8_t not_used_02       : 1;
+  uint8_t p2_act            : 1;
+  uint8_t boot_i2           : 1;
+  uint8_t i2_int2           : 1;
+  uint8_t i2_int1           : 1;
+  uint8_t i2_clicken        : 1;
+} iis2dh_ctrl_reg6_t;
+
+#define IIS2DH_REFERENCE            0x26U
+#define IIS2DH_STATUS_REG           0x27U
+typedef struct {
+  uint8_t xda               : 1;
+  uint8_t yda               : 1;
+  uint8_t zda               : 1;
+  uint8_t zyxda             : 1;
+  uint8_t _xor              : 1;
+  uint8_t yor               : 1;
+  uint8_t zor               : 1;
+  uint8_t zyxor             : 1;
+} iis2dh_status_reg_t;
+
+#define IIS2DH_OUT_X_L              0x28U
+#define IIS2DH_OUT_X_H              0x29U
+#define IIS2DH_OUT_Y_L              0x2AU
+#define IIS2DH_OUT_Y_H              0x2BU
+#define IIS2DH_OUT_Z_L              0x2CU
+#define IIS2DH_OUT_Z_H              0x2DU
+#define IIS2DH_FIFO_CTRL_REG        0x2EU
+typedef struct {
+  uint8_t fth               : 5;
+  uint8_t tr                : 1;
+  uint8_t fm                : 2;
+} iis2dh_fifo_ctrl_reg_t;
+
+#define IIS2DH_FIFO_SRC_REG         0x2FU
+typedef struct {
+  uint8_t fss               : 5;
+  uint8_t empty             : 1;
+  uint8_t ovrn_fifo         : 1;
+  uint8_t wtm               : 1;
+} iis2dh_fifo_src_reg_t;
+
+#define IIS2DH_INT1_CFG             0x30U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} iis2dh_int1_cfg_t;
+
+#define IIS2DH_INT1_SRC             0x31U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} iis2dh_int1_src_t;
+
+#define IIS2DH_INT1_THS             0x32U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} iis2dh_int1_ths_t;
+
+#define IIS2DH_INT1_DURATION        0x33U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} iis2dh_int1_duration_t;
+
+#define IIS2DH_INT2_CFG             0x34U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} iis2dh_int2_cfg_t;
+
+#define IIS2DH_INT2_SRC             0x35U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} iis2dh_int2_src_t;
+
+#define IIS2DH_INT2_THS             0x36U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} iis2dh_int2_ths_t;
+
+#define IIS2DH_INT2_DURATION        0x37U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} iis2dh_int2_duration_t;
+
+#define IIS2DH_CLICK_CFG            0x38U
+typedef struct {
+  uint8_t xs                : 1;
+  uint8_t xd                : 1;
+  uint8_t ys                : 1;
+  uint8_t yd                : 1;
+  uint8_t zs                : 1;
+  uint8_t zd                : 1;
+  uint8_t not_used_01       : 2;
+} iis2dh_click_cfg_t;
+
+#define IIS2DH_CLICK_SRC            0x39U
+typedef struct {
+  uint8_t x                 : 1;
+  uint8_t y                 : 1;
+  uint8_t z                 : 1;
+  uint8_t sign              : 1;
+  uint8_t sclick            : 1;
+  uint8_t dclick            : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} iis2dh_click_src_t;
+
+#define IIS2DH_CLICK_THS            0x3AU
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} iis2dh_click_ths_t;
+
+#define IIS2DH_TIME_LIMIT           0x3BU
+typedef struct {
+  uint8_t tli               : 7;
+  uint8_t not_used_01       : 1;
+} iis2dh_time_limit_t;
+
+#define IIS2DH_TIME_LATENCY         0x3CU
+typedef struct {
+  uint8_t tla               : 8;
+} iis2dh_time_latency_t;
+
+#define IIS2DH_TIME_WINDOW          0x3DU
+typedef struct {
+  uint8_t tw                : 8;
+} iis2dh_time_window_t;
+
+#define IIS2DH_ACT_THS              0x3EU
+typedef struct {
+  uint8_t acth              : 7;
+  uint8_t not_used_01       : 1;
+} iis2dh_act_ths_t;
+
+#define IIS2DH_ACT_DUR              0x3FU
+typedef struct {
+  uint8_t actd              : 8;
+} iis2dh_act_dur_t;
+
+/**
+  * @defgroup IIS2DH_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is usefull but not need by the driver.
+  *
+  *           REMOVING this union you are complient with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  iis2dh_status_reg_aux_t status_reg_aux;
+  iis2dh_temp_cfg_reg_t   temp_cfg_reg;
+  iis2dh_ctrl_reg1_t      ctrl_reg1;
+  iis2dh_ctrl_reg2_t      ctrl_reg2;
+  iis2dh_ctrl_reg3_t      ctrl_reg3;
+  iis2dh_ctrl_reg4_t      ctrl_reg4;
+  iis2dh_ctrl_reg5_t      ctrl_reg5;
+  iis2dh_ctrl_reg6_t      ctrl_reg6;
+  iis2dh_status_reg_t     status_reg;
+  iis2dh_fifo_ctrl_reg_t  fifo_ctrl_reg;
+  iis2dh_fifo_src_reg_t   fifo_src_reg;
+  iis2dh_int1_cfg_t       int1_cfg;
+  iis2dh_int1_src_t       int1_src;
+  iis2dh_int1_ths_t       int1_ths;
+  iis2dh_int1_duration_t  int1_duration;
+  iis2dh_int2_cfg_t       int2_cfg;
+  iis2dh_int2_src_t       int2_src;
+  iis2dh_int2_ths_t       int2_ths;
+  iis2dh_int2_duration_t  int2_duration;
+  iis2dh_click_cfg_t      click_cfg;
+  iis2dh_click_src_t      click_src;
+  iis2dh_click_ths_t      click_ths;
+  iis2dh_time_limit_t     time_limit;
+  iis2dh_time_latency_t   time_latency;
+  iis2dh_time_window_t    time_window;
+  iis2dh_act_ths_t        act_ths;
+  iis2dh_act_dur_t        act_dur;
+  bitwise_t                 bitwise;
+  uint8_t                   byte;
+} iis2dh_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t iis2dh_read_reg(iis2dh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                        uint16_t len);
+int32_t iis2dh_write_reg(iis2dh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+
+extern float iis2dh_from_fs2_hr_to_mg(int16_t lsb);
+extern float iis2dh_from_fs4_hr_to_mg(int16_t lsb);
+extern float iis2dh_from_fs8_hr_to_mg(int16_t lsb);
+extern float iis2dh_from_fs16_hr_to_mg(int16_t lsb);
+extern float iis2dh_from_lsb_hr_to_celsius(int16_t lsb);
+
+extern float iis2dh_from_fs2_nm_to_mg(int16_t lsb);
+extern float iis2dh_from_fs4_nm_to_mg(int16_t lsb);
+extern float iis2dh_from_fs8_nm_to_mg(int16_t lsb);
+extern float iis2dh_from_fs16_nm_to_mg(int16_t lsb);
+extern float iis2dh_from_lsb_nm_to_celsius(int16_t lsb);
+
+extern float iis2dh_from_fs2_lp_to_mg(int16_t lsb);
+extern float iis2dh_from_fs4_lp_to_mg(int16_t lsb);
+extern float iis2dh_from_fs8_lp_to_mg(int16_t lsb);
+extern float iis2dh_from_fs16_lp_to_mg(int16_t lsb);
+extern float iis2dh_from_lsb_lp_to_celsius(int16_t lsb);
+
+int32_t iis2dh_temp_status_reg_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dh_temp_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_temp_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_temperature_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  IIS2DH_TEMP_DISABLE  = 0,
+  IIS2DH_TEMP_ENABLE   = 3,
+} iis2dh_temp_en_t;
+int32_t iis2dh_temperature_meas_set(iis2dh_ctx_t *ctx, iis2dh_temp_en_t val);
+int32_t iis2dh_temperature_meas_get(iis2dh_ctx_t *ctx, iis2dh_temp_en_t *val);
+
+typedef enum {
+  IIS2DH_HR_12bit   = 0,
+  IIS2DH_NM_10bit   = 1,
+  IIS2DH_LP_8bit    = 2,
+} iis2dh_op_md_t;
+int32_t iis2dh_operating_mode_set(iis2dh_ctx_t *ctx, iis2dh_op_md_t val);
+int32_t iis2dh_operating_mode_get(iis2dh_ctx_t *ctx, iis2dh_op_md_t *val);
+
+typedef enum {
+  IIS2DH_POWER_DOWN                      = 0x00,
+  IIS2DH_ODR_1Hz                         = 0x01,
+  IIS2DH_ODR_10Hz                        = 0x02,
+  IIS2DH_ODR_25Hz                        = 0x03,
+  IIS2DH_ODR_50Hz                        = 0x04,
+  IIS2DH_ODR_100Hz                       = 0x05,
+  IIS2DH_ODR_200Hz                       = 0x06,
+  IIS2DH_ODR_400Hz                       = 0x07,
+  IIS2DH_ODR_1kHz620_LP                  = 0x08,
+  IIS2DH_ODR_5kHz376_LP_1kHz344_NM_HP    = 0x09,
+} iis2dh_odr_t;
+int32_t iis2dh_data_rate_set(iis2dh_ctx_t *ctx, iis2dh_odr_t val);
+int32_t iis2dh_data_rate_get(iis2dh_ctx_t *ctx, iis2dh_odr_t *val);
+
+int32_t iis2dh_high_pass_on_outputs_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_high_pass_on_outputs_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DH_AGGRESSIVE  = 0,
+  IIS2DH_STRONG      = 1,
+  IIS2DH_MEDIUM      = 2,
+  IIS2DH_LIGHT       = 3,
+} iis2dh_hpcf_t;
+int32_t iis2dh_high_pass_bandwidth_set(iis2dh_ctx_t *ctx, iis2dh_hpcf_t val);
+int32_t iis2dh_high_pass_bandwidth_get(iis2dh_ctx_t *ctx, iis2dh_hpcf_t *val);
+
+typedef enum {
+  IIS2DH_NORMAL_WITH_RST  = 0,
+  IIS2DH_REFERENCE_MODE   = 1,
+  IIS2DH_NORMAL           = 2,
+  IIS2DH_AUTORST_ON_INT   = 3,
+} iis2dh_hpm_t;
+int32_t iis2dh_high_pass_mode_set(iis2dh_ctx_t *ctx, iis2dh_hpm_t val);
+int32_t iis2dh_high_pass_mode_get(iis2dh_ctx_t *ctx, iis2dh_hpm_t *val);
+
+typedef enum {
+  IIS2DH_2g   = 0,
+  IIS2DH_4g   = 1,
+  IIS2DH_8g   = 2,
+  IIS2DH_16g  = 3,
+} iis2dh_fs_t;
+int32_t iis2dh_full_scale_set(iis2dh_ctx_t *ctx, iis2dh_fs_t val);
+int32_t iis2dh_full_scale_get(iis2dh_ctx_t *ctx, iis2dh_fs_t *val);
+
+int32_t iis2dh_block_data_update_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_block_data_update_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_filter_reference_set(iis2dh_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dh_filter_reference_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2dh_xl_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_xl_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_acceleration_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2dh_device_id_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  IIS2DH_ST_DISABLE   = 0,
+  IIS2DH_ST_POSITIVE  = 1,
+  IIS2DH_ST_NEGATIVE  = 2,
+} iis2dh_st_t;
+int32_t iis2dh_self_test_set(iis2dh_ctx_t *ctx, iis2dh_st_t val);
+int32_t iis2dh_self_test_get(iis2dh_ctx_t *ctx, iis2dh_st_t *val);
+
+typedef enum {
+  IIS2DH_LSB_AT_LOW_ADD = 0,
+  IIS2DH_MSB_AT_LOW_ADD = 1,
+} iis2dh_ble_t;
+int32_t iis2dh_data_format_set(iis2dh_ctx_t *ctx, iis2dh_ble_t val);
+int32_t iis2dh_data_format_get(iis2dh_ctx_t *ctx, iis2dh_ble_t *val);
+
+int32_t iis2dh_boot_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_boot_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_int_occurrencies_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_status_get(iis2dh_ctx_t *ctx, iis2dh_status_reg_t *val);
+
+int32_t iis2dh_int1_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val);
+int32_t iis2dh_int1_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val);
+
+int32_t iis2dh_int1_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int1_src_t *val);
+
+int32_t iis2dh_int1_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int1_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_int1_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int1_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_int2_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val);
+int32_t iis2dh_int2_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val);
+
+int32_t iis2dh_int2_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int2_src_t *val);
+
+int32_t iis2dh_int2_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int2_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_int2_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int2_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DH_DISC_FROM_INT_GENERATOR  = 0,
+  IIS2DH_ON_INT1_GEN              = 1,
+  IIS2DH_ON_INT2_GEN              = 2,
+  IIS2DH_ON_TAP_GEN               = 4,
+  IIS2DH_ON_INT1_INT2_GEN         = 3,
+  IIS2DH_ON_INT1_TAP_GEN          = 5,
+  IIS2DH_ON_INT2_TAP_GEN          = 6,
+  IIS2DH_ON_INT1_INT2_TAP_GEN     = 7,
+} iis2dh_hp_t;
+int32_t iis2dh_high_pass_int_conf_set(iis2dh_ctx_t *ctx, iis2dh_hp_t val);
+int32_t iis2dh_high_pass_int_conf_get(iis2dh_ctx_t *ctx, iis2dh_hp_t *val);
+
+int32_t iis2dh_pin_int1_config_set(iis2dh_ctx_t *ctx,
+                                   iis2dh_ctrl_reg3_t *val);
+int32_t iis2dh_pin_int1_config_get(iis2dh_ctx_t *ctx,
+                                   iis2dh_ctrl_reg3_t *val);
+
+int32_t iis2dh_int2_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int2_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DH_INT2_PULSED   = 0,
+  IIS2DH_INT2_LATCHED  = 1,
+} iis2dh_lir_int2_t;
+int32_t iis2dh_int2_pin_notification_mode_set(iis2dh_ctx_t *ctx,
+                                              iis2dh_lir_int2_t val);
+int32_t iis2dh_int2_pin_notification_mode_get(iis2dh_ctx_t *ctx,
+                                              iis2dh_lir_int2_t *val);
+
+int32_t iis2dh_int1_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int1_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DH_INT1_PULSED   = 0,
+  IIS2DH_INT1_LATCHED  = 1,
+} iis2dh_lir_int1_t;
+int32_t iis2dh_int1_pin_notification_mode_set(iis2dh_ctx_t *ctx,
+                                              iis2dh_lir_int1_t val);
+int32_t iis2dh_int1_pin_notification_mode_get(iis2dh_ctx_t *ctx,
+                                              iis2dh_lir_int1_t *val);
+
+int32_t iis2dh_pin_int2_config_set(iis2dh_ctx_t *ctx,
+                                   iis2dh_ctrl_reg6_t *val);
+int32_t iis2dh_pin_int2_config_get(iis2dh_ctx_t *ctx,
+                                   iis2dh_ctrl_reg6_t *val);
+
+int32_t iis2dh_fifo_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_fifo_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_fifo_watermark_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_fifo_watermark_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DH_INT1_GEN = 0,
+  IIS2DH_INT2_GEN = 1,
+} iis2dh_tr_t;
+int32_t iis2dh_fifo_trigger_event_set(iis2dh_ctx_t *ctx, iis2dh_tr_t val);
+int32_t iis2dh_fifo_trigger_event_get(iis2dh_ctx_t *ctx, iis2dh_tr_t *val);
+
+typedef enum {
+  IIS2DH_BYPASS_MODE           = 0,
+  IIS2DH_FIFO_MODE             = 1,
+  IIS2DH_DYNAMIC_STREAM_MODE   = 2,
+  IIS2DH_STREAM_TO_FIFO_MODE   = 3,
+} iis2dh_fm_t;
+int32_t iis2dh_fifo_mode_set(iis2dh_ctx_t *ctx, iis2dh_fm_t val);
+int32_t iis2dh_fifo_mode_get(iis2dh_ctx_t *ctx, iis2dh_fm_t *val);
+
+int32_t iis2dh_fifo_status_get(iis2dh_ctx_t *ctx,
+                                 iis2dh_fifo_src_reg_t *val);
+
+int32_t iis2dh_fifo_data_level_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_fifo_empty_flag_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_fifo_ovr_flag_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_fifo_fth_flag_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_tap_conf_set(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val);
+int32_t iis2dh_tap_conf_get(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val);
+
+int32_t iis2dh_tap_source_get(iis2dh_ctx_t *ctx, iis2dh_click_src_t *val);
+
+int32_t iis2dh_tap_threshold_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_tap_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DH_TAP_PULSED   = 0,
+  IIS2DH_TAP_LATCHED  = 1,
+} iis2dh_lir_click_t;
+int32_t iis2dh_tap_notification_mode_set(iis2dh_ctx_t *ctx,
+                                         iis2dh_lir_click_t val);
+int32_t iis2dh_tap_notification_mode_get(iis2dh_ctx_t *ctx,
+                                         iis2dh_lir_click_t *val);
+
+int32_t iis2dh_shock_dur_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_shock_dur_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_quiet_dur_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_quiet_dur_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_double_tap_timeout_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_double_tap_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_act_threshold_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_act_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dh_act_timeout_set(iis2dh_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_act_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DH_PULL_UP_DISCONNECT  = 0,
+  IIS2DH_PULL_UP_CONNECT     = 1,
+} iis2dh_sdo_pu_disc_t;
+int32_t iis2dh_pin_sdo_sa0_mode_set(iis2dh_ctx_t *ctx,
+                                    iis2dh_sdo_pu_disc_t val);
+int32_t iis2dh_pin_sdo_sa0_mode_get(iis2dh_ctx_t *ctx,
+                                    iis2dh_sdo_pu_disc_t *val);
+
+typedef enum {
+  IIS2DH_SPI_4_WIRE = 0,
+  IIS2DH_SPI_3_WIRE = 1,
+} iis2dh_sim_t;
+int32_t iis2dh_spi_mode_set(iis2dh_ctx_t *ctx, iis2dh_sim_t val);
+int32_t iis2dh_spi_mode_get(iis2dh_ctx_t *ctx, iis2dh_sim_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IIS2DH_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis2dlpc_STdC/driver/iis2dlpc_reg.c
+++ b/sensor/stmemsc/iis2dlpc_STdC/driver/iis2dlpc_reg.c
@@ -1,0 +1,2918 @@
+/*
+ ******************************************************************************
+ * @file    iis2dlpc_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   IIS2DLPC driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "iis2dlpc_reg.h"
+
+/**
+  * @defgroup  IIS2DLPC
+  * @brief     This file provides a set of functions needed to drive the
+  *            iis2dlpc enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_read_reg(iis2dlpc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_write_reg(iis2dlpc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    IIS2DLPC_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t iis2dlpc_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t iis2dlpc_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t iis2dlpc_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t iis2dlpc_from_fs16_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) *0.488f;
+}
+
+float_t iis2dlpc_from_fs2_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t iis2dlpc_from_fs4_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t iis2dlpc_from_fs8_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t iis2dlpc_from_fs16_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.488f;
+}
+
+float_t iis2dlpc_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 16.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Data_Generation
+  * @brief     This section groups all the functions concerning
+  *            data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select accelerometer operating modes.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mode / lp_mode in reg CTRL1
+  *                  and low_noise in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_power_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t val)
+{
+  iis2dlpc_ctrl1_t ctrl1;
+  iis2dlpc_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ctrl1.mode = ( (uint8_t) val & 0x0CU ) >> 2;
+    ctrl1.lp_mode = (uint8_t) val & 0x03U ;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL1,(uint8_t*) &ctrl1, 1);
+  }
+  if (ret == 0) {
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
+  }
+  if (ret == 0) {
+    ctrl6.low_noise = ( (uint8_t) val & 0x10U ) >> 4;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
+  } else {
+    ret = ret;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select accelerometer operating modes.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mode / lp_mode in reg CTRL1
+  *                  and low_noise in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_power_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t *val)
+{
+  iis2dlpc_ctrl1_t ctrl1;
+  iis2dlpc_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
+
+    switch (((ctrl6.low_noise << 4) + (ctrl1.mode << 2) +
+            ctrl1.lp_mode)) {
+      case IIS2DLPC_HIGH_PERFORMANCE:
+        *val = IIS2DLPC_HIGH_PERFORMANCE;
+        break;
+      case IIS2DLPC_CONT_LOW_PWR_4:
+        *val = IIS2DLPC_CONT_LOW_PWR_4;
+        break;
+      case IIS2DLPC_CONT_LOW_PWR_3:
+        *val = IIS2DLPC_CONT_LOW_PWR_3;
+        break;
+      case IIS2DLPC_CONT_LOW_PWR_2:
+        *val = IIS2DLPC_CONT_LOW_PWR_2;
+        break;
+      case IIS2DLPC_CONT_LOW_PWR_12bit:
+        *val = IIS2DLPC_CONT_LOW_PWR_12bit;
+        break;
+      case IIS2DLPC_SINGLE_LOW_PWR_4:
+        *val = IIS2DLPC_SINGLE_LOW_PWR_4;
+        break;
+      case IIS2DLPC_SINGLE_LOW_PWR_3:
+        *val = IIS2DLPC_SINGLE_LOW_PWR_3;
+        break;
+      case IIS2DLPC_SINGLE_LOW_PWR_2:
+        *val = IIS2DLPC_SINGLE_LOW_PWR_2;
+        break;
+      case IIS2DLPC_SINGLE_LOW_PWR_12bit:
+        *val = IIS2DLPC_SINGLE_LOW_PWR_12bit;
+        break;
+      case IIS2DLPC_HIGH_PERFORMANCE_LOW_NOISE:
+        *val = IIS2DLPC_HIGH_PERFORMANCE_LOW_NOISE;
+        break;
+      case IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_4:
+        *val = IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_4;
+        break;
+      case IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_3:
+        *val = IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_3;
+        break;
+      case IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_2:
+        *val = IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_2;
+        break;
+      case IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_12bit:
+        *val = IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_12bit;
+        break;
+      case IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_4:
+        *val = IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_4;
+        break;
+      case IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_3:
+        *val = IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_3;
+        break;
+      case IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_2:
+        *val = IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_2;
+        break;
+      case IIS2DLPC_SINGLE_LOW_LOW_NOISE_PWR_12bit:
+        *val = IIS2DLPC_SINGLE_LOW_LOW_NOISE_PWR_12bit;
+        break;
+      default:
+        *val = IIS2DLPC_HIGH_PERFORMANCE;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_data_rate_set(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t val)
+{
+  iis2dlpc_ctrl1_t ctrl1;
+  iis2dlpc_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ctrl1.odr = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL1,(uint8_t*) &ctrl1, 1);
+  }
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &ctrl3, 1);
+  }
+  if (ret == 0) {
+    ctrl3.slp_mode = ( (uint8_t) val & 0x30U ) >> 4;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &ctrl3, 1);
+  } else {
+    ret = ret;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr in reg CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_data_rate_get(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t *val)
+{
+  iis2dlpc_ctrl1_t ctrl1;
+  iis2dlpc_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &ctrl3, 1);
+
+    switch ((ctrl3.slp_mode << 4) + ctrl1.odr) {
+      case IIS2DLPC_XL_ODR_OFF:
+        *val = IIS2DLPC_XL_ODR_OFF;
+        break;
+      case IIS2DLPC_XL_ODR_1Hz6_LP_ONLY:
+        *val = IIS2DLPC_XL_ODR_1Hz6_LP_ONLY;
+        break;
+      case IIS2DLPC_XL_ODR_12Hz5:
+        *val = IIS2DLPC_XL_ODR_12Hz5;
+        break;
+      case IIS2DLPC_XL_ODR_25Hz:
+        *val = IIS2DLPC_XL_ODR_25Hz;
+        break;
+       case IIS2DLPC_XL_ODR_50Hz:
+        *val = IIS2DLPC_XL_ODR_50Hz;
+        break;
+      case IIS2DLPC_XL_ODR_100Hz:
+        *val = IIS2DLPC_XL_ODR_100Hz;
+        break;
+      case IIS2DLPC_XL_ODR_200Hz:
+        *val = IIS2DLPC_XL_ODR_200Hz;
+        break;
+      case IIS2DLPC_XL_ODR_400Hz:
+        *val = IIS2DLPC_XL_ODR_400Hz;
+        break;
+       case IIS2DLPC_XL_ODR_800Hz:
+        *val = IIS2DLPC_XL_ODR_800Hz;
+        break;
+      case IIS2DLPC_XL_ODR_1k6Hz:
+        *val = IIS2DLPC_XL_ODR_1k6Hz;
+        break;
+      case IIS2DLPC_XL_SET_SW_TRIG:
+        *val = IIS2DLPC_XL_SET_SW_TRIG;
+        break;
+      case IIS2DLPC_XL_SET_PIN_TRIG:
+        *val = IIS2DLPC_XL_SET_PIN_TRIG;
+        break;
+      default:
+        *val = IIS2DLPC_XL_ODR_OFF;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_block_data_update_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_block_data_update_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_full_scale_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t val)
+{
+  iis2dlpc_ctrl6_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fs = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_full_scale_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t *val)
+{
+  iis2dlpc_ctrl6_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &reg, 1);
+
+  switch (reg.fs) {
+    case IIS2DLPC_2g:
+      *val = IIS2DLPC_2g;
+      break;
+    case IIS2DLPC_4g:
+      *val = IIS2DLPC_4g;
+      break;
+    case IIS2DLPC_8g:
+      *val = IIS2DLPC_8g;
+      break;
+    case IIS2DLPC_16g:
+      *val = IIS2DLPC_16g;
+      break;
+    default:
+      *val = IIS2DLPC_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_status_reg_get(iis2dlpc_ctx_t *ctx, iis2dlpc_status_t *val)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_STATUS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_flag_data_ready_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_status_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_STATUS,(uint8_t*) &reg, 1);
+  *val = reg.drdy;
+
+  return ret;
+}
+/**
+  * @brief   Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers STATUS_DUP, WAKE_UP_SRC,
+  *                  TAP_SRC, SIXD_SRC, ALL_INT_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_all_sources_get(iis2dlpc_ctx_t *ctx,
+                                 iis2dlpc_all_sources_t *val)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_STATUS_DUP, (uint8_t*) val, 5);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_usr_offset_x_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_write_reg(ctx, IIS2DLPC_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_usr_offset_x_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_usr_offset_y_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_write_reg(ctx, IIS2DLPC_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_usr_offset_y_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_usr_offset_z_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_write_reg(ctx, IIS2DLPC_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_usr_offset_z_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR,
+  *         Y_OFS_USR, Z_OFS_USR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_w in
+  *                               reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_offset_weight_set(iis2dlpc_ctx_t *ctx,
+                                   iis2dlpc_usr_off_w_t val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.usr_off_w = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR,
+  *         Y_OFS_USR, Z_OFS_USR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of usr_off_w in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_offset_weight_get(iis2dlpc_ctx_t *ctx,
+                                   iis2dlpc_usr_off_w_t *val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  switch (reg.usr_off_w) {
+    case IIS2DLPC_LSb_977ug:
+      *val = IIS2DLPC_LSb_977ug;
+      break;
+    case IIS2DLPC_LSb_15mg6:
+      *val = IIS2DLPC_LSb_15mg6;
+      break;
+    default:
+      *val = IIS2DLPC_LSb_977ug;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Data_Output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data output register (r). L and H registers
+  *         together express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_temperature_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_OUT_T_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as
+  *         a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_acceleration_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Common
+  * @brief     This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_device_id_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_auto_increment_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.if_add_inc = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during multiple
+  *         byte access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_auto_increment_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_reset in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_reset_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.soft_reset = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_reset in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_reset_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.soft_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_boot_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.boot = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_boot_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_self_test_set(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t val)
+{
+  iis2dlpc_ctrl3_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.st = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor self-test enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_self_test_get(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t *val)
+{
+  iis2dlpc_ctrl3_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.st) {
+    case IIS2DLPC_XL_ST_DISABLE:
+      *val = IIS2DLPC_XL_ST_DISABLE;
+      break;
+    case IIS2DLPC_XL_ST_POSITIVE:
+      *val = IIS2DLPC_XL_ST_POSITIVE;
+      break;
+    case IIS2DLPC_XL_ST_NEGATIVE:
+      *val = IIS2DLPC_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = IIS2DLPC_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_pulsed in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_data_ready_mode_set(iis2dlpc_ctx_t *ctx,
+                                     iis2dlpc_drdy_pulsed_t val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.drdy_pulsed = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of drdy_pulsed in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_data_ready_mode_get(iis2dlpc_ctx_t *ctx,
+                                     iis2dlpc_drdy_pulsed_t *val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.drdy_pulsed) {
+    case IIS2DLPC_DRDY_LATCHED:
+      *val = IIS2DLPC_DRDY_LATCHED;
+      break;
+    case IIS2DLPC_DRDY_PULSED:
+      *val = IIS2DLPC_DRDY_PULSED;
+      break;
+    default:
+      *val = IIS2DLPC_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Filters
+  * @brief     This section group all the functions concerning the filters
+  *            configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer filtering path for outputs.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_filter_path_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t val)
+{
+  iis2dlpc_ctrl6_t ctrl6;
+  iis2dlpc_ctrl_reg7_t ctrl_reg7;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
+  if (ret == 0) {
+    ctrl6.fds = ( (uint8_t) val & 0x10U ) >> 4;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
+  }
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+  }
+  if (ret == 0) {
+    ctrl_reg7.usr_off_on_out = (uint8_t) val & 0x01U;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+  } else {
+    ret = ret;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer filtering path for outputs.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fds in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_filter_path_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t *val)
+{
+  iis2dlpc_ctrl6_t ctrl6;
+  iis2dlpc_ctrl_reg7_t ctrl_reg7;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
+  if (ret == 0) {
+   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+
+    switch ((ctrl6.fds << 4 ) + ctrl_reg7.usr_off_on_out) {
+      case IIS2DLPC_LPF_ON_OUT:
+        *val = IIS2DLPC_LPF_ON_OUT;
+        break;
+      case IIS2DLPC_USER_OFFSET_ON_OUT:
+        *val = IIS2DLPC_USER_OFFSET_ON_OUT;
+        break;
+      case IIS2DLPC_HIGH_PASS_ON_OUT:
+        *val = IIS2DLPC_HIGH_PASS_ON_OUT;
+        break;
+      default:
+        *val = IIS2DLPC_LPF_ON_OUT;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer cutoff filter frequency. Valid for low and high
+  *          pass filter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bw_filt in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_filter_bandwidth_set(iis2dlpc_ctx_t *ctx,
+                                         iis2dlpc_bw_filt_t val)
+{
+  iis2dlpc_ctrl6_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bw_filt = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer cutoff filter frequency. Valid for low and
+  *          high pass filter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of bw_filt in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_filter_bandwidth_get(iis2dlpc_ctx_t *ctx,
+                                         iis2dlpc_bw_filt_t *val)
+{
+  iis2dlpc_ctrl6_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &reg, 1);
+
+  switch (reg.bw_filt) {
+    case IIS2DLPC_ODR_DIV_2:
+      *val = IIS2DLPC_ODR_DIV_2;
+      break;
+    case IIS2DLPC_ODR_DIV_4:
+      *val = IIS2DLPC_ODR_DIV_4;
+      break;
+    case IIS2DLPC_ODR_DIV_10:
+      *val = IIS2DLPC_ODR_DIV_10;
+      break;
+    case IIS2DLPC_ODR_DIV_20:
+      *val = IIS2DLPC_ODR_DIV_20;
+      break;
+    default:
+      *val = IIS2DLPC_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_ref_mode in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_reference_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.hp_ref_mode = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_ref_mode in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_reference_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  *val = reg.hp_ref_mode;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2DLPC_Serial_Interface
+  * @brief      This section groups all the functions concerning main serial
+  *             interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_spi_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sim = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_spi_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t *val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.sim) {
+    case IIS2DLPC_SPI_4_WIRE:
+      *val = IIS2DLPC_SPI_4_WIRE;
+      break;
+    case IIS2DLPC_SPI_3_WIRE:
+      *val = IIS2DLPC_SPI_3_WIRE;
+      break;
+    default:
+      *val = IIS2DLPC_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_disable in
+  *                                 reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_i2c_interface_set(iis2dlpc_ctx_t *ctx,
+                                   iis2dlpc_i2c_disable_t val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i2c_disable = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_disable in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_i2c_interface_get(iis2dlpc_ctx_t *ctx,
+                                   iis2dlpc_i2c_disable_t *val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.i2c_disable) {
+    case IIS2DLPC_I2C_ENABLE:
+      *val = IIS2DLPC_I2C_ENABLE;
+      break;
+    case IIS2DLPC_I2C_DISABLE:
+      *val = IIS2DLPC_I2C_DISABLE;
+      break;
+    default:
+      *val = IIS2DLPC_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disconnect CS pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of cs_pu_disc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_cs_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.cs_pu_disc = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disconnect CS pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of cs_pu_disc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_cs_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t *val)
+{
+  iis2dlpc_ctrl2_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.cs_pu_disc) {
+    case IIS2DLPC_PULL_UP_CONNECT:
+      *val = IIS2DLPC_PULL_UP_CONNECT;
+      break;
+    case IIS2DLPC_PULL_UP_DISCONNECT:
+      *val = IIS2DLPC_PULL_UP_DISCONNECT;
+      break;
+    default:
+      *val = IIS2DLPC_PULL_UP_CONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Interrupt_Pins
+  * @brief     This section groups all the functions that manage interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of h_lactive in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_pin_polarity_set(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_h_lactive_t val)
+{
+  iis2dlpc_ctrl3_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.h_lactive = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of h_lactive in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_pin_polarity_get(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_h_lactive_t *val)
+{
+  iis2dlpc_ctrl3_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.h_lactive) {
+    case IIS2DLPC_ACTIVE_HIGH:
+      *val = IIS2DLPC_ACTIVE_HIGH;
+      break;
+    case IIS2DLPC_ACTIVE_LOW:
+      *val = IIS2DLPC_ACTIVE_LOW;
+      break;
+    default:
+      *val = IIS2DLPC_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_int_notification_set(iis2dlpc_ctx_t *ctx,
+                                      iis2dlpc_lir_t val)
+{
+  iis2dlpc_ctrl3_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lir = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_int_notification_get(iis2dlpc_ctx_t *ctx,
+                                      iis2dlpc_lir_t *val)
+{
+  iis2dlpc_ctrl3_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.lir) {
+    case IIS2DLPC_INT_PULSED:
+      *val = IIS2DLPC_INT_PULSED;
+      break;
+    case IIS2DLPC_INT_LATCHED:
+      *val = IIS2DLPC_INT_LATCHED;
+      break;
+    default:
+      *val = IIS2DLPC_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pp_od in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_pin_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t val)
+{
+  iis2dlpc_ctrl3_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.pp_od = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pp_od in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_pin_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t *val)
+{
+  iis2dlpc_ctrl3_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.pp_od) {
+    case IIS2DLPC_PUSH_PULL:
+      *val = IIS2DLPC_PUSH_PULL;
+      break;
+    case IIS2DLPC_OPEN_DRAIN:
+      *val = IIS2DLPC_OPEN_DRAIN;
+      break;
+    default:
+      *val = IIS2DLPC_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL4_INT1_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_pin_int1_route_set(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_ctrl4_int1_pad_ctrl_t *val)
+{
+  iis2dlpc_ctrl5_int2_pad_ctrl_t ctrl5_int2_pad_ctrl;
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL5_INT2_PAD_CTRL,
+                          (uint8_t*) &ctrl5_int2_pad_ctrl, 1);
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  if (ret == 0) {
+    if ((  ctrl5_int2_pad_ctrl.int2_sleep_state
+     | ctrl5_int2_pad_ctrl.int2_sleep_chg
+     | val->int1_tap
+     | val->int1_ff
+     | val->int1_wu
+     | val->int1_single_tap
+     | val->int1_6d ) != PROPERTY_DISABLE) {
+      reg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      reg.interrupts_enable = PROPERTY_DISABLE;
+    }
+
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL4_INT1_PAD_CTRL,
+                                (uint8_t*) val, 1);
+  }
+  if (ret == 0) {
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  } else {
+    ret = ret;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL4_INT1_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_pin_int1_route_get(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_ctrl4_int1_pad_ctrl_t *val)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL4_INT1_PAD_CTRL,
+                          (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief   Select the signal that need to route on int2 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL5_INT2_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_pin_int2_route_set(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_ctrl5_int2_pad_ctrl_t *val)
+{
+  iis2dlpc_ctrl_reg7_t ctrl_reg7;
+  iis2dlpc_ctrl4_int1_pad_ctrl_t  ctrl4_int1_pad;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL4_INT1_PAD_CTRL,
+                          (uint8_t*)&ctrl4_int1_pad, 1);
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+  }
+  if (ret == 0) {
+    if ((  val->int2_sleep_state
+         | val->int2_sleep_chg
+         | ctrl4_int1_pad.int1_tap
+         | ctrl4_int1_pad.int1_ff
+         | ctrl4_int1_pad.int1_wu
+         | ctrl4_int1_pad.int1_single_tap
+         | ctrl4_int1_pad.int1_6d ) != PROPERTY_DISABLE) {
+      ctrl_reg7.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      ctrl_reg7.interrupts_enable = PROPERTY_DISABLE;
+    }
+
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL5_INT2_PAD_CTRL,
+                             (uint8_t*) val, 1);
+  }
+  if (ret == 0) {
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+  } else {
+    ret = ret;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL5_INT2_PAD_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_pin_int2_route_get(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_ctrl5_int2_pad_ctrl_t *val)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL5_INT2_PAD_CTRL,
+                          (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_all_on_int1_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.int2_on_int1 = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_all_on_int1_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  *val = reg.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Wake_Up_Event
+  * @brief     This section groups all the functions that manage the Wake
+  *            Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_wkup_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wk_ths = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_wkup_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  *val = reg.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_wkup_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wake_dur = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_wkup_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  *val = reg.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Data sent to wake-up interrupt function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_wu in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_wkup_feed_data_set(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_usr_off_on_wu_t val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.usr_off_on_wu = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data sent to wake-up interrupt function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of usr_off_on_wu in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_wkup_feed_data_get(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_usr_off_on_wu_t *val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.usr_off_on_wu) {
+    case IIS2DLPC_HP_FEED:
+      *val = IIS2DLPC_HP_FEED;
+      break;
+    case IIS2DLPC_USER_OFFSET_FEED:
+      *val = IIS2DLPC_USER_OFFSET_FEED;
+      break;
+    default:
+      *val = IIS2DLPC_HP_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2DLPC_Activity/Inactivity_Detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Config activity / inactivity or
+  *         stationary / motion detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_on / stationary in
+  *                  reg WAKE_UP_THS / WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_act_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t val)
+{
+  iis2dlpc_wake_up_ths_t wake_up_ths;
+  iis2dlpc_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  }
+  if (ret == 0) {
+    wake_up_ths.sleep_on = (uint8_t) val & 0x01U;
+    wake_up_dur.stationary = ((uint8_t)val & 0x02U) >> 1;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 2);
+  } else {
+    ret = ret;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Config activity / inactivity or
+  *         stationary / motion detection. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sleep_on in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_act_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t *val)
+{
+  iis2dlpc_wake_up_ths_t wake_up_ths;
+  iis2dlpc_wake_up_dur_t wake_up_dur;;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+
+    switch ((wake_up_dur.stationary << 1) + wake_up_ths.sleep_on){
+      case IIS2DLPC_NO_DETECTION:
+        *val = IIS2DLPC_NO_DETECTION;
+        break;
+      case IIS2DLPC_DETECT_ACT_INACT:
+        *val = IIS2DLPC_DETECT_ACT_INACT;
+        break;
+      case IIS2DLPC_DETECT_STAT_MOTION:
+        *val = IIS2DLPC_DETECT_STAT_MOTION;
+        break;
+      default:
+        *val = IIS2DLPC_NO_DETECTION;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_act_sleep_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sleep_dur = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_act_sleep_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  *val = reg.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Tap_Generator
+  * @brief     This section groups all the functions that manage the tap
+  *            and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsx in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_threshold_x_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsx = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsx in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_threshold_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsx;
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsy in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_threshold_y_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Y,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsy = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_Y,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsy in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_threshold_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Y,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsy;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_prior in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_axis_priority_set(iis2dlpc_ctx_t *ctx,
+                                       iis2dlpc_tap_prior_t val)
+{
+  iis2dlpc_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Y,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_prior = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_Y,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tap_prior in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_axis_priority_get(iis2dlpc_ctx_t *ctx,
+                                       iis2dlpc_tap_prior_t *val)
+{
+  iis2dlpc_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Y,(uint8_t*) &reg, 1);
+
+  switch (reg.tap_prior) {
+    case IIS2DLPC_XYZ:
+      *val = IIS2DLPC_XYZ;
+      break;
+    case IIS2DLPC_YXZ:
+      *val = IIS2DLPC_YXZ;
+      break;
+    case IIS2DLPC_XZY:
+      *val = IIS2DLPC_XZY;
+      break;
+    case IIS2DLPC_ZYX:
+      *val = IIS2DLPC_ZYX;
+      break;
+    case IIS2DLPC_YZX:
+      *val = IIS2DLPC_YZX;
+      break;
+    case IIS2DLPC_ZXY:
+      *val = IIS2DLPC_ZXY;
+      break;
+    default:
+      *val = IIS2DLPC_XYZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsz in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_threshold_z_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsz = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsz in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_threshold_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsz;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_detection_on_z_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_z_en = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_detection_on_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_detection_on_y_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_y_en = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_detection_on_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_detection_on_x_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_x_en = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_detection_on_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value
+  *         of these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_shock_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_int_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.shock = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value
+  *         of these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_shock_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_int_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds
+  *         to 2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_quiet_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_int_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.quiet = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds
+  *         to 2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_quiet_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_int_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses
+  *         the maximum time between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which corresponds
+  *         to 16*ODR_XL time. If the DUR[3:0] bits are set to a different
+  *         value, 1LSB corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of latency in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_int_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.latency = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses
+  *         the maximum time between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which corresponds
+  *         to 16*ODR_XL time. If the DUR[3:0] bits are set to a different
+  *         value, 1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of latency in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_int_dur_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.latency;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of single_double_tap in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_mode_set(iis2dlpc_ctx_t *ctx,
+                              iis2dlpc_single_double_tap_t val)
+{
+  iis2dlpc_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.single_double_tap = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of single_double_tap in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_mode_get(iis2dlpc_ctx_t *ctx,
+                              iis2dlpc_single_double_tap_t *val)
+{
+  iis2dlpc_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_THS,(uint8_t*) &reg, 1);
+
+  switch (reg.single_double_tap) {
+    case IIS2DLPC_ONLY_SINGLE:
+      *val = IIS2DLPC_ONLY_SINGLE;
+      break;
+    case IIS2DLPC_BOTH_SINGLE_DOUBLE:
+      *val = IIS2DLPC_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = IIS2DLPC_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Read the tap / double tap source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  iis2dlpc_tap_src: union of registers from TAP_SRC to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_tap_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_tap_src_t *val)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2DLPC_Six_Position_Detection(6D/4D)
+  * @brief      This section groups all the functions concerning six
+  *             position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 6d_ths in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_6d_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg._6d_ths = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 6d_ths in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_6d_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg._6d_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4d_en in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_4d_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg._4d_en = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4d_en in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_4d_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg._4d_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Read the 6D tap source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from SIXD_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_6d_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sixd_src_t *val)
+{
+  int32_t ret;
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_SIXD_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Data sent to 6D interrupt function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpass_on6d in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_6d_feed_data_set(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_lpass_on6d_t val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lpass_on6d = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data sent to 6D interrupt function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lpass_on6d in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_6d_feed_data_get(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_lpass_on6d_t *val)
+{
+  iis2dlpc_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.lpass_on6d) {
+    case IIS2DLPC_ODR_DIV_2_FEED:
+      *val = IIS2DLPC_ODR_DIV_2_FEED;
+      break;
+    case IIS2DLPC_LPF2_FEED:
+      *val = IIS2DLPC_LPF2_FEED;
+      break;
+    default:
+      *val = IIS2DLPC_ODR_DIV_2_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Free_Fall
+  * @brief     This section group all the functions concerning
+  *            the free fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in reg
+  *                  WAKE_UP_DUR /F REE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_ff_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_wake_up_dur_t wake_up_dur;
+  iis2dlpc_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FREE_FALL,(uint8_t*) &free_fall, 1);
+  }
+  if(ret == 0) {
+    wake_up_dur.ff_dur = ( (uint8_t) val & 0x20U) >> 5;
+    free_fall.ff_dur = (uint8_t) val & 0x1FU;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  }
+  if(ret == 0) {
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_FREE_FALL,(uint8_t*) &free_fall, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in
+  *                  reg WAKE_UP_DUR /F REE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_ff_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_wake_up_dur_t wake_up_dur;
+  iis2dlpc_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  if (ret == 0) {
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FREE_FALL,(uint8_t*) &free_fall, 1);
+    *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_ths in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_ff_threshold_set(iis2dlpc_ctx_t *ctx, iis2dlpc_ff_ths_t val)
+{
+  iis2dlpc_free_fall_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FREE_FALL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.ff_ths = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_FREE_FALL,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ff_ths in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_ff_threshold_get(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_ff_ths_t *val)
+{
+  iis2dlpc_free_fall_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FREE_FALL,(uint8_t*) &reg, 1);
+
+  switch (reg.ff_ths) {
+    case IIS2DLPC_FF_TSH_5LSb_FS2g:
+      *val = IIS2DLPC_FF_TSH_5LSb_FS2g;
+      break;
+    case IIS2DLPC_FF_TSH_7LSb_FS2g:
+      *val = IIS2DLPC_FF_TSH_7LSb_FS2g;
+      break;
+    case IIS2DLPC_FF_TSH_8LSb_FS2g:
+      *val = IIS2DLPC_FF_TSH_8LSb_FS2g;
+      break;
+    case IIS2DLPC_FF_TSH_10LSb_FS2g:
+      *val = IIS2DLPC_FF_TSH_10LSb_FS2g;
+      break;
+    case IIS2DLPC_FF_TSH_11LSb_FS2g:
+      *val = IIS2DLPC_FF_TSH_11LSb_FS2g;
+      break;
+    case IIS2DLPC_FF_TSH_13LSb_FS2g:
+      *val = IIS2DLPC_FF_TSH_13LSb_FS2g;
+      break;
+    case IIS2DLPC_FF_TSH_15LSb_FS2g:
+      *val = IIS2DLPC_FF_TSH_15LSb_FS2g;
+      break;
+    case IIS2DLPC_FF_TSH_16LSb_FS2g:
+      *val = IIS2DLPC_FF_TSH_16LSb_FS2g;
+      break;
+    default:
+      *val = IIS2DLPC_FF_TSH_5LSb_FS2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS2DLPC_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_fifo_watermark_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+{
+  iis2dlpc_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FIFO_CTRL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fth = val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_FIFO_CTRL,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_fifo_watermark_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FIFO_CTRL,(uint8_t*) &reg, 1);
+  *val = reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fmode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_fifo_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t val)
+{
+  iis2dlpc_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FIFO_CTRL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fmode = (uint8_t) val;
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_FIFO_CTRL,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fmode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_fifo_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t *val)
+{
+  iis2dlpc_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FIFO_CTRL,(uint8_t*) &reg, 1);
+
+  switch (reg.fmode) {
+    case IIS2DLPC_BYPASS_MODE:
+      *val = IIS2DLPC_BYPASS_MODE;
+      break;
+    case IIS2DLPC_FIFO_MODE:
+      *val = IIS2DLPC_FIFO_MODE;
+      break;
+    case IIS2DLPC_STREAM_TO_FIFO_MODE:
+      *val = IIS2DLPC_STREAM_TO_FIFO_MODE;
+      break;
+    case IIS2DLPC_BYPASS_TO_STREAM_MODE:
+      *val = IIS2DLPC_BYPASS_TO_STREAM_MODE;
+      break;
+    case IIS2DLPC_STREAM_MODE:
+      *val = IIS2DLPC_STREAM_MODE;
+      break;
+    default:
+      *val = IIS2DLPC_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of unread samples stored in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of diff in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_fifo_data_level_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.diff;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_ovr in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_fifo_ovr_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.fifo_ovr;
+
+  return ret;
+}
+/**
+  * @brief  FIFO threshold status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_fth in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2dlpc_fifo_wtm_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+{
+  iis2dlpc_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.fifo_fth;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis2dlpc_STdC/driver/iis2dlpc_reg.h
+++ b/sensor/stmemsc/iis2dlpc_STdC/driver/iis2dlpc_reg.h
@@ -1,0 +1,781 @@
+/*
+ ******************************************************************************
+ * @file    iis2dlpc_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          iis2dlpc_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef IIS2DLPC_REGS_H
+#define IIS2DLPC_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup IIS2DLPC
+  * @{
+  *
+  */
+
+/** @defgroup IIS2DLPC_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  IIS2DLPC_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*iis2dlpc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*iis2dlpc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  iis2dlpc_write_ptr  write_reg;
+  iis2dlpc_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} iis2dlpc_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup IIS2DLPC_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define IIS2DLPC_I2C_ADD_L   0x31U
+#define IIS2DLPC_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define IIS2DLPC_ID            0x44U
+
+/**
+  * @}
+  *
+  */
+
+#define IIS2DLPC_OUT_T_L                     0x0DU
+#define IIS2DLPC_OUT_T_H                     0x0EU
+#define IIS2DLPC_WHO_AM_I                    0x0FU
+#define IIS2DLPC_CTRL1                       0x20U
+typedef struct {
+  uint8_t lp_mode                    : 2;
+  uint8_t mode                       : 2;
+  uint8_t odr                        : 4;
+} iis2dlpc_ctrl1_t;
+
+#define IIS2DLPC_CTRL2                       0x21U
+typedef struct {
+  uint8_t sim                        : 1;
+  uint8_t i2c_disable                : 1;
+  uint8_t if_add_inc                 : 1;
+  uint8_t bdu                        : 1;
+  uint8_t cs_pu_disc                 : 1;
+  uint8_t not_used_01                : 1;
+  uint8_t soft_reset                 : 1;
+  uint8_t boot                       : 1;
+} iis2dlpc_ctrl2_t;
+
+#define IIS2DLPC_CTRL3                       0x22U
+typedef struct {
+  uint8_t slp_mode                   : 2;  /* slp_mode_sel + slp_mode_1 */
+  uint8_t not_used_01                : 1;
+  uint8_t h_lactive                  : 1;
+  uint8_t lir                        : 1;
+  uint8_t pp_od                      : 1;
+  uint8_t st                         : 2;
+} iis2dlpc_ctrl3_t;
+
+#define IIS2DLPC_CTRL4_INT1_PAD_CTRL         0x23U
+typedef struct {
+  uint8_t int1_drdy                  : 1;
+  uint8_t int1_fth                   : 1;
+  uint8_t int1_diff5                 : 1;
+  uint8_t int1_tap                   : 1;
+  uint8_t int1_ff                    : 1;
+  uint8_t int1_wu                    : 1;
+  uint8_t int1_single_tap            : 1;
+  uint8_t int1_6d                    : 1;
+} iis2dlpc_ctrl4_int1_pad_ctrl_t;
+
+#define IIS2DLPC_CTRL5_INT2_PAD_CTRL         0x24U
+typedef struct {
+  uint8_t int2_drdy                  : 1;
+  uint8_t int2_fth                   : 1;
+  uint8_t int2_diff5                 : 1;
+  uint8_t int2_ovr                   : 1;
+  uint8_t int2_drdy_t                : 1;
+  uint8_t int2_boot                  : 1;
+  uint8_t int2_sleep_chg             : 1;
+  uint8_t int2_sleep_state           : 1;
+} iis2dlpc_ctrl5_int2_pad_ctrl_t;
+
+#define IIS2DLPC_CTRL6                       0x25U
+typedef struct {
+  uint8_t not_used_01                : 2;
+  uint8_t low_noise                  : 1;
+  uint8_t fds                        : 1;
+  uint8_t fs                         : 2;
+  uint8_t bw_filt                    : 2;
+} iis2dlpc_ctrl6_t;
+
+#define IIS2DLPC_OUT_T                       0x26U
+#define IIS2DLPC_STATUS                      0x27U
+typedef struct {
+  uint8_t drdy                       : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t sleep_state                : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t fifo_ths                   : 1;
+} iis2dlpc_status_t;
+
+#define IIS2DLPC_OUT_X_L                     0x28U
+#define IIS2DLPC_OUT_X_H                     0x29U
+#define IIS2DLPC_OUT_Y_L                     0x2AU
+#define IIS2DLPC_OUT_Y_H                     0x2BU
+#define IIS2DLPC_OUT_Z_L                     0x2CU
+#define IIS2DLPC_OUT_Z_H                     0x2DU
+#define IIS2DLPC_FIFO_CTRL                   0x2EU
+typedef struct {
+  uint8_t fth                        : 5;
+  uint8_t fmode                      : 3;
+} iis2dlpc_fifo_ctrl_t;
+
+#define IIS2DLPC_FIFO_SAMPLES                0x2FU
+typedef struct {
+  uint8_t diff                       : 6;
+  uint8_t fifo_ovr                   : 1;
+  uint8_t fifo_fth                   : 1;
+} iis2dlpc_fifo_samples_t;
+
+#define IIS2DLPC_TAP_THS_X                   0x30U
+typedef struct {
+  uint8_t tap_thsx                    : 5;
+  uint8_t _6d_ths                     : 2;
+  uint8_t _4d_en                      : 1;
+} iis2dlpc_tap_ths_x_t;
+
+#define IIS2DLPC_TAP_THS_Y                   0x31U
+typedef struct {
+  uint8_t tap_thsy                   : 5;
+  uint8_t tap_prior                  : 3;
+} iis2dlpc_tap_ths_y_t;
+
+#define IIS2DLPC_TAP_THS_Z                   0x32U
+typedef struct {
+  uint8_t tap_thsz                   : 5;
+  uint8_t tap_z_en                   : 1;
+  uint8_t tap_y_en                   : 1;
+  uint8_t tap_x_en                   : 1;
+} iis2dlpc_tap_ths_z_t;
+
+#define IIS2DLPC_INT_DUR                     0x33U
+typedef struct {
+  uint8_t shock                      : 2;
+  uint8_t quiet                      : 2;
+  uint8_t latency                    : 4;
+} iis2dlpc_int_dur_t;
+
+#define IIS2DLPC_WAKE_UP_THS                 0x34U
+typedef struct {
+  uint8_t wk_ths                     : 6;
+  uint8_t sleep_on                   : 1;
+  uint8_t single_double_tap          : 1;
+} iis2dlpc_wake_up_ths_t;
+
+#define IIS2DLPC_WAKE_UP_DUR                 0x35U
+typedef struct {
+  uint8_t sleep_dur                  : 4;
+  uint8_t stationary                 : 1;
+  uint8_t wake_dur                   : 2;
+  uint8_t ff_dur                     : 1;
+} iis2dlpc_wake_up_dur_t;
+
+#define IIS2DLPC_FREE_FALL                   0x36U
+typedef struct {
+  uint8_t ff_ths                     : 3;
+  uint8_t ff_dur                     : 5;
+} iis2dlpc_free_fall_t;
+
+#define IIS2DLPC_STATUS_DUP                  0x37U
+typedef struct {
+  uint8_t drdy                       : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t sleep_state_ia             : 1;
+  uint8_t drdy_t                     : 1;
+  uint8_t ovr                        : 1;
+} iis2dlpc_status_dup_t;
+
+#define IIS2DLPC_WAKE_UP_SRC                 0x38U
+typedef struct {
+  uint8_t z_wu                       : 1;
+  uint8_t y_wu                       : 1;
+  uint8_t x_wu                       : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t sleep_state_ia             : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t not_used_01                : 2;
+} iis2dlpc_wake_up_src_t;
+
+#define IIS2DLPC_TAP_SRC                     0x39U
+typedef struct {
+  uint8_t z_tap                      : 1;
+  uint8_t y_tap                      : 1;
+  uint8_t x_tap                      : 1;
+  uint8_t tap_sign                   : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t tap_ia                     : 1;
+  uint8_t not_used_01                : 1;
+} iis2dlpc_tap_src_t;
+
+#define IIS2DLPC_SIXD_SRC                    0x3AU
+typedef struct {
+  uint8_t xl                         : 1;
+  uint8_t xh                         : 1;
+  uint8_t yl                         : 1;
+  uint8_t yh                         : 1;
+  uint8_t zl                         : 1;
+  uint8_t zh                         : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t not_used_01                : 1;
+} iis2dlpc_sixd_src_t;
+
+#define IIS2DLPC_ALL_INT_SRC                 0x3BU
+typedef struct {
+  uint8_t ff_ia                      : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t sleep_change_ia            : 1;
+  uint8_t not_used_01                : 2;
+} iis2dlpc_all_int_src_t;
+
+#define IIS2DLPC_X_OFS_USR                   0x3CU
+#define IIS2DLPC_Y_OFS_USR                   0x3DU
+#define IIS2DLPC_Z_OFS_USR                   0x3EU
+#define IIS2DLPC_CTRL_REG7                   0x3FU
+typedef struct {
+  uint8_t lpass_on6d                 : 1;
+  uint8_t hp_ref_mode                : 1;
+  uint8_t usr_off_w                  : 1;
+  uint8_t usr_off_on_wu              : 1;
+  uint8_t usr_off_on_out             : 1;
+  uint8_t interrupts_enable          : 1;
+  uint8_t int2_on_int1               : 1;
+  uint8_t drdy_pulsed                : 1;
+} iis2dlpc_ctrl_reg7_t;
+
+/**
+  * @defgroup IIS2DLPC_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is usefull but not need by the driver.
+  *
+  *           REMOVING this union you are complient with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  iis2dlpc_ctrl1_t                   ctrl1;
+  iis2dlpc_ctrl2_t                   ctrl2;
+  iis2dlpc_ctrl3_t                   ctrl3;
+  iis2dlpc_ctrl4_int1_pad_ctrl_t     ctrl4_int1_pad_ctrl;
+  iis2dlpc_ctrl5_int2_pad_ctrl_t     ctrl5_int2_pad_ctrl;
+  iis2dlpc_ctrl6_t                   ctrl6;
+  iis2dlpc_status_t                  status;
+  iis2dlpc_fifo_ctrl_t               fifo_ctrl;
+  iis2dlpc_fifo_samples_t            fifo_samples;
+  iis2dlpc_tap_ths_x_t               tap_ths_x;
+  iis2dlpc_tap_ths_y_t               tap_ths_y;
+  iis2dlpc_tap_ths_z_t               tap_ths_z;
+  iis2dlpc_int_dur_t                 int_dur;
+  iis2dlpc_wake_up_ths_t             wake_up_ths;
+  iis2dlpc_wake_up_dur_t             wake_up_dur;
+  iis2dlpc_free_fall_t               free_fall;
+  iis2dlpc_status_dup_t              status_dup;
+  iis2dlpc_wake_up_src_t             wake_up_src;
+  iis2dlpc_tap_src_t                 tap_src;
+  iis2dlpc_sixd_src_t                sixd_src;
+  iis2dlpc_all_int_src_t             all_int_src;
+  iis2dlpc_ctrl_reg7_t               ctrl_reg7;
+  bitwise_t                          bitwise;
+  uint8_t                            byte;
+} iis2dlpc_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t iis2dlpc_read_reg(iis2dlpc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t iis2dlpc_write_reg(iis2dlpc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t iis2dlpc_from_fs2_to_mg(int16_t lsb);
+extern float_t iis2dlpc_from_fs4_to_mg(int16_t lsb);
+extern float_t iis2dlpc_from_fs8_to_mg(int16_t lsb);
+extern float_t iis2dlpc_from_fs16_to_mg(int16_t lsb);
+extern float_t iis2dlpc_from_fs2_lp1_to_mg(int16_t lsb);
+extern float_t iis2dlpc_from_fs4_lp1_to_mg(int16_t lsb);
+extern float_t iis2dlpc_from_fs8_lp1_to_mg(int16_t lsb);
+extern float_t iis2dlpc_from_fs16_lp1_to_mg(int16_t lsb);
+extern float_t iis2dlpc_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  IIS2DLPC_HIGH_PERFORMANCE                    = 0x04,
+  IIS2DLPC_CONT_LOW_PWR_4                      = 0x03,
+  IIS2DLPC_CONT_LOW_PWR_3                      = 0x02,
+  IIS2DLPC_CONT_LOW_PWR_2                      = 0x01,
+  IIS2DLPC_CONT_LOW_PWR_12bit                  = 0x00,
+  IIS2DLPC_SINGLE_LOW_PWR_4                    = 0x0B,
+  IIS2DLPC_SINGLE_LOW_PWR_3                    = 0x0A,
+  IIS2DLPC_SINGLE_LOW_PWR_2                    = 0x09,
+  IIS2DLPC_SINGLE_LOW_PWR_12bit                = 0x08,
+  IIS2DLPC_HIGH_PERFORMANCE_LOW_NOISE          = 0x14,
+  IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_4            = 0x13,
+  IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_3            = 0x12,
+  IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_2            = 0x11,
+  IIS2DLPC_CONT_LOW_PWR_LOW_NOISE_12bit        = 0x10,
+  IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_4          = 0x1B,
+  IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_3          = 0x1A,
+  IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_2          = 0x19,
+  IIS2DLPC_SINGLE_LOW_LOW_NOISE_PWR_12bit      = 0x18,
+} iis2dlpc_mode_t;
+int32_t iis2dlpc_power_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t val);
+int32_t iis2dlpc_power_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t *val);
+
+typedef enum {
+  IIS2DLPC_XL_ODR_OFF            = 0x00,
+  IIS2DLPC_XL_ODR_1Hz6_LP_ONLY   = 0x01,
+  IIS2DLPC_XL_ODR_12Hz5          = 0x02,
+  IIS2DLPC_XL_ODR_25Hz           = 0x03,
+  IIS2DLPC_XL_ODR_50Hz           = 0x04,
+  IIS2DLPC_XL_ODR_100Hz          = 0x05,
+  IIS2DLPC_XL_ODR_200Hz          = 0x06,
+  IIS2DLPC_XL_ODR_400Hz          = 0x07,
+  IIS2DLPC_XL_ODR_800Hz          = 0x08,
+  IIS2DLPC_XL_ODR_1k6Hz          = 0x09,
+  IIS2DLPC_XL_SET_SW_TRIG        = 0x10,  /* Use this only in SINGLE mode */
+  IIS2DLPC_XL_SET_PIN_TRIG       = 0x20,  /* Use this only in SINGLE mode */
+} iis2dlpc_odr_t;
+int32_t iis2dlpc_data_rate_set(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t val);
+int32_t iis2dlpc_data_rate_get(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t *val);
+
+int32_t iis2dlpc_block_data_update_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_block_data_update_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DLPC_2g     = 0,
+  IIS2DLPC_4g     = 1,
+  IIS2DLPC_8g     = 2,
+  IIS2DLPC_16g    = 3,
+} iis2dlpc_fs_t;
+int32_t iis2dlpc_full_scale_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t val);
+int32_t iis2dlpc_full_scale_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t *val);
+
+int32_t iis2dlpc_status_reg_get(iis2dlpc_ctx_t *ctx, iis2dlpc_status_t *val);
+
+int32_t iis2dlpc_flag_data_ready_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef struct{
+  iis2dlpc_status_dup_t   status_dup;
+  iis2dlpc_wake_up_src_t  wake_up_src;
+  iis2dlpc_tap_src_t      tap_src;
+  iis2dlpc_sixd_src_t     sixd_src;
+  iis2dlpc_all_int_src_t  all_int_src;
+} iis2dlpc_all_sources_t;
+int32_t iis2dlpc_all_sources_get(iis2dlpc_ctx_t *ctx,
+                                 iis2dlpc_all_sources_t *val);
+
+int32_t iis2dlpc_usr_offset_x_set(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_x_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2dlpc_usr_offset_y_set(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_y_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2dlpc_usr_offset_z_set(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_z_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  IIS2DLPC_LSb_977ug    = 0,
+  IIS2DLPC_LSb_15mg6    = 1,
+} iis2dlpc_usr_off_w_t;
+int32_t iis2dlpc_offset_weight_set(iis2dlpc_ctx_t *ctx,
+                                      iis2dlpc_usr_off_w_t val);
+int32_t iis2dlpc_offset_weight_get(iis2dlpc_ctx_t *ctx,
+                                      iis2dlpc_usr_off_w_t *val);
+
+int32_t iis2dlpc_temperature_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2dlpc_acceleration_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2dlpc_device_id_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2dlpc_auto_increment_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_auto_increment_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_reset_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_reset_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_boot_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_boot_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DLPC_XL_ST_DISABLE      = 0,
+  IIS2DLPC_XL_ST_POSITIVE     = 1,
+  IIS2DLPC_XL_ST_NEGATIVE     = 2,
+} iis2dlpc_st_t;
+int32_t iis2dlpc_self_test_set(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t val);
+int32_t iis2dlpc_self_test_get(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t *val);
+
+typedef enum {
+  IIS2DLPC_DRDY_LATCHED   = 0,
+  IIS2DLPC_DRDY_PULSED    = 1,
+} iis2dlpc_drdy_pulsed_t;
+int32_t iis2dlpc_data_ready_mode_set(iis2dlpc_ctx_t *ctx,
+                                     iis2dlpc_drdy_pulsed_t val);
+int32_t iis2dlpc_data_ready_mode_get(iis2dlpc_ctx_t *ctx,
+                                     iis2dlpc_drdy_pulsed_t *val);
+
+typedef enum {
+  IIS2DLPC_LPF_ON_OUT         = 0x00,
+  IIS2DLPC_USER_OFFSET_ON_OUT  = 0x01,
+  IIS2DLPC_HIGH_PASS_ON_OUT    = 0x10,
+} iis2dlpc_fds_t;
+int32_t iis2dlpc_filter_path_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t val);
+int32_t iis2dlpc_filter_path_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t *val);
+
+typedef enum {
+  IIS2DLPC_ODR_DIV_2     = 0,
+  IIS2DLPC_ODR_DIV_4     = 1,
+  IIS2DLPC_ODR_DIV_10    = 2,
+  IIS2DLPC_ODR_DIV_20    = 3,
+} iis2dlpc_bw_filt_t;
+int32_t iis2dlpc_filter_bandwidth_set(iis2dlpc_ctx_t *ctx,
+                                         iis2dlpc_bw_filt_t val);
+int32_t iis2dlpc_filter_bandwidth_get(iis2dlpc_ctx_t *ctx,
+                                         iis2dlpc_bw_filt_t *val);
+
+int32_t iis2dlpc_reference_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_reference_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DLPC_SPI_4_WIRE   = 0,
+  IIS2DLPC_SPI_3_WIRE   = 1,
+} iis2dlpc_sim_t;
+int32_t iis2dlpc_spi_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t val);
+int32_t iis2dlpc_spi_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t *val);
+
+typedef enum {
+  IIS2DLPC_I2C_ENABLE    = 0,
+  IIS2DLPC_I2C_DISABLE   = 1,
+} iis2dlpc_i2c_disable_t;
+int32_t iis2dlpc_i2c_interface_set(iis2dlpc_ctx_t *ctx,
+                                   iis2dlpc_i2c_disable_t val);
+int32_t iis2dlpc_i2c_interface_get(iis2dlpc_ctx_t *ctx,
+                                   iis2dlpc_i2c_disable_t *val);
+
+typedef enum {
+  IIS2DLPC_PULL_UP_CONNECT     = 0,
+  IIS2DLPC_PULL_UP_DISCONNECT  = 1,
+} iis2dlpc_cs_pu_disc_t;
+int32_t iis2dlpc_cs_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t val);
+int32_t iis2dlpc_cs_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t *val);
+
+typedef enum {
+  IIS2DLPC_ACTIVE_HIGH  = 0,
+  IIS2DLPC_ACTIVE_LOW   = 1,
+} iis2dlpc_h_lactive_t;
+int32_t iis2dlpc_pin_polarity_set(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_h_lactive_t val);
+int32_t iis2dlpc_pin_polarity_get(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_h_lactive_t *val);
+
+typedef enum {
+  IIS2DLPC_INT_PULSED   = 0,
+  IIS2DLPC_INT_LATCHED  = 1,
+} iis2dlpc_lir_t;
+int32_t iis2dlpc_int_notification_set(iis2dlpc_ctx_t *ctx,
+                                      iis2dlpc_lir_t val);
+int32_t iis2dlpc_int_notification_get(iis2dlpc_ctx_t *ctx,
+                                      iis2dlpc_lir_t *val);
+
+typedef enum {
+  IIS2DLPC_PUSH_PULL   = 0,
+  IIS2DLPC_OPEN_DRAIN  = 1,
+} iis2dlpc_pp_od_t;
+int32_t iis2dlpc_pin_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t val);
+int32_t iis2dlpc_pin_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t *val);
+
+int32_t iis2dlpc_pin_int1_route_set(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_ctrl4_int1_pad_ctrl_t *val);
+int32_t iis2dlpc_pin_int1_route_get(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_ctrl4_int1_pad_ctrl_t *val);
+
+int32_t iis2dlpc_pin_int2_route_set(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_ctrl5_int2_pad_ctrl_t *val);
+int32_t iis2dlpc_pin_int2_route_get(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_ctrl5_int2_pad_ctrl_t *val);
+
+int32_t iis2dlpc_all_on_int1_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_all_on_int1_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_wkup_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_wkup_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_wkup_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_wkup_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DLPC_HP_FEED           = 0,
+  IIS2DLPC_USER_OFFSET_FEED  = 1,
+} iis2dlpc_usr_off_on_wu_t;
+int32_t iis2dlpc_wkup_feed_data_set(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_usr_off_on_wu_t val);
+int32_t iis2dlpc_wkup_feed_data_get(iis2dlpc_ctx_t *ctx,
+                                    iis2dlpc_usr_off_on_wu_t *val);
+
+typedef enum {
+  IIS2DLPC_NO_DETECTION        = 0,
+  IIS2DLPC_DETECT_ACT_INACT    = 1,
+  IIS2DLPC_DETECT_STAT_MOTION  = 3,
+} iis2dlpc_sleep_on_t;
+int32_t iis2dlpc_act_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t val);
+int32_t iis2dlpc_act_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t *val);
+
+int32_t iis2dlpc_act_sleep_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_act_sleep_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_tap_threshold_x_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_threshold_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_tap_threshold_y_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_threshold_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DLPC_XYZ    = 0,
+  IIS2DLPC_YXZ    = 1,
+  IIS2DLPC_XZY    = 2,
+  IIS2DLPC_ZYX    = 3,
+  IIS2DLPC_YZX    = 5,
+  IIS2DLPC_ZXY    = 6,
+} iis2dlpc_tap_prior_t;
+int32_t iis2dlpc_tap_axis_priority_set(iis2dlpc_ctx_t *ctx,
+                                       iis2dlpc_tap_prior_t val);
+int32_t iis2dlpc_tap_axis_priority_get(iis2dlpc_ctx_t *ctx,
+                                       iis2dlpc_tap_prior_t *val);
+
+int32_t iis2dlpc_tap_threshold_z_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_threshold_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_tap_detection_on_z_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_detection_on_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_tap_detection_on_y_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_detection_on_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_tap_detection_on_x_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_detection_on_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_tap_shock_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_shock_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_tap_quiet_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_quiet_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_tap_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DLPC_ONLY_SINGLE          = 0,
+  IIS2DLPC_BOTH_SINGLE_DOUBLE   = 1,
+} iis2dlpc_single_double_tap_t;
+int32_t iis2dlpc_tap_mode_set(iis2dlpc_ctx_t *ctx,
+                              iis2dlpc_single_double_tap_t val);
+int32_t iis2dlpc_tap_mode_get(iis2dlpc_ctx_t *ctx,
+                              iis2dlpc_single_double_tap_t *val);
+
+int32_t iis2dlpc_tap_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_tap_src_t *val);
+
+int32_t iis2dlpc_6d_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_6d_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_4d_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_4d_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_6d_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sixd_src_t *val);
+
+typedef enum {
+  IIS2DLPC_ODR_DIV_2_FEED   = 0,
+  IIS2DLPC_LPF2_FEED        = 1,
+} iis2dlpc_lpass_on6d_t;
+int32_t iis2dlpc_6d_feed_data_set(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_lpass_on6d_t val);
+int32_t iis2dlpc_6d_feed_data_get(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_lpass_on6d_t *val);
+
+int32_t iis2dlpc_ff_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_ff_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DLPC_FF_TSH_5LSb_FS2g  = 0,
+  IIS2DLPC_FF_TSH_7LSb_FS2g  = 1,
+  IIS2DLPC_FF_TSH_8LSb_FS2g  = 2,
+  IIS2DLPC_FF_TSH_10LSb_FS2g = 3,
+  IIS2DLPC_FF_TSH_11LSb_FS2g = 4,
+  IIS2DLPC_FF_TSH_13LSb_FS2g = 5,
+  IIS2DLPC_FF_TSH_15LSb_FS2g = 6,
+  IIS2DLPC_FF_TSH_16LSb_FS2g = 7,
+} iis2dlpc_ff_ths_t;
+int32_t iis2dlpc_ff_threshold_set(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_ff_ths_t val);
+int32_t iis2dlpc_ff_threshold_get(iis2dlpc_ctx_t *ctx,
+                                  iis2dlpc_ff_ths_t *val);
+
+int32_t iis2dlpc_fifo_watermark_set(iis2dlpc_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_fifo_watermark_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2DLPC_BYPASS_MODE             = 0,
+  IIS2DLPC_FIFO_MODE               = 1,
+  IIS2DLPC_STREAM_TO_FIFO_MODE     = 3,
+  IIS2DLPC_BYPASS_TO_STREAM_MODE   = 4,
+  IIS2DLPC_STREAM_MODE             = 6,
+} iis2dlpc_fmode_t;
+int32_t iis2dlpc_fifo_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t val);
+int32_t iis2dlpc_fifo_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t *val);
+
+int32_t iis2dlpc_fifo_data_level_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_fifo_ovr_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2dlpc_fifo_wtm_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*IIS2DLPC_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.c
+++ b/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.c
@@ -1,0 +1,1132 @@
+/*
+ ******************************************************************************
+ * @file    iis2mdc_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   IIS2MDC driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+#include "iis2mdc_reg.h"
+/**
+  * @defgroup  IIS2MDC
+  * @brief     This file provides a set of functions needed to drive the
+  *            iis2mdc enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  IIS2MDC_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_read_reg(iis2mdc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_write_reg(iis2mdc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS2MDC_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float iis2mdc_from_lsb_to_mgauss(int16_t lsb)
+{
+  return ((float)lsb) * 1.5f;
+}
+
+float iis2mdc_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float)lsb / 8.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2MDC_data_generation.
+  * @brief      This section group all the functions concerning
+  *             data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  These registers comprise a 3 group of 16-bit number and represent
+  *         hard-iron offset in order to compensate environmental effects.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG.
+  *         These values act on the magnetic output data value in order to
+  *         delete the environmental offset.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_mag_user_offset_set(iis2mdc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  iis2mdc_write_reg(ctx, IIS2MDC_OFFSET_X_REG_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  These registers comprise a 3 group of 16-bit number and represent
+  *         hard-iron offset in order to compensate environmental effects.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG.
+  *         These values act on the magnetic output data value in order to
+  *         delete the environmental offset.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_mag_user_offset_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_OFFSET_X_REG_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of md in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_operating_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_md_t val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.md = (uint8_t)val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of md in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_operating_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_md_t *val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  switch (reg.md) {
+    case IIS2MDC_CONTINUOUS_MODE:
+      *val = IIS2MDC_CONTINUOUS_MODE;
+      break;
+    case IIS2MDC_SINGLE_TRIGGER:
+      *val = IIS2MDC_SINGLE_TRIGGER;
+      break;
+    case IIS2MDC_POWER_DOWN:
+      *val = IIS2MDC_POWER_DOWN;
+      break;
+    default:
+      *val = IIS2MDC_CONTINUOUS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_data_rate_set(iis2mdc_ctx_t *ctx, iis2mdc_odr_t val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.odr = (uint8_t)val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_data_rate_get(iis2mdc_ctx_t *ctx, iis2mdc_odr_t *val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  switch (reg.odr) {
+    case IIS2MDC_ODR_10Hz:
+      *val = IIS2MDC_ODR_10Hz;
+      break;
+    case IIS2MDC_ODR_20Hz:
+      *val = IIS2MDC_ODR_20Hz;
+      break;
+    case IIS2MDC_ODR_50Hz:
+      *val = IIS2MDC_ODR_50Hz;
+      break;
+    case IIS2MDC_ODR_100Hz:
+      *val = IIS2MDC_ODR_100Hz;
+      break;
+    default:
+      *val = IIS2MDC_ODR_10Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables high-resolution/low-power mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lp in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_power_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_lp_t val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lp = (uint8_t)val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables high-resolution/low-power mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lp in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_power_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_lp_t *val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  switch (reg.lp) {
+    case IIS2MDC_HIGH_RESOLUTION:
+      *val = IIS2MDC_HIGH_RESOLUTION;
+      break;
+    case IIS2MDC_LOW_POWER:
+      *val = IIS2MDC_LOW_POWER;
+      break;
+    default:
+      *val = IIS2MDC_HIGH_RESOLUTION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the magnetometer temperature compensation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of comp_temp_en in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_offset_temp_comp_set(iis2mdc_ctx_t *ctx, uint8_t val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.comp_temp_en = val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the magnetometer temperature compensation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of comp_temp_en in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_offset_temp_comp_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  *val = reg.comp_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf in reg CFG_REG_B
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_low_pass_bandwidth_set(iis2mdc_ctx_t *ctx,
+                                       iis2mdc_lpf_t val)
+{
+  iis2mdc_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lpf = (uint8_t)val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lpf in reg CFG_REG_B
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_low_pass_bandwidth_get(iis2mdc_ctx_t *ctx,
+                                       iis2mdc_lpf_t *val)
+{
+  iis2mdc_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  switch (reg.lpf) {
+    case IIS2MDC_ODR_DIV_2:
+      *val = IIS2MDC_ODR_DIV_2;
+      break;
+    case IIS2MDC_ODR_DIV_4:
+      *val = IIS2MDC_ODR_DIV_4;
+      break;
+    default:
+      *val = IIS2MDC_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset puse mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of set_rst in
+  *                            reg CFG_REG_B
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_set_rst_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_set_rst_t val)
+{
+  iis2mdc_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.set_rst = (uint8_t)val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset puse mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of set_rst in reg CFG_REG_B
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_set_rst_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_set_rst_t *val)
+{
+  iis2mdc_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  switch (reg.set_rst) {
+    case IIS2MDC_SET_SENS_ODR_DIV_63:
+      *val = IIS2MDC_SET_SENS_ODR_DIV_63;
+      break;
+    case IIS2MDC_SENS_OFF_CANC_EVERY_ODR:
+      *val = IIS2MDC_SENS_OFF_CANC_EVERY_ODR;
+      break;
+    case IIS2MDC_SET_SENS_ONLY_AT_POWER_ON:
+      *val = IIS2MDC_SET_SENS_ONLY_AT_POWER_ON;
+      break;
+    default:
+      *val = IIS2MDC_SET_SENS_ODR_DIV_63;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables offset cancellation in single measurement mode.
+  *         The OFF_CANC bit must be set to 1 when enabling offset
+  *         cancellation in single measurement mode this means a
+  *         call function "set_rst_mode(SENS_OFF_CANC_EVERY_ODR)"
+  *         is need.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of off_canc_one_shot in
+  *                  reg CFG_REG_B
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_set_rst_sensor_single_set(iis2mdc_ctx_t *ctx, uint8_t val)
+{
+  iis2mdc_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.off_canc_one_shot = val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables offset cancellation in single measurement mode.
+  *         The OFF_CANC bit must be set to 1 when enabling offset
+  *         cancellation in single measurement mode this means a
+  *         call function "set_rst_mode(SENS_OFF_CANC_EVERY_ODR)"
+  *         is need.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of off_canc_one_shot in reg CFG_REG_B
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_set_rst_sensor_single_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  *val = reg.off_canc_one_shot;
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_block_data_update_set(iis2mdc_ctx_t *ctx, uint8_t val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_block_data_update_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic set of data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_mag_data_ready_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_status_reg_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t*) &reg, 1);
+  *val = reg.zyxda;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic set of data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxor in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_mag_data_ovr_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_status_reg_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t*) &reg, 1);
+  *val = reg.zyxor;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_magnetic_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_OUTX_L_REG, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_temperature_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_TEMP_OUT_L_REG, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2MDC_common
+  * @brief      This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_device_id_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user
+  *         registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_rst in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_reset_set(iis2mdc_ctx_t *ctx, uint8_t val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.soft_rst = val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_rst in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_reset_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  *val = reg.soft_rst;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reboot in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_boot_set(iis2mdc_ctx_t *ctx, uint8_t val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.reboot = val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reboot in reg CFG_REG_A
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_boot_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_A, (uint8_t*) &reg, 1);
+  *val = reg.reboot;
+
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of self_test in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_self_test_set(iis2mdc_ctx_t *ctx, uint8_t val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.self_test = val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of self_test in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_self_test_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  *val = reg.self_test;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ble in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_data_format_set(iis2mdc_ctx_t *ctx, iis2mdc_ble_t val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.ble = (uint8_t)val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ble in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_data_format_get(iis2mdc_ctx_t *ctx, iis2mdc_ble_t *val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  switch (reg.ble) {
+    case IIS2MDC_LSB_AT_LOW_ADD:
+      *val = IIS2MDC_LSB_AT_LOW_ADD;
+      break;
+    case IIS2MDC_MSB_AT_LOW_ADD:
+      *val = IIS2MDC_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = IIS2MDC_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_status_get(iis2mdc_ctx_t *ctx, iis2mdc_status_reg_t *val)
+{
+  int32_t ret;
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2MDC_interrupts
+  * @brief      This section group all the functions that manage
+  *             interrupts.
+  * @{
+  *
+  */
+
+/**
+  * @brief  The interrupt block recognition checks data after/before the
+  *         hard-iron correction to discover the interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_on_dataoff in
+  *                                   reg CFG_REG_B
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_offset_int_conf_set(iis2mdc_ctx_t *ctx,
+                                    iis2mdc_int_on_dataoff_t val)
+{
+  iis2mdc_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.int_on_dataoff = (uint8_t)val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The interrupt block recognition checks data after/before the
+  *         hard-iron correction to discover the interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of int_on_dataoff in
+  *                                   reg CFG_REG_B
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_offset_int_conf_get(iis2mdc_ctx_t *ctx,
+                                    iis2mdc_int_on_dataoff_t *val)
+{
+  iis2mdc_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_B, (uint8_t*) &reg, 1);
+  switch (reg.int_on_dataoff) {
+    case IIS2MDC_CHECK_BEFORE:
+      *val = IIS2MDC_CHECK_BEFORE;
+      break;
+    case IIS2MDC_CHECK_AFTER:
+      *val = IIS2MDC_CHECK_AFTER;
+      break;
+    default:
+      *val = IIS2MDC_CHECK_BEFORE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_on_pin in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_drdy_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.drdy_on_pin = val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_on_pin in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_drdy_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  *val = reg.drdy_on_pin;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_on_pin in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_int_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.int_on_pin = val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_on_pin in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_int_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  *val = reg.int_on_pin;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT_CRTL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_int_gen_conf_set(iis2mdc_ctx_t *ctx,
+                                 iis2mdc_int_crtl_reg_t *val)
+{
+  int32_t ret;
+  ret =  iis2mdc_write_reg(ctx, IIS2MDC_INT_CRTL_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT_CRTL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_int_gen_conf_get(iis2mdc_ctx_t *ctx,
+                                 iis2mdc_int_crtl_reg_t *val)
+{
+  int32_t ret;
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_INT_CRTL_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT_SOURCE_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_int_gen_source_get(iis2mdc_ctx_t *ctx,
+                                   iis2mdc_int_source_reg_t *val)
+{
+  int32_t ret;
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_INT_SOURCE_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output data raw:
+  *         two’s complement with 1LSb = 1.5mG.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_int_gen_treshold_set(iis2mdc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  iis2mdc_write_reg(ctx, IIS2MDC_INT_THS_L_REG, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output data raw:
+  *         two’s complement with 1LSb = 1.5mG.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_int_gen_treshold_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  iis2mdc_read_reg(ctx, IIS2MDC_INT_THS_L_REG, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS2MDC_serial_interface
+  * @brief      This section group all the functions concerning serial
+  *             interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable/Disable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_dis in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_i2c_interface_set(iis2mdc_ctx_t *ctx, iis2mdc_i2c_dis_t val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i2c_dis = (uint8_t)val;
+    ret = iis2mdc_write_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable I2C interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_dis in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis2mdc_i2c_interface_get(iis2mdc_ctx_t *ctx, iis2mdc_i2c_dis_t *val)
+{
+  iis2mdc_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = iis2mdc_read_reg(ctx, IIS2MDC_CFG_REG_C, (uint8_t*) &reg, 1);
+  switch (reg.i2c_dis) {
+    case IIS2MDC_I2C_ENABLE:
+      *val = IIS2MDC_I2C_ENABLE;
+      break;
+    case IIS2MDC_I2C_DISABLE:
+      *val = IIS2MDC_I2C_DISABLE;
+      break;
+    default:
+      *val = IIS2MDC_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.h
+++ b/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.h
@@ -1,0 +1,421 @@
+/*
+ ******************************************************************************
+ * @file    iis2mdc_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          iis2mdc_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef IIS2MDC_REGS_H
+#define IIS2MDC_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup IIS2MDC
+  * @{
+  *
+  */
+
+/** @defgroup IIS2MDC_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  IIS2MDC_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*iis2mdc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*iis2mdc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  iis2mdc_write_ptr  write_reg;
+  iis2mdc_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} iis2mdc_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup iis2mdc_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format **/
+#define IIS2MDC_I2C_ADD       0x3DU
+
+/** Device Identification (Who am I) **/
+#define IIS2MDC_ID            0x40U
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  IIS2MDC_Sensitivity
+  * @brief       These macro are maintained for back compatibility.
+  *              in order to convert data into engineering units please
+  *              use functions:
+  *                -> _from_lsb_to_mgauss(int16_t lsb);
+  *                -> _from_lsb_to_celsius(int16_t lsb);
+  *
+  *              REMOVING the MACRO you are compliant with:
+  *              MISRA-C 2012 [Dir 4.9] -> " avoid function-like macros "
+  * @{
+  *
+  */
+
+#define IIS2MDC_FROM_LSB_TO_mG(lsb)     (float)(lsb * 1.5f)
+#define IIS2MDC_FROM_LSB_TO_degC(lsb)   (float)(lsb / 8.0f) + (25.0f)
+
+/**
+  * @}
+  *
+  */
+
+#define IIS2MDC_OFFSET_X_REG_L          0x45U
+#define IIS2MDC_OFFSET_X_REG_H          0x46U
+#define IIS2MDC_OFFSET_Y_REG_L          0x47U
+#define IIS2MDC_OFFSET_Y_REG_H          0x48U
+#define IIS2MDC_OFFSET_Z_REG_L          0x49U
+#define IIS2MDC_OFFSET_Z_REG_H          0x4AU
+#define IIS2MDC_WHO_AM_I                0x4FU
+#define IIS2MDC_CFG_REG_A               0x60U
+typedef struct {
+  uint8_t md                     : 2;
+  uint8_t odr                    : 2;
+  uint8_t lp                     : 1;
+  uint8_t soft_rst               : 1;
+  uint8_t reboot                 : 1;
+  uint8_t comp_temp_en           : 1;
+} iis2mdc_cfg_reg_a_t;
+
+#define IIS2MDC_CFG_REG_B               0x61U
+typedef struct {
+  uint8_t lpf                    : 1;
+  uint8_t set_rst                : 2; /* OFF_CANC + Set_FREQ */
+  uint8_t int_on_dataoff         : 1;
+  uint8_t off_canc_one_shot      : 1;
+  uint8_t not_used_01            : 3;
+} iis2mdc_cfg_reg_b_t;
+
+#define IIS2MDC_CFG_REG_C               0x62U
+typedef struct {
+  uint8_t drdy_on_pin            : 1;
+  uint8_t self_test              : 1;
+  uint8_t not_used_01            : 1;
+  uint8_t ble                    : 1;
+  uint8_t bdu                    : 1;
+  uint8_t i2c_dis                : 1;
+  uint8_t int_on_pin             : 1;
+  uint8_t not_used_02            : 1;
+} iis2mdc_cfg_reg_c_t;
+
+#define IIS2MDC_INT_CRTL_REG            0x63U
+typedef struct {
+  uint8_t ien                    : 1;
+  uint8_t iel                    : 1;
+  uint8_t iea                    : 1;
+  uint8_t not_used_01            : 2;
+  uint8_t zien                   : 1;
+  uint8_t yien                   : 1;
+  uint8_t xien                   : 1;
+} iis2mdc_int_crtl_reg_t;
+
+#define IIS2MDC_INT_SOURCE_REG          0x64U
+typedef struct {
+  uint8_t _int                    : 1;
+  uint8_t mroi                   : 1;
+  uint8_t n_th_s_z               : 1;
+  uint8_t n_th_s_y               : 1;
+  uint8_t n_th_s_x               : 1;
+  uint8_t p_th_s_z               : 1;
+  uint8_t p_th_s_y               : 1;
+  uint8_t p_th_s_x               : 1;
+} iis2mdc_int_source_reg_t;
+
+#define IIS2MDC_INT_THS_L_REG           0x65U
+#define IIS2MDC_INT_THS_H_REG           0x66U
+#define IIS2MDC_STATUS_REG              0x67U
+typedef struct {
+  uint8_t xda                    : 1;
+  uint8_t yda                    : 1;
+  uint8_t zda                    : 1;
+  uint8_t zyxda                  : 1;
+  uint8_t _xor                   : 1;
+  uint8_t yor                    : 1;
+  uint8_t zor                    : 1;
+  uint8_t zyxor                  : 1;
+} iis2mdc_status_reg_t;
+
+#define IIS2MDC_OUTX_L_REG              0x68U
+#define IIS2MDC_OUTX_H_REG              0x69U
+#define IIS2MDC_OUTY_L_REG              0x6AU
+#define IIS2MDC_OUTY_H_REG              0x6BU
+#define IIS2MDC_OUTZ_L_REG              0x6CU
+#define IIS2MDC_OUTZ_H_REG              0x6DU
+#define IIS2MDC_TEMP_OUT_L_REG          0x6EU
+#define IIS2MDC_TEMP_OUT_H_REG          0x6FU
+
+typedef union{
+  iis2mdc_cfg_reg_a_t            cfg_reg_a;
+  iis2mdc_cfg_reg_b_t            cfg_reg_b;
+  iis2mdc_cfg_reg_c_t            cfg_reg_c;
+  iis2mdc_int_crtl_reg_t         int_crtl_reg;
+  iis2mdc_int_source_reg_t       int_source_reg;
+  iis2mdc_status_reg_t           status_reg;
+  bitwise_t                      bitwise;
+  uint8_t                        byte;
+} iis2mdc_reg_t;
+
+int32_t iis2mdc_read_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t iis2mdc_write_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+float iis2mdc_from_lsb_to_mgauss(int16_t lsb);
+float iis2mdc_from_lsb_to_celsius(int16_t lsb);
+
+int32_t iis2mdc_mag_user_offset_set(iis2mdc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_mag_user_offset_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+typedef enum {
+  IIS2MDC_CONTINUOUS_MODE  = 0,
+  IIS2MDC_SINGLE_TRIGGER   = 1,
+  IIS2MDC_POWER_DOWN       = 2,
+} iis2mdc_md_t;
+int32_t iis2mdc_operating_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_md_t val);
+int32_t iis2mdc_operating_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_md_t *val);
+
+typedef enum {
+  IIS2MDC_ODR_10Hz   = 0,
+  IIS2MDC_ODR_20Hz   = 1,
+  IIS2MDC_ODR_50Hz   = 2,
+  IIS2MDC_ODR_100Hz  = 3,
+} iis2mdc_odr_t;
+int32_t iis2mdc_data_rate_set(iis2mdc_ctx_t *ctx, iis2mdc_odr_t val);
+int32_t iis2mdc_data_rate_get(iis2mdc_ctx_t *ctx, iis2mdc_odr_t *val);
+
+typedef enum {
+  IIS2MDC_HIGH_RESOLUTION  = 0,
+  IIS2MDC_LOW_POWER        = 1,
+} iis2mdc_lp_t;
+int32_t iis2mdc_power_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_lp_t val);
+int32_t iis2mdc_power_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_lp_t *val);
+
+int32_t iis2mdc_offset_temp_comp_set(iis2mdc_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_offset_temp_comp_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2MDC_ODR_DIV_2  = 0,
+  IIS2MDC_ODR_DIV_4  = 1,
+} iis2mdc_lpf_t;
+int32_t iis2mdc_low_pass_bandwidth_set(iis2mdc_ctx_t *ctx,
+                                       iis2mdc_lpf_t val);
+int32_t iis2mdc_low_pass_bandwidth_get(iis2mdc_ctx_t *ctx,
+                                       iis2mdc_lpf_t *val);
+
+typedef enum {
+  IIS2MDC_SET_SENS_ODR_DIV_63        = 0,
+  IIS2MDC_SENS_OFF_CANC_EVERY_ODR    = 1,
+  IIS2MDC_SET_SENS_ONLY_AT_POWER_ON  = 2,
+} iis2mdc_set_rst_t;
+int32_t iis2mdc_set_rst_mode_set(iis2mdc_ctx_t *ctx,
+                                 iis2mdc_set_rst_t val);
+int32_t iis2mdc_set_rst_mode_get(iis2mdc_ctx_t *ctx,
+                                 iis2mdc_set_rst_t *val);
+
+int32_t iis2mdc_set_rst_sensor_single_set(iis2mdc_ctx_t *ctx,
+                                          uint8_t val);
+int32_t iis2mdc_set_rst_sensor_single_get(iis2mdc_ctx_t *ctx,
+                                          uint8_t *val);
+
+int32_t iis2mdc_block_data_update_set(iis2mdc_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_block_data_update_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2mdc_mag_data_ready_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2mdc_mag_data_ovr_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2mdc_magnetic_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2mdc_temperature_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2mdc_device_id_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis2mdc_reset_set(iis2mdc_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_reset_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2mdc_boot_set(iis2mdc_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_boot_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2mdc_self_test_set(iis2mdc_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_self_test_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS2MDC_LSB_AT_LOW_ADD  = 0,
+  IIS2MDC_MSB_AT_LOW_ADD  = 1,
+} iis2mdc_ble_t;
+int32_t iis2mdc_data_format_set(iis2mdc_ctx_t *ctx, iis2mdc_ble_t val);
+int32_t iis2mdc_data_format_get(iis2mdc_ctx_t *ctx, iis2mdc_ble_t *val);
+
+int32_t iis2mdc_status_get(iis2mdc_ctx_t *ctx, iis2mdc_status_reg_t *val);
+
+typedef enum {
+  IIS2MDC_CHECK_BEFORE  = 0,
+  IIS2MDC_CHECK_AFTER   = 1,
+} iis2mdc_int_on_dataoff_t;
+int32_t iis2mdc_offset_int_conf_set(iis2mdc_ctx_t *ctx,
+                                    iis2mdc_int_on_dataoff_t val);
+int32_t iis2mdc_offset_int_conf_get(iis2mdc_ctx_t *ctx,
+                                    iis2mdc_int_on_dataoff_t *val);
+
+int32_t iis2mdc_drdy_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_drdy_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2mdc_int_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_int_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis2mdc_int_gen_conf_set(iis2mdc_ctx_t *ctx,
+                                 iis2mdc_int_crtl_reg_t *val);
+int32_t iis2mdc_int_gen_conf_get(iis2mdc_ctx_t *ctx,
+                                 iis2mdc_int_crtl_reg_t *val);
+
+int32_t iis2mdc_int_gen_source_get(iis2mdc_ctx_t *ctx,
+                                   iis2mdc_int_source_reg_t *val);
+
+int32_t iis2mdc_int_gen_treshold_set(iis2mdc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_int_gen_treshold_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  IIS2MDC_I2C_ENABLE   = 0,
+  IIS2MDC_I2C_DISABLE  = 1,
+} iis2mdc_i2c_dis_t;
+int32_t iis2mdc_i2c_interface_set(iis2mdc_ctx_t *ctx,
+                                  iis2mdc_i2c_dis_t val);
+int32_t iis2mdc_i2c_interface_get(iis2mdc_ctx_t *ctx,
+                                  iis2mdc_i2c_dis_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IIS2MDC_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis328dq_STdC/driver/iis328dq_reg.c
+++ b/sensor/stmemsc/iis328dq_STdC/driver/iis328dq_reg.c
@@ -1,0 +1,2001 @@
+/*
+ ******************************************************************************
+ * @file    iis328dq_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   IIS328DQ driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "iis328dq_reg.h"
+
+/**
+  * @defgroup    IIS328DQ
+  * @brief       This file provides a set of functions needed to drive the
+  *              iis328dq enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis328dq_read_reg(iis328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis328dq_write_reg(iis328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    IIS328DQ_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float iis328dq_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 0.98f / 16.0f);
+}
+
+float iis328dq_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 1.95f / 16.0f);
+}
+
+float iis328dq_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 3.91f / 16.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Data_Generation
+  * @brief       This section group all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  X axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t iis328dq_axis_x_data_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.xen = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t iis328dq_axis_x_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.xen;
+
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t iis328dq_axis_y_data_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.yen = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t iis328dq_axis_y_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.yen;
+
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t iis328dq_axis_z_data_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.zen = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t iis328dq_axis_z_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.zen;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t iis328dq_data_rate_set(iis328dq_ctx_t *ctx, iis328dq_dr_t val)
+{
+  iis328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.pm = (uint8_t)val & 0x07U;
+    ctrl_reg1.dr = ( (uint8_t)val & 0x30U ) >> 4;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t iis328dq_data_rate_get(iis328dq_ctx_t *ctx, iis328dq_dr_t *val)
+{
+  iis328dq_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+
+  switch ((ctrl_reg1.dr << 4) + ctrl_reg1.pm)
+  {
+    case IIS328DQ_ODR_OFF:
+      *val = IIS328DQ_ODR_OFF;
+      break;
+    case IIS328DQ_ODR_Hz5:
+      *val = IIS328DQ_ODR_Hz5;
+      break;
+    case IIS328DQ_ODR_1Hz:
+      *val = IIS328DQ_ODR_1Hz;
+      break;
+    case IIS328DQ_ODR_5Hz2:
+      *val = IIS328DQ_ODR_5Hz2;
+      break;
+    case IIS328DQ_ODR_5Hz:
+      *val = IIS328DQ_ODR_5Hz;
+      break;
+    case IIS328DQ_ODR_10Hz:
+      *val = IIS328DQ_ODR_10Hz;
+      break;
+    case IIS328DQ_ODR_50Hz:
+      *val = IIS328DQ_ODR_50Hz;
+      break;
+    case IIS328DQ_ODR_100Hz:
+      *val = IIS328DQ_ODR_100Hz;
+      break;
+    case IIS328DQ_ODR_400Hz:
+      *val = IIS328DQ_ODR_400Hz;
+      break;
+    case IIS328DQ_ODR_1kHz:
+      *val = IIS328DQ_ODR_1kHz;
+      break;
+    default:
+      *val = IIS328DQ_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t iis328dq_reference_mode_set(iis328dq_ctx_t *ctx,
+                                     iis328dq_hpm_t val)
+{
+  iis328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t iis328dq_reference_mode_get(iis328dq_ctx_t *ctx,
+                                     iis328dq_hpm_t *val)
+{
+  iis328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG2,
+                           (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpm)
+  {
+    case IIS328DQ_NORMAL_MODE:
+      *val = IIS328DQ_NORMAL_MODE;
+      break;
+    case IIS328DQ_REF_MODE_ENABLE:
+      *val = IIS328DQ_REF_MODE_ENABLE;
+      break;
+    default:
+      *val = IIS328DQ_NORMAL_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_full_scale_set(iis328dq_ctx_t *ctx, iis328dq_fs_t val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_full_scale_get(iis328dq_ctx_t *ctx, iis328dq_fs_t *val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.fs)
+  {
+    case IIS328DQ_2g:
+      *val = IIS328DQ_2g;
+      break;
+    case IIS328DQ_4g:
+      *val = IIS328DQ_4g;
+      break;
+    case IIS328DQ_8g:
+      *val = IIS328DQ_8g;
+      break;
+    default:
+      *val = IIS328DQ_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_block_data_update_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_block_data_update_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers STATUS_REG
+  *
+  */
+int32_t iis328dq_status_reg_get(iis328dq_ctx_t *ctx,
+                                 iis328dq_status_reg_t *val)
+{
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zyxda in reg STATUS_REG
+  *
+  */
+int32_t iis328dq_flag_data_ready_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Data_Output
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t iis328dq_acceleration_raw_get(iis328dq_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Common
+  * @brief       This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t iis328dq_device_id_get(iis328dq_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t iis328dq_boot_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.boot = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t iis328dq_boot_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of st in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_self_test_set(iis328dq_ctx_t *ctx, iis328dq_st_t val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of st in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_self_test_get(iis328dq_ctx_t *ctx, iis328dq_st_t *val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.st)
+  {
+    case IIS328DQ_ST_DISABLE:
+      *val = IIS328DQ_ST_DISABLE;
+      break;
+    case IIS328DQ_ST_POSITIVE:
+      *val = IIS328DQ_ST_POSITIVE;
+      break;
+    case IIS328DQ_ST_NEGATIVE:
+      *val = IIS328DQ_ST_NEGATIVE;
+      break;
+    default:
+      *val = IIS328DQ_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_data_format_set(iis328dq_ctx_t *ctx, iis328dq_ble_t val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_data_format_get(iis328dq_ctx_t *ctx, iis328dq_ble_t *val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.ble)
+  {
+    case IIS328DQ_LSB_AT_LOW_ADD:
+      *val = IIS328DQ_LSB_AT_LOW_ADD;
+      break;
+    case IIS328DQ_MSB_AT_LOW_ADD:
+      *val = IIS328DQ_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = IIS328DQ_LSB_AT_LOW_ADD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Filters
+  * @brief       This section group all the functions concerning the
+  *              filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t iis328dq_hp_bandwidth_set(iis328dq_ctx_t *ctx, iis328dq_hpcf_t val)
+{
+  iis328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t iis328dq_hp_bandwidth_get(iis328dq_ctx_t *ctx,
+                                   iis328dq_hpcf_t *val)
+{
+  iis328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpcf)
+  {
+    case IIS328DQ_CUT_OFF_8Hz:
+      *val = IIS328DQ_CUT_OFF_8Hz;
+      break;
+    case IIS328DQ_CUT_OFF_16Hz:
+      *val = IIS328DQ_CUT_OFF_16Hz;
+      break;
+    case IIS328DQ_CUT_OFF_32Hz:
+      *val = IIS328DQ_CUT_OFF_32Hz;
+      break;
+    case IIS328DQ_CUT_OFF_64Hz:
+      *val = IIS328DQ_CUT_OFF_64Hz;
+      break;
+    default:
+      *val = IIS328DQ_CUT_OFF_8Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t iis328dq_hp_path_set(iis328dq_ctx_t *ctx, iis328dq_hpen_t val)
+{
+  iis328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpen = (uint8_t)val & 0x03U;
+    ctrl_reg2.fds = ((uint8_t)val & 0x04U) >> 2;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t iis328dq_hp_path_get(iis328dq_ctx_t *ctx, iis328dq_hpen_t *val)
+{
+  iis328dq_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+
+  switch ( (ctrl_reg2.fds << 2) + ctrl_reg2.hpen )
+  {
+    case IIS328DQ_HP_DISABLE:
+      *val = IIS328DQ_HP_DISABLE;
+      break;
+    case IIS328DQ_HP_ON_OUT:
+      *val = IIS328DQ_HP_ON_OUT;
+      break;
+    case IIS328DQ_HP_ON_INT1:
+      *val = IIS328DQ_HP_ON_INT1;
+      break;
+    case IIS328DQ_HP_ON_INT2:
+      *val = IIS328DQ_HP_ON_INT2;
+      break;
+    case IIS328DQ_HP_ON_INT1_INT2:
+      *val = IIS328DQ_HP_ON_INT1_INT2;
+      break;
+    case IIS328DQ_HP_ON_INT1_INT2_OUT:
+      *val = IIS328DQ_HP_ON_INT1_INT2_OUT;
+      break;
+    case IIS328DQ_HP_ON_INT2_OUT:
+      *val = IIS328DQ_HP_ON_INT2_OUT;
+      break;
+    case IIS328DQ_HP_ON_INT1_OUT:
+      *val = IIS328DQ_HP_ON_INT1_OUT;
+      break;
+    default:
+      *val = IIS328DQ_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reading at this address zeroes instantaneously
+  *         the content of the internal high pass-filter.
+  *         If the high pass filter is enabled all three axes
+  *         are instantaneously set to 0g. This allows to
+  *         overcome the settling time of the high pass
+  *         filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  *
+  */
+int32_t iis328dq_hp_reset_get(iis328dq_ctx_t *ctx)
+{
+  uint8_t dummy;
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_HP_FILTER_RESET,
+                           (uint8_t*)&dummy, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t iis328dq_hp_reference_value_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  ret = iis328dq_write_reg(ctx, IIS328DQ_REFERENCE, (uint8_t*)&val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t iis328dq_hp_reference_value_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_REFERENCE, val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Serial_Interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_spi_mode_set(iis328dq_ctx_t *ctx, iis328dq_sim_t val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t iis328dq_spi_mode_get(iis328dq_ctx_t *ctx, iis328dq_sim_t *val)
+{
+  iis328dq_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch ( ctrl_reg4.sim )
+  {
+    case IIS328DQ_SPI_4_WIRE:
+      *val = IIS328DQ_SPI_4_WIRE;
+      break;
+    case IIS328DQ_SPI_3_WIRE:
+      *val = IIS328DQ_SPI_3_WIRE;
+      break;
+    default:
+      *val = IIS328DQ_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Interrupt_Pins
+  * @brief       This section groups all the functions that manage
+  *              interrupt pins.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_pin_int1_route_set(iis328dq_ctx_t *ctx,
+                                     iis328dq_i1_cfg_t val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i1_cfg = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_pin_int1_route_get(iis328dq_ctx_t *ctx,
+                                     iis328dq_i1_cfg_t *val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i1_cfg )
+  {
+    case IIS328DQ_PAD1_INT1_SRC:
+      *val = IIS328DQ_PAD1_INT1_SRC;
+      break;
+    case IIS328DQ_PAD1_INT1_OR_INT2_SRC:
+      *val = IIS328DQ_PAD1_INT1_OR_INT2_SRC;
+      break;
+    case IIS328DQ_PAD1_DRDY:
+      *val = IIS328DQ_PAD1_DRDY;
+      break;
+    case IIS328DQ_PAD1_BOOT:
+      *val = IIS328DQ_PAD1_BOOT;
+      break;
+    default:
+      *val = IIS328DQ_PAD1_INT1_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_int1_notification_set(iis328dq_ctx_t *ctx,
+                                        iis328dq_lir1_t val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir1 = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_int1_notification_get(iis328dq_ctx_t *ctx,
+                                        iis328dq_lir1_t *val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir1 )
+  {
+    case IIS328DQ_INT1_PULSED:
+      *val = IIS328DQ_INT1_PULSED;
+      break;
+    case IIS328DQ_INT1_LATCHED:
+      *val = IIS328DQ_INT1_LATCHED;
+      break;
+    default:
+      *val = IIS328DQ_INT1_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_pin_int2_route_set(iis328dq_ctx_t *ctx,
+                                     iis328dq_i2_cfg_t val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i2_cfg = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_pin_int2_route_get(iis328dq_ctx_t *ctx,
+                                     iis328dq_i2_cfg_t *val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i2_cfg )
+  {
+    case IIS328DQ_PAD2_INT2_SRC:
+      *val = IIS328DQ_PAD2_INT2_SRC;
+      break;
+    case IIS328DQ_PAD2_INT1_OR_INT2_SRC:
+      *val = IIS328DQ_PAD2_INT1_OR_INT2_SRC;
+      break;
+    case IIS328DQ_PAD2_DRDY:
+      *val = IIS328DQ_PAD2_DRDY;
+      break;
+    case IIS328DQ_PAD2_BOOT:
+      *val = IIS328DQ_PAD2_BOOT;
+      break;
+    default:
+      *val = IIS328DQ_PAD2_INT2_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_int2_notification_set(iis328dq_ctx_t *ctx,
+                                        iis328dq_lir2_t val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir2 = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_int2_notification_get(iis328dq_ctx_t *ctx,
+                                        iis328dq_lir2_t *val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir2 )
+  {
+    case IIS328DQ_INT2_PULSED:
+      *val = IIS328DQ_INT2_PULSED;
+      break;
+    case IIS328DQ_INT2_LATCHED:
+      *val = IIS328DQ_INT2_LATCHED;
+      break;
+    default:
+      *val = IIS328DQ_INT2_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_pin_mode_set(iis328dq_ctx_t *ctx, iis328dq_pp_od_t val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_pin_mode_get(iis328dq_ctx_t *ctx, iis328dq_pp_od_t *val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.pp_od )
+  {
+    case IIS328DQ_PUSH_PULL:
+      *val = IIS328DQ_PUSH_PULL;
+      break;
+    case IIS328DQ_OPEN_DRAIN:
+      *val = IIS328DQ_OPEN_DRAIN;
+      break;
+    default:
+      *val = IIS328DQ_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_pin_polarity_set(iis328dq_ctx_t *ctx, iis328dq_ihl_t val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.ihl = (uint8_t)val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t iis328dq_pin_polarity_get(iis328dq_ctx_t *ctx, iis328dq_ihl_t *val)
+{
+  iis328dq_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.ihl )
+  {
+    case IIS328DQ_ACTIVE_HIGH:
+      *val = IIS328DQ_ACTIVE_HIGH;
+      break;
+    case IIS328DQ_ACTIVE_LOW:
+      *val = IIS328DQ_ACTIVE_LOW;
+      break;
+    default:
+      *val = IIS328DQ_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_interrupt_on_threshold
+  * @brief       This section groups all the functions that manage
+  *              the interrupt on threshold event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the interrupt 1 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t iis328dq_int1_on_threshold_conf_set(iis328dq_ctx_t *ctx,
+                                              int1_on_th_conf_t val)
+{
+  iis328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.xlie  = val.int1_xlie;
+    int1_cfg.xhie  = val.int1_xhie;
+    int1_cfg.ylie  = val.int1_ylie;
+    int1_cfg.yhie  = val.int1_yhie;
+    int1_cfg.zlie  = val.int1_zlie;
+    int1_cfg.zhie  = val.int1_zhie;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Configure the interrupt 1 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t iis328dq_int1_on_threshold_conf_get(iis328dq_ctx_t *ctx,
+                                             int1_on_th_conf_t *val)
+{
+  iis328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  val->int1_xlie = int1_cfg.xlie;
+  val->int1_xhie = int1_cfg.xhie;
+  val->int1_ylie = int1_cfg.ylie;
+  val->int1_yhie = int1_cfg.yhie;
+  val->int1_zlie = int1_cfg.zlie;
+  val->int1_zhie = int1_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 1 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t iis328dq_int1_on_threshold_mode_set(iis328dq_ctx_t *ctx,
+                                             iis328dq_int1_aoi_t val)
+{
+  iis328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.aoi = (uint8_t) val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 1 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t iis328dq_int1_on_threshold_mode_get(iis328dq_ctx_t *ctx,
+                                             iis328dq_int1_aoi_t *val)
+{
+  iis328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ( int1_cfg.aoi )
+  {
+    case IIS328DQ_INT1_ON_THRESHOLD_OR:
+      *val = IIS328DQ_INT1_ON_THRESHOLD_OR;
+      break;
+    case IIS328DQ_INT1_ON_THRESHOLD_AND:
+      *val = IIS328DQ_INT1_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = IIS328DQ_INT1_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t iis328dq_int1_src_get(iis328dq_ctx_t *ctx,
+                               iis328dq_int1_src_t *val)
+{
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t iis328dq_int1_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT1_THS,
+                              (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t iis328dq_int1_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t iis328dq_int1_dur_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  if(ret == 0) {
+    int1_duration.d = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT1_DURATION,
+                              (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t iis328dq_int1_dur_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  *val = int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t iis328dq_int2_on_threshold_conf_set(iis328dq_ctx_t *ctx,
+                                              int2_on_th_conf_t val)
+{
+  iis328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_CFG,
+                           (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.xlie  = val.int2_xlie;
+    int2_cfg.xhie  = val.int2_xhie;
+    int2_cfg.ylie  = val.int2_ylie;
+    int2_cfg.yhie  = val.int2_yhie;
+    int2_cfg.zlie  = val.int2_zlie;
+    int2_cfg.zhie  = val.int2_zhie;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t iis328dq_int2_on_threshold_conf_get(iis328dq_ctx_t *ctx,
+                                              int2_on_th_conf_t *val)
+{
+  iis328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  val->int2_xlie = int2_cfg.xlie;
+  val->int2_xhie = int2_cfg.xhie;
+  val->int2_ylie = int2_cfg.ylie;
+  val->int2_yhie = int2_cfg.yhie;
+  val->int2_zlie = int2_cfg.zlie;
+  val->int2_zhie = int2_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 2 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t iis328dq_int2_on_threshold_mode_set(iis328dq_ctx_t *ctx,
+                                             iis328dq_int2_aoi_t val)
+{
+  iis328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.aoi = (uint8_t) val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 2 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t iis328dq_int2_on_threshold_mode_get(iis328dq_ctx_t *ctx,
+                                             iis328dq_int2_aoi_t *val)
+{
+  iis328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ( int2_cfg.aoi )
+  {
+    case IIS328DQ_INT2_ON_THRESHOLD_OR:
+      *val = IIS328DQ_INT2_ON_THRESHOLD_OR;
+      break;
+    case IIS328DQ_INT2_ON_THRESHOLD_AND:
+      *val = IIS328DQ_INT2_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = IIS328DQ_INT2_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t iis328dq_int2_src_get(iis328dq_ctx_t *ctx,
+                               iis328dq_int2_src_t *val)
+{
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t iis328dq_int2_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t iis328dq_int2_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t iis328dq_int2_dur_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  if(ret == 0) {
+    int2_duration.d = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT2_DURATION,
+                              (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Duration value for interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t iis328dq_int2_dur_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  *val = int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Wake_Up_Event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t iis328dq_wkup_to_sleep_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0) {
+    ctrl_reg5.turnon = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_CTRL_REG5,
+                              (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t iis328dq_wkup_to_sleep_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.turnon;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS328DQ_Six_Position_Detection
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the 6d on interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of 6d in reg INT1_CFG
+  *
+  */
+int32_t iis328dq_int1_6d_mode_set(iis328dq_ctx_t *ctx,
+                                   iis328dq_int1_6d_t val)
+{
+  iis328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg._6d = (uint8_t)val & 0x01U;
+    int1_cfg.aoi = ((uint8_t)val & 0x02U) >> 1;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of 6d in reg INT1_CFG
+  *
+  */
+int32_t iis328dq_int1_6d_mode_get(iis328dq_ctx_t *ctx,
+                                   iis328dq_int1_6d_t *val)
+{
+  iis328dq_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ((int1_cfg.aoi << 1) + int1_cfg._6d)
+  {
+    case IIS328DQ_6D_INT1_DISABLE:
+      *val = IIS328DQ_6D_INT1_DISABLE;
+      break;
+    case IIS328DQ_6D_INT1_MOVEMENT:
+      *val = IIS328DQ_6D_INT1_MOVEMENT;
+      break;
+     case IIS328DQ_6D_INT1_POSITION:
+      *val = IIS328DQ_6D_INT1_POSITION;
+      break;
+    default:
+      *val = IIS328DQ_6D_INT1_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  6D on interrupt generator 1 source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t iis328dq_int1_6d_src_get(iis328dq_ctx_t *ctx,
+                                  iis328dq_int1_src_t *val)
+{
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t iis328dq_int1_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t iis328dq_int1_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of 6d in reg INT2_CFG
+  *
+  */
+int32_t iis328dq_int2_6d_mode_set(iis328dq_ctx_t *ctx,
+                                   iis328dq_int2_6d_t val)
+{
+  iis328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg._6d = (uint8_t)val & 0x01U;
+    int2_cfg.aoi = ((uint8_t)val & 0x02U) >> 1;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of 6d in reg INT2_CFG
+  *
+  */
+int32_t iis328dq_int2_6d_mode_get(iis328dq_ctx_t *ctx,
+                                   iis328dq_int2_6d_t *val)
+{
+  iis328dq_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ((int2_cfg.aoi << 1) + int2_cfg._6d)
+  {
+    case IIS328DQ_6D_INT2_DISABLE:
+      *val = IIS328DQ_6D_INT2_DISABLE;
+      break;
+    case IIS328DQ_6D_INT2_MOVEMENT:
+      *val = IIS328DQ_6D_INT2_MOVEMENT;
+      break;
+     case IIS328DQ_6D_INT2_POSITION:
+      *val = IIS328DQ_6D_INT2_POSITION;
+      break;
+    default:
+      *val = IIS328DQ_6D_INT2_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  6D on interrupt generator 2 source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t iis328dq_int2_6d_src_get(iis328dq_ctx_t *ctx,
+                                  iis328dq_int2_src_t *val)
+{
+  int32_t ret;
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t iis328dq_int2_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
+{
+  iis328dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = iis328dq_write_reg(ctx, IIS328DQ_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t iis328dq_int2_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
+{
+  iis328dq_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = iis328dq_read_reg(ctx, IIS328DQ_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis328dq_STdC/driver/iis328dq_reg.h
+++ b/sensor/stmemsc/iis328dq_STdC/driver/iis328dq_reg.h
@@ -1,0 +1,640 @@
+/*
+ ******************************************************************************
+ * @file    iis328dq_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          iis328dq_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef IIS328DQ_REGS_H
+#define IIS328DQ_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup IIS328DQ
+  * @{
+  *
+  */
+
+/** @defgroup IIS328DQ_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  IIS328DQ_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*iis328dq_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*iis328dq_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  iis328dq_write_ptr  write_reg;
+  iis328dq_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} iis328dq_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+
+/** @defgroup IIS328DQ_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0x31 if SA0=1 -> 0x33 **/
+#define IIS328DQ_I2C_ADD_L     0x31
+#define IIS328DQ_I2C_ADD_H     0x33
+
+/** Device Identification (Who am I) **/
+#define IIS328DQ_ID            0x32
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  IIS328DQ_Sensitivity
+  * @brief       These macro are maintained for back compatibility.
+  *              in order to convert data into engineering units please
+  *              use functions:
+  *                -> _from_fs2_to_mg(int16_t lsb);
+  *                -> _from_fs4_to_mg(int16_t lsb);
+  *                -> _from_fs8_to_mg(int16_t lsb);
+  *
+  *              REMOVING the MACRO you are compliant with:
+  *              MISRA-C 2012 [Dir 4.9] -> " avoid function-like macros "
+  * @{
+  *
+  */
+
+#define IIS328DQ_FROM_FS_2g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 0.98f )
+#define IIS328DQ_FROM_FS_4g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 1.95f )
+#define IIS328DQ_FROM_FS_8g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 3.91f )
+
+/**
+  * @}
+  *
+  */
+
+#define IIS328DQ_WHO_AM_I                  0x0FU
+#define IIS328DQ_CTRL_REG1                 0x20U
+typedef struct {
+  uint8_t xen                      : 1;
+  uint8_t yen                      : 1;
+  uint8_t zen                      : 1;
+  uint8_t dr                       : 2;
+  uint8_t pm                       : 3;
+} iis328dq_ctrl_reg1_t;
+
+#define IIS328DQ_CTRL_REG2                 0x21U
+typedef struct {
+  uint8_t hpcf                     : 2;
+  uint8_t hpen                     : 2;
+  uint8_t fds                      : 1;
+  uint8_t hpm                      : 2;
+  uint8_t boot                     : 1;
+} iis328dq_ctrl_reg2_t;
+
+#define IIS328DQ_CTRL_REG3                 0x22U
+typedef struct {
+  uint8_t i1_cfg                   : 2;
+  uint8_t lir1                     : 1;
+  uint8_t i2_cfg                   : 2;
+  uint8_t lir2                     : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t ihl                      : 1;
+} iis328dq_ctrl_reg3_t;
+
+#define IIS328DQ_CTRL_REG4                 0x23U
+typedef struct {
+  uint8_t sim                      : 1;
+  uint8_t st                       : 3; /* STsign + ST */
+  uint8_t fs                       : 2;
+  uint8_t ble                      : 1;
+  uint8_t bdu                      : 1;
+} iis328dq_ctrl_reg4_t;
+
+#define IIS328DQ_CTRL_REG5                 0x24U
+typedef struct {
+  uint8_t turnon                   : 2;
+  uint8_t not_used_01              : 6;
+} iis328dq_ctrl_reg5_t;
+
+#define IIS328DQ_HP_FILTER_RESET           0x25U
+#define IIS328DQ_REFERENCE                 0x26U
+#define IIS328DQ_STATUS_REG                0x27U
+typedef struct {
+  uint8_t xda                      : 1;
+  uint8_t yda                      : 1;
+  uint8_t zda                      : 1;
+  uint8_t zyxda                    : 1;
+  uint8_t _xor                     : 1;
+  uint8_t yor                      : 1;
+  uint8_t zor                      : 1;
+  uint8_t zyxor                    : 1;
+} iis328dq_status_reg_t;
+
+#define IIS328DQ_OUT_X_L                   0x28U
+#define IIS328DQ_OUT_X_H                   0x29U
+#define IIS328DQ_OUT_Y_L                   0x2AU
+#define IIS328DQ_OUT_Y_H                   0x2BU
+#define IIS328DQ_OUT_Z_L                   0x2CU
+#define IIS328DQ_OUT_Z_H                   0x2DU
+#define IIS328DQ_INT1_CFG                  0x30U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi                      : 1;
+} iis328dq_int1_cfg_t;
+
+#define IIS328DQ_INT1_SRC                  0x31U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} iis328dq_int1_src_t;
+
+#define IIS328DQ_INT1_THS                  0x32U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} iis328dq_int1_ths_t;
+
+#define IIS328DQ_INT1_DURATION             0x33U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} iis328dq_int1_duration_t;
+
+#define IIS328DQ_INT2_CFG                  0x34U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi                      : 1;
+} iis328dq_int2_cfg_t;
+
+#define IIS328DQ_INT2_SRC                  0x35U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} iis328dq_int2_src_t;
+
+#define IIS328DQ_INT2_THS                  0x36U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} iis328dq_int2_ths_t;
+
+#define IIS328DQ_INT2_DURATION             0x37U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} iis328dq_int2_duration_t;
+
+/**
+  * @defgroup IIS328DQ_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  iis328dq_ctrl_reg1_t                     ctrl_reg1;
+  iis328dq_ctrl_reg2_t                     ctrl_reg2;
+  iis328dq_ctrl_reg3_t                     ctrl_reg3;
+  iis328dq_ctrl_reg4_t                     ctrl_reg4;
+  iis328dq_ctrl_reg5_t                     ctrl_reg5;
+  iis328dq_status_reg_t                    status_reg;
+  iis328dq_int1_cfg_t                      int1_cfg;
+  iis328dq_int1_src_t                      int1_src;
+  iis328dq_int1_ths_t                      int1_ths;
+  iis328dq_int1_duration_t                 int1_duration;
+  iis328dq_int2_cfg_t                      int2_cfg;
+  iis328dq_int2_src_t                      int2_src;
+  iis328dq_int2_ths_t                      int2_ths;
+  iis328dq_int2_duration_t                 int2_duration;
+  bitwise_t                                 bitwise;
+  uint8_t                                   byte;
+} iis328dq_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t iis328dq_read_reg(iis328dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+int32_t iis328dq_write_reg(iis328dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len);
+
+extern float iis328dq_from_fs2_to_mg(int16_t lsb);
+extern float iis328dq_from_fs4_to_mg(int16_t lsb);
+extern float iis328dq_from_fs8_to_mg(int16_t lsb);
+
+int32_t iis328dq_axis_x_data_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_axis_x_data_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t iis328dq_axis_y_data_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_axis_y_data_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t iis328dq_axis_z_data_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_axis_z_data_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS328DQ_ODR_OFF   = 0x00,
+  IIS328DQ_ODR_Hz5   = 0x02,
+  IIS328DQ_ODR_1Hz   = 0x03,
+  IIS328DQ_ODR_5Hz2  = 0x04,
+  IIS328DQ_ODR_5Hz   = 0x05,
+  IIS328DQ_ODR_10Hz  = 0x06,
+  IIS328DQ_ODR_50Hz  = 0x01,
+  IIS328DQ_ODR_100Hz = 0x11,
+  IIS328DQ_ODR_400Hz = 0x21,
+  IIS328DQ_ODR_1kHz  = 0x31,
+} iis328dq_dr_t;
+int32_t iis328dq_data_rate_set(iis328dq_ctx_t *ctx, iis328dq_dr_t val);
+int32_t iis328dq_data_rate_get(iis328dq_ctx_t *ctx, iis328dq_dr_t *val);
+
+typedef enum {
+  IIS328DQ_NORMAL_MODE      = 0,
+  IIS328DQ_REF_MODE_ENABLE  = 1,
+} iis328dq_hpm_t;
+int32_t iis328dq_reference_mode_set(iis328dq_ctx_t *ctx,
+                                     iis328dq_hpm_t val);
+int32_t iis328dq_reference_mode_get(iis328dq_ctx_t *ctx,
+                                     iis328dq_hpm_t *val);
+
+typedef enum {
+  IIS328DQ_2g  = 0,
+  IIS328DQ_4g  = 1,
+  IIS328DQ_8g  = 3,
+} iis328dq_fs_t;
+int32_t iis328dq_full_scale_set(iis328dq_ctx_t *ctx, iis328dq_fs_t val);
+int32_t iis328dq_full_scale_get(iis328dq_ctx_t *ctx, iis328dq_fs_t *val);
+
+int32_t iis328dq_block_data_update_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_block_data_update_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t iis328dq_status_reg_get(iis328dq_ctx_t *ctx,
+                                 iis328dq_status_reg_t *val);
+
+int32_t iis328dq_flag_data_ready_get(iis328dq_ctx_t *ctx,
+                                      uint8_t *val);
+
+int32_t iis328dq_acceleration_raw_get(iis328dq_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis328dq_device_id_get(iis328dq_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis328dq_boot_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_boot_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS328DQ_ST_DISABLE   = 0,
+  IIS328DQ_ST_POSITIVE  = 1,
+  IIS328DQ_ST_NEGATIVE  = 5,
+} iis328dq_st_t;
+int32_t iis328dq_self_test_set(iis328dq_ctx_t *ctx, iis328dq_st_t val);
+int32_t iis328dq_self_test_get(iis328dq_ctx_t *ctx, iis328dq_st_t *val);
+
+typedef enum {
+  IIS328DQ_LSB_AT_LOW_ADD  = 0,
+  IIS328DQ_MSB_AT_LOW_ADD  = 1,
+} iis328dq_ble_t;
+int32_t iis328dq_data_format_set(iis328dq_ctx_t *ctx, iis328dq_ble_t val);
+int32_t iis328dq_data_format_get(iis328dq_ctx_t *ctx, iis328dq_ble_t *val);
+
+typedef enum {
+  IIS328DQ_CUT_OFF_8Hz   = 0,
+  IIS328DQ_CUT_OFF_16Hz  = 1,
+  IIS328DQ_CUT_OFF_32Hz  = 2,
+  IIS328DQ_CUT_OFF_64Hz  = 3,
+} iis328dq_hpcf_t;
+int32_t iis328dq_hp_bandwidth_set(iis328dq_ctx_t *ctx,
+                                   iis328dq_hpcf_t val);
+int32_t iis328dq_hp_bandwidth_get(iis328dq_ctx_t *ctx,
+                                   iis328dq_hpcf_t *val);
+
+typedef enum {
+  IIS328DQ_HP_DISABLE            = 0,
+  IIS328DQ_HP_ON_OUT             = 4,
+  IIS328DQ_HP_ON_INT1            = 1,
+  IIS328DQ_HP_ON_INT2            = 2,
+  IIS328DQ_HP_ON_INT1_INT2       = 3,
+  IIS328DQ_HP_ON_INT1_INT2_OUT   = 7,
+  IIS328DQ_HP_ON_INT2_OUT        = 6,
+  IIS328DQ_HP_ON_INT1_OUT        = 5,
+} iis328dq_hpen_t;
+int32_t iis328dq_hp_path_set(iis328dq_ctx_t *ctx, iis328dq_hpen_t val);
+int32_t iis328dq_hp_path_get(iis328dq_ctx_t *ctx, iis328dq_hpen_t *val);
+
+int32_t iis328dq_hp_reset_get(iis328dq_ctx_t *ctx);
+
+int32_t iis328dq_hp_reference_value_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_hp_reference_value_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS328DQ_SPI_4_WIRE  = 0,
+  IIS328DQ_SPI_3_WIRE  = 1,
+} iis328dq_sim_t;
+int32_t iis328dq_spi_mode_set(iis328dq_ctx_t *ctx, iis328dq_sim_t val);
+int32_t iis328dq_spi_mode_get(iis328dq_ctx_t *ctx, iis328dq_sim_t *val);
+
+typedef enum {
+  IIS328DQ_PAD1_INT1_SRC           = 0,
+  IIS328DQ_PAD1_INT1_OR_INT2_SRC   = 1,
+  IIS328DQ_PAD1_DRDY               = 2,
+  IIS328DQ_PAD1_BOOT               = 3,
+} iis328dq_i1_cfg_t;
+int32_t iis328dq_pin_int1_route_set(iis328dq_ctx_t *ctx,
+                                     iis328dq_i1_cfg_t val);
+int32_t iis328dq_pin_int1_route_get(iis328dq_ctx_t *ctx,
+                                     iis328dq_i1_cfg_t *val);
+
+typedef enum {
+  IIS328DQ_INT1_PULSED   = 0,
+  IIS328DQ_INT1_LATCHED  = 1,
+} iis328dq_lir1_t;
+int32_t iis328dq_int1_notification_set(iis328dq_ctx_t *ctx,
+                                        iis328dq_lir1_t val);
+int32_t iis328dq_int1_notification_get(iis328dq_ctx_t *ctx,
+                                        iis328dq_lir1_t *val);
+
+typedef enum {
+  IIS328DQ_PAD2_INT2_SRC           = 0,
+  IIS328DQ_PAD2_INT1_OR_INT2_SRC   = 1,
+  IIS328DQ_PAD2_DRDY               = 2,
+  IIS328DQ_PAD2_BOOT               = 3,
+} iis328dq_i2_cfg_t;
+int32_t iis328dq_pin_int2_route_set(iis328dq_ctx_t *ctx,
+                                     iis328dq_i2_cfg_t val);
+int32_t iis328dq_pin_int2_route_get(iis328dq_ctx_t *ctx,
+                                     iis328dq_i2_cfg_t *val);
+
+typedef enum {
+  IIS328DQ_INT2_PULSED   = 0,
+  IIS328DQ_INT2_LATCHED  = 1,
+} iis328dq_lir2_t;
+int32_t iis328dq_int2_notification_set(iis328dq_ctx_t *ctx,
+                                        iis328dq_lir2_t val);
+int32_t iis328dq_int2_notification_get(iis328dq_ctx_t *ctx,
+                                        iis328dq_lir2_t *val);
+
+typedef enum {
+  IIS328DQ_PUSH_PULL   = 0,
+  IIS328DQ_OPEN_DRAIN  = 1,
+} iis328dq_pp_od_t;
+int32_t iis328dq_pin_mode_set(iis328dq_ctx_t *ctx, iis328dq_pp_od_t val);
+int32_t iis328dq_pin_mode_get(iis328dq_ctx_t *ctx, iis328dq_pp_od_t *val);
+
+typedef enum {
+  IIS328DQ_ACTIVE_HIGH  = 0,
+  IIS328DQ_ACTIVE_LOW   = 1,
+} iis328dq_ihl_t;
+int32_t iis328dq_pin_polarity_set(iis328dq_ctx_t *ctx,
+                                   iis328dq_ihl_t val);
+int32_t iis328dq_pin_polarity_get(iis328dq_ctx_t *ctx,
+                                   iis328dq_ihl_t *val);
+
+typedef struct {
+  uint8_t int1_xlie             : 1;
+  uint8_t int1_xhie             : 1;
+  uint8_t int1_ylie             : 1;
+  uint8_t int1_yhie             : 1;
+  uint8_t int1_zlie             : 1;
+  uint8_t int1_zhie             : 1;
+} int1_on_th_conf_t;
+int32_t iis328dq_int1_on_threshold_conf_set(iis328dq_ctx_t *ctx,
+                                             int1_on_th_conf_t val);
+int32_t iis328dq_int1_on_threshold_conf_get(iis328dq_ctx_t *ctx,
+                                             int1_on_th_conf_t *val);
+
+typedef enum {
+  IIS328DQ_INT1_ON_THRESHOLD_OR   = 0,
+  IIS328DQ_INT1_ON_THRESHOLD_AND  = 1,
+} iis328dq_int1_aoi_t;
+int32_t iis328dq_int1_on_threshold_mode_set(iis328dq_ctx_t *ctx,
+                                             iis328dq_int1_aoi_t val);
+int32_t iis328dq_int1_on_threshold_mode_get(iis328dq_ctx_t *ctx,
+                                             iis328dq_int1_aoi_t *val);
+
+int32_t iis328dq_int1_src_get(iis328dq_ctx_t *ctx,
+                               iis328dq_int1_src_t *val);
+
+int32_t iis328dq_int1_treshold_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int1_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t iis328dq_int1_dur_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int1_dur_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t int2_xlie             : 1;
+  uint8_t int2_xhie             : 1;
+  uint8_t int2_ylie             : 1;
+  uint8_t int2_yhie             : 1;
+  uint8_t int2_zlie             : 1;
+  uint8_t int2_zhie             : 1;
+} int2_on_th_conf_t;
+int32_t iis328dq_int2_on_threshold_conf_set(iis328dq_ctx_t *ctx,
+                                             int2_on_th_conf_t val);
+int32_t iis328dq_int2_on_threshold_conf_get(iis328dq_ctx_t *ctx,
+                                             int2_on_th_conf_t *val);
+
+typedef enum {
+  IIS328DQ_INT2_ON_THRESHOLD_OR   = 0,
+  IIS328DQ_INT2_ON_THRESHOLD_AND  = 1,
+} iis328dq_int2_aoi_t;
+int32_t iis328dq_int2_on_threshold_mode_set(iis328dq_ctx_t *ctx,
+                                             iis328dq_int2_aoi_t val);
+int32_t iis328dq_int2_on_threshold_mode_get(iis328dq_ctx_t *ctx,
+                                             iis328dq_int2_aoi_t *val);
+
+int32_t iis328dq_int2_src_get(iis328dq_ctx_t *ctx,
+                               iis328dq_int2_src_t *val);
+
+int32_t iis328dq_int2_treshold_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int2_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t iis328dq_int2_dur_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int2_dur_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+int32_t iis328dq_wkup_to_sleep_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_wkup_to_sleep_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS328DQ_6D_INT1_DISABLE   = 0,
+  IIS328DQ_6D_INT1_MOVEMENT  = 1,
+  IIS328DQ_6D_INT1_POSITION  = 3,
+} iis328dq_int1_6d_t;
+int32_t iis328dq_int1_6d_mode_set(iis328dq_ctx_t *ctx,
+                                   iis328dq_int1_6d_t val);
+int32_t iis328dq_int1_6d_mode_get(iis328dq_ctx_t *ctx,
+                                   iis328dq_int1_6d_t *val);
+
+int32_t iis328dq_int1_6d_src_get(iis328dq_ctx_t *ctx,
+                                  iis328dq_int1_src_t *val);
+
+int32_t iis328dq_int1_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int1_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS328DQ_6D_INT2_DISABLE   = 0,
+  IIS328DQ_6D_INT2_MOVEMENT  = 1,
+  IIS328DQ_6D_INT2_POSITION  = 3,
+} iis328dq_int2_6d_t;
+int32_t iis328dq_int2_6d_mode_set(iis328dq_ctx_t *ctx,
+                                   iis328dq_int2_6d_t val);
+int32_t iis328dq_int2_6d_mode_get(iis328dq_ctx_t *ctx,
+                                   iis328dq_int2_6d_t *val);
+
+int32_t iis328dq_int2_6d_src_get(iis328dq_ctx_t *ctx,
+                                  iis328dq_int2_src_t *val);
+
+int32_t iis328dq_int2_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int2_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IIS328DQ_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis3dhhc_STdC/driver/iis3dhhc_reg.c
+++ b/sensor/stmemsc/iis3dhhc_STdC/driver/iis3dhhc_reg.c
@@ -1,0 +1,1255 @@
+/*
+ ******************************************************************************
+ * @file    iis3dhhc_reg.c
+ * @author  MEMS Software Solution Team
+ * @date    20-December-2017
+ * @brief   IIS3DHHC driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "iis3dhhc_reg.h"
+
+/**
+  * @addtogroup  iis3dhhc
+  * @brief  This file provides a set of functions needed to drive the
+  *         iis3dhhc enanced inertial module.
+  * @{
+  */
+
+/**
+  * @addtogroup  interfaces_functions
+  * @brief  This section provide a set of functions used to read and write
+  *         a generic register of the device.
+  * @{
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  iis3dhhc_ctx_t* ctx: read / write interface definitions
+  * @param  uint8_t reg: register to read
+  * @param  uint8_t* data: pointer to buffer that store the data read
+  * @param  uint16_t len: number of consecutive register to read
+  *
+  */
+int32_t iis3dhhc_read_reg(iis3dhhc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  return ctx->read_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t reg: register to write
+  * @param  uint8_t* data: pointer to data to write in register reg
+  * @param  uint16_t len: number of consecutive register to write
+  *
+*/
+int32_t iis3dhhc_write_reg(iis3dhhc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  return ctx->write_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  data_generation_c
+  * @brief   This section group all the functions concerning data generation
+  * @{
+  */
+
+/**
+  * @brief  block_data_update: [set] Blockdataupdate.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of bdu in reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_block_data_update_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.bdu = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [get] Blockdataupdate.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of bdu in reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_block_data_update_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  *val = reg.ctrl_reg1.bdu;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_rate: [set]  Output data rate selection.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_norm_mod_en_t: change the values of norm_mod_en in
+  *                                reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_data_rate_set(iis3dhhc_ctx_t *ctx, iis3dhhc_norm_mod_en_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.norm_mod_en = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_rate: [get]  Output data rate selection.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_norm_mod_en_t: Get the values of norm_mod_en in
+  *                                reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_data_rate_get(iis3dhhc_ctx_t *ctx, iis3dhhc_norm_mod_en_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  *val = (iis3dhhc_norm_mod_en_t) reg.ctrl_reg1.norm_mod_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  offset_temp_comp: [set]  Offset temperature compensation enable.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of off_tcomp_en in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_offset_temp_comp_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.off_tcomp_en = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  offset_temp_comp: [get]  Offset temperature compensation enable.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of off_tcomp_en in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_offset_temp_comp_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  *val = reg.ctrl_reg4.off_tcomp_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  temperature_raw: [get]  Temperature output value.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t iis3dhhc_temperature_raw_get(iis3dhhc_ctx_t *ctx, uint8_t *buff)
+{
+  return iis3dhhc_read_reg(ctx, IIS3DHHC_OUT_TEMP_L, buff, 2);
+}
+
+/**
+  * @brief  acceleration_raw: [get]  acceleration output value.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t iis3dhhc_acceleration_raw_get(iis3dhhc_ctx_t *ctx, uint8_t *buff)
+{
+  return iis3dhhc_read_reg(ctx, IIS3DHHC_OUT_X_L_XL, buff, 6);
+}
+
+/**
+  * @brief  xl_data_ready: [get]  Acceleration set of data available.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of zyxda in reg STATUS
+  *
+  */
+int32_t iis3dhhc_xl_data_ready_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, &reg.byte, 1);
+  *val = reg.status.zyxda;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_data_ovr: [get]  Acceleration set of data overrun.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of zyxor in reg STATUS
+  *
+  */
+int32_t iis3dhhc_xl_data_ovr_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, &reg.byte, 1);
+  *val = reg.status.zyxor;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  common
+  * @brief   This section group common usefull functions
+  * @{
+  */
+
+/**
+  * @brief  device_id: [get] DeviceWhoamI.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t iis3dhhc_device_id_get(iis3dhhc_ctx_t *ctx, uint8_t *buff)
+{
+  return iis3dhhc_read_reg(ctx, IIS3DHHC_WHO_AM_I, buff, 1);
+}
+
+/**
+  * @brief  reset: [set]  Software reset. Restore the default values
+  *                       in user registers.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sw_reset in reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_reset_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.sw_reset = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [get]  Software reset. Restore the default values
+  *                       in user registers.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sw_reset in reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_reset_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  *val = reg.ctrl_reg1.sw_reset;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [set]  Reboot memory content. Reload the
+  *                      calibration parameters.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of boot in reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_boot_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.boot = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [get]  Reboot memory content. Reload
+  *                      the calibration parameters.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of boot in reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_boot_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  *val = reg.ctrl_reg1.boot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  self_test: [set] Selftest.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_st_t: change the values of st in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_self_test_set(iis3dhhc_ctx_t *ctx, iis3dhhc_st_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.st = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  self_test: [get] Selftest.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_st_t: Get the values of st in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_self_test_get(iis3dhhc_ctx_t *ctx, iis3dhhc_st_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  *val = (iis3dhhc_st_t) reg.ctrl_reg4.st;
+
+  return mm_error;
+}
+
+/**
+  * @brief  filter_config: [set]  Digital filtering Phase/bandwidth selection.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_dsp_t: change the values of dsp in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_filter_config_set(iis3dhhc_ctx_t *ctx, iis3dhhc_dsp_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.dsp = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  filter_config: [get]  Digital filtering Phase/bandwidth selection.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_dsp_t: Get the values of dsp in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_filter_config_get(iis3dhhc_ctx_t *ctx, iis3dhhc_dsp_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  *val = (iis3dhhc_dsp_t) reg.ctrl_reg4.dsp;
+
+  return mm_error;
+}
+
+/**
+  * @brief  status: [get] Statusregister.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_status_t: Registers STATUS
+  *
+  */
+int32_t iis3dhhc_status_get(iis3dhhc_ctx_t *ctx, iis3dhhc_status_t *val)
+{
+  return iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  interrupts
+  * @brief   This section group all the functions that manage interrupts
+  * @{
+  */
+
+/**
+  * @brief   drdy_notification_mode: [set]  DRDY latched / pulsed, pulse
+  *                                         duration is 1/4 ODR
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_drdy_pulse_t: change the values of drdy_pulse in
+  *                               reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_drdy_notification_mode_set(iis3dhhc_ctx_t *ctx,
+                                            iis3dhhc_drdy_pulse_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.drdy_pulse = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   drdy_notification_mode: [get]  DRDY latched / pulsed, pulse
+  *                                         duration is 1/4 ODR
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_drdy_pulse_t: Get the values of drdy_pulse in
+  *                               reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_drdy_notification_mode_get(iis3dhhc_ctx_t *ctx,
+                                            iis3dhhc_drdy_pulse_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  *val = (iis3dhhc_drdy_pulse_t) reg.ctrl_reg1.drdy_pulse;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int1_mode: [set]  It configures the INT1 pad as output for
+  *                           FIFO flags or as external asynchronous
+  *                           input trigger to FIFO.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_int1_ext_t: change the values of int1_ext in
+  *                             reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_int1_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_int1_ext_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  reg.int1_ctrl.int1_ext = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int1_mode: [get]  It configures the INT1 pad as output
+  *                           for FIFO flags or as external asynchronous
+  *                           input trigger to FIFO.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_int1_ext_t: Get the values of int1_ext in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_int1_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_int1_ext_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  *val = (iis3dhhc_int1_ext_t) reg.int1_ctrl.int1_ext;
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_threshold_on_int1: [set]  FIFO watermark status
+  *                                         on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int1_fth in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_threshold_on_int1_set(iis3dhhc_ctx_t *ctx,
+                                            uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  reg.int1_ctrl.int1_fth = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_threshold_on_int1: [get]  FIFO watermark status
+  *                                         on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int1_fth in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_threshold_on_int1_get(iis3dhhc_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  *val = reg.int1_ctrl.int1_fth;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_full_on_int1: [set]  FIFO full flag on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int1_fss5 in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_full_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  reg.int1_ctrl.int1_fss5 = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_full_on_int1: [get]  FIFO full flag on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int1_fss5 in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_full_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  *val = reg.int1_ctrl.int1_fss5;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_on_int1: [set]  FIFO overrun interrupt on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int1_ovr in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_ovr_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  reg.int1_ctrl.int1_ovr = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_on_int1: [get]  FIFO overrun interrupt on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int1_ovr in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_ovr_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  *val = reg.int1_ctrl.int1_ovr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot_on_int1: [set]  BOOT status on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int1_boot in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_boot_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  reg.int1_ctrl.int1_boot = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot_on_int1: [get]  BOOT status on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int1_boot in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_boot_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  *val = reg.int1_ctrl.int1_boot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_int1: [set]  Data-ready signal on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int1_drdy in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_drdy_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  reg.int1_ctrl.int1_drdy = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_int1: [get]  Data-ready signal on INT1 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int1_drdy in reg INT1_CTRL
+  *
+  */
+int32_t iis3dhhc_drdy_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  *val = reg.int1_ctrl.int1_drdy;
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_threshold_on_int2: [set]  FIFO watermark status
+  *                                         on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int2_fth in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_threshold_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  reg.int2_ctrl.int2_fth = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_threshold_on_int2: [get]  FIFO watermark status on
+  *                                         INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int2_fth in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_threshold_on_int2_get(iis3dhhc_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  *val = reg.int2_ctrl.int2_fth;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_full_on_int2: [set]  FIFO full flag on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int2_fss5 in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_full_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  reg.int2_ctrl.int2_fss5 = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_full_on_int2: [get]  FIFO full flag on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int2_fss5 in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_full_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  *val = reg.int2_ctrl.int2_fss5;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_on_int2: [set]  FIFO overrun interrupt on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int2_ovr in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_ovr_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  reg.int2_ctrl.int2_ovr = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_on_int2: [get]  FIFO overrun interrupt on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int2_ovr in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_ovr_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  *val = reg.int2_ctrl.int2_ovr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot_on_int2: [set]  BOOT status on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int2_boot in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_boot_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  reg.int2_ctrl.int2_boot = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot_on_int2: [get]  BOOT status on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int2_boot in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_boot_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  *val = reg.int2_ctrl.int2_boot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_int2: [set]  Data-ready signal on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int2_drdy in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_drdy_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  reg.int2_ctrl.int2_drdy = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_int2: [get]  Data-ready signal on INT2 pin.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int2_drdy in reg INT2_CTRL
+  *
+  */
+int32_t iis3dhhc_drdy_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  *val = reg.int2_ctrl.int2_drdy;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_mode: [set]  Push-pull/open drain selection on
+  *                          interrupt pads.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_pp_od_t: change the values of pp_od in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_pin_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_pp_od_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.pp_od = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_mode: [get]  Push-pull/open drain selection on
+  *                          interrupt pads.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_pp_od_t: Get the values of pp_od in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_pin_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_pp_od_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  *val = (iis3dhhc_pp_od_t) reg.ctrl_reg4.pp_od;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  fifo
+  * @brief   This section group all the functions concerning the
+  *          fifo usage
+  * @{
+  */
+
+/**
+  * @brief  fifo: [set] FIFOenable.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of fifo_en in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_fifo_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.fifo_en = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo: [get] FIFOenable.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_en in reg CTRL_REG4
+  *
+  */
+int32_t iis3dhhc_fifo_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  *val = reg.ctrl_reg4.fifo_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_block_spi_hs: [set]  Enables the SPI high speed
+                                      configuration for the FIFO block that
+                                      is used to guarantee a minimum duration
+                                      of the window in which writing operation
+                                      of RAM output is blocked. This bit is
+                                      recommended for SPI clock frequencies
+                                      higher than 6 MHz.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of fifo_spi_hs_on in reg CTRL_REG5
+  *
+  */
+int32_t iis3dhhc_fifo_block_spi_hs_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG5, &reg.byte, 1);
+  reg.ctrl_reg5.fifo_spi_hs_on = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG5, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_block_spi_hs: [get]  Enables the SPI high speed configuration
+                                      for the FIFO block that is used to
+                                      guarantee a minimum duration of the
+                                      window in which writing operation of
+                                      RAM output is blocked.
+                                      This bit is recommended for SPI
+                                      clock frequencies higher than 6 MHz.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_spi_hs_on in reg CTRL_REG5
+  *
+  */
+int32_t iis3dhhc_fifo_block_spi_hs_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG5, &reg.byte, 1);
+  *val = reg.ctrl_reg5.fifo_spi_hs_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of fth in reg FIFO_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_watermark_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
+  reg.fifo_ctrl.fth = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fth in reg FIFO_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_watermark_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
+  *val = reg.fifo_ctrl.fth;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [set]  FIFO mode selection.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_fmode_t: change the values of fmode in reg FIFO_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_fmode_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
+  reg.fifo_ctrl.fmode = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [get]  FIFO mode selection.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_fmode_t: Get the values of fmode in reg FIFO_CTRL
+  *
+  */
+int32_t iis3dhhc_fifo_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_fmode_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
+  *val = (iis3dhhc_fmode_t) reg.fifo_ctrl.fmode;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_status: [get]  FIFO status register.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  iis3dhhc_fifo_src_t: Registers FIFO_SRC
+  *
+  */
+int32_t iis3dhhc_fifo_status_get(iis3dhhc_ctx_t *ctx, iis3dhhc_fifo_src_t *val)
+{
+  return iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  fifo_full_flag: [get]  FIFO stored data level.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fss in reg FIFO_SRC
+  *
+  */
+int32_t iis3dhhc_fifo_full_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, &reg.byte, 1);
+  *val = reg.fifo_src.fss;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_flag: [get]  FIFO overrun status flag.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ovrn in reg FIFO_SRC
+  *
+  */
+int32_t iis3dhhc_fifo_ovr_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, &reg.byte, 1);
+  *val = reg.fifo_src.ovrn;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_fth_flag: [get]  FIFO watermark status.
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fth in reg FIFO_SRC
+  *
+  */
+int32_t iis3dhhc_fifo_fth_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, &reg.byte, 1);
+  *val = reg.fifo_src.fth;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  serial_interface
+  * @brief   This section group all the functions concerning serial
+  *          interface management
+  * @{
+  */
+
+/**
+  * @brief  auto_add_inc: [set]  Register address automatically
+  *                              incremented during a multiple byte access
+  *                              with a serial interface (I2C or SPI).
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of if_add_inc in reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_auto_add_inc_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.if_add_inc = val;
+  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  auto_add_inc: [get]  Register address automatically incremented
+  *                              during a multiple byte access with a serial
+  *                              interface (I2C or SPI).
+  *
+  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of if_add_inc in reg CTRL_REG1
+  *
+  */
+int32_t iis3dhhc_auto_add_inc_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  *val = reg.ctrl_reg1.if_add_inc;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis3dhhc_STdC/driver/iis3dhhc_reg.h
+++ b/sensor/stmemsc/iis3dhhc_STdC/driver/iis3dhhc_reg.h
@@ -1,0 +1,394 @@
+/*
+ ******************************************************************************
+ * @file    iis3dhhc_reg.h
+ * @author  MEMS Software Solution Team
+ * @date    20-December-2017
+ * @brief   This file contains all the functions prototypes for the
+ *          iis3dhhc_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __IIS3DHHC_DRIVER__H
+#define __IIS3DHHC_DRIVER__H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup IIS3DHHC
+  * @{
+  *
+  */
+
+/** @defgroup IIS3DHHC_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup iis3dhhc_interface
+  * @{
+  */
+
+typedef int32_t (*iis3dhhc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*iis3dhhc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  iis3dhhc_write_ptr  write_reg;
+  iis3dhhc_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} iis3dhhc_ctx_t;
+
+/**
+  * @}
+  */
+
+
+/** @defgroup iis3dhhc_Infos
+  * @{
+  */
+
+/** Device Identification (Who am I) **/
+#define IIS3DHHC_ID            0x11
+
+/**
+  * @}
+  */
+
+/**
+  * @defgroup iis3dhhc_Sensitivity
+  * @{
+  */
+
+#define IIS3DHHC_FROM_LSB_TO_mg(lsb)   (float)((lsb * 76.0f) / 1000.0f)
+#define IIS3DHHC_FROM_LSB_TO_degC(lsb) (float)(((int16_t)lsb>>4) / 16.0f) + 25.0f
+
+/**
+  * @}
+  */
+
+#define IIS3DHHC_WHO_AM_I      0x0F
+
+#define IIS3DHHC_CTRL_REG1     0x20
+typedef struct {
+  uint8_t bdu              : 1;
+  uint8_t drdy_pulse       : 1;
+  uint8_t sw_reset         : 1;
+  uint8_t boot             : 1;
+  uint8_t not_used_01      : 2;
+  uint8_t if_add_inc       : 1;
+  uint8_t norm_mod_en      : 1;
+} iis3dhhc_ctrl_reg1_t;
+
+#define IIS3DHHC_INT1_CTRL     0x21
+typedef struct {
+  uint8_t not_used_01      : 2;
+  uint8_t int1_ext         : 1;
+  uint8_t int1_fth         : 1;
+  uint8_t int1_fss5        : 1;
+  uint8_t int1_ovr         : 1;
+  uint8_t int1_boot        : 1;
+  uint8_t int1_drdy        : 1;
+} iis3dhhc_int1_ctrl_t;
+
+#define IIS3DHHC_INT2_CTRL     0x22
+typedef struct {
+  uint8_t not_used_01      : 3;
+  uint8_t int2_fth         : 1;
+  uint8_t int2_fss5        : 1;
+  uint8_t int2_ovr         : 1;
+  uint8_t int2_boot        : 1;
+  uint8_t int2_drdy        : 1;
+} iis3dhhc_int2_ctrl_t;
+
+#define IIS3DHHC_CTRL_REG4     0x23
+typedef struct {
+  uint8_t off_tcomp_en     : 1;
+  uint8_t fifo_en          : 1;
+  uint8_t pp_od            : 2;
+  uint8_t st               : 2;
+  uint8_t dsp              : 2;
+} iis3dhhc_ctrl_reg4_t;
+
+#define IIS3DHHC_CTRL_REG5     0x24
+typedef struct {
+  uint8_t fifo_spi_hs_on   : 1;
+  uint8_t not_used_01      : 7;
+} iis3dhhc_ctrl_reg5_t;
+
+#define IIS3DHHC_OUT_TEMP_L    0x25
+#define IIS3DHHC_OUT_TEMP_H    0x26
+#define IIS3DHHC_STATUS        0x27
+typedef struct {
+  uint8_t xda              : 1;
+  uint8_t yda              : 1;
+  uint8_t zda              : 1;
+  uint8_t zyxda            : 1;
+  uint8_t _xor             : 1;
+  uint8_t yor              : 1;
+  uint8_t zor              : 1;
+  uint8_t zyxor            : 1;
+} iis3dhhc_status_t;
+
+#define IIS3DHHC_OUT_X_L_XL    0x28
+#define IIS3DHHC_OUT_X_H_XL    0x29
+#define IIS3DHHC_OUT_Y_L_XL    0x2A
+#define IIS3DHHC_OUT_Y_H_XL    0x2B
+#define IIS3DHHC_OUT_Z_L_XL    0x2C
+#define IIS3DHHC_OUT_Z_H_XL    0x2D
+#define IIS3DHHC_FIFO_CTRL     0x2E
+typedef struct {
+  uint8_t fth              : 5;
+  uint8_t fmode            : 3;
+} iis3dhhc_fifo_ctrl_t;
+
+#define IIS3DHHC_FIFO_SRC      0x2F
+typedef struct {
+  uint8_t fss      : 6;
+  uint8_t ovrn      : 1;
+  uint8_t fth      : 1;
+} iis3dhhc_fifo_src_t;
+
+typedef union{
+  iis3dhhc_ctrl_reg1_t    ctrl_reg1;
+  iis3dhhc_int1_ctrl_t    int1_ctrl;
+  iis3dhhc_int2_ctrl_t    int2_ctrl;
+  iis3dhhc_ctrl_reg4_t    ctrl_reg4;
+  iis3dhhc_ctrl_reg5_t    ctrl_reg5;
+  iis3dhhc_status_t       status;
+  iis3dhhc_fifo_ctrl_t    fifo_ctrl;
+  iis3dhhc_fifo_src_t     fifo_src;
+  bitwise_t              bitwise;
+  uint8_t                byte;
+} iis3dhhc_reg_t;
+int32_t iis3dhhc_read_reg(iis3dhhc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t iis3dhhc_write_reg(iis3dhhc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+int32_t iis3dhhc_block_data_update_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_block_data_update_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DHHC_POWER_DOWN  = 0,
+  IIS3DHHC_1kHz1       = 1,
+} iis3dhhc_norm_mod_en_t;
+int32_t iis3dhhc_data_rate_set(iis3dhhc_ctx_t *ctx, iis3dhhc_norm_mod_en_t val);
+int32_t iis3dhhc_data_rate_get(iis3dhhc_ctx_t *ctx, iis3dhhc_norm_mod_en_t *val);
+
+int32_t iis3dhhc_offset_temp_comp_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_offset_temp_comp_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_temperature_raw_get(iis3dhhc_ctx_t *ctx, uint8_t *buff);
+int32_t iis3dhhc_acceleration_raw_get(iis3dhhc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dhhc_xl_data_ready_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_xl_data_ovr_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_device_id_get(iis3dhhc_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dhhc_reset_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_reset_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_boot_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_boot_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DHHC_ST_DISABLE   = 0,
+  IIS3DHHC_ST_POSITIVE  = 1,
+  IIS3DHHC_ST_NEGATIVE  = 2,
+} iis3dhhc_st_t;
+int32_t iis3dhhc_self_test_set(iis3dhhc_ctx_t *ctx, iis3dhhc_st_t val);
+int32_t iis3dhhc_self_test_get(iis3dhhc_ctx_t *ctx, iis3dhhc_st_t *val);
+
+typedef enum {
+  IIS3DHHC_LINEAR_PHASE_440Hz      = 0,
+  IIS3DHHC_LINEAR_PHASE_235Hz      = 1,
+  IIS3DHHC_NO_LINEAR_PHASE_440Hz  = 2,
+  IIS3DHHC_NO_LINEAR_PHASE_235Hz  = 3,
+} iis3dhhc_dsp_t;
+int32_t iis3dhhc_filter_config_set(iis3dhhc_ctx_t *ctx, iis3dhhc_dsp_t val);
+int32_t iis3dhhc_filter_config_get(iis3dhhc_ctx_t *ctx, iis3dhhc_dsp_t *val);
+
+int32_t iis3dhhc_status_get(iis3dhhc_ctx_t *ctx, iis3dhhc_status_t *val);
+
+typedef enum {
+  IIS3DHHC_LATCHED  = 0,
+  IIS3DHHC_PULSED   = 1,
+} iis3dhhc_drdy_pulse_t;
+int32_t iis3dhhc_drdy_notification_mode_set(iis3dhhc_ctx_t *ctx,
+                                            iis3dhhc_drdy_pulse_t val);
+int32_t iis3dhhc_drdy_notification_mode_get(iis3dhhc_ctx_t *ctx,
+                                            iis3dhhc_drdy_pulse_t *val);
+
+
+typedef enum {
+  IIS3DHHC_PIN_AS_INTERRUPT  = 0,
+  IIS3DHHC_PIN_AS_TRIGGER     = 1,
+} iis3dhhc_int1_ext_t;
+int32_t iis3dhhc_int1_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_int1_ext_t val);
+int32_t iis3dhhc_int1_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_int1_ext_t *val);
+
+
+int32_t iis3dhhc_fifo_threshold_on_int1_set(iis3dhhc_ctx_t *ctx,
+                                            uint8_t val);
+int32_t iis3dhhc_fifo_threshold_on_int1_get(iis3dhhc_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t iis3dhhc_fifo_full_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_full_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_fifo_ovr_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_ovr_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_boot_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_boot_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_drdy_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_drdy_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_fifo_threshold_on_int2_set(iis3dhhc_ctx_t *ctx,
+                                            uint8_t val);
+int32_t iis3dhhc_fifo_threshold_on_int2_get(iis3dhhc_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t iis3dhhc_fifo_full_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_full_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_fifo_ovr_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_ovr_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_boot_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_boot_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_drdy_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_drdy_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DHHC_ALL_PUSH_PULL    = 0,
+  IIS3DHHC_INT1_OD_INT2_PP  = 1,
+  IIS3DHHC_INT1_PP_INT2_OD  = 2,
+  IIS3DHHC_ALL_OPEN_DRAIN   = 3,
+} iis3dhhc_pp_od_t;
+int32_t iis3dhhc_pin_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_pp_od_t val);
+int32_t iis3dhhc_pin_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_pp_od_t *val);
+
+int32_t iis3dhhc_fifo_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_fifo_block_spi_hs_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_block_spi_hs_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_fifo_watermark_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_watermark_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DHHC_BYPASS_MODE             = 0,
+  IIS3DHHC_FIFO_MODE               = 1,
+  IIS3DHHC_STREAM_TO_FIFO_MODE    = 3,
+  IIS3DHHC_BYPASS_TO_STREAM_MODE  = 4,
+  IIS3DHHC_DYNAMIC_STREAM_MODE    = 6,
+} iis3dhhc_fmode_t;
+int32_t iis3dhhc_fifo_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_fmode_t val);
+int32_t iis3dhhc_fifo_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_fmode_t *val);
+
+int32_t iis3dhhc_fifo_status_get(iis3dhhc_ctx_t *ctx,
+                                iis3dhhc_fifo_src_t *val);
+
+int32_t iis3dhhc_fifo_full_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_fifo_ovr_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_fifo_fth_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_auto_add_inc_set(iis3dhhc_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_auto_add_inc_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__IIS3DHHC_DRIVER__H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism303dac_STdC/driver/ism303dac_reg.c
+++ b/sensor/stmemsc/ism303dac_STdC/driver/ism303dac_reg.c
@@ -1,0 +1,2822 @@
+/*
+ ******************************************************************************
+ * @file    ism303dac_reg.c
+ * @author  MEMS Software Solution Team
+ * @date    20-December-2017
+ * @brief   ISM303DAC driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "ism303dac_reg.h"
+
+/**
+  * @addtogroup  ism303dac
+  * @brief  This file provides a set of functions needed to drive the
+  *         ism303dac enanced inertial module.
+  * @{
+  */
+
+/**
+  * @addtogroup  interfaces_functions
+  * @brief  This section provide a set of functions used to read and write
+  *         a generic register of the device.
+  * @{
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ism303dac_ctx_t* ctx: read / write interface definitions
+  * @param  uint8_t reg: register to read
+  * @param  uint8_t* data: pointer to buffer that store the data read
+  * @param  uint16_t len: number of consecutive register to read
+  *
+  */
+int32_t ism303dac_read_reg(ism303dac_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  return ctx->read_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t reg: register to write
+  * @param  uint8_t* data: pointer to data to write in register reg
+  * @param  uint16_t len: number of consecutive register to write
+  *
+*/
+int32_t ism303dac_write_reg(ism303dac_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  return ctx->write_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  data_generation_c
+  * @brief   This section groups all the functions concerning data generation
+  * @{
+  */
+
+/**
+  * @brief  all_sources: [get] Read all the interrupt/status flag of
+  *                            the device.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_all_sources: FIFO_SRC, STATUS_DUP, WAKE_UP_SRC,
+  *                               TAP_SRC, 6D_SRC, FUNC_CK_GATE, FUNC_SRC.
+  *
+  */
+int32_t ism303dac_xl_all_sources_get(ism303dac_ctx_t *ctx,
+                                 ism303dac_xl_all_sources_t *val)
+{
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A,
+                               &(val->byte[0]), 1);
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_STATUS_DUP_A,
+                               &(val->byte[1]), 4);
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FUNC_SRC_A,
+                               &(val->byte[5]), 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [set] Blockdataupdate.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of bdu in reg CTRL1
+  *
+  */
+int32_t ism303dac_xl_block_data_update_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  reg.ctrl1_a.bdu = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [get] Blockdataupdate.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of bdu in reg CTRL1
+  *
+  */
+int32_t ism303dac_xl_block_data_update_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  *val = reg.ctrl1_a.bdu;
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [set] Blockdataupdate.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of bdu in reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_block_data_update_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.bdu = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [get] Blockdataupdate.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of bdu in reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_block_data_update_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  *val = reg.cfg_reg_c_m.bdu;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_format: [set]  Big/Little Endian data selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_ble_t: change the values of ble in reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_data_format_set(ism303dac_ctx_t *ctx,
+                                     ism303dac_mg_ble_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.ble = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_format: [get]  Big/Little Endian data selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_ble_t: Get the values of ble in reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_data_format_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_ble_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  *val = (ism303dac_mg_ble_t) reg.cfg_reg_c_m.ble;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_full_scale: [set]   Accelerometer full-scale selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_fs_t: change the values of fs in reg CTRL1
+  *
+  */
+int32_t ism303dac_xl_full_scale_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_fs_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  reg.ctrl1_a.fs = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_full_scale: [get]   Accelerometer full-scale selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_fs_t: Get the values of fs in reg CTRL1
+  *
+  */
+int32_t ism303dac_xl_full_scale_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_fs_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  *val = (ism303dac_xl_fs_t) reg.ctrl1_a.fs;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_data_rate: [set]  Accelerometer data rate selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_odr_t: change the values of odr in reg CTRL1
+  *
+  */
+int32_t ism303dac_xl_data_rate_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_odr_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  reg.ctrl1_a.odr = val & 0x0F;
+  reg.ctrl1_a.hf_odr = (val & 0x10) >> 4;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_data_rate: [get]  Accelerometer data rate selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_odr_t: Get the values of odr in reg CTRL1
+  *
+  */
+int32_t ism303dac_xl_data_rate_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_odr_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  *val = (ism303dac_xl_odr_t) ((reg.ctrl1_a.hf_odr << 4) + reg.ctrl1_a.odr);
+
+  return mm_error;
+}
+
+/**
+  * @brief  status_reg: [get]  The STATUS_REG register.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_status_reg_t: registers STATUS
+  *
+  */
+int32_t ism303dac_xl_status_reg_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_status_a_t *val)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_STATUS_A, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  status: [get]  Info about device status.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_status_reg_t: registers STATUS_REG
+  *
+  */
+int32_t ism303dac_mg_status_get(ism303dac_ctx_t *ctx,
+                               ism303dac_status_reg_m_t *val)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  xl_flag_data_ready: [get]  Accelerometer new data available.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of drdy in reg STATUS
+  *
+  */
+int32_t ism303dac_xl_flag_data_ready_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_STATUS_A, &reg.byte, 1);
+  *val = reg.status_a.drdy;
+
+  return mm_error;
+}
+
+/**
+  * @brief  mag_data_ready: [get]  Magnetic set of data available.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of zyxda in reg STATUS_REG
+  *
+  */
+int32_t ism303dac_mg_data_ready_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M, &reg.byte, 1);
+  *val = reg.status_reg_m.zyxda;
+
+  return mm_error;
+}
+
+/**
+  * @brief  mag_data_ovr: [get]  Magnetic set of data overrun.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of zyxor in reg STATUS_REG
+  *
+  */
+int32_t ism303dac_mg_data_ovr_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M, &reg.byte, 1);
+  *val = reg.status_reg_m.zyxor;
+
+  return mm_error;
+}
+
+/**
+  * @brief  mag_user_offset: [set]  These registers comprise a 3 group of
+  *                                 16-bit number and represent hard-iron
+  *                                 offset in order to compensate environmental
+  *                                 effects. Data format is the same of
+  *                                 output data raw: two’s complement with
+  *                                 1LSb = 1.5mG. These values act on the
+  *                                 magnetic output data value in order to
+  *                                 delete the environmental offset.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t ism303dac_mg_user_offset_set(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_write_reg(ctx, ISM303DAC_OFFSET_X_REG_L_M, buff, 6);
+}
+
+/**
+  * @brief  mag_user_offset: [get]  These registers comprise a 3 group of
+  *                                 16-bit number and represent hard-iron
+  *                                 offset in order to compensate environmental
+  *                                 effects. Data format is the same of
+  *                                 output data raw: two’s complement with
+  *                                 1LSb = 1.5mG. These values act on the
+  *                                 magnetic output data value in order to
+  *                                 delete the environmental offset.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism303dac_mg_user_offset_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_OFFSET_X_REG_L_M, buff, 6);
+}
+
+/**
+  * @brief  operating_mode: [set]  Operating mode selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_md_t: change the values of md in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_operating_mode_set(ism303dac_ctx_t *ctx,
+                                       ism303dac_mg_md_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.md = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  operating_mode: [get]  Operating mode selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_md_t: Get the values of md in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_operating_mode_get(ism303dac_ctx_t *ctx,
+                                       ism303dac_mg_md_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  *val = (ism303dac_mg_md_t) reg.cfg_reg_a_m.md;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_rate: [set]  Output data rate selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_odr_t: change the values of odr in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_data_rate_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_mg_odr_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.odr = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_rate: [get]  Output data rate selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_odr_t: Get the values of odr in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_data_rate_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_mg_odr_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  *val = (ism303dac_mg_odr_t) reg.cfg_reg_a_m.odr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  power_mode: [set]  Enables high-resolution/low-power mode.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_lp_t: change the values of lp in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_power_mode_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_lp_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.lp = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  power_mode: [get]  Enables high-resolution/low-power mode.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_lp_t: Get the values of lp in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_power_mode_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_lp_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  *val = (ism303dac_mg_lp_t) reg.cfg_reg_a_m.lp;
+
+  return mm_error;
+}
+
+/**
+  * @brief  offset_temp_comp: [set]  Enables the magnetometer temperature
+  *                                  compensation.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of comp_temp_en in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_offset_temp_comp_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.comp_temp_en = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  offset_temp_comp: [get]  Enables the magnetometer temperature
+  *                                  compensation.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of comp_temp_en in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_offset_temp_comp_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  *val = reg.cfg_reg_a_m.comp_temp_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  set_rst_mode: [set]
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_set_rst_t: change the values of set_rst in
+  *                            reg CFG_REG_B
+  *
+  */
+int32_t ism303dac_mg_set_rst_mode_set(ism303dac_ctx_t *ctx,
+                                     ism303dac_mg_set_rst_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  reg.cfg_reg_b_m.set_rst = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  set_rst_mode: [get]
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_set_rst_t: Get the values of set_rst in reg CFG_REG_B
+  *
+  */
+int32_t ism303dac_mg_set_rst_mode_get(ism303dac_ctx_t *ctx,
+                                     ism303dac_mg_set_rst_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  *val = (ism303dac_mg_set_rst_t) reg.cfg_reg_b_m.set_rst;
+
+  return mm_error;
+}
+
+/**
+  * @brief   set_rst_sensor_single: [set] Enables offset cancellation
+  *                                       in single measurement mode.
+  *                                       The OFF_CANC bit must be set
+  *                                       to 1 when enabling offset
+  *                                       cancellation in single measurement
+  *                                       mode this means a call function:
+  *                                       set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
+  *                                       is need.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of off_canc_one_shot in
+  *                      reg CFG_REG_B
+  *
+  */
+int32_t ism303dac_mg_set_rst_sensor_single_set(ism303dac_ctx_t *ctx,
+                                              uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  reg.cfg_reg_b_m.off_canc_one_shot = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   set_rst_sensor_single: [get] Enables offset cancellation
+  *                                       in single measurement mode.
+  *                                       The OFF_CANC bit must be set to
+  *                                       1 when enabling offset cancellation
+  *                                       in single measurement mode this
+  *                                       means a call function:
+  *                                       set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
+  *                                       is need.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of off_canc_one_shot in reg CFG_REG_B
+  *
+  */
+int32_t ism303dac_mg_set_rst_sensor_single_get(ism303dac_ctx_t *ctx,
+                                              uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  *val = reg.cfg_reg_b_m.off_canc_one_shot;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Dataoutput
+  * @brief   This section groups all the data output functions.
+  * @{
+  */
+
+/**
+  * @brief   acceleration_module_raw: [get]   Module output value (8-bit).
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism303dac_acceleration_module_raw_get(ism303dac_ctx_t *ctx,
+                                             uint8_t *buff)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_MODULE_8BIT_A, buff, 1);
+}
+
+/**
+  * @brief  temperature_raw: [get] Temperature data output register (r).
+  *                                L and H registers together express a 16-bit
+  *                                word in two’s complement.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism303dac_xl_temperature_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_OUT_T_A, buff, 1);
+}
+
+/**
+  * @brief  acceleration_raw: [get] Linear acceleration output register.
+  *                                 The value is expressed as a 16-bit word
+  *                                 in two’s complement.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism303dac_acceleration_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_OUT_X_L_A, buff, 6);
+}
+
+/**
+  * @brief  magnetic_raw: [get]  Magnetic output value.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism303dac_magnetic_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_OUTX_L_REG_M, buff, 6);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  common
+  * @brief   This section groups common usefull functions.
+  * @{
+  */
+
+/**
+  * @brief  device_id: [get] DeviceWhoamI.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism303dac_xl_device_id_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_WHO_AM_I_A, buff, 1);
+}
+
+/**
+  * @brief  device_id: [get] DeviceWhoamI.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism303dac_mg_device_id_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_WHO_AM_I_M, buff, 1);
+}
+
+/**
+  * @brief  auto_increment: [set] Register address automatically
+  *                               incremented during a multiple byte
+  *                               access with a serial interface.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of if_add_inc in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_auto_increment_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.if_add_inc = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  auto_increment: [get] Register address automatically incremented
+  *                               during a multiple byte access with a
+  *                               serial interface.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of if_add_inc in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_auto_increment_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  *val = reg.ctrl2_a.if_add_inc;
+
+  return mm_error;
+}
+
+
+/**
+  * @brief  reset: [set] Software reset. Restore the default values in
+  *                      user registers.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of soft_reset in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_reset_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.soft_reset = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [get] Software reset. Restore the default values in
+  *                      user registers.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of soft_reset in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_reset_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  *val = reg.ctrl2_a.soft_reset;
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [set]  Software reset. Restore the default values in
+  *                       user registers.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of soft_rst in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_reset_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.soft_rst = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [get]  Software reset. Restore the default values
+  *                       in user registers.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of soft_rst in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_reset_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  *val = reg.cfg_reg_a_m.soft_rst;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [set] Reboot memory content. Reload the calibration
+  *                     parameters.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of boot in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_boot_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.boot = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [get] Reboot memory content. Reload the calibration
+  *                     parameters.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of boot in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_boot_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  *val = reg.ctrl2_a.boot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [set]  Reboot memory content. Reload the calibration
+  *                      parameters.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of reboot in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_boot_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.reboot = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [get]  Reboot memory content. Reload the
+  *                      calibration parameters.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of reboot in reg CFG_REG_A
+  *
+  */
+int32_t ism303dac_mg_boot_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  *val = reg.cfg_reg_a_m.reboot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_self_test: [set]
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_st_t: change the values of st in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_self_test_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_st_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.st = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_self_test: [get]
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_st_t: Get the values of st in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_self_test_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_st_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  *val = (ism303dac_xl_st_t) reg.ctrl3_a.st;
+
+  return mm_error;
+}
+
+/**
+  * @brief  self_test: [set] Selftest.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of self_test in reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_self_test_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.self_test = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  self_test: [get] Selftest.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of self_test in reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_self_test_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  *val = reg.cfg_reg_c_m.self_test;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_ready_mode: [set]
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_drdy_pulsed_t: change the values of drdy_pulsed in
+  *                                 reg CTRL5
+  *
+  */
+int32_t ism303dac_xl_data_ready_mode_set(ism303dac_ctx_t *ctx,
+                                     ism303dac_xl_drdy_pulsed_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  reg.ctrl5_a.drdy_pulsed = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_ready_mode: [get]
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_drdy_pulsed_t: Get the values of drdy_pulsed in
+  *                                    reg CTRL5
+  *
+  */
+int32_t ism303dac_xl_data_ready_mode_get(ism303dac_ctx_t *ctx,
+                                     ism303dac_xl_drdy_pulsed_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  *val = (ism303dac_xl_drdy_pulsed_t) reg.ctrl5_a.drdy_pulsed;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Filters
+  * @brief   This section group all the functions concerning the filters
+  *          configuration.
+  * @{
+  */
+
+/**
+  * @brief  xl_hp_path: [set] High-pass filter data selection on output
+  *                           register and FIFO.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_fds_slope_t: change the values of fds_slope in
+  *                                  reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_hp_path_set(ism303dac_ctx_t *ctx,
+                                ism303dac_xl_fds_slope_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.fds_slope = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_hp_path: [get] High-pass filter data selection on output
+  *                           register and FIFO.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_fds_slope_t: Get the values of fds_slope in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_hp_path_get(ism303dac_ctx_t *ctx,
+                                ism303dac_xl_fds_slope_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  *val = (ism303dac_xl_fds_slope_t) reg.ctrl2_a.fds_slope;
+
+  return mm_error;
+}
+
+/**
+  * @brief  low_pass_bandwidth: [set]  Low-pass bandwidth selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_lpf_t: change the values of lpf in reg CFG_REG_B
+  *
+  */
+int32_t ism303dac_mg_low_pass_bandwidth_set(ism303dac_ctx_t *ctx,
+                                       ism303dac_mg_lpf_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  reg.cfg_reg_b_m.lpf = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  low_pass_bandwidth: [get]  Low-pass bandwidth selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_lpf_t: Get the values of lpf in reg CFG_REG_B
+  *
+  */
+int32_t ism303dac_mg_low_pass_bandwidth_get(ism303dac_ctx_t *ctx,
+                                       ism303dac_mg_lpf_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  *val = (ism303dac_mg_lpf_t) reg.cfg_reg_b_m.lpf;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Auxiliary_interface
+  * @brief   This section groups all the functions concerning auxiliary
+  *          interface.
+  * @{
+  */
+
+/**
+  * @brief  spi_mode: [set]  SPI Serial Interface Mode selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_sim_t: change the values of sim in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_spi_mode_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_sim_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.sim = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  spi_mode: [get]  SPI Serial Interface Mode selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_sim_t: Get the values of sim in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_spi_mode_get(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_sim_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  *val = (ism303dac_xl_sim_t) reg.ctrl2_a.sim;
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [set]  Disable / Enable I2C interface.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_i2c_disable_t: change the values of i2c_disable
+  *                                 in reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_i2c_interface_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_i2c_disable_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.i2c_disable = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [get]  Disable / Enable I2C interface.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_i2c_disable_t: Get the values of i2c_disable in
+  *                                 reg CTRL2
+  *
+  */
+int32_t ism303dac_xl_i2c_interface_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_i2c_disable_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  *val = (ism303dac_xl_i2c_disable_t) reg.ctrl2_a.i2c_disable;
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [set]  Enable/Disable I2C interface.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_i2c_dis_t: change the values of i2c_dis in
+  *                                reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_i2c_interface_set(ism303dac_ctx_t *ctx,
+                                      ism303dac_mg_i2c_dis_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.i2c_dis = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [get]  Enable/Disable I2C interface.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_i2c_dis_t: Get the values of i2c_dis in
+  *                                 reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_i2c_interface_get(ism303dac_ctx_t *ctx,
+                                      ism303dac_mg_i2c_dis_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  *val = (ism303dac_mg_i2c_dis_t) reg.cfg_reg_c_m.i2c_dis;
+
+  return mm_error;
+}
+
+/**
+  * @brief  cs_mode: [set]  Connect/Disconnects pull-up in if_cs pad.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_if_cs_pu_dis_t: change the values of if_cs_pu_dis
+  *                                  in reg FIFO_CTRL
+  *
+  */
+int32_t ism303dac_xl_cs_mode_set(ism303dac_ctx_t *ctx,
+                             ism303dac_xl_if_cs_pu_dis_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  reg.fifo_ctrl_a.if_cs_pu_dis = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  cs_mode: [get]  Connect/Disconnects pull-up in if_cs pad.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_if_cs_pu_dis_t: Get the values of if_cs_pu_dis in
+  *                                  reg FIFO_CTRL
+  *
+  */
+int32_t ism303dac_xl_cs_mode_get(ism303dac_ctx_t *ctx,
+                             ism303dac_xl_if_cs_pu_dis_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  *val = (ism303dac_xl_if_cs_pu_dis_t) reg.fifo_ctrl_a.if_cs_pu_dis;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   main_serial_interface
+  * @brief   This section groups all the functions concerning main serial
+  *          interface management (not auxiliary)
+  * @{
+  */
+
+/**
+  * @brief  pin_mode: [set]  Push-pull/open-drain selection on interrupt pad.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_pp_od_t: change the values of pp_od in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_pin_mode_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_pp_od_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.pp_od = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_mode: [get]  Push-pull/open-drain selection on interrupt pad.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_pp_od_t: Get the values of pp_od in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_pin_mode_get(ism303dac_ctx_t *ctx,
+                                 ism303dac_xl_pp_od_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  *val = (ism303dac_xl_pp_od_t) reg.ctrl3_a.pp_od;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_polarity: [set]  Interrupt active-high/low.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_h_lactive_t: change the values of h_lactive in
+  *                                  reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_pin_polarity_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_h_lactive_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.h_lactive = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_polarity: [get]  Interrupt active-high/low.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_h_lactive_t: Get the values of h_lactive in
+  *                                   reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_pin_polarity_get(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_h_lactive_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  *val = (ism303dac_xl_h_lactive_t) reg.ctrl3_a.h_lactive;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_notification: [set]  Latched/pulsed interrupt.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_lir_t: change the values of lir in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_int_notification_set(ism303dac_ctx_t *ctx,
+                                      ism303dac_xl_lir_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.lir = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_notification: [get]  Latched/pulsed interrupt.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_lir_t: Get the values of lir in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_int_notification_get(ism303dac_ctx_t *ctx,
+                                      ism303dac_xl_lir_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  *val = (ism303dac_xl_lir_t) reg.ctrl3_a.lir;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int1_route: [set] Select the signal that need to route
+  *                               on int1 pad.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_pin_int1_route_t: union of registers from CTRL4 to
+  *
+  */
+int32_t ism303dac_xl_pin_int1_route_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_pin_int1_route_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL4_A, &reg.byte, 1);
+  reg.ctrl4_a.int1_drdy         = val.int1_drdy;
+  reg.ctrl4_a.int1_fth          = val.int1_fth;
+  reg.ctrl4_a.int1_6d           = val.int1_6d;
+  reg.ctrl4_a.int1_tap          = val.int1_tap;
+  reg.ctrl4_a.int1_ff           = val.int1_ff;
+  reg.ctrl4_a.int1_wu           = val.int1_wu;
+  reg.ctrl4_a.int1_s_tap        = val.int1_s_tap;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL4_A, &reg.byte, 1);
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_dur_a.int1_fss7   = val.int1_fss7;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int1_route: [get] Select the signal that need to route on
+  *                               int1 pad.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_pin_int1_route_t: union of registers from CTRL4 to
+  *
+  */
+int32_t ism303dac_xl_pin_int1_route_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_pin_int1_route_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL4_A, &reg.byte, 1);
+  val->int1_drdy          = reg.ctrl4_a.int1_drdy;
+  val->int1_fth           = reg.ctrl4_a.int1_fth;
+  val->int1_6d            = reg.ctrl4_a.int1_6d;
+  val->int1_tap           = reg.ctrl4_a.int1_tap;
+  val->int1_ff            = reg.ctrl4_a.int1_ff;
+  val->int1_wu            = reg.ctrl4_a.int1_wu;
+  val->int1_s_tap         = reg.ctrl4_a.int1_s_tap;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  val->int1_fss7 = reg.wake_up_dur_a.int1_fss7;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int2_route: [set] Select the signal that need to route on
+  *                               int2 pad.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_pin_int2_route_t: union of registers from CTRL5 to
+  *
+  */
+int32_t ism303dac_xl_pin_int2_route_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_pin_int2_route_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  reg.ctrl5_a.int2_boot       = val.int2_boot;
+  reg.ctrl5_a.int2_fth        = val.int2_fth;
+  reg.ctrl5_a.int2_drdy       = val.int2_drdy;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int2_route: [get] Select the signal that need to route on
+  *                               int2 pad.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_pin_int2_route_t: union of registers from CTRL5 to
+  *
+  */
+int32_t ism303dac_xl_pin_int2_route_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_pin_int2_route_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  val->int2_boot     = reg.ctrl5_a.int2_boot;
+  val->int2_fth      = reg.ctrl5_a.int2_fth;
+  val->int2_drdy     = reg.ctrl5_a.int2_drdy;
+
+  return mm_error;
+}
+
+/**
+  * @brief  all_on_int1: [set] All interrupt signals become available on
+  *                            INT1 pin.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int2_on_int1 in reg CTRL5
+  *
+  */
+int32_t ism303dac_xl_all_on_int1_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  reg.ctrl5_a.int2_on_int1 = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  all_on_int1: [get] All interrupt signals become available on
+  *                            INT1 pin.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int2_on_int1 in reg CTRL5
+  *
+  */
+int32_t ism303dac_xl_all_on_int1_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  *val = reg.ctrl5_a.int2_on_int1;
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_pin: [set]  Data-ready signal on INT_DRDY pin.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of drdy_on_pin in reg CFG_REG_C
+  *
+  */
+int32_t ism303dac_mg_drdy_on_pin_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.int_mag = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_pin: [get]  Data-ready signal on INT_DRDY pin.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of drdy_on_pin in reg CFG_REG_C_M
+  *
+  */
+int32_t ism303dac_mg_drdy_on_pin_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  *val = reg.cfg_reg_c_m.int_mag;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_on_pin: [set]  Interrupt signal on INT_DRDY pin.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int_on_pin in reg CFG_REG_C_M
+  *
+  */
+int32_t ism303dac_mg_int_on_pin_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.int_mag_pin = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_on_pin: [get]  Interrupt signal on INT_DRDY pin.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int_on_pin in reg CFG_REG_C_M
+  *
+  */
+int32_t ism303dac_mg_int_on_pin_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  *val = reg.cfg_reg_c_m.int_mag_pin;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_gen_conf: [set]  Interrupt generator configuration register
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_int_crtl_reg_m_t: registers INT_CRTL_REG
+  *
+  */
+int32_t ism303dac_mg_int_gen_conf_set(ism303dac_ctx_t *ctx,
+                                 ism303dac_int_crtl_reg_m_t *val)
+{
+  return ism303dac_write_reg(ctx, ISM303DAC_INT_CRTL_REG_M, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  int_gen_conf: [get]  Interrupt generator configuration register
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_int_crtl_reg_m_t: registers INT_CRTL_REG
+  *
+  */
+int32_t ism303dac_mg_int_gen_conf_get(ism303dac_ctx_t *ctx,
+                                 ism303dac_int_crtl_reg_m_t *val)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_INT_CRTL_REG_M, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  int_gen_source: [get]  Interrupt generator source register
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_int_source_reg_m_t: registers INT_SOURCE_REG
+  *
+  */
+int32_t ism303dac_mg_int_gen_source_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_int_source_reg_m_t *val)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_INT_SOURCE_REG_M, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  int_gen_treshold: [set]  User-defined threshold value for xl
+  *                                  interrupt event on generator.
+  *                                  Data format is the same of output
+  *                                  data raw: two’s complement with
+  *                                  1LSb = 1.5mG.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t ism303dac_mg_int_gen_treshold_set(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_write_reg(ctx, ISM303DAC_INT_THS_L_REG_M, buff, 2);
+}
+
+/**
+  * @brief  int_gen_treshold: [get]  User-defined threshold value for
+  *                                  xl interrupt event on generator.
+  *                                  Data format is the same of output
+  *                                  data raw: two’s complement with
+  *                                  1LSb = 1.5mG.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t ism303dac_mg_int_gen_treshold_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_INT_THS_L_REG_M, buff, 2);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  interrupt_pins
+  * @brief   This section groups all the functions that manage interrup pins
+  * @{
+  */
+
+
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Wake_Up_event
+  * @brief   This section groups all the functions that manage the Wake Up
+  *          event generation.
+  * @{
+  */
+
+/**
+  * @brief  offset_int_conf: [set]  The interrupt block recognition checks
+  *                                 data after/before the hard-iron correction
+  *                                 to discover the interrupt.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_int_on_dataoff_t: change the values of int_on_dataoff
+  *                                       in reg CFG_REG_B
+  *
+  */
+int32_t ism303dac_mg_offset_int_conf_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_int_on_dataoff_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  reg.cfg_reg_b_m.int_on_dataoff = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  offset_int_conf: [get]  The interrupt block recognition checks
+  *                                 data after/before the hard-iron correction
+  *                                 to discover the interrupt.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_mg_int_on_dataoff_t: Get the values of int_on_dataoff in
+  *                                   reg CFG_REG_B
+  *
+  */
+int32_t ism303dac_mg_offset_int_conf_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_int_on_dataoff_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  *val = (ism303dac_mg_int_on_dataoff_t) reg.cfg_reg_b_m.int_on_dataoff;
+
+  return mm_error;
+}
+
+  /**
+  * @brief  wkup_threshold: [set]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of wu_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t ism303dac_xl_wkup_threshold_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_ths_a.wu_ths = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_threshold: [get]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of wu_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t ism303dac_xl_wkup_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = reg.wake_up_ths_a.wu_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_dur: [set]  Wakeup duration [1 LSb = 1 / ODR].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of wu_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t ism303dac_xl_wkup_dur_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_dur_a.wu_dur = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_dur: [get]  Wakeup duration [1 LSb = 1 / ODR].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of wu_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t ism303dac_xl_wkup_dur_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = reg.wake_up_dur_a.wu_dur;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Activity/Inactivity_detection
+  * @brief   This section groups all the functions concerning
+  *          activity/inactivity detection.
+  * @{
+  */
+/**
+  * @brief  sleep_mode: [set]  Enables gyroscope Sleep mode.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sleep_on in reg WAKE_UP_THS
+  *
+  */
+int32_t ism303dac_xl_sleep_mode_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_ths_a.sleep_on = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  sleep_mode: [get]  Enables gyroscope Sleep mode.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sleep_on in reg WAKE_UP_THS
+  *
+  */
+int32_t ism303dac_xl_sleep_mode_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = reg.wake_up_ths_a.sleep_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief  act_sleep_dur: [set] Duration to go in sleep mode
+  *                              [1 LSb = 512 / ODR].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t ism303dac_xl_act_sleep_dur_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_dur_a.sleep_dur = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  act_sleep_dur: [get] Duration to go in sleep mode
+  *                              [1 LSb = 512 / ODR].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t ism303dac_xl_act_sleep_dur_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = reg.wake_up_dur_a.sleep_dur;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  tap_generator
+  * @brief   This section groups all the functions that manage the tap and
+  *          double tap event generation.
+  * @{
+  */
+
+/**
+  * @brief  tap_detection_on_z: [set]  Enable Z direction in tap recognition.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_z_en in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_tap_detection_on_z_set(ism303dac_ctx_t *ctx,
+                                            uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.tap_z_en = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_z: [get]  Enable Z direction in tap recognition.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_z_en in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_tap_detection_on_z_get(ism303dac_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  *val = reg.ctrl3_a.tap_z_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_y: [set]  Enable Y direction in tap recognition.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_y_en in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_tap_detection_on_y_set(ism303dac_ctx_t *ctx,
+                                            uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.tap_y_en = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_y: [get]  Enable Y direction in tap recognition.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_y_en in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_tap_detection_on_y_get(ism303dac_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  *val = reg.ctrl3_a.tap_y_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_x: [set]  Enable X direction in tap recognition.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_x_en in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_tap_detection_on_x_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.tap_x_en = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_x: [get]  Enable X direction in tap recognition.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_x_en in reg CTRL3
+  *
+  */
+int32_t ism303dac_xl_tap_detection_on_x_get(ism303dac_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  *val = reg.ctrl3_a.tap_x_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_threshold: [set] Threshold for tap recognition
+  *                              [1 LSb = FS/32].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_ths in reg TAP_6D_THS
+  *
+  */
+int32_t ism303dac_xl_tap_threshold_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  reg.tap_6d_ths_a.tap_ths = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_threshold: [get] Threshold for tap recognition
+  *                              [1 LSb = FS/32].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_ths in reg TAP_6D_THS
+  *
+  */
+int32_t ism303dac_xl_tap_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  *val = reg.tap_6d_ths_a.tap_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_shock: [set] Maximum duration is the maximum time of
+  *                          an overthreshold signal detection to be
+  *                          recognized as a tap event. The default value
+  *                          of these bits is 00b which corresponds to
+  *                          4*ODR_XL time. If the SHOCK[1:0] bits are set
+  *                          to a different value, 1LSB corresponds to
+  *                          8*ODR_XL time.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of shock in reg INT_DUR
+  *
+  */
+int32_t ism303dac_xl_tap_shock_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  reg.int_dur_a.shock = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_shock: [get] Maximum duration is the maximum time of an
+  *                          overthreshold signal detection to be recognized
+  *                          as a tap event. The default value of these bits
+  *                          is 00b which corresponds to 4*ODR_XL time.
+  *                          If the SHOCK[1:0] bits are set to a different
+                             value, 1LSB corresponds to 8*ODR_XL time.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of shock in reg INT_DUR
+  *
+  */
+int32_t ism303dac_xl_tap_shock_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  *val = reg.int_dur_a.shock;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_quiet: [set] Quiet time is the time after the first
+  *                          detected tap in which there must not be any
+  *                          overthreshold event. The default value of these
+  *                          bits is 00b which corresponds to 2*ODR_XL time.
+  *                          If the QUIET[1:0] bits are set to a different
+  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of quiet in reg INT_DUR
+  *
+  */
+int32_t ism303dac_xl_tap_quiet_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  reg.int_dur_a.quiet = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_quiet: [get] Quiet time is the time after the first detected
+  *                          tap in which there must not be any overthreshold
+  *                          event. The default value of these bits is 00b
+  *                          which corresponds to 2*ODR_XL time.
+  *                          If the QUIET[1:0] bits are set to a different
+  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of quiet in reg INT_DUR
+  *
+  */
+int32_t ism303dac_xl_tap_quiet_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  *val = reg.int_dur_a.quiet;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_dur: [set] When double tap recognition is enabled, this
+  *                        register expresses the maximum time between two
+  *                        consecutive detected taps to determine a double
+  *                        tap event. The default value of these bits is
+  *                        0000b which corresponds to 16*ODR_XL time.
+  *                        If the DUR[3:0] bits are set to a different value,
+  *                        1LSB corresponds to 32*ODR_XL time.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of lat in reg INT_DUR
+  *
+  */
+int32_t ism303dac_xl_tap_dur_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  reg.int_dur_a.lat = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_dur: [get] When double tap recognition is enabled,
+  *                        this register expresses the maximum time
+  *                        between two consecutive detected taps to
+  *                        determine a double tap event. The default
+  *                        value of these bits is 0000b which corresponds
+  *                        to 16*ODR_XL time. If the DUR[3:0] bits are set
+  *                        to a different value, 1LSB corresponds to
+  *                        32*ODR_XL time.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of lat in reg INT_DUR
+  *
+  */
+int32_t ism303dac_xl_tap_dur_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  *val = reg.int_dur_a.lat;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_mode: [set]  Single/double-tap event enable/disable.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_single_double_tap_t: change the values of
+  *                                       single_double_tap in regWAKE_UP_THS
+  *
+  */
+int32_t ism303dac_xl_tap_mode_set(ism303dac_ctx_t *ctx,
+                              ism303dac_xl_single_double_tap_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_ths_a.single_double_tap = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_mode: [get]  Single/double-tap event enable/disable.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_single_double_tap_t: Get the values of
+  *                                        single_double_tap in
+  *                                        reg WAKE_UP_THS
+  *
+  */
+int32_t ism303dac_xl_tap_mode_get(ism303dac_ctx_t *ctx,
+                              ism303dac_xl_single_double_tap_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = (ism303dac_xl_single_double_tap_t)reg.wake_up_ths_a.single_double_tap;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_src: [get]  TAP source register
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_tap_src_t: registers TAP_SRC
+  *
+  */
+int32_t ism303dac_xl_tap_src_get(ism303dac_ctx_t *ctx,
+                                ism303dac_tap_src_a_t *val)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_TAP_SRC_A, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Six_position_detection(6D/4D)
+  * @brief   This section groups all the functions concerning six
+  *          position detection (6D).
+  * @{
+  */
+
+/**
+  * @brief  6d_threshold: [set]  Threshold for 4D/6D function.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_6d_ths_t: change the values of 6d_ths in
+  *                                reg TAP_6D_THS
+  *
+  */
+int32_t ism303dac_xl_6d_threshold_set(ism303dac_ctx_t *ctx,
+                                     ism303dac_xl_6d_ths_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  reg.tap_6d_ths_a._6d_ths = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  6d_threshold: [get]  Threshold for 4D/6D function.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_6d_ths_t: Get the values of 6d_ths in reg TAP_6D_THS
+  *
+  */
+int32_t ism303dac_xl_6d_threshold_get(ism303dac_ctx_t *ctx,
+                                     ism303dac_xl_6d_ths_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  *val = (ism303dac_xl_6d_ths_t) reg.tap_6d_ths_a._6d_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  4d_mode: [set]  4D orientation detection enable.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of 4d_en in reg TAP_6D_THS
+  *
+  */
+int32_t ism303dac_xl_4d_mode_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  reg.tap_6d_ths_a._4d_en = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  4d_mode: [get]  4D orientation detection enable.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of 4d_en in reg TAP_6D_THS
+  *
+  */
+int32_t ism303dac_xl_4d_mode_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  *val = reg.tap_6d_ths_a._4d_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  6d_src: [get]  6D source register.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_6d_src_t: union of registers from 6D_SRC to
+  *
+  */
+int32_t ism303dac_xl_6d_src_get(ism303dac_ctx_t *ctx,
+                                ism303dac_6d_src_a_t *val)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_6D_SRC_A, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  free_fall
+  * @brief   This section group all the functions concerning the
+  *          free fall detection.
+  * @{
+  */
+
+/**
+  * @brief  ff_dur: [set]  Free-fall duration [1 LSb = 1 / ODR].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of ff_dur in reg
+  *                      WAKE_UP_DUR/FREE_FALL
+  *
+  */
+int32_t ism303dac_xl_ff_dur_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                                &reg[0].byte, 2);
+  reg[1].free_fall_a.ff_dur = 0x1F & val;
+  reg[0].wake_up_dur_a.ff_dur = (val & 0x20) >> 5;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                                 &reg[0].byte, 2);
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_dur: [get]  Free-fall duration [1 LSb = 1 / ODR].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  *
+  */
+int32_t ism303dac_xl_ff_dur_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                                &reg[0].byte, 2);
+  *val = (reg[0].wake_up_dur_a.ff_dur << 5) + reg[1].free_fall_a.ff_dur;
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_threshold: [set]  Free-fall threshold [1 LSB = 31.25 mg].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t ism303dac_xl_ff_threshold_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FREE_FALL_A, &reg.byte, 1);
+  reg.free_fall_a.ff_ths = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FREE_FALL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_threshold: [get]  Free-fall threshold [1 LSB = 31.25 mg].
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t ism303dac_xl_ff_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FREE_FALL_A, &reg.byte, 1);
+  *val = reg.free_fall_a.ff_ths;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Fifo
+  * @brief   This section group all the functions concerning the fifo usage
+  * @{
+  */
+
+/**
+  * @brief   fifo_xl_module_batch: [set]  Module routine result is send to
+  *          FIFO instead of X,Y,Z acceleration data
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of module_to_fifo in reg FIFO_CTRL
+  *
+  */
+int32_t ism303dac_xl_fifo_xl_module_batch_set(ism303dac_ctx_t *ctx,
+                                              uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  reg.fifo_ctrl_a.module_to_fifo = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_xl_module_batch: [get]  Module routine result is send to
+  *                                       FIFO instead of X,Y,Z acceleration
+  *                                       data
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of module_to_fifo in reg FIFO_CTRL
+  *
+  */
+int32_t ism303dac_xl_fifo_xl_module_batch_get(ism303dac_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  *val = reg.fifo_ctrl_a.module_to_fifo;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [set]  FIFO mode selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_fmode_t: change the values of fmode in reg FIFO_CTRL
+  *
+  */
+int32_t ism303dac_xl_fifo_mode_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_fmode_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  reg.fifo_ctrl_a.fmode = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [get]  FIFO mode selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_fmode_t: Get the values of fmode in reg FIFO_CTRL
+  *
+  */
+int32_t ism303dac_xl_fifo_mode_get(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_fmode_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  *val = (ism303dac_xl_fmode_t) reg.fifo_ctrl_a.fmode;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of fifo_watermark in reg FIFO_THS
+  *
+  */
+int32_t ism303dac_xl_fifo_watermark_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  int32_t mm_error;
+
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FIFO_THS_A, &val, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_watermark in reg FIFO_THS
+  *
+  */
+int32_t ism303dac_xl_fifo_watermark_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_THS_A, val, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_full_flag: [get]  FIFO full, 256 unread samples.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of diff in reg FIFO_SRC
+  *
+  */
+int32_t ism303dac_xl_fifo_full_flag_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, &reg.byte, 1);
+  *val = reg.fifo_src_a.diff;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_flag: [get]  FIFO overrun status.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_ovr in reg FIFO_SRC
+  *
+  */
+int32_t ism303dac_xl_fifo_ovr_flag_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, &reg.byte, 1);
+  *val = reg.fifo_src_a.fifo_ovr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_wtm_flag: [get]  FIFO threshold status.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fth in reg FIFO_SRC
+  *
+  */
+int32_t ism303dac_xl_fifo_wtm_flag_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, &reg.byte, 1);
+  *val = reg.fifo_src_a.fth;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_data_level: [get] The number of unread samples
+  *                                stored in FIFO.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint16_t: change the values of diff in reg FIFO_SAMPLES
+  *
+  */
+int32_t ism303dac_xl_fifo_data_level_get(ism303dac_ctx_t *ctx, uint16_t *val)
+{
+  ism303dac_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, &reg[0].byte, 2);
+  *val = (reg[1].fifo_src_a.diff << 7) + reg[0].byte;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_src: [get] FIFO_SRCregister.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ism303dac_xl_fifo_src_t: registers FIFO_SRC
+  *
+  */
+int32_t ism303dac_xl_fifo_src_get(ism303dac_ctx_t *ctx,
+                                 ism303dac_fifo_src_a_t *val)
+{
+  return ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  module
+  * @brief   This section groups all the functions that manage
+  *          module calculation
+  * @{
+  */
+
+/**
+  * @brief  module_sens: [set]  Module processing enable.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of module_on in reg FUNC_CTRL
+  *
+  */
+int32_t ism303dac_xl_module_sens_set(ism303dac_ctx_t *ctx, uint8_t val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FUNC_CTRL_A, &reg.byte, 1);
+  reg.func_ctrl_a.module_on = val;
+  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FUNC_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  module_sens: [get]  Module processing enable.
+  *
+  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of module_on in reg FUNC_CTRL
+  *
+  */
+int32_t ism303dac_xl_module_sens_get(ism303dac_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FUNC_CTRL_A, &reg.byte, 1);
+  *val = reg.func_ctrl_a.module_on;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism303dac_STdC/driver/ism303dac_reg.h
+++ b/sensor/stmemsc/ism303dac_STdC/driver/ism303dac_reg.h
@@ -1,0 +1,898 @@
+/*
+ ******************************************************************************
+ * @file    ism303dac_reg.h
+ * @author  MEMS Software Solution Team
+ * @date    20-December-2017
+ * @brief   This file contains all the functions prototypes for the
+ *          ism303dac_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __ISM303DAC_DRIVER__H
+#define __ISM303DAC_DRIVER__H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup ISM303DAC
+  * @{
+  *
+  */
+
+/** @defgroup ISM303DAC_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup ism303dac_interface
+  * @{
+  */
+
+typedef int32_t (*ism303dac_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*ism303dac_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  ism303dac_write_ptr  write_reg;
+  ism303dac_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} ism303dac_ctx_t;
+
+/**
+  * @}
+  */
+
+/** @defgroup ism303dac_Infos
+  * @{
+  */
+  /** I2C Device Address 8 bit format **/
+#define ISM303DAC_I2C_ADD_XL     0x3B
+#define ISM303DAC_I2C_ADD_MG       0x3D
+
+/** Device Identification (Who am I) **/
+#define ISM303DAC_ID_XL            0x43
+#define ISM303DAC_ID_MG            0x40
+
+/**
+  * @}
+  */
+
+/**
+  * @defgroup ism303dac_Sensitivity
+  * @{
+  */
+
+#define ISM303DAC_FROM_FS_2g_TO_mg(lsb)    (float)(lsb *  61.0f) / 1000.0f
+#define ISM303DAC_FROM_FS_4g_TO_mg(lsb)    (float)(lsb * 122.0f) / 1000.0f
+#define ISM303DAC_FROM_FS_8g_TO_mg(lsb)    (float)(lsb * 244.0f) / 1000.0f
+#define ISM303DAC_FROM_FS_16g_TO_mg(lsb)   (float)(lsb * 488.0f) / 1000.0f
+
+#define ISM303DAC_FROM_LSB_TO_mG(lsb)      (float)(lsb * 1.5f)
+
+#define ISM303DAC_FROM_LSB_TO_degC(lsb) ((float)((int16_t)lsb>>8)*1.0f + 25.0f)
+
+/**
+  * @}
+  */
+
+#define ISM303DAC_MODULE_8BIT_A           0x0C
+#define ISM303DAC_WHO_AM_I_A              0x0F
+#define ISM303DAC_CTRL1_A                 0x20
+typedef struct {
+  uint8_t bdu                 : 1;
+  uint8_t hf_odr              : 1;
+  uint8_t fs                  : 2;
+  uint8_t odr                 : 4;
+} ism303dac_ctrl1_a_t;
+
+#define ISM303DAC_CTRL2_A                 0x21
+typedef struct {
+  uint8_t sim                 : 1;
+  uint8_t i2c_disable         : 1;
+  uint8_t if_add_inc          : 1;
+  uint8_t fds_slope           : 1;
+  uint8_t not_used_01         : 2;
+  uint8_t soft_reset          : 1;
+  uint8_t boot                : 1;
+} ism303dac_ctrl2_a_t;
+
+#define ISM303DAC_CTRL3_A                 0x22
+typedef struct {
+  uint8_t pp_od               : 1;
+  uint8_t h_lactive           : 1;
+  uint8_t lir                 : 1;
+  uint8_t tap_z_en            : 1;
+  uint8_t tap_y_en            : 1;
+  uint8_t tap_x_en            : 1;
+  uint8_t st                  : 2;
+} ism303dac_ctrl3_a_t;
+
+#define ISM303DAC_CTRL4_A                 0x23
+typedef struct {
+  uint8_t int1_drdy           : 1;
+  uint8_t int1_fth            : 1;
+  uint8_t int1_6d             : 1;
+  uint8_t int1_tap            : 1;
+  uint8_t int1_ff             : 1;
+  uint8_t int1_wu             : 1;
+  uint8_t int1_s_tap          : 1;
+  uint8_t not_used_01         : 1;
+} ism303dac_ctrl4_a_t;
+
+#define ISM303DAC_CTRL5_A                 0x24
+typedef struct {
+  uint8_t int2_drdy           : 1;
+  uint8_t int2_fth            : 1;
+  uint8_t not_used_01         : 3;
+  uint8_t int2_on_int1        : 1;
+  uint8_t int2_boot           : 1;
+  uint8_t drdy_pulsed         : 1;
+} ism303dac_ctrl5_a_t;
+
+#define ISM303DAC_FIFO_CTRL_A             0x25
+typedef struct {
+  uint8_t if_cs_pu_dis        : 1;
+  uint8_t not_used_01         : 2;
+  uint8_t module_to_fifo      : 1;
+  uint8_t not_used_02         : 1;
+  uint8_t fmode               : 3;
+} ism303dac_fifo_ctrl_a_t;
+
+#define ISM303DAC_OUT_T_A                 0x26
+#define ISM303DAC_STATUS_A                0x27
+typedef struct {
+  uint8_t drdy                : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t single_tap          : 1;
+  uint8_t double_tap          : 1;
+  uint8_t sleep_state         : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t fifo_ths            : 1;
+} ism303dac_status_a_t;
+
+#define ISM303DAC_OUT_X_L_A               0x28
+#define ISM303DAC_OUT_X_H_A               0x29
+#define ISM303DAC_OUT_Y_L_A               0x2A
+#define ISM303DAC_OUT_Y_H_A               0x2B
+#define ISM303DAC_OUT_Z_L_A               0x2C
+#define ISM303DAC_OUT_Z_H_A               0x2D
+#define ISM303DAC_FIFO_THS_A              0x2E
+#define ISM303DAC_FIFO_SRC_A              0x2F
+typedef struct {
+  uint8_t not_used_01         : 5;
+  uint8_t diff                : 1;
+  uint8_t fifo_ovr            : 1;
+  uint8_t fth                 : 1;
+} ism303dac_fifo_src_a_t;
+
+#define ISM303DAC_FIFO_SAMPLES_A          0x30
+#define ISM303DAC_TAP_6D_THS_A            0x31
+typedef struct {
+  uint8_t tap_ths             : 5;
+  uint8_t _6d_ths             : 2;
+  uint8_t _4d_en              : 1;
+} ism303dac_tap_6d_ths_a_t;
+
+#define ISM303DAC_INT_DUR_A               0x32
+typedef struct {
+  uint8_t shock               : 2;
+  uint8_t quiet               : 2;
+  uint8_t lat                 : 4;
+} ism303dac_int_dur_a_t;
+
+#define ISM303DAC_WAKE_UP_THS_A           0x33
+typedef struct {
+  uint8_t wu_ths              : 6;
+  uint8_t sleep_on            : 1;
+  uint8_t single_double_tap   : 1;
+} ism303dac_wake_up_ths_a_t;
+
+#define ISM303DAC_WAKE_UP_DUR_A           0x34
+typedef struct {
+  uint8_t sleep_dur           : 4;
+  uint8_t int1_fss7           : 1;
+  uint8_t wu_dur              : 2;
+  uint8_t ff_dur              : 1;
+} ism303dac_wake_up_dur_a_t;
+
+#define ISM303DAC_FREE_FALL_A             0x35
+typedef struct {
+  uint8_t ff_ths              : 3;
+  uint8_t ff_dur              : 5;
+} ism303dac_free_fall_a_t;
+
+#define ISM303DAC_STATUS_DUP_A            0x36
+typedef struct {
+  uint8_t drdy                : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t single_tap          : 1;
+  uint8_t double_tap          : 1;
+  uint8_t sleep_state         : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t ovr                 : 1;
+} ism303dac_status_dup_a_t;
+
+#define ISM303DAC_WAKE_UP_SRC_A           0x37
+typedef struct {
+  uint8_t z_wu                : 1;
+  uint8_t y_wu                : 1;
+  uint8_t x_wu                : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t sleep_state_ia      : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t not_used_01         : 2;
+} ism303dac_wake_up_src_a_t;
+
+#define ISM303DAC_TAP_SRC_A               0x38
+typedef struct {
+  uint8_t z_tap               : 1;
+  uint8_t y_tap               : 1;
+  uint8_t x_tap               : 1;
+  uint8_t tap_sign            : 1;
+  uint8_t double_tap          : 1;
+  uint8_t single_tap          : 1;
+  uint8_t tap_ia              : 1;
+  uint8_t not_used_01         : 1;
+} ism303dac_tap_src_a_t;
+
+#define ISM303DAC_6D_SRC_A                0x39
+typedef struct {
+  uint8_t xl                  : 1;
+  uint8_t xh                  : 1;
+  uint8_t yl                  : 1;
+  uint8_t yh                  : 1;
+  uint8_t zl                  : 1;
+  uint8_t zh                  : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t not_used_01         : 1;
+} ism303dac_6d_src_a_t;
+
+#define ISM303DAC_FUNC_SRC_A              0x3E
+typedef struct {
+  uint8_t not_used_01         : 1;
+  uint8_t module_ready        : 1;
+  uint8_t not_used_02         : 6;
+} ism303dac_func_src_a_t;
+
+#define ISM303DAC_FUNC_CTRL_A             0x3F
+typedef struct {
+  uint8_t not_used_01         : 5;
+  uint8_t module_on           : 1;
+  uint8_t not_used_02         : 2;
+} ism303dac_func_ctrl_a_t;
+
+#define ISM303DAC_OFFSET_X_REG_L_M          0x45
+#define ISM303DAC_OFFSET_X_REG_H_M          0x46
+#define ISM303DAC_OFFSET_Y_REG_L_M          0x47
+#define ISM303DAC_OFFSET_Y_REG_H_M          0x48
+#define ISM303DAC_OFFSET_Z_REG_L_M          0x49
+#define ISM303DAC_OFFSET_Z_REG_H_M          0x4A
+#define ISM303DAC_WHO_AM_I_M                0x4F
+#define ISM303DAC_CFG_REG_A_M               0x60
+typedef struct {
+  uint8_t md                     : 2;
+  uint8_t odr                    : 2;
+  uint8_t lp                     : 1;
+  uint8_t soft_rst               : 1;
+  uint8_t reboot                 : 1;
+  uint8_t comp_temp_en           : 1;
+} ism303dac_cfg_reg_a_m_t;
+
+#define ISM303DAC_CFG_REG_B_M               0x61
+typedef struct {
+  uint8_t lpf                    : 1;
+  uint8_t set_rst                : 2; /* off_canc + set_freq */
+  uint8_t int_on_dataoff         : 1;
+  uint8_t off_canc_one_shot      : 1;
+  uint8_t not_used_01            : 3;
+} ism303dac_cfg_reg_b_m_t;
+
+#define ISM303DAC_CFG_REG_C_M               0x62
+typedef struct {
+  uint8_t int_mag                : 1;
+  uint8_t self_test              : 1;
+  uint8_t not_used_01            : 1;
+  uint8_t ble                    : 1;
+  uint8_t bdu                    : 1;
+  uint8_t i2c_dis                : 1;
+  uint8_t int_mag_pin            : 1;
+  uint8_t not_used_02            : 1;
+} ism303dac_cfg_reg_c_m_t;
+
+#define ISM303DAC_INT_CRTL_REG_M            0x63
+typedef struct {
+  uint8_t ien                    : 1;
+  uint8_t iel                    : 1;
+  uint8_t iea                    : 1;
+  uint8_t not_used_01            : 2;
+  uint8_t zien                   : 1;
+  uint8_t yien                   : 1;
+  uint8_t xien                   : 1;
+} ism303dac_int_crtl_reg_m_t;
+
+#define ISM303DAC_INT_SOURCE_REG_M          0x64
+typedef struct {
+  uint8_t _int                    : 1;
+  uint8_t mroi                   : 1;
+  uint8_t n_th_s_z               : 1;
+  uint8_t n_th_s_y               : 1;
+  uint8_t n_th_s_x               : 1;
+  uint8_t p_th_s_z               : 1;
+  uint8_t p_th_s_y               : 1;
+  uint8_t p_th_s_x               : 1;
+} ism303dac_int_source_reg_m_t;
+
+#define ISM303DAC_INT_THS_L_REG_M           0x65
+#define ISM303DAC_INT_THS_H_REG_M           0x66
+#define ISM303DAC_STATUS_REG_M              0x67
+typedef struct {
+  uint8_t xda                    : 1;
+  uint8_t yda                    : 1;
+  uint8_t zda                    : 1;
+  uint8_t zyxda                  : 1;
+  uint8_t _xor                   : 1;
+  uint8_t yor                    : 1;
+  uint8_t zor                    : 1;
+  uint8_t zyxor                  : 1;
+} ism303dac_status_reg_m_t;
+
+#define ISM303DAC_OUTX_L_REG_M              0x68
+#define ISM303DAC_OUTX_H_REG_M              0x69
+#define ISM303DAC_OUTY_L_REG_M              0x6A
+#define ISM303DAC_OUTY_H_REG_M              0x6B
+#define ISM303DAC_OUTZ_L_REG_M              0x6C
+#define ISM303DAC_OUTZ_H_REG_M              0x6D
+
+typedef union{
+  ism303dac_ctrl1_a_t                      ctrl1_a;
+  ism303dac_ctrl2_a_t                      ctrl2_a;
+  ism303dac_ctrl3_a_t                      ctrl3_a;
+  ism303dac_ctrl4_a_t                      ctrl4_a;
+  ism303dac_ctrl5_a_t                      ctrl5_a;
+  ism303dac_fifo_ctrl_a_t                  fifo_ctrl_a;
+  ism303dac_status_a_t                     status_a;
+  ism303dac_fifo_src_a_t                   fifo_src_a;
+  ism303dac_tap_6d_ths_a_t                 tap_6d_ths_a;
+  ism303dac_int_dur_a_t                    int_dur_a;
+  ism303dac_wake_up_ths_a_t                wake_up_ths_a;
+  ism303dac_wake_up_dur_a_t                wake_up_dur_a;
+  ism303dac_free_fall_a_t                  free_fall_a;
+  ism303dac_status_dup_a_t                 status_dup_a;
+  ism303dac_wake_up_src_a_t                wake_up_src_a;
+  ism303dac_tap_src_a_t                    tap_src_a;
+  ism303dac_6d_src_a_t                     _6d_src_a;
+  ism303dac_func_src_a_t                   func_src_a;
+  ism303dac_func_ctrl_a_t                  func_ctrl_a;
+  ism303dac_cfg_reg_a_m_t                  cfg_reg_a_m;
+  ism303dac_cfg_reg_b_m_t                  cfg_reg_b_m;
+  ism303dac_cfg_reg_c_m_t                  cfg_reg_c_m;
+  ism303dac_int_crtl_reg_m_t               int_crtl_reg_m;
+  ism303dac_int_source_reg_m_t             int_source_reg_m;
+  ism303dac_status_reg_m_t                 status_reg_m;
+  bitwise_t                               bitwise;
+  uint8_t                                 byte;
+} ism303dac_reg_t;
+int32_t ism303dac_read_reg(ism303dac_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t ism303dac_write_reg(ism303dac_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+typedef union {
+  struct {
+  ism303dac_fifo_src_a_t       fifo_src_a;
+  ism303dac_status_dup_a_t     status_dup_a;
+  ism303dac_wake_up_src_a_t    wake_up_src_a;
+  ism303dac_tap_src_a_t        tap_src_a;
+  ism303dac_6d_src_a_t         _6d_src_a;
+  ism303dac_func_src_a_t       func_src_a;
+  } reg;
+  uint8_t byte[6];
+} ism303dac_xl_all_sources_t;
+int32_t ism303dac_xl_all_sources_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_all_sources_t *val);
+
+
+int32_t ism303dac_xl_block_data_update_set(ism303dac_ctx_t *ctx,
+                                           uint8_t val);
+int32_t ism303dac_xl_block_data_update_get(ism303dac_ctx_t *ctx,
+                                           uint8_t *val);
+
+int32_t ism303dac_mg_block_data_update_set(ism303dac_ctx_t *ctx,
+                                           uint8_t val);
+int32_t ism303dac_mg_block_data_update_get(ism303dac_ctx_t *ctx,
+                                           uint8_t *val);
+
+typedef enum {
+  ISM303DAC_MG_LSB_AT_LOW_ADD  = 0,
+  ISM303DAC_MG_MSB_AT_LOW_ADD  = 1,
+} ism303dac_mg_ble_t;
+int32_t ism303dac_mg_data_format_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_ble_t val);
+int32_t ism303dac_mg_data_format_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_ble_t *val);
+
+typedef enum {
+  ISM303DAC_XL_2g = 0,
+  ISM303DAC_XL_16g = 1,
+  ISM303DAC_XL_4g = 2,
+  ISM303DAC_XL_8g = 3,
+} ism303dac_xl_fs_t;
+int32_t ism303dac_xl_full_scale_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_fs_t val);
+int32_t ism303dac_xl_full_scale_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_fs_t *val);
+
+typedef enum {
+  ISM303DAC_XL_ODR_OFF         = 0x00,
+  ISM303DAC_XL_ODR_1Hz_LP      = 0x08,
+  ISM303DAC_XL_ODR_12Hz5_LP    = 0x09,
+  ISM303DAC_XL_ODR_25Hz_LP     = 0x0A,
+  ISM303DAC_XL_ODR_50Hz_LP     = 0x0B,
+  ISM303DAC_XL_ODR_100Hz_LP    = 0x0C,
+  ISM303DAC_XL_ODR_200Hz_LP    = 0x0D,
+  ISM303DAC_XL_ODR_400Hz_LP    = 0x0E,
+  ISM303DAC_XL_ODR_800Hz_LP    = 0x0F,
+  ISM303DAC_XL_ODR_12Hz5_HR    = 0x01,
+  ISM303DAC_XL_ODR_25Hz_HR     = 0x02,
+  ISM303DAC_XL_ODR_50Hz_HR     = 0x03,
+  ISM303DAC_XL_ODR_100Hz_HR    = 0x04,
+  ISM303DAC_XL_ODR_200Hz_HR    = 0x05,
+  ISM303DAC_XL_ODR_400Hz_HR    = 0x06,
+  ISM303DAC_XL_ODR_800Hz_HR    = 0x07,
+  ISM303DAC_XL_ODR_1k6Hz_HF    = 0x15,
+  ISM303DAC_XL_ODR_3k2Hz_HF    = 0x16,
+  ISM303DAC_XL_ODR_6k4Hz_HF    = 0x17,
+} ism303dac_xl_odr_t;
+int32_t ism303dac_xl_data_rate_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_odr_t val);
+int32_t ism303dac_xl_data_rate_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_odr_t *val);
+
+int32_t ism303dac_xl_status_reg_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_status_a_t *val);
+
+int32_t ism303dac_mg_status_get(ism303dac_ctx_t *ctx,
+                               ism303dac_status_reg_m_t *val);
+
+int32_t ism303dac_xl_flag_data_ready_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_mg_data_ready_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_data_ovr_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_mg_user_offset_set(ism303dac_ctx_t *ctx, uint8_t *buff);
+int32_t ism303dac_mg_user_offset_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  ISM303DAC_MG_CONTINUOUS_MODE  = 0,
+  ISM303DAC_MG_SINGLE_TRIGGER   = 1,
+  ISM303DAC_MG_POWER_DOWN       = 2,
+} ism303dac_mg_md_t;
+int32_t ism303dac_mg_operating_mode_set(ism303dac_ctx_t *ctx,
+                                       ism303dac_mg_md_t val);
+int32_t ism303dac_mg_operating_mode_get(ism303dac_ctx_t *ctx,
+                                       ism303dac_mg_md_t *val);
+
+typedef enum {
+  ISM303DAC_MG_ODR_10Hz   = 0,
+  ISM303DAC_MG_ODR_20Hz   = 1,
+  ISM303DAC_MG_ODR_50Hz   = 2,
+  ISM303DAC_MG_ODR_100Hz  = 3,
+} ism303dac_mg_odr_t;
+int32_t ism303dac_mg_data_rate_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_mg_odr_t val);
+int32_t ism303dac_mg_data_rate_get(ism303dac_ctx_t *ctx,
+                                  ism303dac_mg_odr_t *val);
+
+typedef enum {
+  ISM303DAC_MG_HIGH_RESOLUTION  = 0,
+  ISM303DAC_MG_LOW_POWER        = 1,
+} ism303dac_mg_lp_t;
+int32_t ism303dac_mg_power_mode_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_mg_lp_t val);
+int32_t ism303dac_mg_power_mode_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_mg_lp_t *val);
+
+int32_t ism303dac_mg_offset_temp_comp_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_offset_temp_comp_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM303DAC_MG_SET_SENS_ODR_DIV_63        = 0,
+  ISM303DAC_MG_SENS_OFF_CANC_EVERY_ODR    = 1,
+  ISM303DAC_MG_SET_SENS_ONLY_AT_POWER_ON  = 2,
+} ism303dac_mg_set_rst_t;
+int32_t ism303dac_mg_set_rst_mode_set(ism303dac_ctx_t *ctx,
+                                 ism303dac_mg_set_rst_t val);
+int32_t ism303dac_mg_set_rst_mode_get(ism303dac_ctx_t *ctx,
+                                 ism303dac_mg_set_rst_t *val);
+
+int32_t ism303dac_mg_set_rst_sensor_single_set(ism303dac_ctx_t *ctx,
+                                          uint8_t val);
+int32_t ism303dac_mg_set_rst_sensor_single_get(ism303dac_ctx_t *ctx,
+                                          uint8_t *val);
+
+int32_t ism303dac_acceleration_module_raw_get(ism303dac_ctx_t *ctx,
+                                             uint8_t *buff);
+
+int32_t ism303dac_magnetic_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism303dac_xl_temperature_raw_get(ism303dac_ctx_t *ctx,
+                                         uint8_t *buff);
+
+int32_t ism303dac_acceleration_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism303dac_xl_device_id_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism303dac_mg_device_id_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism303dac_xl_auto_increment_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_auto_increment_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_reset_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_reset_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_mg_reset_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_reset_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_boot_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_boot_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_mg_boot_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_boot_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM303DAC_XL_ST_DISABLE     = 0,
+  ISM303DAC_XL_ST_POSITIVE    = 1,
+  ISM303DAC_XL_ST_NEGATIVE    = 2,
+} ism303dac_xl_st_t;
+int32_t ism303dac_xl_self_test_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_st_t val);
+int32_t ism303dac_xl_self_test_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_st_t *val);
+
+int32_t ism303dac_mg_self_test_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_self_test_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM303DAC_XL_DRDY_LATCHED   = 0,
+  ISM303DAC_XL_DRDY_PULSED    = 1,
+} ism303dac_xl_drdy_pulsed_t;
+int32_t ism303dac_xl_data_ready_mode_set(ism303dac_ctx_t *ctx,
+                                     ism303dac_xl_drdy_pulsed_t val);
+int32_t ism303dac_xl_data_ready_mode_get(ism303dac_ctx_t *ctx,
+                                     ism303dac_xl_drdy_pulsed_t *val);
+
+typedef enum {
+  ISM303DAC_XL_HP_INTERNAL_ONLY  = 0,
+  ISM303DAC_XL_HP_ON_OUTPUTS     = 1,
+} ism303dac_xl_fds_slope_t;
+int32_t ism303dac_xl_hp_path_set(ism303dac_ctx_t *ctx,
+                                ism303dac_xl_fds_slope_t val);
+int32_t ism303dac_xl_hp_path_get(ism303dac_ctx_t *ctx,
+                                ism303dac_xl_fds_slope_t *val);
+
+typedef enum {
+  ISM303DAC_MG_ODR_DIV_2  = 0,
+  ISM303DAC_MG_ODR_DIV_4  = 1,
+} ism303dac_mg_lpf_t;
+int32_t ism303dac_mg_low_pass_bandwidth_set(ism303dac_ctx_t *ctx,
+                                       ism303dac_mg_lpf_t val);
+int32_t ism303dac_mg_low_pass_bandwidth_get(ism303dac_ctx_t *ctx,
+                                       ism303dac_mg_lpf_t *val);
+
+typedef enum {
+  ISM303DAC_XL_SPI_4_WIRE   = 0,
+  ISM303DAC_XL_SPI_3_WIRE   = 1,
+} ism303dac_xl_sim_t;
+int32_t ism303dac_xl_spi_mode_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_sim_t val);
+int32_t ism303dac_xl_spi_mode_get(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_sim_t *val);
+
+typedef enum {
+  ISM303DAC_XL_I2C_ENABLE   = 0,
+  ISM303DAC_XL_I2C_DISABLE  = 1,
+} ism303dac_xl_i2c_disable_t;
+int32_t ism303dac_xl_i2c_interface_set(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_i2c_disable_t val);
+int32_t ism303dac_xl_i2c_interface_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_xl_i2c_disable_t *val);
+
+typedef enum {
+  ISM303DAC_MG_I2C_ENABLE   = 0,
+  ISM303DAC_MG_I2C_DISABLE  = 1,
+} ism303dac_mg_i2c_dis_t;
+int32_t ism303dac_mg_i2c_interface_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_mg_i2c_dis_t val);
+int32_t ism303dac_mg_i2c_interface_get(ism303dac_ctx_t *ctx,
+                                  ism303dac_mg_i2c_dis_t *val);
+
+typedef enum {
+  ISM303DAC_XL_PULL_UP_CONNECTED     = 0,
+  ISM303DAC_XL_PULL_UP_DISCONNECTED  = 1,
+} ism303dac_xl_if_cs_pu_dis_t;
+int32_t ism303dac_xl_cs_mode_set(ism303dac_ctx_t *ctx,
+                             ism303dac_xl_if_cs_pu_dis_t val);
+int32_t ism303dac_xl_cs_mode_get(ism303dac_ctx_t *ctx,
+                             ism303dac_xl_if_cs_pu_dis_t *val);
+
+typedef enum {
+  ISM303DAC_XL_PUSH_PULL   = 0,
+  ISM303DAC_XL_OPEN_DRAIN  = 1,
+} ism303dac_xl_pp_od_t;
+int32_t ism303dac_xl_pin_mode_set(ism303dac_ctx_t *ctx,
+                                 ism303dac_xl_pp_od_t val);
+int32_t ism303dac_xl_pin_mode_get(ism303dac_ctx_t *ctx,
+                                 ism303dac_xl_pp_od_t *val);
+
+typedef enum {
+  ISM303DAC_XL_ACTIVE_HIGH  = 0,
+  ISM303DAC_XL_ACTIVE_LOW   = 1,
+} ism303dac_xl_h_lactive_t;
+int32_t ism303dac_xl_pin_polarity_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_h_lactive_t val);
+int32_t ism303dac_xl_pin_polarity_get(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_h_lactive_t *val);
+
+typedef enum {
+  ISM303DAC_XL_INT_PULSED   = 0,
+  ISM303DAC_XL_INT_LATCHED  = 1,
+} ism303dac_xl_lir_t;
+int32_t ism303dac_xl_int_notification_set(ism303dac_ctx_t *ctx,
+                                      ism303dac_xl_lir_t val);
+int32_t ism303dac_xl_int_notification_get(ism303dac_ctx_t *ctx,
+                                      ism303dac_xl_lir_t *val);
+
+typedef struct{
+  uint8_t int1_drdy               : 1;
+  uint8_t int1_fth                : 1;
+  uint8_t int1_6d                 : 1;
+  uint8_t int1_tap                : 1;
+  uint8_t int1_ff                 : 1;
+  uint8_t int1_wu                 : 1;
+  uint8_t int1_s_tap              : 1;
+  uint8_t int1_fss7               : 1;
+} ism303dac_xl_pin_int1_route_t;
+int32_t ism303dac_xl_pin_int1_route_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_pin_int1_route_t val);
+int32_t ism303dac_xl_pin_int1_route_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_pin_int1_route_t *val);
+
+typedef struct{
+  uint8_t int2_boot               : 1;
+  uint8_t int2_fth                : 1;
+  uint8_t int2_drdy               : 1;
+} ism303dac_xl_pin_int2_route_t;
+int32_t ism303dac_xl_pin_int2_route_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_pin_int2_route_t val);
+int32_t ism303dac_xl_pin_int2_route_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_xl_pin_int2_route_t *val);
+
+int32_t ism303dac_xl_all_on_int1_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_all_on_int1_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_mg_drdy_on_pin_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_drdy_on_pin_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_mg_int_on_pin_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_int_on_pin_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_mg_int_gen_conf_set(ism303dac_ctx_t *ctx,
+                                 ism303dac_int_crtl_reg_m_t *val);
+int32_t ism303dac_mg_int_gen_conf_get(ism303dac_ctx_t *ctx,
+                                 ism303dac_int_crtl_reg_m_t *val);
+
+int32_t ism303dac_mg_int_gen_source_get(ism303dac_ctx_t *ctx,
+                                   ism303dac_int_source_reg_m_t *val);
+
+int32_t ism303dac_mg_int_gen_treshold_set(ism303dac_ctx_t *ctx,
+                                          uint8_t *buff);
+int32_t ism303dac_mg_int_gen_treshold_get(ism303dac_ctx_t *ctx,
+                                          uint8_t *buff);
+
+typedef enum {
+  ISM303DAC_MG_CHECK_BEFORE  = 0,
+  ISM303DAC_MG_CHECK_AFTER   = 1,
+} ism303dac_mg_int_on_dataoff_t;
+int32_t ism303dac_mg_offset_int_conf_set(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_int_on_dataoff_t val);
+int32_t ism303dac_mg_offset_int_conf_get(ism303dac_ctx_t *ctx,
+                                    ism303dac_mg_int_on_dataoff_t *val);
+
+int32_t ism303dac_xl_wkup_threshold_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_wkup_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_wkup_dur_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_wkup_dur_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_sleep_mode_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_sleep_mode_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_act_sleep_dur_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_act_sleep_dur_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_tap_detection_on_z_set(ism303dac_ctx_t *ctx,
+                                            uint8_t val);
+int32_t ism303dac_xl_tap_detection_on_z_get(ism303dac_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t ism303dac_xl_tap_detection_on_y_set(ism303dac_ctx_t *ctx,
+                                            uint8_t val);
+int32_t ism303dac_xl_tap_detection_on_y_get(ism303dac_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t ism303dac_xl_tap_detection_on_x_set(ism303dac_ctx_t *ctx,
+                                            uint8_t val);
+int32_t ism303dac_xl_tap_detection_on_x_get(ism303dac_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t ism303dac_xl_tap_threshold_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_tap_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_tap_shock_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_tap_shock_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_tap_quiet_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_tap_quiet_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_tap_dur_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_tap_dur_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM303DAC_XL_ONLY_SINGLE  = 0,
+  ISM303DAC_XL_ONLY_DOUBLE  = 1,
+} ism303dac_xl_single_double_tap_t;
+int32_t ism303dac_xl_tap_mode_set(ism303dac_ctx_t *ctx,
+                              ism303dac_xl_single_double_tap_t val);
+int32_t ism303dac_xl_tap_mode_get(ism303dac_ctx_t *ctx,
+                              ism303dac_xl_single_double_tap_t *val);
+
+int32_t ism303dac_xl_tap_src_get(ism303dac_ctx_t *ctx,
+                                ism303dac_tap_src_a_t *val);
+
+typedef enum {
+  ISM303DAC_XL_DEG_80   = 0,
+  ISM303DAC_XL_DEG_70   = 1,
+  ISM303DAC_XL_DEG_60   = 2,
+  ISM303DAC_XL_DEG_50   = 3,
+} ism303dac_xl_6d_ths_t;
+int32_t ism303dac_xl_6d_threshold_set(ism303dac_ctx_t *ctx,
+                                     ism303dac_xl_6d_ths_t val);
+int32_t ism303dac_xl_6d_threshold_get(ism303dac_ctx_t *ctx,
+                                     ism303dac_xl_6d_ths_t *val);
+
+int32_t ism303dac_xl_4d_mode_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_4d_mode_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_6d_src_get(ism303dac_ctx_t *ctx,
+                                ism303dac_6d_src_a_t *val);
+
+int32_t ism303dac_xl_ff_dur_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_ff_dur_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_ff_threshold_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_ff_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_fifo_xl_module_batch_set(ism303dac_ctx_t *ctx,
+                                             uint8_t val);
+int32_t ism303dac_xl_fifo_xl_module_batch_get(ism303dac_ctx_t *ctx,
+                                             uint8_t *val);
+
+typedef enum {
+  ISM303DAC_XL_BYPASS_MODE            = 0,
+  ISM303DAC_XL_FIFO_MODE              = 1,
+  ISM303DAC_XL_STREAM_TO_FIFO_MODE    = 3,
+  ISM303DAC_XL_BYPASS_TO_STREAM_MODE  = 4,
+  ISM303DAC_XL_STREAM_MODE            = 6,
+} ism303dac_xl_fmode_t;
+int32_t ism303dac_xl_fifo_mode_set(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_fmode_t val);
+int32_t ism303dac_xl_fifo_mode_get(ism303dac_ctx_t *ctx,
+                                  ism303dac_xl_fmode_t *val);
+
+int32_t ism303dac_xl_fifo_watermark_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_fifo_watermark_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_fifo_full_flag_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_fifo_ovr_flag_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_fifo_wtm_flag_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+int32_t ism303dac_xl_fifo_data_level_get(ism303dac_ctx_t *ctx, uint16_t *val);
+
+int32_t ism303dac_xl_fifo_src_get(ism303dac_ctx_t *ctx,
+                                 ism303dac_fifo_src_a_t *val);
+
+int32_t ism303dac_xl_module_sens_set(ism303dac_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_module_sens_get(ism303dac_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__ISM303DAC_DRIVER__H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.c
+++ b/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.c
@@ -1,0 +1,7083 @@
+/*
+ ******************************************************************************
+ * @file    ism330dlc_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   ISM330DLC driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+#include "ism330dlc_reg.h"
+
+/**
+  * @defgroup    ISM330DLC
+  * @brief       This file provides a set of functions needed to drive the
+  *              ism330dlc enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_interfaces_functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ism330dlc_read_reg(ism330dlc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ism330dlc_write_reg(ism330dlc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t ism330dlc_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t ism330dlc_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t ism330dlc_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t ism330dlc_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t ism330dlc_from_fs125dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 4.375f);
+}
+
+float_t ism330dlc_from_fs250dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 8.750f);
+}
+
+float_t ism330dlc_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 17.50f);
+}
+
+float_t ism330dlc_from_fs1000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 35.0f);
+}
+
+float_t ism330dlc_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t ism330dlc_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_data_generation
+  * @brief       This section groups all the functions concerning data
+  *              generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_full_scale_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_fs_xl_t val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL,
+                           (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_full_scale_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_fs_xl_t *val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL,
+                           (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.fs_xl) {
+    case ISM330DLC_2g:
+      *val = ISM330DLC_2g;
+      break;
+    case ISM330DLC_16g:
+      *val = ISM330DLC_16g;
+      break;
+    case ISM330DLC_4g:
+      *val = ISM330DLC_4g;
+      break;
+    case ISM330DLC_8g:
+      *val = ISM330DLC_8g;
+      break;
+    default:
+      *val = ISM330DLC_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_data_rate_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_odr_xl_t val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.odr_xl = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_data_rate_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_odr_xl_t *val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.odr_xl) {
+    case ISM330DLC_XL_ODR_OFF:
+      *val = ISM330DLC_XL_ODR_OFF;
+      break;
+    case ISM330DLC_XL_ODR_12Hz5:
+      *val = ISM330DLC_XL_ODR_12Hz5;
+      break;
+    case ISM330DLC_XL_ODR_26Hz:
+      *val = ISM330DLC_XL_ODR_26Hz;
+      break;
+    case ISM330DLC_XL_ODR_52Hz:
+      *val = ISM330DLC_XL_ODR_52Hz;
+      break;
+    case ISM330DLC_XL_ODR_104Hz:
+      *val = ISM330DLC_XL_ODR_104Hz;
+      break;
+    case ISM330DLC_XL_ODR_208Hz:
+      *val = ISM330DLC_XL_ODR_208Hz;
+      break;
+    case ISM330DLC_XL_ODR_416Hz:
+      *val = ISM330DLC_XL_ODR_416Hz;
+      break;
+    case ISM330DLC_XL_ODR_833Hz:
+      *val = ISM330DLC_XL_ODR_833Hz;
+      break;
+    case ISM330DLC_XL_ODR_1k66Hz:
+      *val = ISM330DLC_XL_ODR_1k66Hz;
+      break;
+    case ISM330DLC_XL_ODR_3k33Hz:
+      *val = ISM330DLC_XL_ODR_3k33Hz;
+      break;
+    case ISM330DLC_XL_ODR_6k66Hz:
+      *val = ISM330DLC_XL_ODR_6k66Hz;
+      break;
+    case ISM330DLC_XL_ODR_1Hz6:
+      *val = ISM330DLC_XL_ODR_1Hz6;
+      break;
+    default:
+      *val = ISM330DLC_XL_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope chain full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_full_scale_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_fs_g_t val)
+{
+  ism330dlc_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.fs_g = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_full_scale_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_fs_g_t *val)
+{
+  ism330dlc_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.fs_g) {
+    case ISM330DLC_250dps:
+      *val = ISM330DLC_250dps;
+      break;
+    case ISM330DLC_125dps:
+      *val = ISM330DLC_125dps;
+      break;
+    case ISM330DLC_500dps:
+      *val = ISM330DLC_500dps;
+      break;
+    case ISM330DLC_1000dps:
+      *val = ISM330DLC_1000dps;
+      break;
+    case ISM330DLC_2000dps:
+      *val = ISM330DLC_2000dps;
+      break;
+    default:
+      *val = ISM330DLC_250dps;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_data_rate_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_odr_g_t val)
+{
+  ism330dlc_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.odr_g = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_data_rate_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_odr_g_t *val)
+{
+  ism330dlc_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.odr_g) {
+    case ISM330DLC_GY_ODR_OFF:
+      *val = ISM330DLC_GY_ODR_OFF;
+      break;
+    case ISM330DLC_GY_ODR_12Hz5:
+      *val = ISM330DLC_GY_ODR_12Hz5;
+      break;
+    case ISM330DLC_GY_ODR_26Hz:
+      *val = ISM330DLC_GY_ODR_26Hz;
+      break;
+    case ISM330DLC_GY_ODR_52Hz:
+      *val = ISM330DLC_GY_ODR_52Hz;
+      break;
+    case ISM330DLC_GY_ODR_104Hz:
+      *val = ISM330DLC_GY_ODR_104Hz;
+      break;
+    case ISM330DLC_GY_ODR_208Hz:
+      *val = ISM330DLC_GY_ODR_208Hz;
+      break;
+    case ISM330DLC_GY_ODR_416Hz:
+      *val = ISM330DLC_GY_ODR_416Hz;
+      break;
+    case ISM330DLC_GY_ODR_833Hz:
+      *val = ISM330DLC_GY_ODR_833Hz;
+      break;
+    case ISM330DLC_GY_ODR_1k66Hz:
+      *val = ISM330DLC_GY_ODR_1k66Hz;
+      break;
+    case ISM330DLC_GY_ODR_3k33Hz:
+      *val = ISM330DLC_GY_ODR_3k33Hz;
+      break;
+    case ISM330DLC_GY_ODR_6k66Hz:
+      *val = ISM330DLC_GY_ODR_6k66Hz;
+      break;
+    default:
+      *val = ISM330DLC_GY_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_block_data_update_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_block_data_update_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers
+  *         X_OFS_USR(73h), Y_OFS_USR(74h), Z_OFS_USR(75h).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_offset_weight_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_usr_off_w_t val)
+{
+  ism330dlc_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.usr_off_w = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers
+  *         X_OFS_USR(73h), Y_OFS_USR(74h), Z_OFS_USR(75h).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_offset_weight_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_usr_off_w_t *val)
+{
+  ism330dlc_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.usr_off_w) {
+    case ISM330DLC_LSb_1mg:
+      *val = ISM330DLC_LSb_1mg;
+      break;
+    case ISM330DLC_LSb_16mg:
+      *val = ISM330DLC_LSb_16mg;
+      break;
+    default:
+      *val = ISM330DLC_LSb_1mg;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode for accelerometer[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_power_mode_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_xl_hm_mode_t val)
+{
+  ism330dlc_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.xl_hm_mode = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode for accelerometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_power_mode_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_xl_hm_mode_t *val)
+{
+  ism330dlc_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.xl_hm_mode) {
+    case ISM330DLC_XL_HIGH_PERFORMANCE:
+      *val = ISM330DLC_XL_HIGH_PERFORMANCE;
+      break;
+    case ISM330DLC_XL_NORMAL:
+      *val = ISM330DLC_XL_NORMAL;
+      break;
+    default:
+      *val = ISM330DLC_XL_HIGH_PERFORMANCE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Source register rounding function on WAKE_UP_SRC (1Bh),
+  *         TAP_SRC (1Ch), D6D_SRC (1Dh), STATUS_REG (1Eh) and
+  *         FUNC_SRC1 (53h) registers in the primary interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rounding_status in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_rounding_on_status_set(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_rounding_status_t val)
+{
+  ism330dlc_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.rounding_status = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Source register rounding function on WAKE_UP_SRC (1Bh),
+  *         TAP_SRC (1Ch), D6D_SRC (1Dh), STATUS_REG (1Eh) and
+  *         FUNC_SRC1 (53h) registers in the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rounding_status in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_rounding_on_status_get(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_rounding_status_t *val)
+{
+  ism330dlc_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.rounding_status) {
+    case ISM330DLC_STAT_RND_DISABLE:
+      *val = ISM330DLC_STAT_RND_DISABLE;
+      break;
+    case ISM330DLC_STAT_RND_ENABLE:
+      *val = ISM330DLC_STAT_RND_ENABLE;
+      break;
+    default:
+      *val = ISM330DLC_STAT_RND_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode disable for gyroscope.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_power_mode_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_g_hm_mode_t val)
+{
+  ism330dlc_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.g_hm_mode = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode disable for gyroscope.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_power_mode_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_g_hm_mode_t *val)
+{
+  ism330dlc_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.g_hm_mode) {
+    case ISM330DLC_GY_HIGH_PERFORMANCE:
+      *val = ISM330DLC_GY_HIGH_PERFORMANCE;
+      break;
+    case ISM330DLC_GY_NORMAL:
+      *val = ISM330DLC_GY_NORMAL;
+      break;
+    default:
+      *val = ISM330DLC_GY_HIGH_PERFORMANCE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    WAKE_UP_SRC, TAP_SRC, D6D_SRC, STATUS_REG,
+  *                FUNC_SRC1, FUNC_SRC2, WRIST_TILT_IA, A_WRIST_TILT_Mask
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_all_sources_get(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_SRC,
+                           (uint8_t*)&(val->wake_up_src), 1);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_SRC,
+                             (uint8_t*)&(val->tap_src), 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_D6D_SRC,
+                             (uint8_t*)&(val->d6d_src), 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_STATUS_REG,
+                             (uint8_t*)&(val->status_reg), 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_FUNC_SRC1,
+                             (uint8_t*)&(val->func_src1), 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_FUNC_SRC2,
+                             (uint8_t*)&(val->func_src2), 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+  }
+
+  return ret;
+}
+/**
+  * @brief  The STATUS_REG register is read by the primary interface[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_status_reg_get(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_status_reg_t *val)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of gda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_temp_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C.
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_usr_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dlc_write_reg(ctx, ISM330DLC_X_OFS_USR, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer axis user offset correction xpressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C.
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_usr_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_X_OFS_USR, buff, 3);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_Timestamp
+  * @brief       This section groups all the functions that manage the
+  *              timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable timestamp count. The count is saved in TIMESTAMP0_REG (40h),
+  *         TIMESTAMP1_REG (41h) and TIMESTAMP2_REG (42h).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_timestamp_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.timer_en = val;
+    if ( val != 0x00U) {
+      ctrl10_c.func_en = val;
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL10_C,
+                                (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable timestamp count. The count is saved in TIMESTAMP0_REG (40h),
+  *         TIMESTAMP1_REG (41h) and TIMESTAMP2_REG (42h).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_timestamp_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.timer_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp register resolution setting.
+  *         Configuration of this bit affects
+  *         TIMESTAMP0_REG(40h), TIMESTAMP1_REG(41h),
+  *         TIMESTAMP2_REG(42h), STEP_TIMESTAMP_L(49h),
+  *         STEP_TIMESTAMP_H(4Ah) and
+  *         STEP_COUNT_DELTA(15h) registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_hr in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_timestamp_res_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_timer_hr_t val)
+{
+  ism330dlc_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.timer_hr = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Timestamp register resolution setting.
+  *         Configuration of this bit affects
+  *         TIMESTAMP0_REG(40h), TIMESTAMP1_REG(41h),
+  *         TIMESTAMP2_REG(42h), STEP_TIMESTAMP_L(49h),
+  *         STEP_TIMESTAMP_H(4Ah) and
+  *         STEP_COUNT_DELTA(15h) registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of timer_hr in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_timestamp_res_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_timer_hr_t *val)
+{
+  ism330dlc_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  switch (wake_up_dur.timer_hr) {
+    case ISM330DLC_LSB_6ms4:
+      *val = ISM330DLC_LSB_6ms4;
+      break;
+    case ISM330DLC_LSB_25us:
+      *val = ISM330DLC_LSB_25us;
+      break;
+    default:
+      *val = ISM330DLC_LSB_6ms4;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_Dataoutput
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read from output registers
+  *         through the primary interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_rounding_mode_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_rounding_t val)
+{
+  ism330dlc_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Circular burst-mode (rounding) read from output registers
+  *         through the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_rounding_mode_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_rounding_t *val)
+{
+  ism330dlc_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.rounding) {
+    case ISM330DLC_ROUND_DISABLE:
+      *val = ISM330DLC_ROUND_DISABLE;
+      break;
+    case ISM330DLC_ROUND_XL:
+      *val = ISM330DLC_ROUND_XL;
+      break;
+    case ISM330DLC_ROUND_GY:
+      *val = ISM330DLC_ROUND_GY;
+      break;
+    case ISM330DLC_ROUND_GY_XL:
+      *val = ISM330DLC_ROUND_GY_XL;
+      break;
+    case ISM330DLC_ROUND_SH1_TO_SH6:
+      *val = ISM330DLC_ROUND_SH1_TO_SH6;
+      break;
+    case ISM330DLC_ROUND_XL_SH1_TO_SH6:
+      *val = ISM330DLC_ROUND_XL_SH1_TO_SH6;
+      break;
+    case ISM330DLC_ROUND_GY_XL_SH1_TO_SH12:
+      *val = ISM330DLC_ROUND_GY_XL_SH1_TO_SH12;
+      break;
+    case ISM330DLC_ROUND_GY_XL_SH1_TO_SH6:
+      *val = ISM330DLC_ROUND_GY_XL_SH1_TO_SH6;
+      break;
+    default:
+      *val = ISM330DLC_ROUND_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r). L and H registers together
+  *         express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_temperature_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_angular_rate_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_acceleration_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_OUTX_L_XL, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer raw data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_calibrated_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_OUT_MAG_RAW_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Read data in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buffer Data buffer to store FIFO data.
+  * @param  len    Number of data to read from FIFO.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_raw_data_get(ism330dlc_ctx_t *ctx, uint8_t *buffer,
+                                  uint8_t len)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_DATA_OUT_L, buffer, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub
+  *         configuration registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mem_bank_set(ism330dlc_ctx_t *ctx,
+                               ism330dlc_func_cfg_en_t val)
+{
+  ism330dlc_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  if(ret == 0){
+    func_cfg_access.func_cfg_en = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FUNC_CFG_ACCESS,
+                            (uint8_t*)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mem_bank_get(ism330dlc_ctx_t *ctx,
+                               ism330dlc_func_cfg_en_t *val)
+{
+  ism330dlc_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  switch (func_cfg_access.func_cfg_en) {
+    case ISM330DLC_USER_BANK:
+      *val = ISM330DLC_USER_BANK;
+      break;
+    default:
+      *val = ISM330DLC_USER_BANK;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_pulsed in reg DRDY_PULSE_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_data_ready_mode_set(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_drdy_pulsed_t val)
+{
+  ism330dlc_drdy_pulse_cfg_t drdy_pulse_cfg_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_DRDY_PULSE_CFG,
+                           (uint8_t*)&drdy_pulse_cfg_g, 1);
+  if(ret == 0){
+    drdy_pulse_cfg_g.drdy_pulsed = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_DRDY_PULSE_CFG,
+                              (uint8_t*)&drdy_pulse_cfg_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of drdy_pulsed in reg DRDY_PULSE_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_data_ready_mode_get(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_drdy_pulsed_t *val)
+{
+  ism330dlc_drdy_pulse_cfg_t drdy_pulse_cfg_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_DRDY_PULSE_CFG,
+                           (uint8_t*)&drdy_pulse_cfg_g, 1);
+  switch (drdy_pulse_cfg_g.drdy_pulsed) {
+    case ISM330DLC_DRDY_LATCHED:
+      *val = ISM330DLC_DRDY_LATCHED;
+      break;
+    case ISM330DLC_DRDY_PULSED:
+      *val = ISM330DLC_DRDY_PULSED;
+      break;
+    default:
+      *val = ISM330DLC_DRDY_LATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_device_id_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_reset_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_reset_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ble in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_data_format_set(ism330dlc_ctx_t *ctx, ism330dlc_ble_t val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.ble = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ble in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_data_format_get(ism330dlc_ctx_t *ctx, ism330dlc_ble_t *val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.ble) {
+    case ISM330DLC_LSB_AT_LOW_ADD:
+      *val = ISM330DLC_LSB_AT_LOW_ADD;
+      break;
+    case ISM330DLC_MSB_AT_LOW_ADD:
+      *val = ISM330DLC_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = ISM330DLC_LSB_AT_LOW_ADD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_auto_increment_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_auto_increment_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_boot_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_boot_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_self_test_set(ism330dlc_ctx_t *ctx, ism330dlc_st_xl_t val)
+{
+  ism330dlc_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_self_test_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_st_xl_t *val)
+{
+  ism330dlc_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.st_xl) {
+    case ISM330DLC_XL_ST_DISABLE:
+      *val = ISM330DLC_XL_ST_DISABLE;
+      break;
+    case ISM330DLC_XL_ST_POSITIVE:
+      *val = ISM330DLC_XL_ST_POSITIVE;
+      break;
+    case ISM330DLC_XL_ST_NEGATIVE:
+      *val = ISM330DLC_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = ISM330DLC_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_self_test_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_st_g_t val)
+{
+  ism330dlc_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_g = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_self_test_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_st_g_t *val)
+{
+  ism330dlc_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.st_g) {
+    case ISM330DLC_GY_ST_DISABLE:
+      *val = ISM330DLC_GY_ST_DISABLE;
+      break;
+    case ISM330DLC_GY_ST_POSITIVE:
+      *val = ISM330DLC_GY_ST_POSITIVE;
+      break;
+    case ISM330DLC_GY_ST_NEGATIVE:
+      *val = ISM330DLC_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = ISM330DLC_GY_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact both accelerometer and gyro.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_filter_settling_mask_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_filter_settling_mask_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slope_fds in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_hp_path_internal_set(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_slope_fds_t val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.slope_fds = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slope_fds in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_hp_path_internal_get(ism330dlc_ctx_t *ctx,
+                                          ism330dlc_slope_fds_t *val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.slope_fds) {
+    case ISM330DLC_USE_SLOPE:
+      *val = ISM330DLC_USE_SLOPE;
+      break;
+    case ISM330DLC_USE_HPF:
+      *val = ISM330DLC_USE_HPF;
+      break;
+    default:
+      *val = ISM330DLC_USE_SLOPE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_accelerometer_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer in every mode.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer analog chain bandwidth selection (only for
+  *         accelerometer ODR ≥ 1.67 kHz).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bw0_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_filter_analog_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_bw0_xl_t val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.bw0_xl = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer analog chain bandwidth selection (only for
+  *         accelerometer ODR ≥ 1.67 kHz).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of bw0_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_filter_analog_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_bw0_xl_t *val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL,
+                           (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.bw0_xl) {
+    case ISM330DLC_XL_ANA_BW_1k5Hz:
+      *val = ISM330DLC_XL_ANA_BW_1k5Hz;
+      break;
+    case ISM330DLC_XL_ANA_BW_400Hz:
+      *val = ISM330DLC_XL_ANA_BW_400Hz;
+      break;
+    default:
+      *val = ISM330DLC_XL_ANA_BW_1k5Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_accelerometer_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection LPF2 is
+  *         not used.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_lpf1_bw_sel_t val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf1_bw_sel = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+    if(ret == 0){
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL,
+                               (uint8_t*)&ctrl8_xl, 1);
+      if(ret == 0){
+        ctrl8_xl.lpf2_xl_en = 0;
+        ctrl8_xl.hp_slope_xl_en = 0;
+        ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL8_XL,
+                                  (uint8_t*)&ctrl8_xl, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection LPF2
+  *         is not used.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_lpf1_bw_sel_t *val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if ((ctrl8_xl.lpf2_xl_en != 0x00U) ||
+        (ctrl8_xl.hp_slope_xl_en != 0x00U)){
+      *val = ISM330DLC_XL_LP1_NA;
+    }
+    else{
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL,
+                               (uint8_t*)&ctrl1_xl, 1);
+      switch ( ctrl1_xl.lpf1_bw_sel) {
+        case ISM330DLC_XL_LP1_ODR_DIV_2:
+          *val = ISM330DLC_XL_LP1_ODR_DIV_2;
+          break;
+        case ISM330DLC_XL_LP1_ODR_DIV_4:
+          *val = ISM330DLC_XL_LP1_ODR_DIV_4;
+          break;
+        default:
+          *val = ISM330DLC_XL_LP1_NA;
+          break;
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 on outputs[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of input_composite in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_lp2_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_input_composite_t val)
+{
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.input_composite = ( (uint8_t) val & 0x10U ) >> 4;
+    ctrl8_xl.hpcf_xl = (uint8_t) val & 0x03U;
+    ctrl8_xl.lpf2_xl_en = 1;
+    ctrl8_xl.hp_slope_xl_en = 0;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 on outputs[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of input_composite in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_lp2_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_input_composite_t *val)
+{
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if ((ctrl8_xl.lpf2_xl_en == 0x00U) ||
+        (ctrl8_xl.hp_slope_xl_en != 0x00U)){
+      *val = ISM330DLC_XL_LP_NA;
+    }
+    else{
+      switch ((ctrl8_xl.input_composite << 4) + ctrl8_xl.hpcf_xl) {
+        case ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_50:
+          *val = ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_50;
+          break;
+        case ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_100:
+          *val = ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_100;
+          break;
+        case ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_9:
+          *val = ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_9;
+          break;
+        case ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_400:
+          *val = ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_400;
+          break;
+        case ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_50:
+          *val = ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_50;
+          break;
+        case ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_100:
+          *val = ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_100;
+          break;
+        case ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_9:
+          *val = ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_9;
+          break;
+        case ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_400:
+          *val = ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_400;
+          break;
+        default:
+          *val = ISM330DLC_XL_LP_NA;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hp_ref_mode in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_reference_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.hp_ref_mode = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hp_ref_mode in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_reference_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.hp_ref_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  High pass/Slope on outputs.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hpcf_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_hp_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_hpcf_xl_t val)
+{
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.input_composite = 0;
+    ctrl8_xl.hpcf_xl = (uint8_t)val & 0x03U;
+    ctrl8_xl.hp_slope_xl_en = 1;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass/Slope on outputs.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of hpcf_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_hp_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_hpcf_xl_t *val)
+{
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if (ctrl8_xl.hp_slope_xl_en == 0x00U){
+    *val = ISM330DLC_XL_HP_NA;
+  }
+  switch (ctrl8_xl.hpcf_xl) {
+    case ISM330DLC_XL_HP_ODR_DIV_4:
+      *val = ISM330DLC_XL_HP_ODR_DIV_4;
+      break;
+    case ISM330DLC_XL_HP_ODR_DIV_100:
+      *val = ISM330DLC_XL_HP_ODR_DIV_100;
+      break;
+    case ISM330DLC_XL_HP_ODR_DIV_9:
+      *val = ISM330DLC_XL_HP_ODR_DIV_9;
+      break;
+    case ISM330DLC_XL_HP_ODR_DIV_400:
+      *val = ISM330DLC_XL_HP_ODR_DIV_400;
+      break;
+    default:
+      *val = ISM330DLC_XL_HP_NA;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_accelerometer_filters_mode:4
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer when mode 4
+  *              (accelerometer on aux interface enable).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection. Only
+  *         for mode 4.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_ui_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                          ism330dlc_ui_lpf1_bw_sel_t val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL,
+                           (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf1_bw_sel = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL,
+                             (uint8_t*)&ctrl8_xl, 1);
+  }
+  if(ret == 0){
+    ctrl8_xl.hp_slope_xl_en = 0;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Accelerometer digital LPF (LPF1) bandwidth selection. Only
+  *           for mode 4.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpf1_bw_sel in
+  *                                reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_ui_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                          ism330dlc_ui_lpf1_bw_sel_t *val)
+{
+  ism330dlc_ctrl1_xl_t ctrl1_xl;
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if (ctrl8_xl.hp_slope_xl_en == PROPERTY_DISABLE){
+      *val = ISM330DLC_XL_UI_LP1_NA;
+    }
+    else{
+    }
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_XL,
+                               (uint8_t*)&ctrl1_xl, 1);
+      switch (ctrl1_xl.lpf1_bw_sel ) {
+        case ISM330DLC_XL_UI_LP1_ODR_DIV_2:
+          *val = ISM330DLC_XL_UI_LP1_ODR_DIV_2;
+          break;
+        case ISM330DLC_XL_UI_LP1_ODR_DIV_4:
+          *val = ISM330DLC_XL_UI_LP1_ODR_DIV_4;
+          break;
+        default:
+          *val = ISM330DLC_XL_UI_LP1_NA;
+      break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  xl_ui_slope:   Slope filter on outputs[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_ui_slope_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.hp_slope_xl_en = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  xl_ui_slope:   Slope filter on outputs[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_ui_slope_get(ism330dlc_ctx_t *ctx,  uint8_t *val)
+{
+  ism330dlc_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&reg, 1);
+  *val = reg.hp_slope_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief   xl_aux_lp_bandwidth: [set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of filter_xl_conf_ois in reg CTRL3_OIS.
+  *
+  * Cut off feq [ODR_UI = 0 / ODR UI ≥ 1600 Hz]
+  * LIGHT      636   Hz  2.96°
+  * NORMAL     295   Hz  5.12°
+  * STRONG     140   Hz  9.39°
+  * AGGRESSIVE  68.2 Hz 17.6°
+  *
+  * Cut off feq [ODR UI ≤ 800 Hz ]
+  * LIGHT      329   Hz  5.08°
+  * NORMAL     222   Hz  7.23°
+  * STRONG     128   Hz 11.5°
+  * AGGRESSIVE  66.5 Hz 19.7°
+  *
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_aux_lp_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                          ism330dlc_filter_xl_conf_ois_t val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.filter_xl_conf_ois = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   xl_aux_lp_bandwidth: [get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of filter_xl_conf_ois in reg CTRL3_OIS
+  *
+  * Cut off feq [ODR_UI = 0 / ODR UI ≥ 1600 Hz]
+  * LIGHT      636   Hz  2.96°
+  * NORMAL     295   Hz  5.12°
+  * STRONG     140   Hz  9.39°
+  * AGGRESSIVE  68.2 Hz 17.6°
+  *
+  * Cut off feq [ODR UI ≤ 800 Hz ]
+  * LIGHT      329   Hz  5.08°
+  * NORMAL     222   Hz  7.23°
+  * STRONG     128   Hz 11.5°
+  * AGGRESSIVE  66.5 Hz 19.7°
+  *
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_xl_aux_lp_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                          ism330dlc_filter_xl_conf_ois_t *val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.filter_xl_conf_ois ) {
+    case ISM330DLC_AUX_LP_LIGHT:
+      *val = ISM330DLC_AUX_LP_LIGHT;
+      break;
+    case ISM330DLC_AUX_LP_NORMAL:
+      *val = ISM330DLC_AUX_LP_NORMAL;
+      break;
+    case ISM330DLC_AUX_LP_STRONG:
+      *val = ISM330DLC_AUX_LP_STRONG;
+      break;
+    case ISM330DLC_AUX_LP_AGGRESSIVE:
+      *val = ISM330DLC_AUX_LP_AGGRESSIVE;
+      break;
+    default:
+      *val = ISM330DLC_AUX_LP_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_gyroscope_filters_mode:1,2
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact gyroscope mode 1, 2
+  *              (gyroscope on aux interface disable).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Gyroscope low pass path bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope filtering chain configuration.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_band_pass_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_lpf1_sel_g_t val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  ism330dlc_ctrl6_c_t ctrl6_c;
+  ism330dlc_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hpm_g  =  ( (uint8_t)val & 0x30U ) >> 4;
+    ctrl7_g.hp_en_g = ( (uint8_t)val & 0x80U ) >> 7;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+    if(ret == 0){
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+      if(ret == 0){
+        ctrl6_c.ftype = (uint8_t)val & 0x03U;
+        ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL6_C,
+                                  (uint8_t*)&ctrl6_c, 1);
+        if(ret == 0){
+          ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C,
+                                   (uint8_t*)&ctrl4_c, 1);
+          if(ret == 0){
+            ctrl4_c.lpf1_sel_g = ( (uint8_t)val & 0x08U ) >> 3;
+            ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL4_C,
+                                      (uint8_t*)&ctrl4_c, 1);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass path bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope filtering chain
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_band_pass_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_lpf1_sel_g_t *val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  ism330dlc_ctrl6_c_t ctrl6_c;
+  ism330dlc_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+    if(ret == 0){
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+      switch ( ( ctrl7_g.hp_en_g << 7 ) + ( ctrl7_g.hpm_g << 4 ) +
+               ( ctrl4_c.lpf1_sel_g << 3) + ctrl6_c.ftype ) {
+        case ISM330DLC_HP_16mHz_LP2:
+          *val = ISM330DLC_HP_16mHz_LP2;
+          break;
+        case ISM330DLC_HP_65mHz_LP2:
+          *val = ISM330DLC_HP_65mHz_LP2;
+          break;
+        case ISM330DLC_HP_260mHz_LP2:
+          *val = ISM330DLC_HP_260mHz_LP2;
+          break;
+        case ISM330DLC_HP_1Hz04_LP2:
+          *val = ISM330DLC_HP_1Hz04_LP2;
+          break;
+        case ISM330DLC_HP_DISABLE_LP1_LIGHT:
+          *val = ISM330DLC_HP_DISABLE_LP1_LIGHT;
+          break;
+        case ISM330DLC_HP_DISABLE_LP1_NORMAL:
+          *val = ISM330DLC_HP_DISABLE_LP1_NORMAL;
+          break;
+        case ISM330DLC_HP_DISABLE_LP_STRONG:
+          *val = ISM330DLC_HP_DISABLE_LP_STRONG;
+          break;
+        case ISM330DLC_HP_DISABLE_LP1_AGGRESSIVE:
+          *val = ISM330DLC_HP_DISABLE_LP1_AGGRESSIVE;
+          break;
+        case ISM330DLC_HP_16mHz_LP1_LIGHT:
+          *val = ISM330DLC_HP_16mHz_LP1_LIGHT;
+          break;
+        case ISM330DLC_HP_65mHz_LP1_NORMAL:
+          *val = ISM330DLC_HP_65mHz_LP1_NORMAL;
+          break;
+        case ISM330DLC_HP_260mHz_LP1_STRONG:
+          *val = ISM330DLC_HP_260mHz_LP1_STRONG;
+          break;
+        case ISM330DLC_HP_1Hz04_LP1_AGGRESSIVE:
+          *val = ISM330DLC_HP_1Hz04_LP1_AGGRESSIVE;
+          break;
+        default:
+          *val = ISM330DLC_HP_16mHz_LP2;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_gyroscope_filters_mode:3,4
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact gyroscope when mode 3, 4
+  *              (gyroscope on aux interface enable).
+  * @{
+  *
+  */
+
+/**
+  * @brief  HPF is available on gyroscope's OIS chain only if HP_EN_G in
+  *         CTRL7_G (16h) is set to '0'.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope ui filtering chain configuration in Mode: 3, 4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_ui_high_pass_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.hp_en_g = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF is available on gyroscope's OIS chain only if HP_EN_G in
+  *         CTRL7_G (16h) is set to '0'.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope ui filtering chain configuration in Mode: 3, 4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_ui_high_pass_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&reg, 1);
+
+  *val = reg.hp_en_g;
+
+  return ret;
+}
+
+
+/**
+  * @brief  HPF is available on gyroscope's OIS chain only if HP_EN_G in
+  *         CTRL7_G (16h) is set to '0'.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope aux (ois) filtering chain configuration in
+  *                Mode: 3, 4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_aux_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_hp_en_ois_t val)
+{
+  ism330dlc_ctrl7_g_t ctrl7_g;
+  ism330dlc_ctrl2_ois_t ctrl2_ois;
+  
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+  ctrl7_g.hp_en_g = 0;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL2_OIS,
+                             (uint8_t*)&ctrl2_ois, 1);
+  }
+  if(ret == 0){
+    ctrl2_ois.ftype_ois = (uint8_t)val & 0x03U;
+    ctrl2_ois.hp_en_ois = ( (uint8_t)val & 0x80U ) >> 7;
+    ctrl2_ois.hpm_ois = ( (uint8_t)val & 0x30U ) >> 4;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL2_OIS,
+                              (uint8_t*)&ctrl2_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF is available on gyroscope's OIS chain only if HP_EN_G in
+  *         CTRL7_G (16h) is set to '0'.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope aux (ois) filtering chain configuration in
+  *                Mode: 3, 4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_aux_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_hp_en_ois_t *val)
+{
+  ism330dlc_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL2_OIS, (uint8_t*)&reg, 1);
+                                   
+    switch ( ( reg.hp_en_ois << 7 ) + ( reg.hpm_ois << 4) + reg.ftype_ois ) {
+      case ISM330DLC_HP_DISABLE_LP_173Hz:
+        *val = ISM330DLC_HP_DISABLE_LP_173Hz;
+        break;
+      case ISM330DLC_HP_DISABLE_LP_237Hz:
+        *val = ISM330DLC_HP_DISABLE_LP_237Hz;
+        break;
+      case ISM330DLC_HP_DISABLE_LP_351Hz:
+        *val = ISM330DLC_HP_DISABLE_LP_351Hz;
+        break;
+      case ISM330DLC_HP_DISABLE_LP_937Hz:
+        *val = ISM330DLC_HP_DISABLE_LP_937Hz;
+        break;
+      case ISM330DLC_HP_16mHz_LP_173Hz:
+        *val = ISM330DLC_HP_16mHz_LP_173Hz;
+        break;
+      case ISM330DLC_HP_65mHz_LP_237Hz:
+        *val = ISM330DLC_HP_65mHz_LP_237Hz;
+        break;
+      case ISM330DLC_HP_260mHz_LP_351Hz:
+        *val = ISM330DLC_HP_260mHz_LP_351Hz;
+        break;
+      case ISM330DLC_HP_1Hz04_LP_937Hz:
+        *val = ISM330DLC_HP_1Hz04_LP_937Hz;
+        break;
+      default:
+        *val = ISM330DLC_HP_DISABLE_LP_173Hz;
+        break;
+    }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+  
+/**
+  * @defgroup    ISM330DLC_Auxiliary_interface
+  * @brief       This section groups all the functions concerning
+  *              auxiliary interface.
+  * @{
+  *
+  */
+
+/**
+  * @brief  The STATUS_SPIAux register is read by the auxiliary SPI.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    registers STATUS_SPIAUX.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_status_reg_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_status_spiaux_t *val)
+{
+  int32_t ret;
+  ret =  ism330dlc_read_reg(ctx, ISM330DLC_STATUS_SPIAUX, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  AUX accelerometer data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of xlda in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  ism330dlc_status_spiaux_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_STATUS_SPIAUX, (uint8_t*)&reg, 1);
+  *val = reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  AUX gyroscope data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of gda in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  ism330dlc_status_spiaux_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_STATUS_SPIAUX, (uint8_t*)&reg, 1);
+  *val = reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  High when the gyroscope output is in the settling phase.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of gyro_settling in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_gy_flag_settling_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_status_spiaux_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_STATUS_SPIAUX, (uint8_t*)&reg, 1);
+  *val = reg.gyro_settling;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[set] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of lvl2_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_den_mode_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_lvl_ois_t val)
+{
+  ism330dlc_ctrl1_ois_t ctrl1_ois;
+  ism330dlc_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.lvl2_ois = (uint8_t)val & 0x01U;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_INT_OIS,
+                              (uint8_t*)&int_ois, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+  if(ret == 0){
+    ctrl1_ois.lvl1_ois = ((uint8_t)val & 0x02U) >> 1;
+
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lvl2_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_den_mode_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_lvl_ois_t *val)
+{
+  ism330dlc_int_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.lvl2_ois ) {
+    case ISM330DLC_AUX_DEN_DISABLE:
+      *val = ISM330DLC_AUX_DEN_DISABLE;
+      break;
+    case ISM330DLC_AUX_DEN_LEVEL_LATCH:
+      *val = ISM330DLC_AUX_DEN_LEVEL_LATCH;
+      break;
+    case ISM330DLC_AUX_DEN_LEVEL_TRIG:
+      *val = ISM330DLC_AUX_DEN_LEVEL_TRIG;
+      break;
+    default:
+      *val = ISM330DLC_AUX_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin. This setting 
+  *         has priority over all other INT2 settings.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of int2_drdy_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_drdy_on_int2_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_int_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.int2_drdy_ois = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_INT_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin. This setting 
+  *         has priority over all other INT2 settings.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of int2_drdy_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_drdy_on_int2_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_int_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_OIS, (uint8_t*)&reg, 1);
+  *val = reg.int2_drdy_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro
+  *         in Mode 3 and Mode 4 (mode4_en = 1) and
+  *         accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are
+  *         available through the SPI2 in registers
+  *         OUTX_L_G(22h) through OUTZ_H_G(27h) and
+  *         STATUS_REG(1Eh) / STATUS_SPIAux, and LPF1 is
+  *         dedicated to this chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of ois_en_spi2 in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_mode_set(ism330dlc_ctx_t *ctx,
+                               ism330dlc_ois_en_spi2_t val)
+{
+  ism330dlc_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.ois_en_spi2 = (uint8_t)val & 0x01U;
+    reg.mode4_en = ((uint8_t)val & 0x02U) >> 1;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro
+  *         in Mode 3 and Mode 4 (mode4_en = 1) and
+  *         accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs
+  *         are available through the SPI2 in registers
+  *         OUTX_L_G(22h) through OUTZ_H_G(27h) and
+  *         STATUS_REG(1Eh) / STATUS_SPIAux, and LPF1 is
+  *         dedicated to this chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ois_en_spi2 in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_mode_get(ism330dlc_ctx_t *ctx,
+                               ism330dlc_ois_en_spi2_t *val)
+{
+  ism330dlc_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch ( (reg.mode4_en << 1) + reg.ois_en_spi2 ) {
+    case ISM330DLC_AUX_DISABLE:
+      *val = ISM330DLC_AUX_DISABLE;
+      break;
+    case ISM330DLC_MODE_3_GY:
+      *val = ISM330DLC_MODE_3_GY;
+      break;
+    case ISM330DLC_MODE_4_GY_XL:
+      *val = ISM330DLC_MODE_4_GY_XL;
+      break;
+    default:
+      *val = ISM330DLC_AUX_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of fs_g_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_gy_full_scale_set(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_fs_g_ois_t val)
+{
+  ism330dlc_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.fs_g_ois = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_g_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_gy_full_scale_get(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_fs_g_ois_t *val)
+{
+  ism330dlc_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.fs_g_ois ) {
+    case ISM330DLC_250dps_AUX:
+      *val = ISM330DLC_250dps_AUX;
+      break;
+    case ISM330DLC_125dps_AUX:
+      *val = ISM330DLC_125dps_AUX;
+      break;
+    case ISM330DLC_500dps_AUX:
+      *val = ISM330DLC_500dps_AUX;
+      break;
+    case ISM330DLC_1000dps_AUX:
+      *val = ISM330DLC_1000dps_AUX;
+      break;
+    case ISM330DLC_2000dps_AUX:
+      *val = ISM330DLC_2000dps_AUX;
+      break;
+    default:
+      *val = ISM330DLC_250dps_AUX;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of sim_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_spi_mode_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sim_ois_t val)
+{
+  ism330dlc_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.sim_ois = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_spi_mode_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sim_ois_t *val)
+{
+  ism330dlc_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.sim_ois ) {
+    case ISM330DLC_AUX_SPI_4_WIRE:
+      *val = ISM330DLC_AUX_SPI_4_WIRE;
+      break;
+    case ISM330DLC_AUX_SPI_3_WIRE:
+      *val = ISM330DLC_AUX_SPI_3_WIRE;
+      break;
+    default:
+      *val = ISM330DLC_AUX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection on aux interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of ble_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_data_format_set(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_ble_ois_t val)
+{
+  ism330dlc_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.ble_ois = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection on aux interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ble_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_data_format_get(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_ble_ois_t *val)
+{
+  ism330dlc_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.ble_ois ) {
+    case ISM330DLC_AUX_LSB_AT_LOW_ADD:
+      *val = ISM330DLC_AUX_LSB_AT_LOW_ADD;
+      break;
+    case ISM330DLC_AUX_MSB_AT_LOW_ADD:
+      *val = ISM330DLC_AUX_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = ISM330DLC_AUX_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp. Enable: All OIS chain 
+  *         outputs = 8000h during self-test; Disable: OIS chain
+  *         self-test outputs dependent from the aux gyro full scale
+  *         selected.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of st_ois_clampdis in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_gy_clamp_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_st_ois_clampdis_t val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.st_ois_clampdis = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp. Enable: All OIS chain 
+  *         outputs = 8000h during self-test; Disable: OIS chain
+  *         self-test outputs dependent from the aux gyro full scale
+  *         selected.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_ois_clampdis in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_gy_clamp_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_st_ois_clampdis_t *val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.st_ois_clampdis ) {
+    case ISM330DLC_ENABLE_CLAMP:
+      *val = ISM330DLC_ENABLE_CLAMP;
+      break;
+    case ISM330DLC_DISABLE_CLAMP:
+      *val = ISM330DLC_DISABLE_CLAMP;
+      break;
+    default:
+      *val = ISM330DLC_ENABLE_CLAMP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[set] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of st_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_gy_self_test_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_st_ois_t val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.st_ois = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_gy_self_test_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_st_ois_t *val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.st_ois ) {
+    case ISM330DLC_AUX_GY_DISABLE:
+      *val = ISM330DLC_AUX_GY_DISABLE;
+      break;
+    case ISM330DLC_AUX_GY_POS:
+      *val = ISM330DLC_AUX_GY_POS;
+      break;
+    case ISM330DLC_AUX_GY_NEG:
+      *val = ISM330DLC_AUX_GY_NEG;
+      break;
+    default:
+      *val = ISM330DLC_AUX_GY_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of fs_xl_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_xl_full_scale_set(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_fs_xl_ois_t val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.fs_xl_ois = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_xl_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_xl_full_scale_get(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_fs_xl_ois_t *val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.fs_xl_ois ) {
+    case ISM330DLC_AUX_2g:
+      *val = ISM330DLC_AUX_2g;
+      break;
+    case ISM330DLC_AUX_16g:
+      *val = ISM330DLC_AUX_16g;
+      break;
+    case ISM330DLC_AUX_4g:
+      *val = ISM330DLC_AUX_4g;
+      break;
+    case ISM330DLC_AUX_8g:
+      *val = ISM330DLC_AUX_8g;
+      break;
+    default:
+      *val = ISM330DLC_AUX_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of den_lh_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_den_polarity_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_den_lh_ois_t val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.den_lh_ois = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_lh_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_aux_den_polarity_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_den_lh_ois_t *val)
+{
+  ism330dlc_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch ( reg.den_lh_ois ) {
+    case ISM330DLC_AUX_DEN_ACTIVE_LOW:
+      *val = ISM330DLC_AUX_DEN_ACTIVE_LOW;
+      break;
+    case ISM330DLC_AUX_DEN_ACTIVE_HIGH:
+      *val = ISM330DLC_AUX_DEN_ACTIVE_HIGH;
+      break;
+    default:
+      *val = ISM330DLC_AUX_DEN_ACTIVE_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+  
+/**
+  * @defgroup    ISM330DLC_main_serial_interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_spi_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_sim_t val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_spi_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_sim_t *val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.sim) {
+    case ISM330DLC_SPI_4_WIRE:
+      *val = ISM330DLC_SPI_4_WIRE;
+      break;
+    case ISM330DLC_SPI_3_WIRE:
+      *val = ISM330DLC_SPI_3_WIRE;
+      break;
+    default:
+      *val = ISM330DLC_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_i2c_interface_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_i2c_disable_t val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_i2c_interface_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_i2c_disable_t *val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  switch (ctrl4_c.i2c_disable) {
+    case ISM330DLC_I2C_ENABLE:
+      *val = ISM330DLC_I2C_ENABLE;
+      break;
+    case ISM330DLC_I2C_DISABLE:
+      *val = ISM330DLC_I2C_DISABLE;
+      break;
+    default:
+      *val = ISM330DLC_I2C_ENABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_interrupt_pins
+  * @brief       This section groups all the functions that manage
+  *              interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select the signal that need to route on int1 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    configure INT1_CTRL, MD1_CFG, CTRL4_C(den_drdy_int1),
+  *                MASTER_CONFIG(drdy_on_int1)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_pin_int1_route_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_int1_route_t val)
+{
+  ism330dlc_master_config_t master_config;
+  ism330dlc_int1_ctrl_t int1_ctrl;
+  ism330dlc_md1_cfg_t md1_cfg;
+  ism330dlc_md2_cfg_t md2_cfg;
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT1_CTRL,
+                           (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_drdy_xl        = val.int1_drdy_xl;
+    int1_ctrl.int1_drdy_g         = val.int1_drdy_g;
+    int1_ctrl.int1_boot           = val.int1_boot;
+    int1_ctrl.int1_fth            = val.int1_fth;
+    int1_ctrl.int1_fifo_ovr       = val.int1_fifo_ovr;
+    int1_ctrl.int1_full_flag      = val.int1_full_flag;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_INT1_CTRL,
+                              (uint8_t*)&int1_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+        md1_cfg.int1_tilt            = val.int1_tilt;
+        md1_cfg.int1_6d              = val.int1_6d;
+        md1_cfg.int1_double_tap      = val.int1_double_tap;
+        md1_cfg.int1_ff              = val.int1_ff;
+        md1_cfg.int1_wu              = val.int1_wu;
+        md1_cfg.int1_single_tap      = val.int1_single_tap;
+        md1_cfg.int1_inact_state     = val.int1_inact_state;
+        ret = ism330dlc_write_reg(ctx, ISM330DLC_MD1_CFG,
+                                  (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ctrl4_c.den_drdy_int1 = val.den_drdy_int1;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+     master_config.drdy_on_int1   = val.den_drdy_int1;
+     ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+    if ((val.int1_6d != 0x00U) ||
+        (val.int1_ff != 0x00U) ||
+        (val.int1_wu != 0x00U) ||
+        (val.int1_single_tap != 0x00U) ||
+        (val.int1_double_tap != 0x00U) ||
+        (val.int1_inact_state != 0x00U)||
+        (md2_cfg.int2_6d != 0x00U) ||
+        (md2_cfg.int2_ff != 0x00U) ||
+        (md2_cfg.int2_wu != 0x00U) ||
+        (md2_cfg.int2_single_tap != 0x00U) ||
+        (md2_cfg.int2_double_tap != 0x00U) ||
+        (md2_cfg.int2_inact_state!= 0x00U) ){
+      tap_cfg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){    
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    read INT1_CTRL, MD1_CFG, CTRL4_C(den_drdy_int1),
+  *                MASTER_CONFIG(drdy_on_int1)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_pin_int1_route_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_int1_route_t *val)
+{
+  ism330dlc_master_config_t master_config;
+  ism330dlc_int1_ctrl_t int1_ctrl;
+  ism330dlc_md1_cfg_t md1_cfg;
+  ism330dlc_ctrl4_c_t ctrl4_c;
+
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    val->int1_drdy_xl       = int1_ctrl.int1_drdy_xl;
+    val->int1_drdy_g        = int1_ctrl.int1_drdy_g;
+    val->int1_boot          = int1_ctrl.int1_boot;
+    val->int1_fth           = int1_ctrl.int1_fth;
+    val->int1_fifo_ovr      = int1_ctrl.int1_fifo_ovr;
+    val->int1_full_flag     = int1_ctrl.int1_full_flag;
+
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+    if(ret == 0){
+      val->int1_tilt        = md1_cfg.int1_tilt;
+      val->int1_6d          = md1_cfg.int1_6d;
+      val->int1_double_tap  = md1_cfg.int1_double_tap;
+      val->int1_ff          = md1_cfg.int1_ff;
+      val->int1_wu          = md1_cfg.int1_wu;
+      val->int1_single_tap  = md1_cfg.int1_single_tap;
+      val->int1_inact_state = md1_cfg.int1_inact_state;
+
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      if(ret == 0){
+        val->den_drdy_int1 = ctrl4_c.den_drdy_int1;
+        ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                               (uint8_t*)&master_config, 1);
+        val->den_drdy_int1 = master_config.drdy_on_int1;
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    INT2_CTRL, DRDY_PULSE_CFG(int2_wrist_tilt), MD2_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_pin_int2_route_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_int2_route_t val)
+{
+  ism330dlc_int2_ctrl_t int2_ctrl;
+  ism330dlc_md1_cfg_t md1_cfg;
+  ism330dlc_md2_cfg_t md2_cfg;
+  ism330dlc_drdy_pulse_cfg_t drdy_pulse_cfg;
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT2_CTRL,
+                           (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_drdy_xl        = val.int2_drdy_xl;
+    int2_ctrl.int2_drdy_g         = val.int2_drdy_g;
+    int2_ctrl.int2_drdy_temp      = val.int2_drdy_temp;
+    int2_ctrl.int2_fth            = val.int2_fth;
+    int2_ctrl.int2_fifo_ovr       = val.int2_fifo_ovr;
+    int2_ctrl.int2_full_flag      = val.int2_full_flag;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_INT2_CTRL,
+                              (uint8_t*)&int2_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MD1_CFG,
+                             (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MD2_CFG,
+                             (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+    md2_cfg.int2_iron              = val.int2_iron;
+    md2_cfg.int2_tilt              = val.int2_tilt;
+    md2_cfg.int2_6d                = val.int2_6d;
+    md2_cfg.int2_double_tap        = val.int2_double_tap;
+    md2_cfg.int2_ff                = val.int2_ff;
+    md2_cfg.int2_wu                = val.int2_wu;
+    md2_cfg.int2_single_tap        = val.int2_single_tap;
+    md2_cfg.int2_inact_state       = val.int2_inact_state;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_DRDY_PULSE_CFG,
+                             (uint8_t*)&drdy_pulse_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_DRDY_PULSE_CFG,
+                              (uint8_t*)&drdy_pulse_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+    if ((md1_cfg.int1_6d != 0x00U) ||
+        (md1_cfg.int1_ff != 0x00U) ||
+        (md1_cfg.int1_wu != 0x00U) ||
+        (md1_cfg.int1_single_tap != 0x00U) ||
+        (md1_cfg.int1_double_tap != 0x00U) ||
+        (md1_cfg.int1_inact_state != 0x00U) ||
+        (val.int2_6d != 0x00U) ||
+        (val.int2_ff != 0x00U) ||
+        (val.int2_wu != 0x00U) ||
+        (val.int2_single_tap != 0x00U) ||
+        (val.int2_double_tap != 0x00U) ||
+        (val.int2_inact_state!= 0x00U) ){
+      tap_cfg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    INT2_CTRL, DRDY_PULSE_CFG(int2_wrist_tilt), MD2_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_pin_int2_route_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_int2_route_t *val)
+{
+  ism330dlc_int2_ctrl_t int2_ctrl;
+  ism330dlc_md2_cfg_t md2_cfg;
+
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    val->int2_drdy_xl         = int2_ctrl.int2_drdy_xl;
+    val->int2_drdy_g          = int2_ctrl.int2_drdy_g;
+    val->int2_drdy_temp       = int2_ctrl.int2_drdy_temp;
+    val->int2_fth             = int2_ctrl.int2_fth;
+    val->int2_fifo_ovr        = int2_ctrl.int2_fifo_ovr;
+    val->int2_full_flag       = int2_ctrl.int2_full_flag;
+
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+    if(ret == 0){
+      val->int2_iron           = md2_cfg.int2_iron;
+      val->int2_tilt           = md2_cfg.int2_tilt;
+      val->int2_6d             = md2_cfg.int2_6d;
+      val->int2_double_tap     = md2_cfg.int2_double_tap;
+      val->int2_ff             = md2_cfg.int2_ff;
+      val->int2_wu             = md2_cfg.int2_wu;
+      val->int2_single_tap     = md2_cfg.int2_single_tap;
+      val->int2_inact_state    = md2_cfg.int2_inact_state;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_pin_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_pin_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t *val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.pp_od) {
+    case ISM330DLC_PUSH_PULL:
+      *val = ISM330DLC_PUSH_PULL;
+      break;
+    case ISM330DLC_OPEN_DRAIN:
+      *val = ISM330DLC_OPEN_DRAIN;
+      break;
+    default:
+      *val = ISM330DLC_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_pin_polarity_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_h_lactive_t val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_pin_polarity_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_h_lactive_t *val)
+{
+  ism330dlc_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.h_lactive) {
+    case ISM330DLC_ACTIVE_HIGH:
+      *val = ISM330DLC_ACTIVE_HIGH;
+      break;
+    case ISM330DLC_ACTIVE_LOW:
+      *val = ISM330DLC_ACTIVE_LOW;
+      break;
+    default:
+      *val = ISM330DLC_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_all_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1 = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_all_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lir in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_int_notification_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_lir_t val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.lir = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lir in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_int_notification_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_lir_t *val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.lir) {
+    case ISM330DLC_INT_PULSED:
+      *val = ISM330DLC_INT_PULSED;
+      break;
+    case ISM330DLC_INT_LATCHED:
+      *val = ISM330DLC_INT_LATCHED;
+      break;
+    default:
+      *val = ISM330DLC_INT_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_Wake_Up_event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_wkup_threshold_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_wkup_threshold_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_wkup_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_wkup_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_Activity/Inactivity_detection
+  * @brief       This section groups all the functions concerning
+  *              activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_sleep_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.sleep = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_gy_sleep_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.sleep;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of inact_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_act_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_inact_en_t val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.inact_en = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of inact_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_act_mode_get(ism330dlc_ctx_t *ctx,
+                               ism330dlc_inact_en_t *val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.inact_en) {
+    case ISM330DLC_PROPERTY_DISABLE:
+      *val = ISM330DLC_PROPERTY_DISABLE;
+      break;
+    case ISM330DLC_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = ISM330DLC_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case ISM330DLC_XL_12Hz5_GY_SLEEP:
+      *val = ISM330DLC_XL_12Hz5_GY_SLEEP;
+      break;
+    case ISM330DLC_XL_12Hz5_GY_PD:
+      *val = ISM330DLC_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = ISM330DLC_PROPERTY_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.1 LSb = 512 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_act_sleep_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+          (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode. 1 LSb = 512 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_act_sleep_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_tap_generator
+  * @brief       This section groups all the functions that manage the
+  *              tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read the tap / double tap source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from TAP_SRC
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_src_get(ism330dlc_ctx_t *ctx, ism330dlc_tap_src_t *val)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG
+  *
+  */
+int32_t ism330dlc_tap_detection_on_z_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_z_en = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_detection_on_z_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_detection_on_y_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_y_en = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_detection_on_y_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_detection_on_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_x_en = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_detection_on_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_threshold_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.tap_ths = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_threshold_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.tap_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event.
+  *         The default value of these bits is 00b which corresponds to
+  *         4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_shock_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.shock = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_INT_DUR2,
+                              (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event.
+  *         The default value of these bits is 00b which corresponds to
+  *         4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_shock_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_quiet_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.quiet = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_quiet_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,1LSB corresponds
+  *         to 32*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.dur = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,1LSB corresponds
+  *         to 32*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_mode_set(ism330dlc_ctx_t *ctx,
+                             ism330dlc_single_double_tap_t val)
+{
+  ism330dlc_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.single_double_tap = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_tap_mode_get(ism330dlc_ctx_t *ctx,
+                               ism330dlc_single_double_tap_t *val)
+{
+  ism330dlc_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_THS, 
+                           (uint8_t*)&wake_up_ths, 1);
+  switch (wake_up_ths.single_double_tap) {
+    case ISM330DLC_ONLY_SINGLE:
+      *val = ISM330DLC_ONLY_SINGLE;
+      break;
+    case ISM330DLC_BOTH_SINGLE_DOUBLE:
+      *val = ISM330DLC_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = ISM330DLC_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_ Six_position_detection(6D/4D)
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  LPF2 feed 6D function selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_6d_feed_data_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_low_pass_on_6d_t val)
+{
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.low_pass_on_6d = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 feed 6D function selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_6d_feed_data_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_low_pass_on_6d_t *val)
+{
+  ism330dlc_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  switch (ctrl8_xl.low_pass_on_6d) {
+    case ISM330DLC_ODR_DIV_2_FEED:
+      *val = ISM330DLC_ODR_DIV_2_FEED;
+      break;
+    case ISM330DLC_LPF2_FEED:
+      *val = ISM330DLC_LPF2_FEED;
+      break;
+    default:
+      *val = ISM330DLC_ODR_DIV_2_FEED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_6d_threshold_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sixd_ths_t val)
+{
+  ism330dlc_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.sixd_ths = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_6d_threshold_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sixd_ths_t *val)
+{
+  ism330dlc_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  switch (tap_ths_6d.sixd_ths) {
+    case ISM330DLC_DEG_80:
+      *val = ISM330DLC_DEG_80;
+      break;
+    case ISM330DLC_DEG_70:
+      *val = ISM330DLC_DEG_70;
+      break;
+    case ISM330DLC_DEG_60:
+      *val = ISM330DLC_DEG_60;
+      break;
+    case ISM330DLC_DEG_50:
+      *val = ISM330DLC_DEG_50;
+      break;
+    default:
+      *val = ISM330DLC_DEG_80;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_4d_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.d4d_en = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_TAP_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_4d_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_free_fall
+  * @brief       This section group all the functions concerning the free
+  *              fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief Free-fall duration event. 1LSb = 1 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_ff_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_wake_up_dur_t wake_up_dur;
+  ism330dlc_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_dur = (val & 0x1FU);
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FREE_FALL,
+                              (uint8_t*)&free_fall, 1);
+    if(ret == 0){
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                               (uint8_t*)&wake_up_dur, 1);
+      if(ret == 0){
+        wake_up_dur.ff_dur = (val & 0x20U) >> 5;
+        ret = ism330dlc_write_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                                  (uint8_t*)&wake_up_dur, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event. 1LSb = 1 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_ff_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_wake_up_dur_t wake_up_dur;
+  ism330dlc_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_FREE_FALL,
+                             (uint8_t*)&free_fall, 1);
+  }
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_ff_threshold_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_ff_ths_t val)
+{
+  ism330dlc_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FREE_FALL,
+                              (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_ff_threshold_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_ff_ths_t *val)
+{
+  ism330dlc_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FREE_FALL, (uint8_t*)&free_fall, 1);
+  switch (free_fall.ff_ths) {
+    case ISM330DLC_FF_TSH_156mg:
+      *val = ISM330DLC_FF_TSH_156mg;
+      break;
+    case ISM330DLC_FF_TSH_219mg:
+      *val = ISM330DLC_FF_TSH_219mg;
+      break;
+    case ISM330DLC_FF_TSH_250mg:
+      *val = ISM330DLC_FF_TSH_250mg;
+      break;
+    case ISM330DLC_FF_TSH_312mg:
+      *val = ISM330DLC_FF_TSH_312mg;
+      break;
+    case ISM330DLC_FF_TSH_344mg:
+      *val = ISM330DLC_FF_TSH_344mg;
+      break;
+    case ISM330DLC_FF_TSH_406mg:
+      *val = ISM330DLC_FF_TSH_406mg;
+      break;
+    case ISM330DLC_FF_TSH_469mg:
+      *val = ISM330DLC_FF_TSH_469mg;
+      break;
+    case ISM330DLC_FF_TSH_500mg:
+      *val = ISM330DLC_FF_TSH_500mg;
+      break;
+    default:
+      *val = ISM330DLC_FF_TSH_156mg;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_fifo
+  * @brief       This section group all the functions concerning the
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_watermark_set(ism330dlc_ctx_t *ctx, uint16_t val)
+{
+  ism330dlc_fifo_ctrl1_t fifo_ctrl1;
+  ism330dlc_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl1.fth = (uint8_t) (0x00FFU & val);
+    fifo_ctrl2.fth = (uint8_t) (( 0x0700U & val ) >> 8);
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL1,
+                              (uint8_t*)&fifo_ctrl1, 1);
+    if(ret == 0){
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_watermark_get(ism330dlc_ctx_t *ctx, uint16_t *val)
+{
+  ism330dlc_fifo_ctrl1_t fifo_ctrl1;
+  ism330dlc_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL1,
+                           (uint8_t*)&fifo_ctrl1, 1);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL2,
+                             (uint8_t*)&fifo_ctrl2, 1);
+  }
+  *val = ((uint16_t)fifo_ctrl2.fth << 8) + (uint16_t)fifo_ctrl1.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of diff_fifo in reg  FIFO_STATUS1 and
+  *                FIFO_STATUS2(diff_fifo), it is recommended to set the
+  *                BDU bit.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_data_level_get(ism330dlc_ctx_t *ctx, uint16_t *val)
+{
+  ism330dlc_fifo_status1_t fifo_status1;
+  ism330dlc_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_STATUS1,
+                           (uint8_t*)&fifo_status1, 1);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_STATUS2,
+                             (uint8_t*)&fifo_status2, 1);
+    *val = ( (uint16_t) fifo_status2.diff_fifo << 8) +
+             (uint16_t) fifo_status1.diff_fifo;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of watermark in reg  FIFO_STATUS2 and
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_wtm_flag_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.waterm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO pattern.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of fifo_pattern in reg  FIFO_STATUS3 and
+  *                FIFO_STATUS4, it is recommended to set the BDU bit
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_pattern_get(ism330dlc_ctx_t *ctx, uint16_t *val)
+{
+  ism330dlc_fifo_status3_t fifo_status3;
+  ism330dlc_fifo_status4_t fifo_status4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_STATUS3,
+                           (uint8_t*)&fifo_status3, 1);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_STATUS4,
+                             (uint8_t*)&fifo_status4, 1);
+    *val = ( (uint16_t)fifo_status4.fifo_pattern << 8) +
+             fifo_status3.fifo_pattern;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_temp_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_temp_batch_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.fifo_temp_en = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_temp_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_temp_batch_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.fifo_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger signal for FIFO write operation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    act on FIFO_CTRL2(timer_pedo_fifo_drdy)
+  *                and MASTER_CONFIG(data_valid_sel_fifo)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_write_trigger_set(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_trigger_fifo_t val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.data_valid_sel_fifo = (((uint8_t)val & 0x02U) >> 1);
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO) for
+  *         accelerometer data.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_fifo_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_xl_batch_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_dec_fifo_xl_t val)
+{
+  ism330dlc_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_xl = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO) for
+  *         accelerometer data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_fifo_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_xl_batch_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_dec_fifo_xl_t *val)
+{
+  ism330dlc_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  switch (fifo_ctrl3.dec_fifo_xl) {
+    case ISM330DLC_FIFO_XL_DISABLE:
+      *val = ISM330DLC_FIFO_XL_DISABLE;
+      break;
+    case ISM330DLC_FIFO_XL_NO_DEC:
+      *val = ISM330DLC_FIFO_XL_NO_DEC;
+      break;
+    case ISM330DLC_FIFO_XL_DEC_2:
+      *val = ISM330DLC_FIFO_XL_DEC_2;
+      break;
+    case ISM330DLC_FIFO_XL_DEC_3:
+      *val = ISM330DLC_FIFO_XL_DEC_3;
+      break;
+    case ISM330DLC_FIFO_XL_DEC_4:
+      *val = ISM330DLC_FIFO_XL_DEC_4;
+      break;
+    case ISM330DLC_FIFO_XL_DEC_8:
+      *val = ISM330DLC_FIFO_XL_DEC_8;
+      break;
+    case ISM330DLC_FIFO_XL_DEC_16:
+      *val = ISM330DLC_FIFO_XL_DEC_16;
+      break;
+    case ISM330DLC_FIFO_XL_DEC_32:
+      *val = ISM330DLC_FIFO_XL_DEC_32;
+      break;
+    default:
+      *val = ISM330DLC_FIFO_XL_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_fifo_gyro in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_gy_batch_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_dec_fifo_gyro_t val)
+{
+  ism330dlc_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_gyro = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_fifo_gyro in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_gy_batch_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_dec_fifo_gyro_t *val)
+{
+  ism330dlc_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  switch (fifo_ctrl3.dec_fifo_gyro) {
+    case ISM330DLC_FIFO_GY_DISABLE:
+      *val = ISM330DLC_FIFO_GY_DISABLE;
+      break;
+    case ISM330DLC_FIFO_GY_NO_DEC:
+      *val = ISM330DLC_FIFO_GY_NO_DEC;
+      break;
+    case ISM330DLC_FIFO_GY_DEC_2:
+      *val = ISM330DLC_FIFO_GY_DEC_2;
+      break;
+    case ISM330DLC_FIFO_GY_DEC_3:
+      *val = ISM330DLC_FIFO_GY_DEC_3;
+      break;
+    case ISM330DLC_FIFO_GY_DEC_4:
+      *val = ISM330DLC_FIFO_GY_DEC_4;
+      break;
+    case ISM330DLC_FIFO_GY_DEC_8:
+      *val = ISM330DLC_FIFO_GY_DEC_8;
+      break;
+    case ISM330DLC_FIFO_GY_DEC_16:
+      *val = ISM330DLC_FIFO_GY_DEC_16;
+      break;
+    case ISM330DLC_FIFO_GY_DEC_32:
+      *val = ISM330DLC_FIFO_GY_DEC_32;
+      break;
+    default:
+      *val = ISM330DLC_FIFO_GY_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_ds3_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_dataset_3_batch_set(ism330dlc_ctx_t *ctx,
+                                           ism330dlc_dec_ds3_fifo_t val)
+{
+  ism330dlc_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds3_fifo = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_ds3_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_dataset_3_batch_get(ism330dlc_ctx_t *ctx,
+                                           ism330dlc_dec_ds3_fifo_t *val)
+{
+  ism330dlc_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  switch (fifo_ctrl4.dec_ds3_fifo) {
+    case ISM330DLC_FIFO_DS3_DISABLE:
+      *val = ISM330DLC_FIFO_DS3_DISABLE;
+      break;
+    case ISM330DLC_FIFO_DS3_NO_DEC:
+      *val = ISM330DLC_FIFO_DS3_NO_DEC;
+      break;
+    case ISM330DLC_FIFO_DS3_DEC_2:
+      *val = ISM330DLC_FIFO_DS3_DEC_2;
+      break;
+    case ISM330DLC_FIFO_DS3_DEC_3:
+      *val = ISM330DLC_FIFO_DS3_DEC_3;
+      break;
+    case ISM330DLC_FIFO_DS3_DEC_4:
+      *val = ISM330DLC_FIFO_DS3_DEC_4;
+      break;
+    case ISM330DLC_FIFO_DS3_DEC_8:
+      *val = ISM330DLC_FIFO_DS3_DEC_8;
+      break;
+    case ISM330DLC_FIFO_DS3_DEC_16:
+      *val = ISM330DLC_FIFO_DS3_DEC_16;
+      break;
+    case ISM330DLC_FIFO_DS3_DEC_32:
+      *val = ISM330DLC_FIFO_DS3_DEC_32;
+      break;
+    default:
+      *val = ISM330DLC_FIFO_DS3_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for fourth data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_ds4_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_dataset_4_batch_set(ism330dlc_ctx_t *ctx,
+                                           ism330dlc_dec_ds4_fifo_t val)
+{
+  ism330dlc_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds4_fifo = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO) for
+  *          fourth data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_ds4_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_dataset_4_batch_get(ism330dlc_ctx_t *ctx,
+                                           ism330dlc_dec_ds4_fifo_t *val)
+{
+  ism330dlc_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  switch (fifo_ctrl4.dec_ds4_fifo) {
+    case ISM330DLC_FIFO_DS4_DISABLE:
+      *val = ISM330DLC_FIFO_DS4_DISABLE;
+      break;
+    case ISM330DLC_FIFO_DS4_NO_DEC:
+      *val = ISM330DLC_FIFO_DS4_NO_DEC;
+      break;
+    case ISM330DLC_FIFO_DS4_DEC_2:
+      *val = ISM330DLC_FIFO_DS4_DEC_2;
+      break;
+    case ISM330DLC_FIFO_DS4_DEC_3:
+      *val = ISM330DLC_FIFO_DS4_DEC_3;
+      break;
+    case ISM330DLC_FIFO_DS4_DEC_4:
+      *val = ISM330DLC_FIFO_DS4_DEC_4;
+      break;
+    case ISM330DLC_FIFO_DS4_DEC_8:
+      *val = ISM330DLC_FIFO_DS4_DEC_8;
+      break;
+    case ISM330DLC_FIFO_DS4_DEC_16:
+      *val = ISM330DLC_FIFO_DS4_DEC_16;
+      break;
+    case ISM330DLC_FIFO_DS4_DEC_32:
+      *val = ISM330DLC_FIFO_DS4_DEC_32;
+      break;
+    default:
+      *val = ISM330DLC_FIFO_DS4_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   8-bit data storage in FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of only_high_data in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_xl_gy_8bit_format_set(ism330dlc_ctx_t *ctx,
+                                             uint8_t val)
+{
+  ism330dlc_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.only_high_data = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  8-bit data storage in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of only_high_data in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_xl_gy_8bit_format_get(ism330dlc_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  ism330dlc_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.only_high_data;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_stop_on_wtm_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.stop_on_fth = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_stop_on_wtm_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_mode in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_mode_set(ism330dlc_ctx_t *ctx,
+                                ism330dlc_fifo_mode_t val)
+{
+  ism330dlc_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL5,
+                           (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.fifo_mode = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL5,
+                              (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fifo_mode in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_mode_get(ism330dlc_ctx_t *ctx,
+                                ism330dlc_fifo_mode_t *val)
+{
+  ism330dlc_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL5,
+                           (uint8_t*)&fifo_ctrl5, 1);
+  switch (fifo_ctrl5.fifo_mode) {
+    case ISM330DLC_BYPASS_MODE:
+      *val = ISM330DLC_BYPASS_MODE;
+      break;
+    case ISM330DLC_FIFO_MODE:
+      *val = ISM330DLC_FIFO_MODE;
+      break;
+    case ISM330DLC_STREAM_TO_FIFO_MODE:
+      *val = ISM330DLC_STREAM_TO_FIFO_MODE;
+      break;
+    case ISM330DLC_BYPASS_TO_STREAM_MODE:
+      *val = ISM330DLC_BYPASS_TO_STREAM_MODE;
+      break;
+    case ISM330DLC_STREAM_MODE:
+      *val = ISM330DLC_STREAM_MODE;
+      break;
+    default:
+      *val = ISM330DLC_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO ODR selection, setting FIFO_MODE also.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_fifo in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_data_rate_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_odr_fifo_t val)
+{
+  ism330dlc_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL5,
+                           (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.odr_fifo = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_FIFO_CTRL5,
+                              (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO ODR selection, setting FIFO_MODE also.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_fifo in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_fifo_data_rate_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_odr_fifo_t *val)
+{
+  ism330dlc_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_FIFO_CTRL5,
+                           (uint8_t*)&fifo_ctrl5, 1);
+  switch (fifo_ctrl5.odr_fifo) {
+    case ISM330DLC_FIFO_DISABLE:
+      *val = ISM330DLC_FIFO_DISABLE;
+      break;
+    case ISM330DLC_FIFO_12Hz5:
+      *val = ISM330DLC_FIFO_12Hz5;
+      break;
+    case ISM330DLC_FIFO_26Hz:
+      *val = ISM330DLC_FIFO_26Hz;
+      break;
+    case ISM330DLC_FIFO_52Hz:
+      *val = ISM330DLC_FIFO_52Hz;
+      break;
+    case ISM330DLC_FIFO_104Hz:
+      *val = ISM330DLC_FIFO_104Hz;
+      break;
+    case ISM330DLC_FIFO_208Hz:
+      *val = ISM330DLC_FIFO_208Hz;
+      break;
+    case ISM330DLC_FIFO_416Hz:
+      *val = ISM330DLC_FIFO_416Hz;
+      break;
+    case ISM330DLC_FIFO_833Hz:
+      *val = ISM330DLC_FIFO_833Hz;
+      break;
+    case ISM330DLC_FIFO_1k66Hz:
+      *val = ISM330DLC_FIFO_1k66Hz;
+      break;
+    case ISM330DLC_FIFO_3k33Hz:
+      *val = ISM330DLC_FIFO_3k33Hz;
+      break;
+    case ISM330DLC_FIFO_6k66Hz:
+      *val = ISM330DLC_FIFO_6k66Hz;
+      break;
+    default:
+      *val = ISM330DLC_FIFO_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_DEN_functionality
+  * @brief       This section groups all the functions concerning DEN
+  *              functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_lh in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+ int32_t ism330dlc_den_polarity_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_den_lh_t val)
+{
+  ism330dlc_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.den_lh = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_lh in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_polarity_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_den_lh_t *val)
+{
+  ism330dlc_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.den_lh) {
+    case ISM330DLC_DEN_ACT_LOW:
+      *val = ISM330DLC_DEN_ACT_LOW;
+      break;
+    case ISM330DLC_DEN_ACT_HIGH:
+      *val = ISM330DLC_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = ISM330DLC_DEN_ACT_LOW;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t val)
+{
+  ism330dlc_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.den_mode = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t *val)
+{
+  ism330dlc_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.den_mode) {
+    case ISM330DLC_DEN_DISABLE:
+      *val = ISM330DLC_DEN_DISABLE;
+      break;
+    case ISM330DLC_LEVEL_LETCHED:
+      *val = ISM330DLC_LEVEL_LETCHED;
+      break;
+    case ISM330DLC_LEVEL_TRIGGER:
+      *val = ISM330DLC_LEVEL_TRIGGER;
+      break;
+    case ISM330DLC_EDGE_TRIGGER:
+      *val = ISM330DLC_EDGE_TRIGGER;
+      break;
+    default:
+      *val = ISM330DLC_DEN_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Extend DEN functionality to accelerometer sensor.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_xl_g in reg CTRL9_XL
+  *                             and den_xl_en in CTRL4_C.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_enable_set(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_den_xl_en_t val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_xl_g = (uint8_t)val & 0x01U;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+    if(ret == 0){
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C,
+                               (uint8_t*)&ctrl4_c, 1);
+      if(ret == 0){
+        ctrl4_c.den_xl_en = (uint8_t)val & 0x02U;
+        ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL4_C,
+                                  (uint8_t*)&ctrl4_c, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Extend DEN functionality to accelerometer sensor. [get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_xl_g in reg CTRL9_XL
+  *                             and den_xl_en in CTRL4_C.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_enable_get(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_den_xl_en_t *val)
+{
+  ism330dlc_ctrl4_c_t ctrl4_c;
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+    switch ( ( ctrl4_c.den_xl_en << 1) + ctrl9_xl.den_xl_g ) {
+      case ISM330DLC_STAMP_IN_GY_DATA:
+        *val = ISM330DLC_STAMP_IN_GY_DATA;
+        break;
+      case ISM330DLC_STAMP_IN_XL_DATA:
+        *val = ISM330DLC_STAMP_IN_XL_DATA;
+        break;
+      case ISM330DLC_STAMP_IN_GY_XL_DATA:
+        *val = ISM330DLC_STAMP_IN_GY_XL_DATA;
+        break;
+      default:
+        *val = ISM330DLC_STAMP_IN_GY_DATA;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_mark_axis_z_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_z = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_mark_axis_z_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_mark_axis_y_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_y = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_mark_axis_y_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_mark_axis_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_x = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_den_mark_axis_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_ magnetometer_sensor
+  * @brief       This section groups all the functions that manage additional
+  *              magnetometer sensor.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable soft-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of soft_en in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_soft_iron_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.soft_en = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable soft-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of soft_en in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_soft_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.soft_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable hard-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of iron_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_hard_iron_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_master_config_t master_config;
+  ism330dlc_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.iron_en = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+    if(ret == 0){
+      ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL10_C,
+                               (uint8_t*)&ctrl10_c, 1);
+      if(ret == 0){
+        if (val != 0x00U) {
+          ctrl10_c.func_en = val;
+        }
+        ret = ism330dlc_write_reg(ctx, ISM330DLC_CTRL10_C,
+                                  (uint8_t*)&ctrl10_c, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable hard-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of iron_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_hard_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  *val = master_config.iron_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Soft iron 3x3 matrix. Value are expressed in sign-module format.
+  *         (Es. SVVVVVVVb where S is the sign 0/+1/- and V is the value).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_soft_iron_mat_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MAG_SI_XX, buff, 9);
+    if(ret == 0){
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft iron 3x3 matrix. Value are expressed in sign-module format.
+  *         (Es. SVVVVVVVb where S is the sign 0/+1/- and V is the value).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_soft_iron_mat_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MAG_SI_XX, buff, 9);
+    if(ret == 0){
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w). The value is
+  *         expressed as a 16-bit word in two’s complement.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MAG_OFFX_L, buff, 6);
+    if(ret == 0){
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register(r/w).
+  *         The value is expressed as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_mag_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_MAG_OFFX_L, buff, 6);
+    if(ret == 0){
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DLC_Sensor_hub
+  * @brief       This section groups all the functions that manage the sensor
+  *              hub functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sensor synchronization time frame with the step of 500 ms and
+  *         full range of 5s. Unsigned 8-bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tph in reg SENSOR_SYNC_TIME_FRAME
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_sync_sens_frame_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_sensor_sync_time_frame_t sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_SENSOR_SYNC_TIME_FRAME,
+                           (uint8_t*)&sensor_sync_time_frame, 1);
+  if(ret == 0){
+     sensor_sync_time_frame.tph = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_SENSOR_SYNC_TIME_FRAME,
+                              (uint8_t*)&sensor_sync_time_frame, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame with the step of 500 ms and
+  *         full range of 5s. Unsigned 8-bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tph in reg  SENSOR_SYNC_TIME_FRAME
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_sync_sens_frame_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_sensor_sync_time_frame_t sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_SENSOR_SYNC_TIME_FRAME,
+                           (uint8_t*)&sensor_sync_time_frame, 1);
+  *val =  sensor_sync_time_frame.tph;
+
+  return ret;
+}
+
+/**
+  * @brief  Resolution ratio of error code for sensor synchronization.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rr in reg  SENSOR_SYNC_RES_RATIO
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_sync_sens_ratio_set(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_rr_t val)
+{
+  ism330dlc_sensor_sync_res_ratio_t sensor_sync_res_ratio;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_SENSOR_SYNC_RES_RATIO,
+                           (uint8_t*)&sensor_sync_res_ratio, 1);
+  if(ret == 0){
+    sensor_sync_res_ratio.rr = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_SENSOR_SYNC_RES_RATIO,
+                              (uint8_t*)&sensor_sync_res_ratio, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resolution ratio of error code for sensor synchronization.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rr in reg  SENSOR_SYNC_RES_RATIO
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_sync_sens_ratio_get(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_rr_t *val)
+{
+  ism330dlc_sensor_sync_res_ratio_t sensor_sync_res_ratio;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_SENSOR_SYNC_RES_RATIO,
+                           (uint8_t*)&sensor_sync_res_ratio, 1);
+
+  switch ( sensor_sync_res_ratio.rr) {
+    case ISM330DLC_RES_RATIO_2_11:
+      *val = ISM330DLC_RES_RATIO_2_11;
+      break;
+    case ISM330DLC_RES_RATIO_2_12:
+      *val = ISM330DLC_RES_RATIO_2_12;
+      break;
+    case ISM330DLC_RES_RATIO_2_13:
+      *val = ISM330DLC_RES_RATIO_2_13;
+      break;
+    case ISM330DLC_RES_RATIO_2_14:
+      *val = ISM330DLC_RES_RATIO_2_14;
+      break;
+    default:
+      *val = ISM330DLC_RES_RATIO_2_11;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_master_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.master_on = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_master_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  *val = master_config.master_on;
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_pass_through_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pass_through_mode = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_pass_through_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  *val = master_config.pass_through_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable/disable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pull_up_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_pin_mode_set(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_pull_up_en_t val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pull_up_en = (uint8_t) val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable/disable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pull_up_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_pin_mode_get(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_pull_up_en_t *val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  switch (master_config.pull_up_en) {
+    case ISM330DLC_EXT_PULL_UP:
+      *val = ISM330DLC_EXT_PULL_UP;
+      break;
+    case ISM330DLC_INTERNAL_PULL_UP:
+      *val = ISM330DLC_INTERNAL_PULL_UP;
+      break;
+    default:
+      *val = ISM330DLC_EXT_PULL_UP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_syncro_mode_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_start_config_t val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.start_config = (uint8_t)val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_syncro_mode_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_start_config_t *val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  switch (master_config.start_config) {
+    case ISM330DLC_XL_GY_DRDY:
+      *val = ISM330DLC_XL_GY_DRDY;
+      break;
+    case ISM330DLC_EXT_ON_INT2_PIN:
+      *val = ISM330DLC_EXT_ON_INT2_PIN;
+      break;
+    default:
+      *val = ISM330DLC_XL_GY_DRDY;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Manage the Master DRDY signal on INT1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_on_int1 in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_drdy_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.drdy_on_int1 = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Manage the Master DRDY signal on INT1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_on_int1 in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_drdy_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  *val = master_config.drdy_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from SENSORHUB1_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_read_data_raw_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_emb_sh_read_t *val)
+{
+  int32_t ret;
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_SENSORHUB1_REG,
+                           (uint8_t*)&(val->sh_byte_1), 12);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SENSORHUB13_REG,
+                             (uint8_t*)&(val->sh_byte_13), 6);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master command code used for stamping for sensor sync.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_cmd_code in
+  *                reg MASTER_CMD_CODE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_cmd_sens_sync_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_master_cmd_code_t master_cmd_code;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CMD_CODE,
+                           (uint8_t*)&master_cmd_code, 1);
+  if(ret == 0){
+    master_cmd_code.master_cmd_code = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_MASTER_CMD_CODE,
+                              (uint8_t*)&master_cmd_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master command code used for stamping for sensor sync.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_cmd_code in
+  *                reg MASTER_CMD_CODE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_cmd_sens_sync_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_master_cmd_code_t master_cmd_code;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_MASTER_CMD_CODE,
+                           (uint8_t*)&master_cmd_code, 1);
+  *val = master_cmd_code.master_cmd_code;
+
+  return ret;
+}
+
+/**
+  * @brief  Error code used for sensor synchronization.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of error_code in
+  *                reg SENS_SYNC_SPI_ERROR_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_spi_sync_error_set(ism330dlc_ctx_t *ctx, uint8_t val)
+{
+  ism330dlc_sens_sync_spi_error_code_t sens_sync_spi_error_code;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_SENS_SYNC_SPI_ERROR_CODE,
+                           (uint8_t*)&sens_sync_spi_error_code, 1);
+  if(ret == 0){
+    sens_sync_spi_error_code.error_code = val;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_SENS_SYNC_SPI_ERROR_CODE,
+                              (uint8_t*)&sens_sync_spi_error_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Error code used for sensor synchronization.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of error_code in
+  *                reg SENS_SYNC_SPI_ERROR_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_spi_sync_error_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+{
+  ism330dlc_sens_sync_spi_error_code_t sens_sync_spi_error_code;
+  int32_t ret;
+
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_SENS_SYNC_SPI_ERROR_CODE,
+                           (uint8_t*)&sens_sync_spi_error_code, 1);
+  *val =  sens_sync_spi_error_code.error_code;
+
+  return ret;
+}
+
+/**
+  * @brief   Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of aux_sens_on in reg SLAVE0_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_num_of_dev_connected_set(ism330dlc_ctx_t *ctx,
+                                            ism330dlc_aux_sens_on_t val)
+{
+  ism330dlc_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE0_CONFIG,
+                             (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      slave0_config.aux_sens_on = (uint8_t) val;
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE0_CONFIG,
+                                (uint8_t*)&slave0_config, 1);
+      if(ret == 0){
+        ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of aux_sens_on in reg SLAVE0_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_num_of_dev_connected_get(ism330dlc_ctx_t *ctx,
+                                              ism330dlc_aux_sens_on_t *val)
+{
+  ism330dlc_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE0_CONFIG, 
+                             (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      switch (slave0_config.aux_sens_on) {
+        case ISM330DLC_SLV_0:
+          *val = ISM330DLC_SLV_0;
+          break;
+        case ISM330DLC_SLV_0_1:
+          *val = ISM330DLC_SLV_0_1;
+          break;
+        case ISM330DLC_SLV_0_1_2:
+          *val = ISM330DLC_SLV_0_1_2;
+          break;
+        case ISM330DLC_SLV_0_1_2_3:
+          *val = ISM330DLC_SLV_0_1_2_3;
+          break;
+        default:
+          *val = ISM330DLC_SLV_0;
+          break;
+      }
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_data;   8 bit data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_cfg_write(ism330dlc_ctx_t *ctx,
+                               ism330dlc_sh_cfg_write_t *val)
+{
+  ism330dlc_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv0_add;
+    slv0_add.rw_0 = 0;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV0_ADD,
+                              (uint8_t*)&slv0_add, 1);
+    if(ret == 0){
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV0_SUBADD,
+                                &(val->slv0_subadd), 1);
+      if(ret == 0){
+        ret = ism330dlc_write_reg(ctx, ISM330DLC_DATAWRITE_SRC_MODE_SUB_SLV0,
+                                  &(val->slv0_data), 1);
+        if(ret == 0){
+          ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slv0_cfg_read(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sh_cfg_read_t *val)
+{
+  ism330dlc_slave0_config_t slave0_config;
+  ism330dlc_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv_add;
+    slv0_add.rw_0 = 1;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV0_ADD,
+                              (uint8_t*)&slv0_add, 1);
+    if(ret == 0){
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV0_SUBADD,
+                              &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE0_CONFIG,
+                               (uint8_t*)&slave0_config, 1);
+        slave0_config.slave0_numop = val->slv_len;
+        if(ret == 0){
+          ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE0_CONFIG,
+                                  (uint8_t*)&slave0_config, 1);
+          if(ret == 0){
+            ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 1 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slv1_cfg_read(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sh_cfg_read_t *val)
+{
+  ism330dlc_slave1_config_t slave1_config;
+  ism330dlc_slv1_add_t slv1_add;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    slv1_add.slave1_add  = val->slv_add;
+    slv1_add.r_1 = 1;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV1_ADD,
+                              (uint8_t*)&slv1_add, 1);
+    if(ret == 0){
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV1_SUBADD,
+                                   &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE1_CONFIG,
+                               (uint8_t*)&slave1_config, 1);
+        slave1_config.slave1_numop = val->slv_len;
+        if(ret == 0){
+          ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE1_CONFIG,
+                                  (uint8_t*)&slave1_config, 1);
+          if(ret == 0){
+            ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 2 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slv2_cfg_read(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sh_cfg_read_t *val)
+{
+  ism330dlc_slv2_add_t slv2_add;
+  ism330dlc_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    slv2_add.slave2_add  = val->slv_add;
+    slv2_add.r_2 = 1;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV2_ADD,
+                              (uint8_t*)&slv2_add, 1);
+    if(ret == 0){
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV2_SUBADD,
+                                &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE2_CONFIG,
+                                 (uint8_t*)&slave2_config, 1);
+        if(ret == 0){
+          slave2_config.slave2_numop = val->slv_len;
+          ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE2_CONFIG,
+                                    (uint8_t*)&slave2_config, 1);
+          if(ret == 0){
+            ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 3 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slv3_cfg_read(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sh_cfg_read_t *val)
+{
+  ism330dlc_slave3_config_t slave3_config;
+  ism330dlc_slv3_add_t slv3_add;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    slv3_add.slave3_add  = val->slv_add;
+    slv3_add.r_3 = 1;
+    ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV3_ADD,
+                              (uint8_t*)&slv3_add, 1);
+    if(ret == 0){
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLV3_SUBADD,
+                                (uint8_t*)&(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE3_CONFIG,
+                                 (uint8_t*)&slave3_config, 1);
+        if(ret == 0){
+          slave3_config.slave3_numop = val->slv_len;
+          ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE3_CONFIG,
+                                    (uint8_t*)&slave3_config, 1);
+          if(ret == 0){
+            ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 0 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave0_rate in reg SLAVE0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slave_0_dec_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_slave0_rate_t val)
+{
+  ism330dlc_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE0_CONFIG,
+                             (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      slave0_config.slave0_rate = (uint8_t) val;
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE0_CONFIG,
+                                (uint8_t*)&slave0_config, 1);
+      if(ret == 0){
+        ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 0 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave0_rate in reg SLAVE0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slave_0_dec_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_slave0_rate_t *val)
+{
+  ism330dlc_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE0_CONFIG, 
+                             (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      switch (slave0_config.slave0_rate) {
+        case ISM330DLC_SL0_NO_DEC:
+          *val = ISM330DLC_SL0_NO_DEC;
+          break;
+        case ISM330DLC_SL0_DEC_2:
+          *val = ISM330DLC_SL0_DEC_2;
+          break;
+        case ISM330DLC_SL0_DEC_4:
+          *val = ISM330DLC_SL0_DEC_4;
+          break;
+        case ISM330DLC_SL0_DEC_8:
+          *val = ISM330DLC_SL0_DEC_8;
+          break;
+        default:
+          *val = ISM330DLC_SL0_NO_DEC;
+          break;
+      }
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.
+  *         This is effective if the Aux_sens_on[1:0] field in
+  *         SLAVE0_CONFIG(04h) is set to a value other than 00.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of write_once in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_write_mode_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_write_once_t val)
+{
+  ism330dlc_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE1_CONFIG,
+                             (uint8_t*)&slave1_config, 1);
+    slave1_config.write_once = (uint8_t) val;
+    if(ret == 0){
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE1_CONFIG,
+                                (uint8_t*)&slave1_config, 1);
+      if(ret == 0){
+        ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.
+  *         This is effective if the Aux_sens_on[1:0] field in
+  *         SLAVE0_CONFIG(04h) is set to a value other than 00.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of write_once in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_write_mode_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_write_once_t *val)
+{
+  ism330dlc_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE1_CONFIG, 
+                             (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      switch (slave1_config.write_once) {
+        case ISM330DLC_EACH_SH_CYCLE:
+          *val = ISM330DLC_EACH_SH_CYCLE;
+          break;
+        case ISM330DLC_ONLY_FIRST_CYCLE:
+          *val = ISM330DLC_ONLY_FIRST_CYCLE;
+          break;
+        default:
+          *val = ISM330DLC_EACH_SH_CYCLE;
+          break;
+      }
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 1 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave1_rate in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slave_1_dec_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_slave1_rate_t val)
+{
+  ism330dlc_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE1_CONFIG, 
+                             (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      slave1_config.slave1_rate = (uint8_t) val;
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE1_CONFIG, 
+                                (uint8_t*)&slave1_config, 1);
+      if(ret == 0){
+          ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 1 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slave_1_dec_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_slave1_rate_t *val)
+{
+  ism330dlc_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE1_CONFIG, 
+                             (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      switch (slave1_config.slave1_rate) {
+        case ISM330DLC_SL1_NO_DEC:
+          *val = ISM330DLC_SL1_NO_DEC;
+          break;
+        case ISM330DLC_SL1_DEC_2:
+          *val = ISM330DLC_SL1_DEC_2;
+          break;
+        case ISM330DLC_SL1_DEC_4:
+          *val = ISM330DLC_SL1_DEC_4;
+          break;
+        case ISM330DLC_SL1_DEC_8:
+          *val = ISM330DLC_SL1_DEC_8;
+          break;
+        default:
+          *val = ISM330DLC_SL1_NO_DEC;
+          break;
+      }
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 2 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave2_rate in reg SLAVE2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slave_2_dec_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_slave2_rate_t val)
+{
+  ism330dlc_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE2_CONFIG, 
+                             (uint8_t*)&slave2_config, 1);
+    if(ret == 0){
+      slave2_config.slave2_rate =(uint8_t) val;
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE2_CONFIG, 
+                                (uint8_t*)&slave2_config, 1);
+      if(ret == 0){
+        ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 2 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave2_rate in reg SLAVE2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slave_2_dec_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_slave2_rate_t *val)
+{
+  ism330dlc_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE2_CONFIG, 
+                             (uint8_t*)&slave2_config, 1);
+    if(ret == 0){
+      switch (slave2_config.slave2_rate) {
+        case ISM330DLC_SL2_NO_DEC:
+          *val = ISM330DLC_SL2_NO_DEC;
+          break;
+        case ISM330DLC_SL2_DEC_2:
+          *val = ISM330DLC_SL2_DEC_2;
+          break;
+        case ISM330DLC_SL2_DEC_4:
+          *val = ISM330DLC_SL2_DEC_4;
+          break;
+        case ISM330DLC_SL2_DEC_8:
+          *val = ISM330DLC_SL2_DEC_8;
+          break;
+        default:
+          *val = ISM330DLC_SL2_NO_DEC;
+          break;
+      }
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 3 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave3_rate in reg SLAVE3_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slave_3_dec_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_slave3_rate_t val)
+{
+  ism330dlc_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE3_CONFIG, 
+                             (uint8_t*)&slave3_config, 1);
+    slave3_config.slave3_rate = (uint8_t)val;
+    if(ret == 0){
+      ret = ism330dlc_write_reg(ctx, ISM330DLC_SLAVE3_CONFIG, 
+                                (uint8_t*)&slave3_config, 1);
+      if(ret == 0){
+        ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 3 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave3_rate in reg SLAVE3_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dlc_sh_slave_3_dec_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_slave3_rate_t *val)
+{
+  ism330dlc_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_BANK_A);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_SLAVE3_CONFIG, 
+                             (uint8_t*)&slave3_config, 1);
+    if(ret == 0){
+      switch (slave3_config.slave3_rate) {
+        case ISM330DLC_SL3_NO_DEC:
+          *val = ISM330DLC_SL3_NO_DEC;
+          break;
+        case ISM330DLC_SL3_DEC_2:
+          *val = ISM330DLC_SL3_DEC_2;
+          break;
+        case ISM330DLC_SL3_DEC_4:
+          *val = ISM330DLC_SL3_DEC_4;
+          break;
+        case ISM330DLC_SL3_DEC_8:
+          *val = ISM330DLC_SL3_DEC_8;
+          break;
+        default:
+          *val = ISM330DLC_SL3_NO_DEC;
+          break;
+      }
+      ret = ism330dlc_mem_bank_set(ctx, ISM330DLC_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.h
+++ b/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.h
@@ -1,0 +1,1969 @@
+/*
+ ******************************************************************************
+ * @file    ism330dlc_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          ism330dlc_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef ISM330DLC_DRIVER_H
+#define ISM330DLC_DRIVER_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup ISM330DLC
+  * @{
+  *
+  */
+
+/** @defgroup ISM330DLC_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LSM9DS1_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*ism330dlc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*ism330dlc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  ism330dlc_write_ptr  write_reg;
+  ism330dlc_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} ism330dlc_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup ISM330DLC_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define ISM330DLC_I2C_ADD_L     0xD5U
+#define ISM330DLC_I2C_ADD_H     0xD7U
+
+/** Device Identification (Who am I) **/
+#define ISM330DLC_ID            0x6AU
+
+/**
+  * @}
+  *
+  */
+
+#define ISM330DLC_FUNC_CFG_ACCESS              0x01U
+typedef struct {
+  uint8_t not_used_01              : 7;
+  uint8_t func_cfg_en              : 1;
+} ism330dlc_func_cfg_access_t;
+
+#define ISM330DLC_SENSOR_SYNC_TIME_FRAME       0x04U
+typedef struct {
+  uint8_t tph                      : 4;
+  uint8_t not_used_01              : 4;
+} ism330dlc_sensor_sync_time_frame_t;
+
+#define ISM330DLC_SENSOR_SYNC_RES_RATIO        0x05U
+typedef struct {
+  uint8_t rr                       : 2;
+  uint8_t not_used_01              : 6;
+} ism330dlc_sensor_sync_res_ratio_t;
+
+#define ISM330DLC_FIFO_CTRL1                   0x06U
+typedef struct {
+  uint8_t fth                      : 8;  /* + FIFO_CTRL2(fth) */
+} ism330dlc_fifo_ctrl1_t;
+
+#define ISM330DLC_FIFO_CTRL2                   0x07U
+typedef struct {
+  uint8_t fth                      : 3;  /* + FIFO_CTRL1(fth) */
+  uint8_t fifo_temp_en             : 1;
+  uint8_t not_used_01              : 4;
+  uint8_t fifo_timer_en            : 1;
+} ism330dlc_fifo_ctrl2_t;
+
+#define ISM330DLC_FIFO_CTRL3                   0x08U
+typedef struct {
+  uint8_t dec_fifo_xl              : 3;
+  uint8_t dec_fifo_gyro            : 3;
+  uint8_t not_used_01              : 2;
+} ism330dlc_fifo_ctrl3_t;
+
+#define ISM330DLC_FIFO_CTRL4                   0x09U
+typedef struct {
+  uint8_t dec_ds3_fifo             : 3;
+  uint8_t dec_ds4_fifo             : 3;
+  uint8_t only_high_data           : 1;
+  uint8_t stop_on_fth              : 1;
+} ism330dlc_fifo_ctrl4_t;
+
+#define ISM330DLC_FIFO_CTRL5                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t odr_fifo                 : 4;
+  uint8_t not_used_01              : 1;
+} ism330dlc_fifo_ctrl5_t;
+
+#define ISM330DLC_DRDY_PULSE_CFG               0x0BU
+typedef struct {
+  uint8_t not_used_01              : 7;
+  uint8_t drdy_pulsed              : 1;
+} ism330dlc_drdy_pulse_cfg_t;
+
+#define ISM330DLC_INT1_CTRL                    0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_full_flag           : 1;
+  uint8_t not_used_01              : 2;  
+} ism330dlc_int1_ctrl_t;
+
+#define ISM330DLC_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_full_flag           : 1;
+  uint8_t not_used_01              : 2;
+} ism330dlc_int2_ctrl_t;
+
+#define ISM330DLC_WHO_AM_I                     0x0FU
+#define ISM330DLC_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t bw0_xl                   : 1;
+  uint8_t lpf1_bw_sel              : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} ism330dlc_ctrl1_xl_t;
+
+#define ISM330DLC_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t fs_g                     : 3;  /* fs_g + fs_125 */
+  uint8_t odr_g                    : 4;
+} ism330dlc_ctrl2_g_t;
+
+#define ISM330DLC_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t ble                      : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} ism330dlc_ctrl3_c_t;
+
+#define ISM330DLC_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t den_drdy_int1            : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep                    : 1;
+  uint8_t den_xl_en                : 1;
+} ism330dlc_ctrl4_c_t;
+
+#define ISM330DLC_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t den_lh                   : 1;
+  uint8_t rounding                 : 3;
+} ism330dlc_ctrl5_c_t;
+
+#define ISM330DLC_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t ftype                    : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t usr_off_w                : 1;
+  uint8_t xl_hm_mode               : 1;
+  uint8_t den_mode                 : 3;  /* trig_en + lvl_en + lvl2_en */
+} ism330dlc_ctrl6_c_t;
+
+#define ISM330DLC_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t rounding_status          : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t g_hm_mode                : 1;
+} ism330dlc_ctrl7_g_t;
+
+#define ISM330DLC_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t input_composite          : 1;
+  uint8_t hp_ref_mode              : 1;
+  uint8_t hpcf_xl                  : 2;
+  uint8_t lpf2_xl_en               : 1;
+} ism330dlc_ctrl8_xl_t;
+
+#define ISM330DLC_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t soft_en                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t den_xl_g                 : 1;
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} ism330dlc_ctrl9_xl_t;
+
+#define ISM330DLC_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t func_en                  : 1;
+  uint8_t tilt_en                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t timer_en                 : 1;
+  uint8_t not_used_03              : 2;
+} ism330dlc_ctrl10_c_t;
+
+#define ISM330DLC_MASTER_CONFIG                0x1AU
+typedef struct {
+  uint8_t master_on                : 1;
+  uint8_t iron_en                  : 1;
+  uint8_t pass_through_mode        : 1;
+  uint8_t pull_up_en               : 1;
+  uint8_t start_config             : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t  data_valid_sel_fifo     : 1;
+  uint8_t drdy_on_int1             : 1;
+} ism330dlc_master_config_t;
+
+#define ISM330DLC_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state_ia           : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t not_used_01              : 2;
+} ism330dlc_wake_up_src_t;
+
+#define ISM330DLC_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_01              : 1;
+} ism330dlc_tap_src_t;
+
+#define ISM330DLC_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} ism330dlc_d6d_src_t;
+
+#define ISM330DLC_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} ism330dlc_status_reg_t;
+
+#define ISM330DLC_STATUS_SPIAUX                0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t gyro_settling            : 1;
+  uint8_t not_used_01              : 5;
+} ism330dlc_status_spiaux_t;
+
+#define ISM330DLC_OUT_TEMP_L                   0x20U
+#define ISM330DLC_OUT_TEMP_H                   0x21U
+#define ISM330DLC_OUTX_L_G                     0x22U
+#define ISM330DLC_OUTX_H_G                     0x23U
+#define ISM330DLC_OUTY_L_G                     0x24U
+#define ISM330DLC_OUTY_H_G                     0x25U
+#define ISM330DLC_OUTZ_L_G                     0x26U
+#define ISM330DLC_OUTZ_H_G                     0x27U
+#define ISM330DLC_OUTX_L_XL                    0x28U
+#define ISM330DLC_OUTX_H_XL                    0x29U
+#define ISM330DLC_OUTY_L_XL                    0x2AU
+#define ISM330DLC_OUTY_H_XL                    0x2BU
+#define ISM330DLC_OUTZ_L_XL                    0x2CU
+#define ISM330DLC_OUTZ_H_XL                    0x2DU
+#define ISM330DLC_SENSORHUB1_REG               0x2EU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub1_reg_t;
+
+#define ISM330DLC_SENSORHUB2_REG               0x2FU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub2_reg_t;
+
+#define ISM330DLC_SENSORHUB3_REG               0x30U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub3_reg_t;
+
+#define ISM330DLC_SENSORHUB4_REG               0x31U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub4_reg_t;
+
+#define ISM330DLC_SENSORHUB5_REG               0x32U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub5_reg_t;
+
+#define ISM330DLC_SENSORHUB6_REG               0x33U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub6_reg_t;
+
+#define ISM330DLC_SENSORHUB7_REG               0x34U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub7_reg_t;
+
+#define ISM330DLC_SENSORHUB8_REG               0x35U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub8_reg_t;
+
+#define ISM330DLC_SENSORHUB9_REG               0x36U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub9_reg_t;
+
+#define ISM330DLC_SENSORHUB10_REG              0x37U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub10_reg_t;
+
+#define ISM330DLC_SENSORHUB11_REG              0x38U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub11_reg_t;
+
+#define ISM330DLC_SENSORHUB12_REG              0x39U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub12_reg_t;
+
+#define ISM330DLC_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;  /* + FIFO_STATUS2(diff_fifo) */
+} ism330dlc_fifo_status1_t;
+
+#define ISM330DLC_FIFO_STATUS2                 0x3BU
+typedef struct {
+  uint8_t diff_fifo                : 3;  /* + FIFO_STATUS1(diff_fifo) */
+  uint8_t not_used_01              : 1;
+  uint8_t fifo_empty               : 1;
+  uint8_t fifo_full_smart          : 1;
+  uint8_t over_run                 : 1;
+  uint8_t waterm                   : 1;
+} ism330dlc_fifo_status2_t;
+
+#define ISM330DLC_FIFO_STATUS3                 0x3CU
+typedef struct {
+  uint8_t fifo_pattern             : 8;  /* + FIFO_STATUS4(fifo_pattern) */
+} ism330dlc_fifo_status3_t;
+
+#define ISM330DLC_FIFO_STATUS4                 0x3DU
+typedef struct {
+  uint8_t fifo_pattern             : 2;  /* + FIFO_STATUS3(fifo_pattern) */
+  uint8_t not_used_01              : 6;
+} ism330dlc_fifo_status4_t;
+
+#define ISM330DLC_FIFO_DATA_OUT_L              0x3E
+#define ISM330DLC_FIFO_DATA_OUT_H              0x3F
+#define ISM330DLC_TIMESTAMP0_REG               0x40
+#define ISM330DLC_TIMESTAMP1_REG               0x41
+#define ISM330DLC_TIMESTAMP2_REG               0x42
+
+#define ISM330DLC_SENSORHUB13_REG              0x4DU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub13_reg_t;
+
+#define ISM330DLC_SENSORHUB14_REG              0x4EU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub14_reg_t;
+
+#define ISM330DLC_SENSORHUB15_REG              0x4FU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub15_reg_t;
+
+#define ISM330DLC_SENSORHUB16_REG              0x50U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub16_reg_t;
+
+#define ISM330DLC_SENSORHUB17_REG              0x51U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub17_reg_t;
+
+#define ISM330DLC_SENSORHUB18_REG              0x52U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} ism330dlc_sensorhub18_reg_t;
+
+#define ISM330DLC_FUNC_SRC1                    0x53U
+typedef struct {
+  uint8_t sensorhub_end_op         : 1;
+  uint8_t si_end_op                : 1;
+  uint8_t hi_fail                  : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t tilt_ia                  : 1;
+  uint8_t not_used_02              : 2;
+} ism330dlc_func_src1_t;
+
+#define ISM330DLC_FUNC_SRC2                    0x54U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t slave0_nack              : 1;
+  uint8_t slave1_nack              : 1;
+  uint8_t slave2_nack              : 1;
+  uint8_t slave3_nack              : 1;
+  uint8_t not_used_02              : 1;
+} ism330dlc_func_src2_t;
+
+#define ISM330DLC_TAP_CFG                      0x58U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t tap_z_en                 : 1;
+  uint8_t tap_y_en                 : 1;
+  uint8_t tap_x_en                 : 1;
+  uint8_t slope_fds                : 1;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} ism330dlc_tap_cfg_t;
+
+#define ISM330DLC_TAP_THS_6D                   0x59U
+typedef struct {
+  uint8_t tap_ths                  : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} ism330dlc_tap_ths_6d_t;
+
+#define ISM330DLC_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} ism330dlc_int_dur2_t;
+
+#define ISM330DLC_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t not_used_01              : 1;
+  uint8_t single_double_tap        : 1;
+} ism330dlc_wake_up_ths_t;
+
+#define ISM330DLC_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t timer_hr                 : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} ism330dlc_wake_up_dur_t;
+
+#define ISM330DLC_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} ism330dlc_free_fall_t;
+
+#define ISM330DLC_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t int1_timer               : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_inact_state         : 1;
+} ism330dlc_md1_cfg_t;
+
+#define ISM330DLC_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_iron                : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_inact_state         : 1;
+} ism330dlc_md2_cfg_t;
+
+#define ISM330DLC_MASTER_CMD_CODE              0x60U
+typedef struct {
+  uint8_t master_cmd_code          : 8;
+} ism330dlc_master_cmd_code_t;
+
+#define ISM330DLC_SENS_SYNC_SPI_ERROR_CODE     0x61U
+typedef struct {
+  uint8_t error_code               : 8;
+} ism330dlc_sens_sync_spi_error_code_t;
+
+#define ISM330DLC_OUT_MAG_RAW_X_L              0x66U
+#define ISM330DLC_OUT_MAG_RAW_X_H              0x67U
+#define ISM330DLC_OUT_MAG_RAW_Y_L              0x68U
+#define ISM330DLC_OUT_MAG_RAW_Y_H              0x69U
+#define ISM330DLC_OUT_MAG_RAW_Z_L              0x6AU
+#define ISM330DLC_OUT_MAG_RAW_Z_H              0x6BU
+#define ISM330DLC_INT_OIS                      0x6FU
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t lvl2_ois                 : 1;
+  uint8_t int2_drdy_ois            : 1;
+} ism330dlc_int_ois_t;
+
+#define ISM330DLC_CTRL1_OIS                    0x70U
+typedef struct {
+  uint8_t ois_en_spi2              : 1;
+  uint8_t fs_g_ois                 : 3;  /* fs_g_ois + fs_125_ois */
+  uint8_t mode4_en                 : 1;
+  uint8_t sim_ois                  : 1;
+  uint8_t lvl1_ois                 : 1;
+  uint8_t ble_ois                  : 1;
+} ism330dlc_ctrl1_ois_t;
+
+#define ISM330DLC_CTRL2_OIS                    0x71U
+typedef struct {
+  uint8_t hp_en_ois                : 1;
+  uint8_t ftype_ois                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_ois                  : 2;
+  uint8_t not_used_02              : 2;
+} ism330dlc_ctrl2_ois_t;
+
+#define ISM330DLC_CTRL3_OIS                    0x72U
+typedef struct {
+  uint8_t st_ois_clampdis          : 1;
+  uint8_t st_ois                   : 2;
+  uint8_t filter_xl_conf_ois       : 2;
+  uint8_t fs_xl_ois                : 2;
+  uint8_t den_lh_ois               : 1;
+} ism330dlc_ctrl3_ois_t;
+
+#define ISM330DLC_X_OFS_USR                    0x73U
+#define ISM330DLC_Y_OFS_USR                    0x74U
+#define ISM330DLC_Z_OFS_USR                    0x75U
+#define ISM330DLC_SLV0_ADD                     0x02U
+typedef struct {
+  uint8_t rw_0                     : 1;
+  uint8_t slave0_add               : 7;
+} ism330dlc_slv0_add_t;
+
+#define ISM330DLC_SLV0_SUBADD                  0x03U
+typedef struct {
+  uint8_t slave0_reg               : 8;
+} ism330dlc_slv0_subadd_t;
+
+#define ISM330DLC_SLAVE0_CONFIG                0x04U
+typedef struct {
+  uint8_t slave0_numop             : 3;
+  uint8_t src_mode                 : 1;
+  uint8_t aux_sens_on              : 2;
+  uint8_t slave0_rate              : 2;
+} ism330dlc_slave0_config_t;
+
+#define ISM330DLC_SLV1_ADD                     0x05U
+typedef struct {
+  uint8_t r_1                      : 1;
+  uint8_t slave1_add               : 7;
+} ism330dlc_slv1_add_t;
+
+#define ISM330DLC_SLV1_SUBADD                  0x06U
+typedef struct {
+  uint8_t slave1_reg               : 8;
+} ism330dlc_slv1_subadd_t;
+
+#define ISM330DLC_SLAVE1_CONFIG                0x07U
+typedef struct {
+  uint8_t slave1_numop             : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t write_once               : 1;
+  uint8_t slave1_rate              : 2;
+} ism330dlc_slave1_config_t;
+
+#define ISM330DLC_SLV2_ADD                     0x08U
+typedef struct {
+  uint8_t r_2                      : 1;
+  uint8_t slave2_add               : 7;
+} ism330dlc_slv2_add_t;
+
+#define ISM330DLC_SLV2_SUBADD                  0x09U
+typedef struct {
+  uint8_t slave2_reg               : 8;
+} ism330dlc_slv2_subadd_t;
+
+#define ISM330DLC_SLAVE2_CONFIG                0x0AU
+typedef struct {
+  uint8_t slave2_numop             : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t slave2_rate              : 2;
+} ism330dlc_slave2_config_t;
+
+#define ISM330DLC_SLV3_ADD                     0x0BU
+typedef struct {
+  uint8_t r_3                      : 1;
+  uint8_t slave3_add               : 7;
+} ism330dlc_slv3_add_t;
+
+#define ISM330DLC_SLV3_SUBADD                  0x0CU
+typedef struct {
+  uint8_t slave3_reg               : 8;
+} ism330dlc_slv3_subadd_t;
+
+#define ISM330DLC_SLAVE3_CONFIG                0x0DU
+typedef struct {
+  uint8_t slave3_numop             : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t slave3_rate              : 2;
+} ism330dlc_slave3_config_t;
+
+#define ISM330DLC_DATAWRITE_SRC_MODE_SUB_SLV0  0x0EU
+typedef struct {
+  uint8_t slave_dataw              : 8;
+} ism330dlc_datawrite_src_mode_sub_slv0_t;
+
+#define ISM330DLC_MAG_SI_XX                    0x24U
+#define ISM330DLC_MAG_SI_XY                    0x25U
+#define ISM330DLC_MAG_SI_XZ                    0x26U
+#define ISM330DLC_MAG_SI_YX                    0x27U
+#define ISM330DLC_MAG_SI_YY                    0x28U
+#define ISM330DLC_MAG_SI_YZ                    0x29U
+#define ISM330DLC_MAG_SI_ZX                    0x2AU
+#define ISM330DLC_MAG_SI_ZY                    0x2BU
+#define ISM330DLC_MAG_SI_ZZ                    0x2CU
+#define ISM330DLC_MAG_OFFX_L                   0x2DU
+#define ISM330DLC_MAG_OFFX_H                   0x2EU
+#define ISM330DLC_MAG_OFFY_L                   0x2FU
+#define ISM330DLC_MAG_OFFY_H                   0x30U
+#define ISM330DLC_MAG_OFFZ_L                   0x31U
+#define ISM330DLC_MAG_OFFZ_H                   0x32U
+
+/**
+  * @defgroup ISM330DLC_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  ism330dlc_func_cfg_access_t                  func_cfg_access;
+  ism330dlc_sensor_sync_time_frame_t           sensor_sync_time_frame;
+  ism330dlc_sensor_sync_res_ratio_t            sensor_sync_res_ratio;
+  ism330dlc_fifo_ctrl1_t                       fifo_ctrl1;
+  ism330dlc_fifo_ctrl2_t                       fifo_ctrl2;
+  ism330dlc_fifo_ctrl3_t                       fifo_ctrl3;
+  ism330dlc_fifo_ctrl4_t                       fifo_ctrl4;
+  ism330dlc_fifo_ctrl5_t                       fifo_ctrl5;
+  ism330dlc_drdy_pulse_cfg_t                   drdy_pulse_cfg;
+  ism330dlc_int1_ctrl_t                        int1_ctrl;
+  ism330dlc_int2_ctrl_t                        int2_ctrl;
+  ism330dlc_ctrl1_xl_t                         ctrl1_xl;
+  ism330dlc_ctrl2_g_t                          ctrl2_g;
+  ism330dlc_ctrl3_c_t                          ctrl3_c;
+  ism330dlc_ctrl4_c_t                          ctrl4_c;
+  ism330dlc_ctrl5_c_t                          ctrl5_c;
+  ism330dlc_ctrl6_c_t                          ctrl6_c;
+  ism330dlc_ctrl7_g_t                          ctrl7_g;
+  ism330dlc_ctrl8_xl_t                         ctrl8_xl;
+  ism330dlc_ctrl9_xl_t                         ctrl9_xl;
+  ism330dlc_ctrl10_c_t                         ctrl10_c;
+  ism330dlc_master_config_t                    master_config;
+  ism330dlc_wake_up_src_t                      wake_up_src;
+  ism330dlc_tap_src_t                          tap_src;
+  ism330dlc_d6d_src_t                          d6d_src;
+  ism330dlc_status_reg_t                       status_reg;
+  ism330dlc_status_spiaux_t                    status_spiaux;
+  ism330dlc_sensorhub1_reg_t                   sensorhub1_reg;
+  ism330dlc_sensorhub2_reg_t                   sensorhub2_reg;
+  ism330dlc_sensorhub3_reg_t                   sensorhub3_reg;
+  ism330dlc_sensorhub4_reg_t                   sensorhub4_reg;
+  ism330dlc_sensorhub5_reg_t                   sensorhub5_reg;
+  ism330dlc_sensorhub6_reg_t                   sensorhub6_reg;
+  ism330dlc_sensorhub7_reg_t                   sensorhub7_reg;
+  ism330dlc_sensorhub8_reg_t                   sensorhub8_reg;
+  ism330dlc_sensorhub9_reg_t                   sensorhub9_reg;
+  ism330dlc_sensorhub10_reg_t                  sensorhub10_reg;
+  ism330dlc_sensorhub11_reg_t                  sensorhub11_reg;
+  ism330dlc_sensorhub12_reg_t                  sensorhub12_reg;
+  ism330dlc_fifo_status1_t                     fifo_status1;
+  ism330dlc_fifo_status2_t                     fifo_status2;
+  ism330dlc_fifo_status3_t                     fifo_status3;
+  ism330dlc_fifo_status4_t                     fifo_status4;
+  ism330dlc_sensorhub13_reg_t                  sensorhub13_reg;
+  ism330dlc_sensorhub14_reg_t                  sensorhub14_reg;
+  ism330dlc_sensorhub15_reg_t                  sensorhub15_reg;
+  ism330dlc_sensorhub16_reg_t                  sensorhub16_reg;
+  ism330dlc_sensorhub17_reg_t                  sensorhub17_reg;
+  ism330dlc_sensorhub18_reg_t                  sensorhub18_reg;
+  ism330dlc_func_src1_t                        func_src1;
+  ism330dlc_func_src2_t                        func_src2;
+  ism330dlc_tap_cfg_t                          tap_cfg;
+  ism330dlc_tap_ths_6d_t                       tap_ths_6d;
+  ism330dlc_int_dur2_t                         int_dur2;
+  ism330dlc_wake_up_ths_t                      wake_up_ths;
+  ism330dlc_wake_up_dur_t                      wake_up_dur;
+  ism330dlc_free_fall_t                        free_fall;
+  ism330dlc_md1_cfg_t                          md1_cfg;
+  ism330dlc_md2_cfg_t                          md2_cfg;
+  ism330dlc_master_cmd_code_t                  master_cmd_code;
+  ism330dlc_sens_sync_spi_error_code_t         sens_sync_spi_error_code;
+  ism330dlc_int_ois_t                          int_ois;
+  ism330dlc_ctrl1_ois_t                        ctrl1_ois;
+  ism330dlc_ctrl2_ois_t                        ctrl2_ois;
+  ism330dlc_ctrl3_ois_t                        ctrl3_ois;
+  ism330dlc_slv0_add_t                         slv0_add;
+  ism330dlc_slv0_subadd_t                      slv0_subadd;
+  ism330dlc_slave0_config_t                    slave0_config;
+  ism330dlc_slv1_add_t                         slv1_add;
+  ism330dlc_slv1_subadd_t                      slv1_subadd;
+  ism330dlc_slave1_config_t                    slave1_config;
+  ism330dlc_slv2_add_t                         slv2_add;
+  ism330dlc_slv2_subadd_t                      slv2_subadd;
+  ism330dlc_slave2_config_t                    slave2_config;
+  ism330dlc_slv3_add_t                         slv3_add;
+  ism330dlc_slv3_subadd_t                      slv3_subadd;
+  ism330dlc_slave3_config_t                    slave3_config;
+  ism330dlc_datawrite_src_mode_sub_slv0_t      datawrite_src_mode_sub_slv0;
+  bitwise_t                                    bitwise;
+  uint8_t                                      byte;
+} ism330dlc_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t ism330dlc_read_reg(ism330dlc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t ism330dlc_write_reg(ism330dlc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t ism330dlc_from_fs2g_to_mg(int16_t lsb);
+extern float_t ism330dlc_from_fs4g_to_mg(int16_t lsb);
+extern float_t ism330dlc_from_fs8g_to_mg(int16_t lsb);
+extern float_t ism330dlc_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t ism330dlc_from_fs125dps_to_mdps(int16_t lsb);
+extern float_t ism330dlc_from_fs250dps_to_mdps(int16_t lsb);
+extern float_t ism330dlc_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t ism330dlc_from_fs1000dps_to_mdps(int16_t lsb);
+extern float_t ism330dlc_from_fs2000dps_to_mdps(int16_t lsb);
+
+extern float_t ism330dlc_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  ISM330DLC_2g       = 0,
+  ISM330DLC_16g      = 1,
+  ISM330DLC_4g       = 2,
+  ISM330DLC_8g       = 3,
+  ISM330DLC_XL_FS_ND = 4,  /* ERROR CODE */
+} ism330dlc_fs_xl_t;
+int32_t ism330dlc_xl_full_scale_set(ism330dlc_ctx_t *ctx, ism330dlc_fs_xl_t val);
+int32_t ism330dlc_xl_full_scale_get(ism330dlc_ctx_t *ctx, ism330dlc_fs_xl_t *val);
+
+typedef enum {
+  ISM330DLC_XL_ODR_OFF      =  0,
+  ISM330DLC_XL_ODR_12Hz5    =  1,
+  ISM330DLC_XL_ODR_26Hz     =  2,
+  ISM330DLC_XL_ODR_52Hz     =  3,
+  ISM330DLC_XL_ODR_104Hz    =  4,
+  ISM330DLC_XL_ODR_208Hz    =  5,
+  ISM330DLC_XL_ODR_416Hz    =  6,
+  ISM330DLC_XL_ODR_833Hz    =  7,
+  ISM330DLC_XL_ODR_1k66Hz   =  8,
+  ISM330DLC_XL_ODR_3k33Hz   =  9,
+  ISM330DLC_XL_ODR_6k66Hz   = 10,
+  ISM330DLC_XL_ODR_1Hz6     = 11,
+} ism330dlc_odr_xl_t;
+int32_t ism330dlc_xl_data_rate_set(ism330dlc_ctx_t *ctx, ism330dlc_odr_xl_t val);
+int32_t ism330dlc_xl_data_rate_get(ism330dlc_ctx_t *ctx, ism330dlc_odr_xl_t *val);
+
+typedef enum {
+  ISM330DLC_250dps   = 0,
+  ISM330DLC_125dps   = 1,
+  ISM330DLC_500dps   = 2,
+  ISM330DLC_1000dps  = 4,
+  ISM330DLC_2000dps  = 6,
+} ism330dlc_fs_g_t;
+int32_t ism330dlc_gy_full_scale_set(ism330dlc_ctx_t *ctx, ism330dlc_fs_g_t val);
+int32_t ism330dlc_gy_full_scale_get(ism330dlc_ctx_t *ctx, ism330dlc_fs_g_t *val);
+
+typedef enum {
+  ISM330DLC_GY_ODR_OFF    =  0,
+  ISM330DLC_GY_ODR_12Hz5  =  1,
+  ISM330DLC_GY_ODR_26Hz   =  2,
+  ISM330DLC_GY_ODR_52Hz   =  3,
+  ISM330DLC_GY_ODR_104Hz  =  4,
+  ISM330DLC_GY_ODR_208Hz  =  5,
+  ISM330DLC_GY_ODR_416Hz  =  6,
+  ISM330DLC_GY_ODR_833Hz  =  7,
+  ISM330DLC_GY_ODR_1k66Hz =  8,
+  ISM330DLC_GY_ODR_3k33Hz =  9,
+  ISM330DLC_GY_ODR_6k66Hz = 10,
+} ism330dlc_odr_g_t;
+int32_t ism330dlc_gy_data_rate_set(ism330dlc_ctx_t *ctx, ism330dlc_odr_g_t val);
+int32_t ism330dlc_gy_data_rate_get(ism330dlc_ctx_t *ctx, ism330dlc_odr_g_t *val);
+
+int32_t ism330dlc_block_data_update_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_block_data_update_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_LSb_1mg  = 0,
+  ISM330DLC_LSb_16mg = 1,
+} ism330dlc_usr_off_w_t;
+int32_t ism330dlc_xl_offset_weight_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_usr_off_w_t val);
+int32_t ism330dlc_xl_offset_weight_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_usr_off_w_t *val);
+
+typedef enum {
+  ISM330DLC_XL_HIGH_PERFORMANCE  = 0,
+  ISM330DLC_XL_NORMAL            = 1,
+} ism330dlc_xl_hm_mode_t;
+int32_t ism330dlc_xl_power_mode_set(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_xl_hm_mode_t val);
+int32_t ism330dlc_xl_power_mode_get(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_xl_hm_mode_t *val);
+
+typedef enum {
+  ISM330DLC_STAT_RND_DISABLE  = 0,
+  ISM330DLC_STAT_RND_ENABLE   = 1,
+} ism330dlc_rounding_status_t;
+int32_t ism330dlc_rounding_on_status_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_rounding_status_t val);
+int32_t ism330dlc_rounding_on_status_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_rounding_status_t *val);
+
+typedef enum {
+  ISM330DLC_GY_HIGH_PERFORMANCE  = 0,
+  ISM330DLC_GY_NORMAL            = 1,
+} ism330dlc_g_hm_mode_t;
+int32_t ism330dlc_gy_power_mode_set(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_g_hm_mode_t val);
+int32_t ism330dlc_gy_power_mode_get(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_g_hm_mode_t *val);
+
+typedef struct {
+  ism330dlc_wake_up_src_t        wake_up_src;
+  ism330dlc_tap_src_t            tap_src;
+  ism330dlc_d6d_src_t            d6d_src;
+  ism330dlc_status_reg_t         status_reg;
+  ism330dlc_func_src1_t          func_src1;
+  ism330dlc_func_src2_t          func_src2;
+} ism330dlc_all_sources_t;
+int32_t ism330dlc_all_sources_get(ism330dlc_ctx_t *ctx,
+                                ism330dlc_all_sources_t *val);
+
+int32_t ism330dlc_status_reg_get(ism330dlc_ctx_t *ctx, ism330dlc_status_reg_t *val);
+
+int32_t ism330dlc_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_temp_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_xl_usr_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_xl_usr_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_timestamp_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_timestamp_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_LSB_6ms4 = 0,
+  ISM330DLC_LSB_25us = 1,
+} ism330dlc_timer_hr_t;
+int32_t ism330dlc_timestamp_res_set(ism330dlc_ctx_t *ctx, ism330dlc_timer_hr_t val);
+int32_t ism330dlc_timestamp_res_get(ism330dlc_ctx_t *ctx, ism330dlc_timer_hr_t *val);
+
+typedef enum {
+  ISM330DLC_ROUND_DISABLE            = 0,
+  ISM330DLC_ROUND_XL                 = 1,
+  ISM330DLC_ROUND_GY                 = 2,
+  ISM330DLC_ROUND_GY_XL              = 3,
+  ISM330DLC_ROUND_SH1_TO_SH6         = 4,
+  ISM330DLC_ROUND_XL_SH1_TO_SH6      = 5,
+  ISM330DLC_ROUND_GY_XL_SH1_TO_SH12  = 6,
+  ISM330DLC_ROUND_GY_XL_SH1_TO_SH6   = 7,
+} ism330dlc_rounding_t;
+int32_t ism330dlc_rounding_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_rounding_t val);
+int32_t ism330dlc_rounding_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_rounding_t *val);
+
+int32_t ism330dlc_temperature_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dlc_angular_rate_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dlc_acceleration_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dlc_mag_calibrated_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dlc_fifo_raw_data_get(ism330dlc_ctx_t *ctx, uint8_t *buffer,
+                                  uint8_t len);
+
+typedef enum {
+  ISM330DLC_USER_BANK   = 0,
+  ISM330DLC_BANK_A      = 1,
+} ism330dlc_func_cfg_en_t;
+int32_t ism330dlc_mem_bank_set(ism330dlc_ctx_t *ctx, ism330dlc_func_cfg_en_t val);
+int32_t ism330dlc_mem_bank_get(ism330dlc_ctx_t *ctx, ism330dlc_func_cfg_en_t *val);
+
+typedef enum {
+  ISM330DLC_DRDY_LATCHED    = 0,
+  ISM330DLC_DRDY_PULSED     = 1,
+} ism330dlc_drdy_pulsed_t;
+int32_t ism330dlc_data_ready_mode_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_drdy_pulsed_t val);
+int32_t ism330dlc_data_ready_mode_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_drdy_pulsed_t *val);
+
+int32_t ism330dlc_device_id_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_reset_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_reset_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_LSB_AT_LOW_ADD  = 0,
+  ISM330DLC_MSB_AT_LOW_ADD  = 1,
+} ism330dlc_ble_t;
+int32_t ism330dlc_data_format_set(ism330dlc_ctx_t *ctx, ism330dlc_ble_t val);
+int32_t ism330dlc_data_format_get(ism330dlc_ctx_t *ctx, ism330dlc_ble_t *val);
+
+int32_t ism330dlc_auto_increment_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_auto_increment_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_boot_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_boot_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_XL_ST_DISABLE    = 0,
+  ISM330DLC_XL_ST_POSITIVE   = 1,
+  ISM330DLC_XL_ST_NEGATIVE   = 2,
+} ism330dlc_st_xl_t;
+int32_t ism330dlc_xl_self_test_set(ism330dlc_ctx_t *ctx, ism330dlc_st_xl_t val);
+int32_t ism330dlc_xl_self_test_get(ism330dlc_ctx_t *ctx, ism330dlc_st_xl_t *val);
+
+typedef enum {
+  ISM330DLC_GY_ST_DISABLE    = 0,
+  ISM330DLC_GY_ST_POSITIVE   = 1,
+  ISM330DLC_GY_ST_NEGATIVE   = 3,
+} ism330dlc_st_g_t;
+int32_t ism330dlc_gy_self_test_set(ism330dlc_ctx_t *ctx, ism330dlc_st_g_t val);
+int32_t ism330dlc_gy_self_test_get(ism330dlc_ctx_t *ctx, ism330dlc_st_g_t *val);
+
+int32_t ism330dlc_filter_settling_mask_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_filter_settling_mask_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_USE_SLOPE = 0,
+  ISM330DLC_USE_HPF   = 1,
+} ism330dlc_slope_fds_t;
+int32_t ism330dlc_xl_hp_path_internal_set(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_slope_fds_t val);
+int32_t ism330dlc_xl_hp_path_internal_get(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_slope_fds_t *val);
+
+typedef enum {
+  ISM330DLC_XL_ANA_BW_1k5Hz = 0,
+  ISM330DLC_XL_ANA_BW_400Hz = 1,
+} ism330dlc_bw0_xl_t;
+int32_t ism330dlc_xl_filter_analog_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_bw0_xl_t val);
+int32_t ism330dlc_xl_filter_analog_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_bw0_xl_t *val);
+
+typedef enum {
+  ISM330DLC_XL_LP1_ODR_DIV_2 = 0,
+  ISM330DLC_XL_LP1_ODR_DIV_4 = 1,
+  ISM330DLC_XL_LP1_NA        = 2,
+} ism330dlc_lpf1_bw_sel_t;
+int32_t ism330dlc_xl_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_lpf1_bw_sel_t val);
+int32_t ism330dlc_xl_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_lpf1_bw_sel_t *val);
+
+typedef enum {
+  ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_50     = 0x00,
+  ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_100    = 0x01,
+  ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_9      = 0x02,
+  ISM330DLC_XL_LOW_LAT_LP_ODR_DIV_400    = 0x03,
+  ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_50   = 0x10,
+  ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_100  = 0x11,
+  ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_9    = 0x12,
+  ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_400  = 0x13,
+  ISM330DLC_XL_LP_NA                     = 0x14
+} ism330dlc_input_composite_t;
+int32_t ism330dlc_xl_lp2_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_input_composite_t val);
+int32_t ism330dlc_xl_lp2_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_input_composite_t *val);
+
+int32_t ism330dlc_xl_reference_mode_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_xl_reference_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_XL_HP_ODR_DIV_4      = 0x00, /* Slope filter */
+  ISM330DLC_XL_HP_ODR_DIV_100    = 0x01,
+  ISM330DLC_XL_HP_ODR_DIV_9      = 0x02,
+  ISM330DLC_XL_HP_ODR_DIV_400    = 0x03,
+  ISM330DLC_XL_HP_NA             = 0x04,
+} ism330dlc_hpcf_xl_t;
+int32_t ism330dlc_xl_hp_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_hpcf_xl_t val);
+int32_t ism330dlc_xl_hp_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_hpcf_xl_t *val);
+
+typedef enum {
+  ISM330DLC_XL_UI_LP1_ODR_DIV_2 = 0,
+  ISM330DLC_XL_UI_LP1_ODR_DIV_4 = 1,
+  ISM330DLC_XL_UI_LP1_NA        = 2,  /* ERROR CODE */
+} ism330dlc_ui_lpf1_bw_sel_t;
+int32_t ism330dlc_xl_ui_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_ui_lpf1_bw_sel_t val);
+int32_t ism330dlc_xl_ui_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_ui_lpf1_bw_sel_t *val);
+
+int32_t ism330dlc_xl_ui_slope_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_xl_ui_slope_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_AUX_LP_LIGHT          = 2,
+  ISM330DLC_AUX_LP_NORMAL         = 3,
+  ISM330DLC_AUX_LP_STRONG         = 0,
+  ISM330DLC_AUX_LP_AGGRESSIVE     = 1,
+} ism330dlc_filter_xl_conf_ois_t;
+int32_t ism330dlc_xl_aux_lp_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_filter_xl_conf_ois_t val);
+int32_t ism330dlc_xl_aux_lp_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                        ism330dlc_filter_xl_conf_ois_t *val);
+
+typedef enum {
+  ISM330DLC_LP2_ONLY                    = 0x00,
+
+  ISM330DLC_HP_16mHz_LP2                = 0x80,
+  ISM330DLC_HP_65mHz_LP2                = 0x90,
+  ISM330DLC_HP_260mHz_LP2               = 0xA0,
+  ISM330DLC_HP_1Hz04_LP2                = 0xB0,
+
+  ISM330DLC_HP_DISABLE_LP1_LIGHT        = 0x0A,
+  ISM330DLC_HP_DISABLE_LP1_NORMAL       = 0x09,
+  ISM330DLC_HP_DISABLE_LP_STRONG        = 0x08,
+  ISM330DLC_HP_DISABLE_LP1_AGGRESSIVE   = 0x0B,
+
+  ISM330DLC_HP_16mHz_LP1_LIGHT          = 0x8A,
+  ISM330DLC_HP_65mHz_LP1_NORMAL         = 0x99,
+  ISM330DLC_HP_260mHz_LP1_STRONG        = 0xA8,
+  ISM330DLC_HP_1Hz04_LP1_AGGRESSIVE     = 0xBB,
+} ism330dlc_lpf1_sel_g_t;
+int32_t ism330dlc_gy_band_pass_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_lpf1_sel_g_t val);
+int32_t ism330dlc_gy_band_pass_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_lpf1_sel_g_t *val);
+
+int32_t ism330dlc_gy_ui_high_pass_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_gy_ui_high_pass_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_HP_DISABLE_LP_173Hz        = 0x02,
+  ISM330DLC_HP_DISABLE_LP_237Hz        = 0x01,
+  ISM330DLC_HP_DISABLE_LP_351Hz        = 0x00,
+  ISM330DLC_HP_DISABLE_LP_937Hz        = 0x03,
+
+  ISM330DLC_HP_16mHz_LP_173Hz          = 0x82,
+  ISM330DLC_HP_65mHz_LP_237Hz          = 0x91,
+  ISM330DLC_HP_260mHz_LP_351Hz         = 0xA0,
+  ISM330DLC_HP_1Hz04_LP_937Hz          = 0xB3,
+} ism330dlc_hp_en_ois_t;
+int32_t ism330dlc_gy_aux_bandwidth_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_hp_en_ois_t val);
+int32_t ism330dlc_gy_aux_bandwidth_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_hp_en_ois_t *val);
+
+int32_t ism330dlc_aux_status_reg_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_status_spiaux_t *val);
+
+int32_t ism330dlc_aux_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t ism330dlc_aux_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t ism330dlc_aux_gy_flag_settling_get(ism330dlc_ctx_t *ctx,
+                                           uint8_t *val);
+
+typedef enum {
+  ISM330DLC_AUX_DEN_DISABLE         = 0,
+  ISM330DLC_AUX_DEN_LEVEL_LATCH     = 3,
+  ISM330DLC_AUX_DEN_LEVEL_TRIG      = 2,
+} ism330dlc_lvl_ois_t;
+int32_t ism330dlc_aux_den_mode_set(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_lvl_ois_t val);
+int32_t ism330dlc_aux_den_mode_get(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_lvl_ois_t *val);
+
+int32_t ism330dlc_aux_drdy_on_int2_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_aux_drdy_on_int2_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_AUX_DISABLE   = 0,
+  ISM330DLC_MODE_3_GY     = 1,
+  ISM330DLC_MODE_4_GY_XL  = 3,
+} ism330dlc_ois_en_spi2_t;
+int32_t ism330dlc_aux_mode_set(ism330dlc_ctx_t *ctx,
+                               ism330dlc_ois_en_spi2_t val);
+int32_t ism330dlc_aux_mode_get(ism330dlc_ctx_t *ctx,
+                               ism330dlc_ois_en_spi2_t *val);
+
+typedef enum {
+  ISM330DLC_250dps_AUX   = 0,
+  ISM330DLC_125dps_AUX   = 1,
+  ISM330DLC_500dps_AUX   = 2,
+  ISM330DLC_1000dps_AUX  = 4,
+  ISM330DLC_2000dps_AUX  = 6,
+} ism330dlc_fs_g_ois_t;
+int32_t ism330dlc_aux_gy_full_scale_set(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_fs_g_ois_t val);
+int32_t ism330dlc_aux_gy_full_scale_get(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_fs_g_ois_t *val);
+
+typedef enum {
+  ISM330DLC_AUX_SPI_4_WIRE = 0,
+  ISM330DLC_AUX_SPI_3_WIRE = 1,
+} ism330dlc_sim_ois_t;
+int32_t ism330dlc_aux_spi_mode_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sim_ois_t val);
+int32_t ism330dlc_aux_spi_mode_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_sim_ois_t *val);
+
+typedef enum {
+  ISM330DLC_AUX_LSB_AT_LOW_ADD = 0,
+  ISM330DLC_AUX_MSB_AT_LOW_ADD = 1,
+} ism330dlc_ble_ois_t;
+int32_t ism330dlc_aux_data_format_set(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_ble_ois_t val);
+int32_t ism330dlc_aux_data_format_get(ism330dlc_ctx_t *ctx,
+                                    ism330dlc_ble_ois_t *val);
+
+typedef enum {
+  ISM330DLC_ENABLE_CLAMP    = 0,
+  ISM330DLC_DISABLE_CLAMP   = 1,
+} ism330dlc_st_ois_clampdis_t;
+int32_t ism330dlc_aux_gy_clamp_set(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_st_ois_clampdis_t val);
+int32_t ism330dlc_aux_gy_clamp_get(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_st_ois_clampdis_t *val);
+
+typedef enum {
+  ISM330DLC_AUX_GY_DISABLE  = 0,
+  ISM330DLC_AUX_GY_POS      = 1,
+  ISM330DLC_AUX_GY_NEG      = 3,
+} ism330dlc_st_ois_t;
+int32_t ism330dlc_aux_gy_self_test_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_st_ois_t val);
+int32_t ism330dlc_aux_gy_self_test_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_st_ois_t *val);
+
+typedef enum {
+  ISM330DLC_AUX_2g   = 0,
+  ISM330DLC_AUX_16g  = 1,
+  ISM330DLC_AUX_4g   = 2,
+  ISM330DLC_AUX_8g   = 3,
+} ism330dlc_fs_xl_ois_t;
+int32_t ism330dlc_aux_xl_full_scale_set(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_fs_xl_ois_t val);
+int32_t ism330dlc_aux_xl_full_scale_get(ism330dlc_ctx_t *ctx,
+                                      ism330dlc_fs_xl_ois_t *val);
+
+typedef enum {
+  ISM330DLC_AUX_DEN_ACTIVE_LOW   = 0,
+  ISM330DLC_AUX_DEN_ACTIVE_HIGH  = 1,
+} ism330dlc_den_lh_ois_t;
+int32_t ism330dlc_aux_den_polarity_set(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_den_lh_ois_t val);
+int32_t ism330dlc_aux_den_polarity_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_den_lh_ois_t *val);
+
+typedef enum {
+  ISM330DLC_SPI_4_WIRE  = 0,
+  ISM330DLC_SPI_3_WIRE  = 1,
+} ism330dlc_sim_t;
+int32_t ism330dlc_spi_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_sim_t val);
+int32_t ism330dlc_spi_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_sim_t *val);
+
+typedef enum {
+  ISM330DLC_I2C_ENABLE   = 0,
+  ISM330DLC_I2C_DISABLE  = 1,
+} ism330dlc_i2c_disable_t;
+int32_t ism330dlc_i2c_interface_set(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_i2c_disable_t val);
+int32_t ism330dlc_i2c_interface_get(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_i2c_disable_t *val);
+
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_full_flag           : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_inact_state         : 1;
+  uint8_t den_drdy_int1            : 1;
+  uint8_t drdy_on_int1             : 1;
+} ism330dlc_int1_route_t;
+int32_t ism330dlc_pin_int1_route_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_int1_route_t val);
+int32_t ism330dlc_pin_int1_route_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_int1_route_t *val);
+
+typedef struct{
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_full_flag           : 1;
+  uint8_t int2_iron                : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_inact_state         : 1;
+} ism330dlc_int2_route_t;
+int32_t ism330dlc_pin_int2_route_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_int2_route_t val);
+int32_t ism330dlc_pin_int2_route_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_int2_route_t *val);
+
+typedef enum {
+  ISM330DLC_PUSH_PULL   = 0,
+  ISM330DLC_OPEN_DRAIN  = 1,
+} ism330dlc_pp_od_t;
+int32_t ism330dlc_pin_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t val);
+int32_t ism330dlc_pin_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t *val);
+
+typedef enum {
+  ISM330DLC_ACTIVE_HIGH   = 0,
+  ISM330DLC_ACTIVE_LOW    = 1,
+} ism330dlc_h_lactive_t;
+int32_t ism330dlc_pin_polarity_set(ism330dlc_ctx_t *ctx, ism330dlc_h_lactive_t val);
+int32_t ism330dlc_pin_polarity_get(ism330dlc_ctx_t *ctx, ism330dlc_h_lactive_t *val);
+
+int32_t ism330dlc_all_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_all_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_INT_PULSED   = 0,
+  ISM330DLC_INT_LATCHED  = 1,
+} ism330dlc_lir_t;
+int32_t ism330dlc_int_notification_set(ism330dlc_ctx_t *ctx, ism330dlc_lir_t val);
+int32_t ism330dlc_int_notification_get(ism330dlc_ctx_t *ctx, ism330dlc_lir_t *val);
+
+int32_t ism330dlc_wkup_threshold_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_wkup_threshold_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_wkup_dur_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_wkup_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_gy_sleep_mode_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_gy_sleep_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_PROPERTY_DISABLE          = 0,
+  ISM330DLC_XL_12Hz5_GY_NOT_AFFECTED  = 1,
+  ISM330DLC_XL_12Hz5_GY_SLEEP         = 2,
+  ISM330DLC_XL_12Hz5_GY_PD            = 3,
+} ism330dlc_inact_en_t;
+int32_t ism330dlc_act_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_inact_en_t val);
+int32_t ism330dlc_act_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_inact_en_t *val);
+
+int32_t ism330dlc_act_sleep_dur_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_act_sleep_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tap_src_get(ism330dlc_ctx_t *ctx, ism330dlc_tap_src_t *val);
+
+int32_t ism330dlc_tap_detection_on_z_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_detection_on_z_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tap_detection_on_y_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_detection_on_y_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tap_detection_on_x_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_detection_on_x_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tap_threshold_x_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_threshold_x_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tap_shock_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_shock_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tap_quiet_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_quiet_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tap_dur_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_ONLY_SINGLE          = 0,
+  ISM330DLC_BOTH_SINGLE_DOUBLE   = 1,
+} ism330dlc_single_double_tap_t;
+int32_t ism330dlc_tap_mode_set(ism330dlc_ctx_t *ctx,
+                             ism330dlc_single_double_tap_t val);
+int32_t ism330dlc_tap_mode_get(ism330dlc_ctx_t *ctx,
+                             ism330dlc_single_double_tap_t *val);
+
+typedef enum {
+  ISM330DLC_ODR_DIV_2_FEED      = 0,
+  ISM330DLC_LPF2_FEED           = 1,
+} ism330dlc_low_pass_on_6d_t;
+int32_t ism330dlc_6d_feed_data_set(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_low_pass_on_6d_t val);
+int32_t ism330dlc_6d_feed_data_get(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_low_pass_on_6d_t *val);
+
+typedef enum {
+  ISM330DLC_DEG_80      = 0,
+  ISM330DLC_DEG_70      = 1,
+  ISM330DLC_DEG_60      = 2,
+  ISM330DLC_DEG_50      = 3,
+} ism330dlc_sixd_ths_t;
+int32_t ism330dlc_6d_threshold_set(ism330dlc_ctx_t *ctx, ism330dlc_sixd_ths_t val);
+int32_t ism330dlc_6d_threshold_get(ism330dlc_ctx_t *ctx, ism330dlc_sixd_ths_t *val);
+
+int32_t ism330dlc_4d_mode_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_4d_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_ff_dur_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_ff_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_FF_TSH_156mg = 0,
+  ISM330DLC_FF_TSH_219mg = 1,
+  ISM330DLC_FF_TSH_250mg = 2,
+  ISM330DLC_FF_TSH_312mg = 3,
+  ISM330DLC_FF_TSH_344mg = 4,
+  ISM330DLC_FF_TSH_406mg = 5,
+  ISM330DLC_FF_TSH_469mg = 6,
+  ISM330DLC_FF_TSH_500mg = 7,
+} ism330dlc_ff_ths_t;
+int32_t ism330dlc_ff_threshold_set(ism330dlc_ctx_t *ctx, ism330dlc_ff_ths_t val);
+int32_t ism330dlc_ff_threshold_get(ism330dlc_ctx_t *ctx, ism330dlc_ff_ths_t *val);
+
+int32_t ism330dlc_fifo_watermark_set(ism330dlc_ctx_t *ctx, uint16_t val);
+int32_t ism330dlc_fifo_watermark_get(ism330dlc_ctx_t *ctx, uint16_t *val);
+
+int32_t ism330dlc_fifo_data_level_get(ism330dlc_ctx_t *ctx, uint16_t *val);
+
+int32_t ism330dlc_fifo_wtm_flag_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_fifo_pattern_get(ism330dlc_ctx_t *ctx, uint16_t *val);
+
+int32_t ism330dlc_fifo_temp_batch_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_fifo_temp_batch_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_TRG_XL_GY_DRDY     = 0,
+  ISM330DLC_TRG_SH_DRDY        = 1,
+} ism330dlc_trigger_fifo_t;
+int32_t ism330dlc_fifo_write_trigger_set(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_trigger_fifo_t val);
+int32_t ism330dlc_fifo_write_trigger_get(ism330dlc_ctx_t *ctx,
+                                       ism330dlc_trigger_fifo_t *val);
+
+typedef enum {
+  ISM330DLC_FIFO_XL_DISABLE  = 0,
+  ISM330DLC_FIFO_XL_NO_DEC   = 1,
+  ISM330DLC_FIFO_XL_DEC_2    = 2,
+  ISM330DLC_FIFO_XL_DEC_3    = 3,
+  ISM330DLC_FIFO_XL_DEC_4    = 4,
+  ISM330DLC_FIFO_XL_DEC_8    = 5,
+  ISM330DLC_FIFO_XL_DEC_16   = 6,
+  ISM330DLC_FIFO_XL_DEC_32   = 7,
+} ism330dlc_dec_fifo_xl_t;
+int32_t ism330dlc_fifo_xl_batch_set(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_dec_fifo_xl_t val);
+int32_t ism330dlc_fifo_xl_batch_get(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_dec_fifo_xl_t *val);
+
+typedef enum {
+  ISM330DLC_FIFO_GY_DISABLE = 0,
+  ISM330DLC_FIFO_GY_NO_DEC  = 1,
+  ISM330DLC_FIFO_GY_DEC_2   = 2,
+  ISM330DLC_FIFO_GY_DEC_3   = 3,
+  ISM330DLC_FIFO_GY_DEC_4   = 4,
+  ISM330DLC_FIFO_GY_DEC_8   = 5,
+  ISM330DLC_FIFO_GY_DEC_16  = 6,
+  ISM330DLC_FIFO_GY_DEC_32  = 7,
+} ism330dlc_dec_fifo_gyro_t;
+int32_t ism330dlc_fifo_gy_batch_set(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_dec_fifo_gyro_t val);
+int32_t ism330dlc_fifo_gy_batch_get(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_dec_fifo_gyro_t *val);
+
+typedef enum {
+  ISM330DLC_FIFO_DS3_DISABLE   = 0,
+  ISM330DLC_FIFO_DS3_NO_DEC    = 1,
+  ISM330DLC_FIFO_DS3_DEC_2     = 2,
+  ISM330DLC_FIFO_DS3_DEC_3     = 3,
+  ISM330DLC_FIFO_DS3_DEC_4     = 4,
+  ISM330DLC_FIFO_DS3_DEC_8     = 5,
+  ISM330DLC_FIFO_DS3_DEC_16    = 6,
+  ISM330DLC_FIFO_DS3_DEC_32    = 7,
+} ism330dlc_dec_ds3_fifo_t;
+int32_t ism330dlc_fifo_dataset_3_batch_set(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_dec_ds3_fifo_t val);
+int32_t ism330dlc_fifo_dataset_3_batch_get(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_dec_ds3_fifo_t *val);
+
+typedef enum {
+  ISM330DLC_FIFO_DS4_DISABLE  = 0,
+  ISM330DLC_FIFO_DS4_NO_DEC   = 1,
+  ISM330DLC_FIFO_DS4_DEC_2    = 2,
+  ISM330DLC_FIFO_DS4_DEC_3    = 3,
+  ISM330DLC_FIFO_DS4_DEC_4    = 4,
+  ISM330DLC_FIFO_DS4_DEC_8    = 5,
+  ISM330DLC_FIFO_DS4_DEC_16   = 6,
+  ISM330DLC_FIFO_DS4_DEC_32   = 7,
+} ism330dlc_dec_ds4_fifo_t;
+int32_t ism330dlc_fifo_dataset_4_batch_set(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_dec_ds4_fifo_t val);
+int32_t ism330dlc_fifo_dataset_4_batch_get(ism330dlc_ctx_t *ctx,
+                                         ism330dlc_dec_ds4_fifo_t *val);
+
+int32_t ism330dlc_fifo_xl_gy_8bit_format_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_fifo_xl_gy_8bit_format_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_fifo_stop_on_wtm_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_fifo_stop_on_wtm_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_BYPASS_MODE           = 0,
+  ISM330DLC_FIFO_MODE             = 1,
+  ISM330DLC_STREAM_TO_FIFO_MODE   = 3,
+  ISM330DLC_BYPASS_TO_STREAM_MODE = 4,
+  ISM330DLC_STREAM_MODE           = 6,
+} ism330dlc_fifo_mode_t;
+int32_t ism330dlc_fifo_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_fifo_mode_t val);
+int32_t ism330dlc_fifo_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_fifo_mode_t *val);
+
+typedef enum {
+  ISM330DLC_FIFO_DISABLE   =  0,
+  ISM330DLC_FIFO_12Hz5     =  1,
+  ISM330DLC_FIFO_26Hz      =  2,
+  ISM330DLC_FIFO_52Hz      =  3,
+  ISM330DLC_FIFO_104Hz     =  4,
+  ISM330DLC_FIFO_208Hz     =  5,
+  ISM330DLC_FIFO_416Hz     =  6,
+  ISM330DLC_FIFO_833Hz     =  7,
+  ISM330DLC_FIFO_1k66Hz    =  8,
+  ISM330DLC_FIFO_3k33Hz    =  9,
+  ISM330DLC_FIFO_6k66Hz    = 10,
+} ism330dlc_odr_fifo_t;
+int32_t ism330dlc_fifo_data_rate_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_odr_fifo_t val);
+int32_t ism330dlc_fifo_data_rate_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_odr_fifo_t *val);
+
+typedef enum {
+  ISM330DLC_DEN_ACT_LOW    = 0,
+  ISM330DLC_DEN_ACT_HIGH   = 1,
+} ism330dlc_den_lh_t;
+int32_t ism330dlc_den_polarity_set(ism330dlc_ctx_t *ctx, ism330dlc_den_lh_t val);
+int32_t ism330dlc_den_polarity_get(ism330dlc_ctx_t *ctx, ism330dlc_den_lh_t *val);
+
+typedef enum {
+  ISM330DLC_DEN_DISABLE    = 0,
+  ISM330DLC_LEVEL_FIFO     = 6,
+  ISM330DLC_LEVEL_LETCHED  = 3,
+  ISM330DLC_LEVEL_TRIGGER  = 2,
+  ISM330DLC_EDGE_TRIGGER   = 4,
+} ism330dlc_den_mode_t;
+int32_t ism330dlc_den_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t val);
+int32_t ism330dlc_den_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t *val);
+
+typedef enum {
+  ISM330DLC_STAMP_IN_GY_DATA     = 0,
+  ISM330DLC_STAMP_IN_XL_DATA     = 1,
+  ISM330DLC_STAMP_IN_GY_XL_DATA  = 2,
+} ism330dlc_den_xl_en_t;
+int32_t ism330dlc_den_enable_set(ism330dlc_ctx_t *ctx, ism330dlc_den_xl_en_t val);
+int32_t ism330dlc_den_enable_get(ism330dlc_ctx_t *ctx, ism330dlc_den_xl_en_t *val);
+
+int32_t ism330dlc_den_mark_axis_z_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_den_mark_axis_z_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_den_mark_axis_y_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_den_mark_axis_y_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_den_mark_axis_x_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_den_mark_axis_x_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tilt_sens_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tilt_sens_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_wrist_tilt_sens_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_wrist_tilt_sens_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_tilt_latency_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_tilt_latency_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dlc_tilt_threshold_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_tilt_threshold_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dlc_mag_soft_iron_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_mag_soft_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_mag_hard_iron_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_mag_hard_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_mag_soft_iron_mat_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_mag_soft_iron_mat_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dlc_mag_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_mag_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dlc_sh_sync_sens_frame_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_sync_sens_frame_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_RES_RATIO_2_11  = 0,
+  ISM330DLC_RES_RATIO_2_12  = 1,
+  ISM330DLC_RES_RATIO_2_13  = 2,
+  ISM330DLC_RES_RATIO_2_14  = 3,
+} ism330dlc_rr_t;
+int32_t ism330dlc_sh_sync_sens_ratio_set(ism330dlc_ctx_t *ctx, ism330dlc_rr_t val);
+int32_t ism330dlc_sh_sync_sens_ratio_get(ism330dlc_ctx_t *ctx, ism330dlc_rr_t *val);
+
+int32_t ism330dlc_sh_master_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_master_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_sh_pass_through_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_pass_through_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_EXT_PULL_UP       = 0,
+  ISM330DLC_INTERNAL_PULL_UP  = 1,
+} ism330dlc_pull_up_en_t;
+int32_t ism330dlc_sh_pin_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_pull_up_en_t val);
+int32_t ism330dlc_sh_pin_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_pull_up_en_t *val);
+
+typedef enum {
+  ISM330DLC_XL_GY_DRDY        = 0,
+  ISM330DLC_EXT_ON_INT2_PIN   = 1,
+} ism330dlc_start_config_t;
+int32_t ism330dlc_sh_syncro_mode_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_start_config_t val);
+int32_t ism330dlc_sh_syncro_mode_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_start_config_t *val);
+
+int32_t ism330dlc_sh_drdy_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_drdy_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+    ism330dlc_sensorhub1_reg_t   sh_byte_1;
+    ism330dlc_sensorhub2_reg_t   sh_byte_2;
+    ism330dlc_sensorhub3_reg_t   sh_byte_3;
+    ism330dlc_sensorhub4_reg_t   sh_byte_4;
+    ism330dlc_sensorhub5_reg_t   sh_byte_5;
+    ism330dlc_sensorhub6_reg_t   sh_byte_6;
+    ism330dlc_sensorhub7_reg_t   sh_byte_7;
+    ism330dlc_sensorhub8_reg_t   sh_byte_8;
+    ism330dlc_sensorhub9_reg_t   sh_byte_9;
+    ism330dlc_sensorhub10_reg_t  sh_byte_10;
+    ism330dlc_sensorhub11_reg_t  sh_byte_11;
+    ism330dlc_sensorhub12_reg_t  sh_byte_12;
+    ism330dlc_sensorhub13_reg_t  sh_byte_13;
+    ism330dlc_sensorhub14_reg_t  sh_byte_14;
+    ism330dlc_sensorhub15_reg_t  sh_byte_15;
+    ism330dlc_sensorhub16_reg_t  sh_byte_16;
+    ism330dlc_sensorhub17_reg_t  sh_byte_17;
+    ism330dlc_sensorhub18_reg_t  sh_byte_18;
+} ism330dlc_emb_sh_read_t;
+int32_t ism330dlc_sh_read_data_raw_get(ism330dlc_ctx_t *ctx,
+                                     ism330dlc_emb_sh_read_t *val);
+
+int32_t ism330dlc_sh_cmd_sens_sync_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_cmd_sens_sync_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dlc_sh_spi_sync_error_set(ism330dlc_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_spi_sync_error_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DLC_NORMAL_MODE_READ  = 0,
+  ISM330DLC_SRC_MODE_READ     = 1,
+} ism330dlc_src_mode_t;
+int32_t ism330dlc_sh_cfg_slave_0_rd_mode_set(ism330dlc_ctx_t *ctx,
+                                           ism330dlc_src_mode_t val);
+int32_t ism330dlc_sh_cfg_slave_0_rd_mode_get(ism330dlc_ctx_t *ctx,
+                                           ism330dlc_src_mode_t *val);
+
+typedef enum {
+  ISM330DLC_SLV_0        = 0,
+  ISM330DLC_SLV_0_1      = 1,
+  ISM330DLC_SLV_0_1_2    = 2,
+  ISM330DLC_SLV_0_1_2_3  = 3,
+} ism330dlc_aux_sens_on_t;
+int32_t ism330dlc_sh_num_of_dev_connected_set(ism330dlc_ctx_t *ctx,
+                                            ism330dlc_aux_sens_on_t val);
+int32_t ism330dlc_sh_num_of_dev_connected_get(ism330dlc_ctx_t *ctx,
+                                            ism330dlc_aux_sens_on_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} ism330dlc_sh_cfg_write_t;
+int32_t ism330dlc_sh_cfg_write(ism330dlc_ctx_t *ctx, ism330dlc_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} ism330dlc_sh_cfg_read_t;
+int32_t ism330dlc_sh_slv0_cfg_read(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_sh_cfg_read_t *val);
+int32_t ism330dlc_sh_slv1_cfg_read(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_sh_cfg_read_t *val);
+int32_t ism330dlc_sh_slv2_cfg_read(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_sh_cfg_read_t *val);
+int32_t ism330dlc_sh_slv3_cfg_read(ism330dlc_ctx_t *ctx,
+                                 ism330dlc_sh_cfg_read_t *val);
+
+typedef enum {
+  ISM330DLC_SL0_NO_DEC   = 0,
+  ISM330DLC_SL0_DEC_2    = 1,
+  ISM330DLC_SL0_DEC_4    = 2,
+  ISM330DLC_SL0_DEC_8    = 3,
+} ism330dlc_slave0_rate_t;
+int32_t ism330dlc_sh_slave_0_dec_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_slave0_rate_t val);
+int32_t ism330dlc_sh_slave_0_dec_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_slave0_rate_t *val);
+
+typedef enum {
+  ISM330DLC_EACH_SH_CYCLE     = 0,
+  ISM330DLC_ONLY_FIRST_CYCLE  = 1,
+} ism330dlc_write_once_t;
+int32_t ism330dlc_sh_write_mode_set(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_write_once_t val);
+int32_t ism330dlc_sh_write_mode_get(ism330dlc_ctx_t *ctx,
+                                  ism330dlc_write_once_t *val);
+
+typedef enum {
+  ISM330DLC_SL1_NO_DEC   = 0,
+  ISM330DLC_SL1_DEC_2    = 1,
+  ISM330DLC_SL1_DEC_4    = 2,
+  ISM330DLC_SL1_DEC_8    = 3,
+} ism330dlc_slave1_rate_t;
+int32_t ism330dlc_sh_slave_1_dec_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_slave1_rate_t val);
+int32_t ism330dlc_sh_slave_1_dec_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_slave1_rate_t *val);
+
+typedef enum {
+  ISM330DLC_SL2_NO_DEC  = 0,
+  ISM330DLC_SL2_DEC_2   = 1,
+  ISM330DLC_SL2_DEC_4   = 2,
+  ISM330DLC_SL2_DEC_8   = 3,
+} ism330dlc_slave2_rate_t;
+int32_t ism330dlc_sh_slave_2_dec_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_slave2_rate_t val);
+int32_t ism330dlc_sh_slave_2_dec_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_slave2_rate_t *val);
+
+typedef enum {
+  ISM330DLC_SL3_NO_DEC  = 0,
+  ISM330DLC_SL3_DEC_2   = 1,
+  ISM330DLC_SL3_DEC_4   = 2,
+  ISM330DLC_SL3_DEC_8   = 3,
+} ism330dlc_slave3_rate_t;
+int32_t ism330dlc_sh_slave_3_dec_set(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_slave3_rate_t val);
+int32_t ism330dlc_sh_slave_3_dec_get(ism330dlc_ctx_t *ctx,
+                                   ism330dlc_slave3_rate_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ISM330DLC_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/l20g20is_STdC/driver/l20g20is_reg.c
+++ b/sensor/stmemsc/l20g20is_STdC/driver/l20g20is_reg.c
@@ -1,0 +1,1193 @@
+/*
+ ******************************************************************************
+ * @file    l20g20is_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   L20G20IS driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "l20g20is_reg.h"
+
+/**
+  * @defgroup    L20G20IS
+  * @brief       This file provides a set of functions needed to drive the
+  *              l20g20is enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t l20g20is_read_reg(l20g20is_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t l20g20is_write_reg(l20g20is_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Sensitivity
+  * @brief      These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t l20g20is_from_fs100dps_to_mdps(int16_t lsb)
+{
+  return (((float_t)lsb *1000.0f)/262.0f);
+}
+
+float_t l20g20is_from_fs200dps_to_mdps(int16_t lsb)
+{
+  return (((float_t)lsb *1000.0f)/131.0f);
+}
+
+float_t l20g20is_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb *0.0625f)+25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Data_generation
+  * @brief       This section groups all the functions concerning data
+  *              generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "xyda_ois" in reg DATA_STATUS_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_flag_data_ready_get(l20g20is_ctx_t *ctx, uint8_t *val)
+{
+  l20g20is_data_status_ois_t data_status_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_DATA_STATUS_OIS,
+                          (uint8_t*)&data_status_ois, 1);
+  *val = data_status_ois.xyda_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "pw" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_data_rate_set(l20g20is_ctx_t *ctx,
+                                  l20g20is_gy_data_rate_t val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.pw = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pw in reg CTRL1_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_data_rate_get(l20g20is_ctx_t *ctx,
+                                  l20g20is_gy_data_rate_t *val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  switch (ctrl1_ois.pw){
+    case L20G20IS_GY_OFF:
+      *val = L20G20IS_GY_OFF;
+      break;
+    case L20G20IS_GY_SLEEP:
+      *val = L20G20IS_GY_SLEEP;
+      break;
+    case L20G20IS_GY_9k33Hz:
+      *val = L20G20IS_GY_9k33Hz;
+      break;
+    default:
+      *val = L20G20IS_GY_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Directional user orientation selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    "orient" Swap X axis with Y axis.
+  *                "signy"  Y-axis angular rate sign selection.
+  *                "signx"  X-axis angular rate sign selection.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_orient_set(l20g20is_ctx_t *ctx,
+                               l20g20is_gy_orient_t val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0) {
+    ctrl1_ois.orient  = val.orient;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  }
+  if(ret == 0) {
+    ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  }
+  if(ret == 0) {
+    ctrl2_ois.signx  = val.signx;
+    ctrl2_ois.signy  = val.signy;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Directional user orientation selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    "orient" Swap X axis with Y axis.
+  *                "signy"  Y-axis angular rate sign selection.
+  *                "signx"  X-axis angular rate sign selection.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_orient_get(l20g20is_ctx_t *ctx,
+                                         l20g20is_gy_orient_t *val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0) {
+    ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+    val->orient = ctrl1_ois.orient;
+    val->signy = ctrl2_ois.signy;
+    val->signy = ctrl2_ois.signy;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odu in reg CTRL1_OIS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_block_data_update_set(l20g20is_ctx_t *ctx, uint8_t val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.odu = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odu in reg CTRL1_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_block_data_update_get(l20g20is_ctx_t *ctx, uint8_t *val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  *val = (uint8_t)ctrl1_ois.odu;
+
+  return ret;
+}
+
+/**
+  * @brief  User offset correction.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    "offx" offset on X axis.
+                   "offy" offset on Y axis.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_angular_rate_offset_set(l20g20is_ctx_t *ctx,
+                                         l20g20is_off_t val)
+{
+  l20g20is_off_x_t off_x;
+  l20g20is_off_y_t off_y;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_OFF_X, (uint8_t*)&off_x, 1);
+  if(ret == 0) {
+    off_x.offx  = val.offx;
+    ret = l20g20is_write_reg(ctx, L20G20IS_OFF_X, (uint8_t*)&off_x, 1);
+  }
+  if(ret == 0) {
+    ret = l20g20is_read_reg(ctx, L20G20IS_OFF_Y, (uint8_t*)&off_y, 1);
+  }
+  if(ret == 0) {
+    off_y.offy  = val.offy;
+    ret = l20g20is_write_reg(ctx, L20G20IS_OFF_Y, (uint8_t*)&off_y, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  User offset correction.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    "offx" offset on X axis.
+                   "offy" offset on Y axis.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_angular_rate_offset_get(l20g20is_ctx_t *ctx,
+                                          l20g20is_off_t *val)
+{
+  l20g20is_off_x_t off_x;
+  l20g20is_off_y_t off_y;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_OFF_X, (uint8_t*)&off_x, 1);
+  if(ret == 0) {
+    ret = l20g20is_read_reg(ctx, L20G20IS_OFF_Y, (uint8_t*)&off_y, 1);
+    val->offx = off_x.offx;
+    val->offy = off_y.offy;
+  }
+
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fs_sel" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_full_scale_set(l20g20is_ctx_t *ctx,
+                                   l20g20is_gy_fs_t val)
+{
+  l20g20is_ois_cfg_reg_t ois_cfg_reg;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_OIS_CFG_REG,
+                          (uint8_t*)&ois_cfg_reg, 1);
+  if(ret == 0){
+    ois_cfg_reg.fs_sel = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_OIS_CFG_REG,
+                             (uint8_t*)&ois_cfg_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_sel in reg OIS_CFG_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_full_scale_get(l20g20is_ctx_t *ctx,
+                                   l20g20is_gy_fs_t *val)
+{
+  l20g20is_ois_cfg_reg_t ois_cfg_reg;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_OIS_CFG_REG,
+                          (uint8_t*)&ois_cfg_reg, 1);
+  switch (ois_cfg_reg.fs_sel){
+    case L20G20IS_100dps:
+      *val = L20G20IS_100dps;
+      break;
+    case L20G20IS_200dps:
+      *val = L20G20IS_200dps;
+      break;
+    default:
+      *val = L20G20IS_100dps;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Dataoutput
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data output register (r). L and H registers together
+  *         express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_temperature_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = l20g20is_read_reg(ctx, L20G20IS_TEMP_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_angular_rate_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = l20g20is_read_reg(ctx, L20G20IS_OUT_X_L, buff, 4);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_dev_id_get(l20g20is_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = l20g20is_read_reg(ctx, L20G20IS_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Device status register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Data available on all axis.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_dev_status_get(l20g20is_ctx_t *ctx,
+                                l20g20is_dev_status_t *val)
+{
+  l20g20is_data_status_ois_t data_status_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_DATA_STATUS_OIS,
+                          (uint8_t*)&data_status_ois, 1);
+  val->xyda_ois = data_status_ois.xyda_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "ble" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_dev_data_format_set(l20g20is_ctx_t *ctx,
+                                     l20g20is_ble_t val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.ble = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ble in reg CTRL1_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_dev_data_format_get(l20g20is_ctx_t *ctx,
+                                     l20g20is_ble_t *val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  switch (ctrl1_ois.ble){
+    case L20G20IS_LSB_LOW_ADDRESS:
+      *val = L20G20IS_LSB_LOW_ADDRESS;
+      break;
+    case L20G20IS_MSB_LOW_ADDRESS:
+      *val = L20G20IS_MSB_LOW_ADDRESS;
+      break;
+    default:
+      *val = L20G20IS_LSB_LOW_ADDRESS;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL1_OIS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_dev_boot_set(l20g20is_ctx_t *ctx, uint8_t val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.boot = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL1_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_dev_boot_get(l20g20is_ctx_t *ctx, uint8_t *val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  *val = (uint8_t)ctrl1_ois.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_rst in reg CTRL2_OIS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_dev_reset_set(l20g20is_ctx_t *ctx, uint8_t val)
+{
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  if(ret == 0){
+    ctrl2_ois.sw_rst = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user
+  *          registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sw_rst in reg CTRL2_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_dev_reset_get(l20g20is_ctx_t *ctx, uint8_t *val)
+{
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  *val = (uint8_t)ctrl2_ois.sw_rst;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Filters
+  * @brief      This section group all the functions concerning the
+  *              filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Gyroscope high-pass filter bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "hpf" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_filter_hp_bandwidth_set(l20g20is_ctx_t *ctx,
+                                            l20g20is_gy_hp_bw_t val)
+{
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  l20g20is_ois_cfg_reg_t ois_cfg_reg;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  if(ret == 0){
+    ctrl2_ois.hpf = ((uint8_t)val & 0x80U) >> 4;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL2_OIS,
+                             (uint8_t*)&ctrl2_ois, 1);
+  }
+  if(ret == 0){
+    ret = l20g20is_read_reg(ctx, L20G20IS_OIS_CFG_REG,
+                            (uint8_t*)&ois_cfg_reg, 1);
+  }
+  if(ret == 0){
+    ois_cfg_reg.hpf_bw = (uint8_t)val & 0x03U;
+    ret = l20g20is_write_reg(ctx, L20G20IS_OIS_CFG_REG,
+                             (uint8_t*)&ois_cfg_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope high-pass filter bandwidth selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpf in reg CTRL2_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_filter_hp_bandwidth_get(l20g20is_ctx_t *ctx,
+                                            l20g20is_gy_hp_bw_t *val)
+{
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  switch (ctrl2_ois.hpf){
+    case L20G20IS_HPF_BYPASS:
+      *val = L20G20IS_HPF_BYPASS;
+      break;
+    case L20G20IS_HPF_BW_23mHz:
+      *val = L20G20IS_HPF_BW_23mHz;
+      break;
+    case L20G20IS_HPF_BW_91mHz:
+      *val = L20G20IS_HPF_BW_91mHz;
+      break;
+    case L20G20IS_HPF_BW_324mHz:
+      *val = L20G20IS_HPF_BW_324mHz;
+      break;
+    case L20G20IS_HPF_BW_1Hz457:
+      *val = L20G20IS_HPF_BW_1Hz457;
+      break;
+    default:
+      *val = L20G20IS_HPF_BYPASS;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope high-pass filter reset.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hp_rst in reg CTRL2_OIS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_filter_hp_reset_set(l20g20is_ctx_t *ctx, uint8_t val)
+{
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  if(ret == 0){
+    ctrl2_ois.hp_rst = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope high-pass filter reset.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_rst in reg CTRL2_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_filter_hp_reset_get(l20g20is_ctx_t *ctx, uint8_t *val)
+{
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  *val = (uint8_t)ctrl2_ois.hp_rst;
+
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope filter low pass cutoff frequency selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "lpf_bw" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_filter_lp_bandwidth_set(l20g20is_ctx_t *ctx,
+                                            l20g20is_gy_lp_bw_t val)
+{
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  l20g20is_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  if(ret == 0){
+    ctrl2_ois.lpf_bw = (uint8_t)val & 0x03U;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  }
+  if(ret == 0){
+    ret = l20g20is_read_reg(ctx, L20G20IS_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  if(ret == 0){
+    ctrl3_ois.lpf_bw = ((uint8_t)val & 0x04U) >> 2;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL3_OIS,
+                               (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope filter low pass cutoff frequency selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lpf_bw in reg CTRL2_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_filter_lp_bandwidth_get(l20g20is_ctx_t *ctx,
+                                            l20g20is_gy_lp_bw_t *val)
+{
+  l20g20is_ctrl2_ois_t ctrl2_ois;
+  l20g20is_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL3_OIS,(uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+    switch ( (ctrl3_ois.lpf_bw << 2) + ctrl2_ois.lpf_bw){
+      case L20G20IS_LPF_BW_1150Hz:
+        *val = L20G20IS_LPF_BW_1150Hz;
+        break;
+      case L20G20IS_LPF_BW_290Hz:
+        *val = L20G20IS_LPF_BW_290Hz;
+        break;
+      case L20G20IS_LPF_BW_210Hz:
+        *val = L20G20IS_LPF_BW_210Hz;
+        break;
+      case L20G20IS_LPF_BW_160Hz:
+        *val = L20G20IS_LPF_BW_160Hz;
+        break;
+      case L20G20IS_LPF_BW_450Hz:
+        *val = L20G20IS_LPF_BW_450Hz;
+        break;
+      default:
+        *val = L20G20IS_LPF_BW_290Hz;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Serial_interface
+  * @brief      This section groups all the functions concerning main
+  *              serial interface management.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "sim" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_spi_mode_set(l20g20is_ctx_t *ctx, l20g20is_sim_t val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.sim = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL1_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_spi_mode_get(l20g20is_ctx_t *ctx, l20g20is_sim_t *val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  switch (ctrl1_ois.sim){
+    case L20G20IS_SPI_4_WIRE:
+      *val = L20G20IS_SPI_4_WIRE;
+      break;
+    case L20G20IS_SPI_3_WIRE:
+      *val = L20G20IS_SPI_3_WIRE;
+      break;
+    default:
+      *val = L20G20IS_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Interrupt_pins
+  * @brief       This section groups all the functions that manage
+  *              interrupt pins.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dr_pulsed" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_pin_notification_set(l20g20is_ctx_t *ctx,
+                                      l20g20is_lir_t val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.dr_pulsed = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dr_pulsed in reg CTRL1_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_pin_notification_get(l20g20is_ctx_t *ctx,
+                                      l20g20is_lir_t *val)
+{
+  l20g20is_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  switch (ctrl1_ois.dr_pulsed){
+    case L20G20IS_INT_LATCHED:
+      *val = L20G20IS_INT_LATCHED;
+      break;
+    case L20G20IS_INT_PULSED:
+      *val = L20G20IS_INT_PULSED;
+      break;
+    default:
+      *val = L20G20IS_INT_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt pin active-high/low.Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "h_l_active" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_pin_polarity_set(l20g20is_ctx_t *ctx,
+                                  l20g20is_pin_pol_t val)
+{
+  l20g20is_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.h_l_active = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL3_OIS,
+                             (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt pin active-high/low.Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_l_active in reg CTRL3_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_pin_polarity_get(l20g20is_ctx_t *ctx,
+                                  l20g20is_pin_pol_t *val)
+{
+  l20g20is_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  switch (ctrl3_ois.h_l_active){
+    case L20G20IS_ACTIVE_HIGH:
+      *val = L20G20IS_ACTIVE_HIGH;
+      break;
+    case L20G20IS_ACTIVE_LOW:
+      *val = L20G20IS_ACTIVE_LOW;
+      break;
+    default:
+      *val = L20G20IS_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "drdy_od" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_pin_mode_set(l20g20is_ctx_t *ctx, l20g20is_pp_od_t val)
+{
+  l20g20is_ctrl4_ois_t ctrl4_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL4_OIS, (uint8_t*)&ctrl4_ois, 1);
+  if(ret == 0){
+    ctrl4_ois.drdy_od = (uint8_t)val;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL4_OIS, (uint8_t*)&ctrl4_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_od in reg CTRL4_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_pin_mode_get(l20g20is_ctx_t *ctx, l20g20is_pp_od_t *val)
+{
+  l20g20is_ctrl4_ois_t ctrl4_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL4_OIS, (uint8_t*)&ctrl4_ois, 1);
+  switch (ctrl4_ois.drdy_od){
+    case L20G20IS_PUSH_PULL:
+      *val = L20G20IS_PUSH_PULL;
+      break;
+    case L20G20IS_OPEN_DRAIN:
+      *val = L20G20IS_OPEN_DRAIN;
+      break;
+    default:
+      *val = L20G20IS_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    "temp_data_on_drdy" Temperature data-ready signal.
+  *                "drdy_en" Angular rate data-ready signal.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_pin_drdy_route_set(l20g20is_ctx_t *ctx,
+                                    l20g20is_pin_drdy_route_t val)
+{
+  l20g20is_ctrl4_ois_t ctrl4_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL4_OIS, (uint8_t*)&ctrl4_ois, 1);
+  if(ret == 0) {
+    ctrl4_ois.drdy_en  = val.drdy_en;
+    ctrl4_ois.temp_data_on_drdy  = val.temp_data_on_drdy;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL4_OIS, (uint8_t*)&ctrl4_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    "temp_data_on_drdy" Temperature data-ready signal.
+  *                "drdy_en" Angular rate data-ready signal.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_pin_drdy_route_get(l20g20is_ctx_t *ctx,
+                                    l20g20is_pin_drdy_route_t *val)
+{
+  l20g20is_ctrl4_ois_t ctrl4_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL4_OIS, (uint8_t*)&ctrl4_ois, 1);
+  val->temp_data_on_drdy = ctrl4_ois.temp_data_on_drdy;
+  val->drdy_en = ctrl4_ois.drdy_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L20G20IS_Self_test
+  * @brief       This section groups all the functions that manage self
+  *              test configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable/disable self-test mode for gyroscope.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "st_en" in reg L20G20IS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_self_test_set(l20g20is_ctx_t *ctx,
+                                  l20g20is_gy_self_test_t val)
+{
+  l20g20is_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.st_en = ((uint8_t)val & 0x02U) >> 1;
+    ctrl3_ois.st_sign = (uint8_t)val & 0x01U;
+    ret = l20g20is_write_reg(ctx, L20G20IS_CTRL3_OIS,
+                             (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable self-test mode for gyroscope.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_en in reg CTRL3_OIS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l20g20is_gy_self_test_get(l20g20is_ctx_t *ctx,
+                                  l20g20is_gy_self_test_t *val)
+{
+  l20g20is_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = l20g20is_read_reg(ctx, L20G20IS_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  switch ((ctrl3_ois.st_en << 1) + ctrl3_ois.st_sign){
+    case L20G20IS_ST_DISABLE:
+      *val = L20G20IS_ST_DISABLE;
+      break;
+    case L20G20IS_ST_POSITIVE:
+      *val = L20G20IS_ST_POSITIVE;
+      break;
+    case L20G20IS_ST_NEGATIVE:
+      *val = L20G20IS_ST_NEGATIVE;
+      break;
+    default:
+      *val = L20G20IS_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/l20g20is_STdC/driver/l20g20is_reg.h
+++ b/sensor/stmemsc/l20g20is_STdC/driver/l20g20is_reg.h
@@ -1,0 +1,438 @@
+/*
+ ******************************************************************************
+ * @file    l20g20is_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          l20g20is_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef L20G20IS_REGS_H
+#define L20G20IS_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup L20G20IS
+  * @{
+  *
+  */
+
+/** @defgroup L20G20IS_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  L20G20IS_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*l20g20is_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*l20g20is_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  l20g20is_write_ptr  write_reg;
+  l20g20is_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} l20g20is_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup L20G20IS_Infos
+  * @{
+  *
+  */
+
+/** Device Identification (Who am I) **/
+#define L20G20IS_ID                     0xDAU
+
+/**
+  * @}
+  *
+  */
+
+#define L20G20IS_WHO_AM_I               0x00U
+#define L20G20IS_TEMP_OUT_L             0x01U
+#define L20G20IS_TEMP_OUT_H             0x02U
+#define L20G20IS_OUT_X_L                0x03U
+#define L20G20IS_OUT_X_H                0x04U
+#define L20G20IS_OUT_Y_L                0x05U
+#define L20G20IS_OUT_Y_H                0x06U
+#define L20G20IS_DATA_STATUS_OIS        0x0AU
+typedef struct {
+  uint8_t not_used_01         : 1;
+  uint8_t yda_ois             : 1;
+  uint8_t xda_ois             : 1;
+  uint8_t xyda_ois            : 1;
+  uint8_t not_used_02         : 1;
+  uint8_t yor_ois             : 1;
+  uint8_t xor_ois             : 1;
+  uint8_t xyor_ois            : 1;
+} l20g20is_data_status_ois_t;
+
+#define L20G20IS_CTRL1_OIS              0x0BU
+typedef struct {
+  uint8_t pw                  : 2;
+  uint8_t orient              : 1;
+  uint8_t odu                 : 1;
+  uint8_t sim                 : 1;
+  uint8_t ble                 : 1;
+  uint8_t dr_pulsed           : 1;
+  uint8_t boot                : 1;
+} l20g20is_ctrl1_ois_t;
+
+#define L20G20IS_CTRL2_OIS              0x0CU
+typedef struct {
+  uint8_t hpf                 : 1;
+  uint8_t sw_rst              : 1;
+  uint8_t hp_rst              : 1;
+  uint8_t not_used_01         : 1;
+  uint8_t lpf_bw              : 2;
+  uint8_t signy               : 1;
+  uint8_t signx               : 1;
+} l20g20is_ctrl2_ois_t;
+
+#define L20G20IS_CTRL3_OIS              0x0DU
+typedef struct {
+  uint8_t lpf_bw              : 1;
+  uint8_t h_l_active          : 1;
+  uint8_t not_used_01         : 1;
+  uint8_t st_en               : 1;
+  uint8_t st_sign             : 1;
+  uint8_t not_used_02         : 3;
+} l20g20is_ctrl3_ois_t;
+
+#define L20G20IS_CTRL4_OIS              0x0EU
+typedef struct {
+  uint8_t not_used_01         : 1;
+  uint8_t drdy_od             : 1;
+  uint8_t temp_data_on_drdy   : 1;
+  uint8_t not_used_02         : 1;
+  uint8_t drdy_en             : 1;
+  uint8_t not_used_03         : 3;
+} l20g20is_ctrl4_ois_t;
+
+#define L20G20IS_OFF_X                  0x0FU
+typedef struct {
+  uint8_t offx                : 7;
+  uint8_t not_used_01         : 1;
+} l20g20is_off_x_t;
+
+#define L20G20IS_OFF_Y                  0x10U
+typedef struct {
+  uint8_t offy                : 7;
+  uint8_t not_used_01         : 1;
+} l20g20is_off_y_t;
+
+#define L20G20IS_OIS_CFG_REG            0x1FU
+typedef struct {
+  uint8_t hpf_bw              : 2;
+  uint8_t not_used_01         : 1;
+  uint8_t fs_sel              : 1;
+  uint8_t not_used_02         : 4;
+} l20g20is_ois_cfg_reg_t;
+
+/**
+  * @defgroup L20G20IS_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  l20g20is_data_status_ois_t            data_status_ois;
+  l20g20is_ctrl1_ois_t                  ctrl1_ois;
+  l20g20is_ctrl2_ois_t                  ctrl2_ois;
+  l20g20is_ctrl3_ois_t                  ctrl3_ois;
+  l20g20is_ctrl4_ois_t                  ctrl4_ois;
+  l20g20is_off_x_t                      off_x;
+  l20g20is_off_y_t                      off_y;
+  l20g20is_ois_cfg_reg_t                ois_cfg_reg;
+  bitwise_t                             bitwise;
+  uint8_t                               byte;
+} l20g20is_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t l20g20is_read_reg(l20g20is_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t l20g20is_write_reg(l20g20is_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t l20g20is_from_fs100dps_to_mdps(int16_t lsb);
+extern float_t l20g20is_from_fs200dps_to_mdps(int16_t lsb);
+
+extern float_t l20g20is_from_lsb_to_celsius(int16_t lsb);
+
+int32_t l20g20is_gy_flag_data_ready_get(l20g20is_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  L20G20IS_GY_OFF    = 0,
+  L20G20IS_GY_SLEEP  = 2,
+  L20G20IS_GY_9k33Hz = 3,
+} l20g20is_gy_data_rate_t;
+int32_t l20g20is_gy_data_rate_set(l20g20is_ctx_t *ctx,
+                                  l20g20is_gy_data_rate_t val);
+int32_t l20g20is_gy_data_rate_get(l20g20is_ctx_t *ctx,
+                                  l20g20is_gy_data_rate_t *val);
+
+typedef struct {
+  uint8_t orient    : 1;
+  uint8_t signy     : 1;
+  uint8_t signx     : 1;
+} l20g20is_gy_orient_t;
+int32_t l20g20is_gy_orient_set(l20g20is_ctx_t *ctx,
+                               l20g20is_gy_orient_t val);
+int32_t l20g20is_gy_orient_get(l20g20is_ctx_t *ctx,
+                               l20g20is_gy_orient_t *val);
+
+int32_t l20g20is_block_data_update_set(l20g20is_ctx_t *ctx, uint8_t val);
+int32_t l20g20is_block_data_update_get(l20g20is_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t offx             : 7;
+  uint8_t offy             : 7;
+} l20g20is_off_t;
+int32_t l20g20is_angular_rate_offset_set(l20g20is_ctx_t *ctx,
+                                         l20g20is_off_t val);
+int32_t l20g20is_angular_rate_offset_get(l20g20is_ctx_t *ctx,
+                                         l20g20is_off_t *val);
+
+typedef enum {
+  L20G20IS_100dps   = 0,
+  L20G20IS_200dps   = 1,
+} l20g20is_gy_fs_t;
+int32_t l20g20is_gy_full_scale_set(l20g20is_ctx_t *ctx,
+                                   l20g20is_gy_fs_t val);
+int32_t l20g20is_gy_full_scale_get(l20g20is_ctx_t *ctx,
+                                   l20g20is_gy_fs_t *val);
+
+int32_t l20g20is_temperature_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff);
+
+int32_t l20g20is_angular_rate_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff);
+
+int32_t l20g20is_dev_id_get(l20g20is_ctx_t *ctx, uint8_t *buff);
+
+typedef struct {
+  uint8_t xyda_ois             : 1;
+} l20g20is_dev_status_t;
+int32_t l20g20is_dev_status_get(l20g20is_ctx_t *ctx,
+                                l20g20is_dev_status_t *val);
+
+typedef enum {
+  L20G20IS_LSB_LOW_ADDRESS = 0,
+  L20G20IS_MSB_LOW_ADDRESS = 1,
+} l20g20is_ble_t;
+int32_t l20g20is_dev_data_format_set(l20g20is_ctx_t *ctx,
+                                     l20g20is_ble_t val);
+int32_t l20g20is_dev_data_format_get(l20g20is_ctx_t *ctx,
+                                     l20g20is_ble_t *val);
+
+int32_t l20g20is_dev_boot_set(l20g20is_ctx_t *ctx, uint8_t val);
+int32_t l20g20is_dev_boot_get(l20g20is_ctx_t *ctx, uint8_t *val);
+
+int32_t l20g20is_dev_reset_set(l20g20is_ctx_t *ctx, uint8_t val);
+int32_t l20g20is_dev_reset_get(l20g20is_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  L20G20IS_HPF_BYPASS    = 0x00,
+  L20G20IS_HPF_BW_23mHz  = 0x80,
+  L20G20IS_HPF_BW_91mHz  = 0x81,
+  L20G20IS_HPF_BW_324mHz = 0x82,
+  L20G20IS_HPF_BW_1Hz457 = 0x83,
+} l20g20is_gy_hp_bw_t;
+int32_t l20g20is_gy_filter_hp_bandwidth_set(l20g20is_ctx_t *ctx,
+                                            l20g20is_gy_hp_bw_t val);
+int32_t l20g20is_gy_filter_hp_bandwidth_get(l20g20is_ctx_t *ctx,
+                                            l20g20is_gy_hp_bw_t *val);
+
+int32_t l20g20is_gy_filter_hp_reset_set(l20g20is_ctx_t *ctx, uint8_t val);
+int32_t l20g20is_gy_filter_hp_reset_get(l20g20is_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  L20G20IS_LPF_BW_290Hz  = 0x00,
+  L20G20IS_LPF_BW_210Hz  = 0x01,
+  L20G20IS_LPF_BW_160Hz  = 0x02,
+  L20G20IS_LPF_BW_450Hz  = 0x03,
+  L20G20IS_LPF_BW_1150Hz = 0x04,
+} l20g20is_gy_lp_bw_t;
+int32_t l20g20is_gy_filter_lp_bandwidth_set(l20g20is_ctx_t *ctx,
+                                            l20g20is_gy_lp_bw_t val);
+int32_t l20g20is_gy_filter_lp_bandwidth_get(l20g20is_ctx_t *ctx,
+                                            l20g20is_gy_lp_bw_t *val);
+
+typedef enum {
+  L20G20IS_SPI_4_WIRE = 0,
+  L20G20IS_SPI_3_WIRE = 1,
+} l20g20is_sim_t;
+int32_t l20g20is_spi_mode_set(l20g20is_ctx_t *ctx, l20g20is_sim_t val);
+int32_t l20g20is_spi_mode_get(l20g20is_ctx_t *ctx, l20g20is_sim_t *val);
+
+typedef enum {
+  L20G20IS_INT_PULSED = 1,
+  L20G20IS_INT_LATCHED = 0,
+} l20g20is_lir_t;
+int32_t l20g20is_pin_notification_set(l20g20is_ctx_t *ctx,
+                                      l20g20is_lir_t val);
+int32_t l20g20is_pin_notification_get(l20g20is_ctx_t *ctx,
+                                      l20g20is_lir_t *val);
+
+typedef enum {
+  L20G20IS_ACTIVE_HIGH = 0,
+  L20G20IS_ACTIVE_LOW = 1,
+} l20g20is_pin_pol_t;
+int32_t l20g20is_pin_polarity_set(l20g20is_ctx_t *ctx,
+                                  l20g20is_pin_pol_t val);
+int32_t l20g20is_pin_polarity_get(l20g20is_ctx_t *ctx,
+                                  l20g20is_pin_pol_t *val);
+
+typedef enum {
+  L20G20IS_PUSH_PULL = 0,
+  L20G20IS_OPEN_DRAIN = 1,
+} l20g20is_pp_od_t;
+int32_t l20g20is_pin_mode_set(l20g20is_ctx_t *ctx, l20g20is_pp_od_t val);
+int32_t l20g20is_pin_mode_get(l20g20is_ctx_t *ctx, l20g20is_pp_od_t *val);
+
+typedef struct {
+  uint8_t temp_data_on_drdy             : 1;
+  uint8_t drdy_en                       : 1;
+} l20g20is_pin_drdy_route_t;
+int32_t l20g20is_pin_drdy_route_set(l20g20is_ctx_t *ctx,
+                                    l20g20is_pin_drdy_route_t val);
+int32_t l20g20is_pin_drdy_route_get(l20g20is_ctx_t *ctx,
+                                    l20g20is_pin_drdy_route_t *val);
+
+typedef enum {
+  L20G20IS_ST_DISABLE  = 0x00,
+  L20G20IS_ST_POSITIVE = 0x02,
+  L20G20IS_ST_NEGATIVE = 0x03,
+} l20g20is_gy_self_test_t;
+int32_t l20g20is_gy_self_test_set(l20g20is_ctx_t *ctx,
+                                  l20g20is_gy_self_test_t val);
+int32_t l20g20is_gy_self_test_get(l20g20is_ctx_t *ctx,
+                                  l20g20is_gy_self_test_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* L20G20IS_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2de12_STdC/driver/lis2de12_reg.c
+++ b/sensor/stmemsc/lis2de12_STdC/driver/lis2de12_reg.c
@@ -1,0 +1,2226 @@
+/*
+ ******************************************************************************
+ * @file    lis2de12_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS2DE12 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis2de12_reg.h"
+
+/**
+  * @defgroup  LIS2DE12
+  * @brief     This file provides a set of functions needed to drive the
+  *            lis2de12 enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LIS2DE12_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_read_reg(lis2de12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_write_reg(lis2de12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    LIS2DE12_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lis2de12_from_fs2_to_mg(int16_t lsb)
+{
+  return ( (float_t)lsb / 256.0f ) * 16.0f;
+}
+
+float_t lis2de12_from_fs4_to_mg(int16_t lsb)
+{
+  return ( (float_t)lsb / 256.0f ) * 32.0f;
+}
+
+float_t lis2de12_from_fs8_to_mg(int16_t lsb)
+{
+  return ( (float_t)lsb / 256.0f ) * 64.0f;
+}
+
+float_t lis2de12_from_fs16_to_mg(int16_t lsb)
+{
+  return ( (float_t)lsb / 256.0f ) * 192.0f;
+}
+
+float_t lis2de12_from_lsb_to_celsius(int16_t lsb)
+{
+  return ( ( (float_t)lsb / 256.0f ) * 1.0f ) + 25.0f;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DE12_Data_generation
+  * @brief     This section group all the functions concerning data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_temp_status_reg_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_STATUS_REG_AUX, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tda in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_temp_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_STATUS_REG_AUX,
+                          (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux.tda;
+
+  return ret;
+}
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tor in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_temp_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_STATUS_REG_AUX,
+                          (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux.tor;
+
+  return ret;
+}
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_temperature_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+/**
+  * @brief  Temperature sensor enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of temp_en in reg TEMP_CFG_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_temperature_meas_set(lis2de12_ctx_t *ctx,
+                                      lis2de12_temp_en_t val)
+{
+  lis2de12_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  if (ret == 0) {
+    temp_cfg_reg.temp_en = (uint8_t) val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of temp_en in reg TEMP_CFG_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_temperature_meas_get(lis2de12_ctx_t *ctx,
+                                      lis2de12_temp_en_t *val)
+{
+  lis2de12_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  switch (temp_cfg_reg.temp_en) {
+    case LIS2DE12_TEMP_DISABLE:
+      *val = LIS2DE12_TEMP_DISABLE;
+      break;
+    case LIS2DE12_TEMP_ENABLE:
+      *val = LIS2DE12_TEMP_ENABLE;
+      break;
+    default:
+      *val = LIS2DE12_TEMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_data_rate_set(lis2de12_ctx_t *ctx, lis2de12_odr_t val)
+{
+  lis2de12_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ctrl_reg1.lpen = PROPERTY_ENABLE;
+    ctrl_reg1.odr = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_data_rate_get(lis2de12_ctx_t *ctx, lis2de12_odr_t *val)
+{
+  lis2de12_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.odr) {
+    case LIS2DE12_POWER_DOWN:
+      *val = LIS2DE12_POWER_DOWN;
+      break;
+    case LIS2DE12_ODR_1Hz:
+      *val = LIS2DE12_ODR_1Hz;
+      break;
+    case LIS2DE12_ODR_10Hz:
+      *val = LIS2DE12_ODR_10Hz;
+      break;
+    case LIS2DE12_ODR_25Hz:
+      *val = LIS2DE12_ODR_25Hz;
+      break;
+    case LIS2DE12_ODR_50Hz:
+      *val = LIS2DE12_ODR_50Hz;
+      break;
+    case LIS2DE12_ODR_100Hz:
+      *val = LIS2DE12_ODR_100Hz;
+      break;
+    case LIS2DE12_ODR_200Hz:
+      *val = LIS2DE12_ODR_200Hz;
+      break;
+    case LIS2DE12_ODR_400Hz:
+      *val = LIS2DE12_ODR_400Hz;
+      break;
+    case LIS2DE12_ODR_1kHz620_LP:
+      *val = LIS2DE12_ODR_1kHz620_LP;
+      break;
+    case LIS2DE12_ODR_5kHz376_LP_1kHz344_NM_HP:
+      *val = LIS2DE12_ODR_5kHz376_LP_1kHz344_NM_HP;
+      break;
+    default:
+      *val = LIS2DE12_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_high_pass_on_outputs_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.fds = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_high_pass_on_outputs_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = (uint8_t)ctrl_reg2.fds;
+
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[set]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_high_pass_bandwidth_set(lis2de12_ctx_t *ctx,
+                                         lis2de12_hpcf_t val)
+{
+  lis2de12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[get]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_high_pass_bandwidth_get(lis2de12_ctx_t *ctx,
+                                         lis2de12_hpcf_t *val)
+{
+  lis2de12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpcf) {
+    case LIS2DE12_AGGRESSIVE:
+      *val = LIS2DE12_AGGRESSIVE;
+      break;
+    case LIS2DE12_STRONG:
+      *val = LIS2DE12_STRONG;
+      break;
+    case LIS2DE12_MEDIUM:
+      *val = LIS2DE12_MEDIUM;
+      break;
+    case LIS2DE12_LIGHT:
+      *val = LIS2DE12_LIGHT;
+      break;
+    default:
+      *val = LIS2DE12_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_high_pass_mode_set(lis2de12_ctx_t *ctx, lis2de12_hpm_t val)
+{
+  lis2de12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_high_pass_mode_get(lis2de12_ctx_t *ctx, lis2de12_hpm_t *val)
+{
+  lis2de12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpm) {
+    case LIS2DE12_NORMAL_WITH_RST:
+      *val = LIS2DE12_NORMAL_WITH_RST;
+      break;
+    case LIS2DE12_REFERENCE_MODE:
+      *val = LIS2DE12_REFERENCE_MODE;
+      break;
+    case LIS2DE12_NORMAL:
+      *val = LIS2DE12_NORMAL;
+      break;
+    case LIS2DE12_AUTORST_ON_INT:
+      *val = LIS2DE12_AUTORST_ON_INT;
+      break;
+    default:
+      *val = LIS2DE12_NORMAL_WITH_RST;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_full_scale_set(lis2de12_ctx_t *ctx, lis2de12_fs_t val)
+{
+  lis2de12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_full_scale_get(lis2de12_ctx_t *ctx, lis2de12_fs_t *val)
+{
+  lis2de12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.fs) {
+    case LIS2DE12_2g:
+      *val = LIS2DE12_2g;
+      break;
+    case LIS2DE12_4g:
+      *val = LIS2DE12_4g;
+      break;
+    case LIS2DE12_8g:
+      *val = LIS2DE12_8g;
+      break;
+    case LIS2DE12_16g:
+      *val = LIS2DE12_16g;
+      break;
+    default:
+      *val = LIS2DE12_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_block_data_update_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_block_data_update_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = (uint8_t)ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[set]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_filter_reference_set(lis2de12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2de12_write_reg(ctx, LIS2DE12_REFERENCE, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[get]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_filter_reference_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_REFERENCE, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_xl_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxor in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_xl_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxor;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_acceleration_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_READ_START, buff, 6);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DE12_Common
+  * @brief     This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI .[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_device_id_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_WHO_AM_I, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Self Test.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_self_test_set(lis2de12_ctx_t *ctx, lis2de12_st_t val)
+{
+  lis2de12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Self Test.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_self_test_get(lis2de12_ctx_t *ctx, lis2de12_st_t *val)
+{
+  lis2de12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.st) {
+    case LIS2DE12_ST_DISABLE:
+      *val = LIS2DE12_ST_DISABLE;
+      break;
+    case LIS2DE12_ST_POSITIVE:
+      *val = LIS2DE12_ST_POSITIVE;
+      break;
+    case LIS2DE12_ST_NEGATIVE:
+      *val = LIS2DE12_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS2DE12_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_boot_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.boot = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_boot_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_status_get(lis2de12_ctx_t *ctx, lis2de12_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DE12_Interrupts_generator_1
+  * @brief      This section group all the functions that manage the first
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_gen_conf_set(lis2de12_ctx_t *ctx,
+                                   lis2de12_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_write_reg(ctx, LIS2DE12_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_gen_conf_get(lis2de12_ctx_t *ctx,
+                                   lis2de12_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Registers INT1_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_gen_source_get(lis2de12_ctx_t *ctx,
+                                     lis2de12_int1_src_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[set]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if (ret == 0) {
+    int1_ths.ths = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_INT1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = (uint8_t)int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  if (ret == 0) {
+    int1_duration.d = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  *val = (uint8_t)int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DE12_Interrupts_generator_2
+  * @brief      This section group all the functions that manage the second
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_gen_conf_set(lis2de12_ctx_t *ctx,
+                                   lis2de12_int2_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_write_reg(ctx, LIS2DE12_INT2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_gen_conf_get(lis2de12_ctx_t *ctx,
+                                   lis2de12_int2_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Interrupt generator 2 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_gen_source_get(lis2de12_ctx_t *ctx,
+                                     lis2de12_int2_src_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief   User-defined threshold value for xl interrupt event on
+  *          generator 2.[set]
+  *          LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if (ret == 0) {
+    int2_ths.ths = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_INT2_THS, (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 2.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = (uint8_t)int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized .[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  if (ret == 0) {
+    int2_duration.d = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  *val = (uint8_t)int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DE12_Interrupt_pins
+  * @brief     This section group all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_high_pass_int_conf_set(lis2de12_ctx_t *ctx,
+                                        lis2de12_hp_t val)
+{
+  lis2de12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hp = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_high_pass_int_conf_get(lis2de12_ctx_t *ctx,
+                                        lis2de12_hp_t *val)
+{
+  lis2de12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hp) {
+    case LIS2DE12_DISC_FROM_INT_GENERATOR:
+      *val = LIS2DE12_DISC_FROM_INT_GENERATOR;
+      break;
+    case LIS2DE12_ON_INT1_GEN:
+      *val = LIS2DE12_ON_INT1_GEN;
+      break;
+    case LIS2DE12_ON_INT2_GEN:
+      *val = LIS2DE12_ON_INT2_GEN;
+      break;
+    case LIS2DE12_ON_TAP_GEN:
+      *val = LIS2DE12_ON_TAP_GEN;
+      break;
+    case LIS2DE12_ON_INT1_INT2_GEN:
+      *val = LIS2DE12_ON_INT1_INT2_GEN;
+      break;
+    case LIS2DE12_ON_INT1_TAP_GEN:
+      *val = LIS2DE12_ON_INT1_TAP_GEN;
+      break;
+    case LIS2DE12_ON_INT2_TAP_GEN:
+      *val = LIS2DE12_ON_INT2_TAP_GEN;
+      break;
+    case LIS2DE12_ON_INT1_INT2_TAP_GEN:
+      *val = LIS2DE12_ON_INT1_INT2_TAP_GEN;
+      break;
+    default:
+      *val = LIS2DE12_DISC_FROM_INT_GENERATOR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_pin_int1_config_set(lis2de12_ctx_t *ctx,
+                                     lis2de12_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_pin_int1_config_get(lis2de12_ctx_t *ctx,
+                                     lis2de12_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  int2_pin_detect_4d: [set]  4D enable: 4D detection is enabled
+  *                                    on INT2 pin when 6D bit on
+  *                                    INT2_CFG (34h) is set to 1.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_int2 = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT2 pin when 6D bit on
+  *         INT2_CFG (34h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_int2;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_pin_notification_mode_set(lis2de12_ctx_t *ctx,
+                                                lis2de12_lir_int2_t val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_int2 = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int2_pin_notification_mode_get(lis2de12_ctx_t *ctx,
+                                                lis2de12_lir_int2_t *val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_int2) {
+    case LIS2DE12_INT2_PULSED:
+      *val = LIS2DE12_INT2_PULSED;
+      break;
+    case LIS2DE12_INT2_LATCHED:
+      *val = LIS2DE12_INT2_LATCHED;
+      break;
+    default:
+      *val = LIS2DE12_INT2_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit
+  *                    on INT1_CFG(30h) is set to 1.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_int1 = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit on
+  *         INT1_CFG(30h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_int1;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_pin_notification_mode_set(lis2de12_ctx_t *ctx,
+                                                lis2de12_lir_int1_t val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_int1 = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_int1_pin_notification_mode_get(lis2de12_ctx_t *ctx,
+                                                lis2de12_lir_int1_t *val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_int1) {
+    case LIS2DE12_INT1_PULSED:
+      *val = LIS2DE12_INT1_PULSED;
+      break;
+    case LIS2DE12_INT1_LATCHED:
+      *val = LIS2DE12_INT1_LATCHED;
+      break;
+    default:
+      *val = LIS2DE12_INT1_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_pin_int2_config_set(lis2de12_ctx_t *ctx,
+                                     lis2de12_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_pin_int2_config_get(lis2de12_ctx_t *ctx,
+                                     lis2de12_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DE12_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.fifo_en = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_watermark_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fth = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_watermark_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  *val = (uint8_t)fifo_ctrl_reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_trigger_event_set(lis2de12_ctx_t *ctx,
+                                        lis2de12_tr_t val)
+{
+  lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.tr = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_trigger_event_get(lis2de12_ctx_t *ctx,
+                                        lis2de12_tr_t *val)
+{
+  lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.tr) {
+    case LIS2DE12_INT1_GEN:
+      *val = LIS2DE12_INT1_GEN;
+      break;
+    case LIS2DE12_INT2_GEN:
+      *val = LIS2DE12_INT2_GEN;
+      break;
+    default:
+      *val = LIS2DE12_INT1_GEN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_mode_set(lis2de12_ctx_t *ctx, lis2de12_fm_t val)
+{
+  lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fm = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_mode_get(lis2de12_ctx_t *ctx, lis2de12_fm_t *val)
+{
+  lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.fm) {
+    case LIS2DE12_BYPASS_MODE:
+      *val = LIS2DE12_BYPASS_MODE;
+      break;
+    case LIS2DE12_FIFO_MODE:
+      *val = LIS2DE12_FIFO_MODE;
+      break;
+    case LIS2DE12_DYNAMIC_STREAM_MODE:
+      *val = LIS2DE12_DYNAMIC_STREAM_MODE;
+      break;
+    case LIS2DE12_STREAM_TO_FIFO_MODE:
+      *val = LIS2DE12_STREAM_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LIS2DE12_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_status_get(lis2de12_ctx_t *ctx,
+                                 lis2de12_fifo_src_reg_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_SRC_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fss in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_data_level_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.fss;
+
+  return ret;
+}
+/**
+  * @brief  Empty FIFO status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of empty in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_empty_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.empty;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ovrn_fifo in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_ovr_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.ovrn_fifo;
+
+  return ret;
+}
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_fifo_fth_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.wtm;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DE12_Tap_generator
+  * @brief     This section group all the functions that manage the tap and
+  *            double tap event generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_tap_conf_set(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_write_reg(ctx, LIS2DE12_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_tap_conf_get(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Tap/Double Tap generator source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_tap_source_get(lis2de12_ctx_t *ctx, lis2de12_click_src_t *val)
+{
+  int32_t ret;
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CLICK_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[set]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_tap_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.ths = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[get]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_tap_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  *val = (uint8_t)click_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+  *          for the duration of the latency window.
+  *          If the LIR_Click bit is set, the interrupt is kept high until the
+  *          CLICK_SRC(39h) register is read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_click in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_tap_notification_mode_set(lis2de12_ctx_t *ctx,
+                                           lis2de12_lir_click_t val)
+{
+  lis2de12_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.lir_click = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+  *          for the duration of the latency window.
+  *          If the LIR_Click bit is set, the interrupt is kept high until the
+  *          CLICK_SRC(39h) register is read.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_click in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_tap_notification_mode_get(lis2de12_ctx_t *ctx,
+                                           lis2de12_lir_click_t *val)
+{
+  lis2de12_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  switch (click_ths.lir_click) {
+    case LIS2DE12_TAP_PULSED:
+      *val = LIS2DE12_TAP_PULSED;
+      break;
+    case LIS2DE12_TAP_LATCHED:
+      *val = LIS2DE12_TAP_LATCHED;
+      break;
+    default:
+      *val = LIS2DE12_TAP_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse
+  *         between the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_shock_dur_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  if (ret == 0) {
+    time_limit.tli = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse between
+  *         the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_shock_dur_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  *val = (uint8_t)time_limit.tli;
+
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_quiet_dur_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  if (ret == 0) {
+    time_latency.tla = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_quiet_dur_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  *val = (uint8_t)time_latency.tla;
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the click-detection
+  *         procedure can start, in cases where the device is configured
+  *         for double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_double_tap_timeout_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  if (ret == 0) {
+    time_window.tw = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the
+  *         click-detection procedure can start, in cases where the device
+  *         is configured for double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_double_tap_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  *val = (uint8_t)time_window.tw;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DE12_Activity_inactivity
+  * @brief     This section group all the functions concerning activity
+  *            inactivity functionality
+  * @{
+  *
+  */
+
+/**
+  * @brief    Sleep-to-wake, return-to-sleep activation threshold in
+  *           low-power mode.[set]
+  *           1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_act_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_ACT_THS, (uint8_t*)&act_ths, 1);
+  if (ret == 0) {
+    act_ths.acth = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_ACT_THS, (uint8_t*)&act_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep activation threshold in low-power
+  *         mode.[get]
+  *         1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_act_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_ACT_THS, (uint8_t*)&act_ths, 1);
+  *val = (uint8_t)act_ths.acth;
+
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[set]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_act_timeout_set(lis2de12_ctx_t *ctx, uint8_t val)
+{
+  lis2de12_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  if (ret == 0) {
+    act_dur.actd = val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[get]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_act_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val)
+{
+  lis2de12_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  *val = (uint8_t)act_dur.actd;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DE12_Serial_interface
+  * @brief     This section group all the functions concerning serial
+  *            interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sdo_pu_disc in reg CTRL_REG0
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_pin_sdo_sa0_mode_set(lis2de12_ctx_t *ctx,
+                                      lis2de12_sdo_pu_disc_t val)
+{
+  lis2de12_ctrl_reg0_t ctrl_reg0;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  if (ret == 0) {
+    ctrl_reg0.sdo_pu_disc = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sdo_pu_disc in reg CTRL_REG0
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_pin_sdo_sa0_mode_get(lis2de12_ctx_t *ctx,
+                                      lis2de12_sdo_pu_disc_t *val)
+{
+  lis2de12_ctrl_reg0_t ctrl_reg0;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  switch (ctrl_reg0.sdo_pu_disc) {
+    case LIS2DE12_PULL_UP_DISCONNECT:
+      *val = LIS2DE12_PULL_UP_DISCONNECT;
+      break;
+    case LIS2DE12_PULL_UP_CONNECT:
+      *val = LIS2DE12_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LIS2DE12_PULL_UP_DISCONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_spi_mode_set(lis2de12_ctx_t *ctx, lis2de12_sim_t val)
+{
+  lis2de12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = lis2de12_write_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2de12_spi_mode_get(lis2de12_ctx_t *ctx, lis2de12_sim_t *val)
+{
+  lis2de12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2de12_read_reg(ctx, LIS2DE12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.sim) {
+    case LIS2DE12_SPI_4_WIRE:
+      *val = LIS2DE12_SPI_4_WIRE;
+      break;
+    case LIS2DE12_SPI_3_WIRE:
+      *val = LIS2DE12_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS2DE12_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2de12_STdC/driver/lis2de12_reg.h
+++ b/sensor/stmemsc/lis2de12_STdC/driver/lis2de12_reg.h
@@ -1,0 +1,732 @@
+/*
+ ******************************************************************************
+ * @file    lis2de12_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis2de12_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS2DE12_REGS_H
+#define LIS2DE12_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS2DE12
+  * @{
+  *
+  */
+
+/** @defgroup LIS2DE12_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup LIS3MDL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis2de12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis2de12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis2de12_write_ptr  write_reg;
+  lis2de12_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis2de12_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS2DE12_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define LIS2DE12_I2C_ADD_L   0x31U
+#define LIS2DE12_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define LIS2DE12_ID          0x33U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS2DE12_STATUS_REG_AUX        0x07U
+typedef struct {
+  uint8_t not_used_01       : 2;
+  uint8_t tda               : 1;
+  uint8_t not_used_02       : 3;
+  uint8_t tor               : 1;
+  uint8_t not_used_03       : 1;
+} lis2de12_status_reg_aux_t;
+
+#define LIS2DE12_OUT_TEMP_L            0x0CU
+#define LIS2DE12_OUT_TEMP_H            0x0DU
+#define LIS2DE12_WHO_AM_I              0x0FU
+
+#define LIS2DE12_CTRL_REG0             0x1EU
+typedef struct {
+  uint8_t not_used_01       : 7;
+  uint8_t sdo_pu_disc       : 1;
+} lis2de12_ctrl_reg0_t;
+
+#define LIS2DE12_TEMP_CFG_REG          0x1FU
+typedef struct {
+  uint8_t not_used_01       : 6;
+  uint8_t temp_en           : 2;
+} lis2de12_temp_cfg_reg_t;
+
+#define LIS2DE12_CTRL_REG1             0x20U
+typedef struct {
+  uint8_t xen               : 1;
+  uint8_t yen               : 1;
+  uint8_t zen               : 1;
+  uint8_t lpen              : 1;
+  uint8_t odr               : 4;
+} lis2de12_ctrl_reg1_t;
+
+#define LIS2DE12_CTRL_REG2             0x21U
+typedef struct {
+  uint8_t hp                : 3; /* HPCLICK + HP_IA2 + HP_IA1 -> HP */
+  uint8_t fds               : 1;
+  uint8_t hpcf              : 2;
+  uint8_t hpm               : 2;
+} lis2de12_ctrl_reg2_t;
+
+#define LIS2DE12_CTRL_REG3             0x22U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t i1_overrun        : 1;
+  uint8_t i1_wtm            : 1;
+  uint8_t not_used_02       : 1;
+  uint8_t i1_zyxda          : 1;
+  uint8_t i1_ia2            : 1;
+  uint8_t i1_ia1            : 1;
+  uint8_t i1_click          : 1;
+} lis2de12_ctrl_reg3_t;
+
+#define LIS2DE12_CTRL_REG4             0x23U
+typedef struct {
+  uint8_t sim               : 1;
+  uint8_t st                : 2;
+  uint8_t not_used_01       : 1;
+  uint8_t fs                : 2;
+  uint8_t not_used_02       : 1;
+  uint8_t bdu               : 1;
+} lis2de12_ctrl_reg4_t;
+
+#define LIS2DE12_CTRL_REG5             0x24U
+typedef struct {
+  uint8_t d4d_int2          : 1;
+  uint8_t lir_int2          : 1;
+  uint8_t d4d_int1          : 1;
+  uint8_t lir_int1          : 1;
+  uint8_t not_used_01       : 2;
+  uint8_t fifo_en           : 1;
+  uint8_t boot              : 1;
+} lis2de12_ctrl_reg5_t;
+
+#define LIS2DE12_CTRL_REG6            0x25U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t int_polarity      : 1;
+  uint8_t not_used_02       : 1;
+  uint8_t i2_act            : 1;
+  uint8_t i2_boot           : 1;
+  uint8_t i2_ia2            : 1;
+  uint8_t i2_ia1            : 1;
+  uint8_t i2_click          : 1;
+} lis2de12_ctrl_reg6_t;
+
+#define LIS2DE12_REFERENCE            0x26U
+#define LIS2DE12_STATUS_REG           0x27U
+typedef struct {
+  uint8_t xda               : 1;
+  uint8_t yda               : 1;
+  uint8_t zda               : 1;
+  uint8_t zyxda             : 1;
+  uint8_t _xor              : 1;
+  uint8_t yor               : 1;
+  uint8_t zor               : 1;
+  uint8_t zyxor             : 1;
+} lis2de12_status_reg_t;
+
+#define LIS2DE12_FIFO_READ_START      0x28U
+#define LIS2DE12_OUT_X_H              0x29U
+#define LIS2DE12_OUT_Y_H              0x2BU
+#define LIS2DE12_OUT_Z_H              0x2DU
+#define LIS2DE12_FIFO_CTRL_REG        0x2EU
+typedef struct {
+  uint8_t fth               : 5;
+  uint8_t tr                : 1;
+  uint8_t fm                : 2;
+} lis2de12_fifo_ctrl_reg_t;
+
+#define LIS2DE12_FIFO_SRC_REG         0x2FU
+typedef struct {
+  uint8_t fss               : 5;
+  uint8_t empty             : 1;
+  uint8_t ovrn_fifo         : 1;
+  uint8_t wtm               : 1;
+} lis2de12_fifo_src_reg_t;
+
+#define LIS2DE12_INT1_CFG             0x30U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} lis2de12_int1_cfg_t;
+
+#define LIS2DE12_INT1_SRC             0x31U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis2de12_int1_src_t;
+
+#define LIS2DE12_INT1_THS             0x32U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} lis2de12_int1_ths_t;
+
+#define LIS2DE12_INT1_DURATION        0x33U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} lis2de12_int1_duration_t;
+
+#define LIS2DE12_INT2_CFG             0x34U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} lis2de12_int2_cfg_t;
+
+#define LIS2DE12_INT2_SRC             0x35U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis2de12_int2_src_t;
+
+#define LIS2DE12_INT2_THS             0x36U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} lis2de12_int2_ths_t;
+
+#define LIS2DE12_INT2_DURATION        0x37U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} lis2de12_int2_duration_t;
+
+#define LIS2DE12_CLICK_CFG            0x38U
+typedef struct {
+  uint8_t xs                : 1;
+  uint8_t xd                : 1;
+  uint8_t ys                : 1;
+  uint8_t yd                : 1;
+  uint8_t zs                : 1;
+  uint8_t zd                : 1;
+  uint8_t not_used_01       : 2;
+} lis2de12_click_cfg_t;
+
+#define LIS2DE12_CLICK_SRC            0x39U
+typedef struct {
+  uint8_t x                 : 1;
+  uint8_t y                 : 1;
+  uint8_t z                 : 1;
+  uint8_t sign              : 1;
+  uint8_t sclick            : 1;
+  uint8_t dclick            : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis2de12_click_src_t;
+
+#define LIS2DE12_CLICK_THS            0x3AU
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t lir_click         : 1;
+} lis2de12_click_ths_t;
+
+#define LIS2DE12_TIME_LIMIT           0x3BU
+typedef struct {
+  uint8_t tli               : 7;
+  uint8_t not_used_01       : 1;
+} lis2de12_time_limit_t;
+
+#define LIS2DE12_TIME_LATENCY         0x3CU
+typedef struct {
+  uint8_t tla               : 8;
+} lis2de12_time_latency_t;
+
+#define LIS2DE12_TIME_WINDOW          0x3DU
+typedef struct {
+  uint8_t tw                : 8;
+} lis2de12_time_window_t;
+
+#define LIS2DE12_ACT_THS              0x3EU
+typedef struct {
+  uint8_t acth              : 7;
+  uint8_t not_used_01       : 1;
+} lis2de12_act_ths_t;
+
+#define LIS2DE12_ACT_DUR              0x3FU
+typedef struct {
+  uint8_t actd              : 8;
+} lis2de12_act_dur_t;
+
+/**
+  * @defgroup LIS2DE12_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is usefull but not need by the driver.
+  *
+  *           REMOVING this union you are complient with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis2de12_status_reg_aux_t status_reg_aux;
+  lis2de12_ctrl_reg0_t      ctrl_reg0;
+  lis2de12_temp_cfg_reg_t   temp_cfg_reg;
+  lis2de12_ctrl_reg1_t      ctrl_reg1;
+  lis2de12_ctrl_reg2_t      ctrl_reg2;
+  lis2de12_ctrl_reg3_t      ctrl_reg3;
+  lis2de12_ctrl_reg4_t      ctrl_reg4;
+  lis2de12_ctrl_reg5_t      ctrl_reg5;
+  lis2de12_ctrl_reg6_t      ctrl_reg6;
+  lis2de12_status_reg_t     status_reg;
+  lis2de12_fifo_ctrl_reg_t  fifo_ctrl_reg;
+  lis2de12_fifo_src_reg_t   fifo_src_reg;
+  lis2de12_int1_cfg_t       int1_cfg;
+  lis2de12_int1_src_t       int1_src;
+  lis2de12_int1_ths_t       int1_ths;
+  lis2de12_int1_duration_t  int1_duration;
+  lis2de12_int2_cfg_t       int2_cfg;
+  lis2de12_int2_src_t       int2_src;
+  lis2de12_int2_ths_t       int2_ths;
+  lis2de12_int2_duration_t  int2_duration;
+  lis2de12_click_cfg_t      click_cfg;
+  lis2de12_click_src_t      click_src;
+  lis2de12_click_ths_t      click_ths;
+  lis2de12_time_limit_t     time_limit;
+  lis2de12_time_latency_t   time_latency;
+  lis2de12_time_window_t    time_window;
+  lis2de12_act_ths_t        act_ths;
+  lis2de12_act_dur_t        act_dur;
+  bitwise_t                 bitwise;
+  uint8_t                   byte;
+} lis2de12_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis2de12_read_reg(lis2de12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lis2de12_write_reg(lis2de12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t lis2de12_from_fs2_to_mg(int16_t lsb);
+extern float_t lis2de12_from_fs4_to_mg(int16_t lsb);
+extern float_t lis2de12_from_fs8_to_mg(int16_t lsb);
+extern float_t lis2de12_from_fs16_to_mg(int16_t lsb);
+extern float_t lis2de12_from_lsb_to_celsius(int16_t lsb);
+
+int32_t lis2de12_temp_status_reg_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2de12_temp_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_temp_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_temperature_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2DE12_TEMP_DISABLE  = 0,
+  LIS2DE12_TEMP_ENABLE   = 3,
+} lis2de12_temp_en_t;
+int32_t lis2de12_temperature_meas_set(lis2de12_ctx_t *ctx,
+                                      lis2de12_temp_en_t val);
+int32_t lis2de12_temperature_meas_get(lis2de12_ctx_t *ctx,
+                                      lis2de12_temp_en_t *val);
+
+typedef enum {
+  LIS2DE12_POWER_DOWN                      = 0x00,
+  LIS2DE12_ODR_1Hz                         = 0x01,
+  LIS2DE12_ODR_10Hz                        = 0x02,
+  LIS2DE12_ODR_25Hz                        = 0x03,
+  LIS2DE12_ODR_50Hz                        = 0x04,
+  LIS2DE12_ODR_100Hz                       = 0x05,
+  LIS2DE12_ODR_200Hz                       = 0x06,
+  LIS2DE12_ODR_400Hz                       = 0x07,
+  LIS2DE12_ODR_1kHz620_LP                  = 0x08,
+  LIS2DE12_ODR_5kHz376_LP_1kHz344_NM_HP    = 0x09,
+} lis2de12_odr_t;
+int32_t lis2de12_data_rate_set(lis2de12_ctx_t *ctx, lis2de12_odr_t val);
+int32_t lis2de12_data_rate_get(lis2de12_ctx_t *ctx, lis2de12_odr_t *val);
+
+int32_t lis2de12_high_pass_on_outputs_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_high_pass_on_outputs_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DE12_AGGRESSIVE  = 0,
+  LIS2DE12_STRONG      = 1,
+  LIS2DE12_MEDIUM      = 2,
+  LIS2DE12_LIGHT       = 3,
+} lis2de12_hpcf_t;
+int32_t lis2de12_high_pass_bandwidth_set(lis2de12_ctx_t *ctx,
+                                         lis2de12_hpcf_t val);
+int32_t lis2de12_high_pass_bandwidth_get(lis2de12_ctx_t *ctx,
+                                         lis2de12_hpcf_t *val);
+
+typedef enum {
+  LIS2DE12_NORMAL_WITH_RST  = 0,
+  LIS2DE12_REFERENCE_MODE   = 1,
+  LIS2DE12_NORMAL           = 2,
+  LIS2DE12_AUTORST_ON_INT   = 3,
+} lis2de12_hpm_t;
+int32_t lis2de12_high_pass_mode_set(lis2de12_ctx_t *ctx, lis2de12_hpm_t val);
+int32_t lis2de12_high_pass_mode_get(lis2de12_ctx_t *ctx, lis2de12_hpm_t *val);
+
+typedef enum {
+  LIS2DE12_2g   = 0,
+  LIS2DE12_4g   = 1,
+  LIS2DE12_8g   = 2,
+  LIS2DE12_16g  = 3,
+} lis2de12_fs_t;
+int32_t lis2de12_full_scale_set(lis2de12_ctx_t *ctx, lis2de12_fs_t val);
+int32_t lis2de12_full_scale_get(lis2de12_ctx_t *ctx, lis2de12_fs_t *val);
+
+int32_t lis2de12_block_data_update_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_block_data_update_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_filter_reference_set(lis2de12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2de12_filter_reference_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2de12_xl_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_xl_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_acceleration_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2de12_device_id_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2DE12_ST_DISABLE   = 0,
+  LIS2DE12_ST_POSITIVE  = 1,
+  LIS2DE12_ST_NEGATIVE  = 2,
+} lis2de12_st_t;
+int32_t lis2de12_self_test_set(lis2de12_ctx_t *ctx, lis2de12_st_t val);
+int32_t lis2de12_self_test_get(lis2de12_ctx_t *ctx, lis2de12_st_t *val);
+
+int32_t lis2de12_boot_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_boot_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_status_get(lis2de12_ctx_t *ctx, lis2de12_status_reg_t *val);
+
+int32_t lis2de12_int1_gen_conf_set(lis2de12_ctx_t *ctx,
+                                   lis2de12_int1_cfg_t *val);
+int32_t lis2de12_int1_gen_conf_get(lis2de12_ctx_t *ctx,
+                                   lis2de12_int1_cfg_t *val);
+
+int32_t lis2de12_int1_gen_source_get(lis2de12_ctx_t *ctx,
+                                     lis2de12_int1_src_t *val);
+
+int32_t lis2de12_int1_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int1_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_int1_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int1_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_int2_gen_conf_set(lis2de12_ctx_t *ctx,
+                                   lis2de12_int2_cfg_t *val);
+int32_t lis2de12_int2_gen_conf_get(lis2de12_ctx_t *ctx,
+                                   lis2de12_int2_cfg_t *val);
+
+int32_t lis2de12_int2_gen_source_get(lis2de12_ctx_t *ctx,
+                                     lis2de12_int2_src_t *val);
+
+int32_t lis2de12_int2_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int2_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_int2_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int2_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DE12_DISC_FROM_INT_GENERATOR  = 0,
+  LIS2DE12_ON_INT1_GEN              = 1,
+  LIS2DE12_ON_INT2_GEN              = 2,
+  LIS2DE12_ON_TAP_GEN               = 4,
+  LIS2DE12_ON_INT1_INT2_GEN         = 3,
+  LIS2DE12_ON_INT1_TAP_GEN          = 5,
+  LIS2DE12_ON_INT2_TAP_GEN          = 6,
+  LIS2DE12_ON_INT1_INT2_TAP_GEN     = 7,
+} lis2de12_hp_t;
+int32_t lis2de12_high_pass_int_conf_set(lis2de12_ctx_t *ctx,
+                                        lis2de12_hp_t val);
+int32_t lis2de12_high_pass_int_conf_get(lis2de12_ctx_t *ctx,
+                                        lis2de12_hp_t *val);
+
+int32_t lis2de12_pin_int1_config_set(lis2de12_ctx_t *ctx,
+                                     lis2de12_ctrl_reg3_t *val);
+int32_t lis2de12_pin_int1_config_get(lis2de12_ctx_t *ctx,
+                                     lis2de12_ctrl_reg3_t *val);
+
+int32_t lis2de12_int2_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int2_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DE12_INT2_PULSED   = 0,
+  LIS2DE12_INT2_LATCHED  = 1,
+} lis2de12_lir_int2_t;
+int32_t lis2de12_int2_pin_notification_mode_set(lis2de12_ctx_t *ctx,
+                                                lis2de12_lir_int2_t val);
+int32_t lis2de12_int2_pin_notification_mode_get(lis2de12_ctx_t *ctx,
+                                                lis2de12_lir_int2_t *val);
+
+int32_t lis2de12_int1_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int1_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DE12_INT1_PULSED   = 0,
+  LIS2DE12_INT1_LATCHED  = 1,
+} lis2de12_lir_int1_t;
+int32_t lis2de12_int1_pin_notification_mode_set(lis2de12_ctx_t *ctx,
+                                                lis2de12_lir_int1_t val);
+int32_t lis2de12_int1_pin_notification_mode_get(lis2de12_ctx_t *ctx,
+                                                lis2de12_lir_int1_t *val);
+
+int32_t lis2de12_pin_int2_config_set(lis2de12_ctx_t *ctx,
+                                     lis2de12_ctrl_reg6_t *val);
+int32_t lis2de12_pin_int2_config_get(lis2de12_ctx_t *ctx,
+                                     lis2de12_ctrl_reg6_t *val);
+
+int32_t lis2de12_fifo_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_fifo_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_fifo_watermark_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_fifo_watermark_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DE12_INT1_GEN = 0,
+  LIS2DE12_INT2_GEN = 1,
+} lis2de12_tr_t;
+int32_t lis2de12_fifo_trigger_event_set(lis2de12_ctx_t *ctx,
+                                        lis2de12_tr_t val);
+int32_t lis2de12_fifo_trigger_event_get(lis2de12_ctx_t *ctx,
+                                        lis2de12_tr_t *val);
+
+typedef enum {
+  LIS2DE12_BYPASS_MODE           = 0,
+  LIS2DE12_FIFO_MODE             = 1,
+  LIS2DE12_DYNAMIC_STREAM_MODE   = 2,
+  LIS2DE12_STREAM_TO_FIFO_MODE   = 3,
+} lis2de12_fm_t;
+int32_t lis2de12_fifo_mode_set(lis2de12_ctx_t *ctx, lis2de12_fm_t val);
+int32_t lis2de12_fifo_mode_get(lis2de12_ctx_t *ctx, lis2de12_fm_t *val);
+
+int32_t lis2de12_fifo_status_get(lis2de12_ctx_t *ctx,
+                                 lis2de12_fifo_src_reg_t *val);
+
+int32_t lis2de12_fifo_data_level_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_fifo_empty_flag_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_fifo_ovr_flag_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_fifo_fth_flag_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_tap_conf_set(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val);
+int32_t lis2de12_tap_conf_get(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val);
+
+int32_t lis2de12_tap_source_get(lis2de12_ctx_t *ctx,
+                                lis2de12_click_src_t *val);
+
+int32_t lis2de12_tap_threshold_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_tap_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DE12_TAP_PULSED   = 0,
+  LIS2DE12_TAP_LATCHED  = 1,
+} lis2de12_lir_click_t;
+int32_t lis2de12_tap_notification_mode_set(lis2de12_ctx_t *ctx,
+                                           lis2de12_lir_click_t val);
+int32_t lis2de12_tap_notification_mode_get(lis2de12_ctx_t *ctx,
+                                           lis2de12_lir_click_t *val);
+
+int32_t lis2de12_shock_dur_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_shock_dur_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_quiet_dur_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_quiet_dur_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_double_tap_timeout_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_double_tap_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_act_threshold_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_act_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2de12_act_timeout_set(lis2de12_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_act_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DE12_PULL_UP_DISCONNECT  = 0,
+  LIS2DE12_PULL_UP_CONNECT     = 1,
+} lis2de12_sdo_pu_disc_t;
+int32_t lis2de12_pin_sdo_sa0_mode_set(lis2de12_ctx_t *ctx,
+                                      lis2de12_sdo_pu_disc_t val);
+int32_t lis2de12_pin_sdo_sa0_mode_get(lis2de12_ctx_t *ctx,
+                                      lis2de12_sdo_pu_disc_t *val);
+
+typedef enum {
+  LIS2DE12_SPI_4_WIRE = 0,
+  LIS2DE12_SPI_3_WIRE = 1,
+} lis2de12_sim_t;
+int32_t lis2de12_spi_mode_set(lis2de12_ctx_t *ctx, lis2de12_sim_t val);
+int32_t lis2de12_spi_mode_get(lis2de12_ctx_t *ctx, lis2de12_sim_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS2DE12_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2dh12_STdC/driver/lis2dh12_reg.c
+++ b/sensor/stmemsc/lis2dh12_STdC/driver/lis2dh12_reg.c
@@ -1,0 +1,2394 @@
+/*
+ ******************************************************************************
+ * @file    lis2dh12_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS2DH12 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis2dh12_reg.h"
+
+/**
+  * @defgroup  LIS2DH12
+  * @brief     This file provides a set of functions needed to drive the
+  *            lis2dh12 enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LIS2DH12_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_read_reg(lis2dh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_write_reg(lis2dh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    LIS2DH12_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float lis2dh12_from_fs2_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 1.0f;
+}
+
+float lis2dh12_from_fs4_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) *  2.0f;
+}
+
+float lis2dh12_from_fs8_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 4.0f;
+}
+
+float lis2dh12_from_fs16_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 12.0f;
+}
+
+float lis2dh12_from_lsb_hr_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 64.0f ) / 4.0f ) + 25.0f;
+}
+
+float lis2dh12_from_fs2_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) *  4.0f;
+}
+
+float lis2dh12_from_fs4_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) *  8.0f;
+}
+
+float lis2dh12_from_fs8_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) * 16.0f;
+}
+
+float lis2dh12_from_fs16_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) * 48.0f;
+}
+
+float lis2dh12_from_lsb_nm_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 64.0f ) / 4.0f ) + 25.0f;
+}
+
+float lis2dh12_from_fs2_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 16.0f;
+}
+
+float lis2dh12_from_fs4_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 32.0f;
+}
+
+float lis2dh12_from_fs8_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 64.0f;
+}
+
+float lis2dh12_from_fs16_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 192.0f;
+}
+
+float lis2dh12_from_lsb_lp_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 256.0f ) * 1.0f ) + 25.0f;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DH12_Data_generation
+  * @brief     This section group all the functions concerning data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_temp_status_reg_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_STATUS_REG_AUX, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tda in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_temp_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_STATUS_REG_AUX,
+                          (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux.tda;
+
+  return ret;
+}
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tor in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_temp_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_STATUS_REG_AUX,
+                          (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux.tor;
+
+  return ret;
+}
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_temperature_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+/**
+  * @brief  Temperature sensor enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of temp_en in reg TEMP_CFG_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_temperature_meas_set(lis2dh12_ctx_t *ctx,
+                                      lis2dh12_temp_en_t val)
+{
+  lis2dh12_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  if (ret == 0) {
+    temp_cfg_reg.temp_en = (uint8_t) val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of temp_en in reg TEMP_CFG_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_temperature_meas_get(lis2dh12_ctx_t *ctx,
+                                      lis2dh12_temp_en_t *val)
+{
+  lis2dh12_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  switch (temp_cfg_reg.temp_en) {
+    case LIS2DH12_TEMP_DISABLE:
+      *val = LIS2DH12_TEMP_DISABLE;
+      break;
+    case LIS2DH12_TEMP_ENABLE:
+      *val = LIS2DH12_TEMP_ENABLE;
+      break;
+    default:
+      *val = LIS2DH12_TEMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpen in reg CTRL_REG1
+  *                  and HR in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_operating_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_op_md_t val)
+{
+  lis2dh12_ctrl_reg1_t ctrl_reg1;
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG1,
+                          (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  } 
+  if (ret == 0) {
+    if ( val == LIS2DH12_HR_12bit ) {
+      ctrl_reg1.lpen = 0;
+      ctrl_reg4.hr   = 1;
+    }
+    if (val == LIS2DH12_NM_10bit) {
+      ctrl_reg1.lpen = 0;
+      ctrl_reg4.hr   = 0;
+    }
+    if (val == LIS2DH12_LP_8bit) {
+      ctrl_reg1.lpen = 1;
+      ctrl_reg4.hr   = 0;
+    }
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  } 
+  if (ret == 0) {
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpen in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_operating_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_op_md_t *val)
+{
+  lis2dh12_ctrl_reg1_t ctrl_reg1;
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+    if ( ctrl_reg1.lpen == PROPERTY_ENABLE ) {
+      *val = LIS2DH12_LP_8bit;
+    } else if (ctrl_reg4.hr == PROPERTY_ENABLE ) {
+      *val = LIS2DH12_HR_12bit;
+    } else {
+      *val = LIS2DH12_NM_10bit;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_data_rate_set(lis2dh12_ctx_t *ctx, lis2dh12_odr_t val)
+{
+  lis2dh12_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ctrl_reg1.odr = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_data_rate_get(lis2dh12_ctx_t *ctx, lis2dh12_odr_t *val)
+{
+  lis2dh12_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.odr) {
+    case LIS2DH12_POWER_DOWN:
+      *val = LIS2DH12_POWER_DOWN;
+      break;
+    case LIS2DH12_ODR_1Hz:
+      *val = LIS2DH12_ODR_1Hz;
+      break;
+    case LIS2DH12_ODR_10Hz:
+      *val = LIS2DH12_ODR_10Hz;
+      break;
+    case LIS2DH12_ODR_25Hz:
+      *val = LIS2DH12_ODR_25Hz;
+      break;
+    case LIS2DH12_ODR_50Hz:
+      *val = LIS2DH12_ODR_50Hz;
+      break;
+    case LIS2DH12_ODR_100Hz:
+      *val = LIS2DH12_ODR_100Hz;
+      break;
+    case LIS2DH12_ODR_200Hz:
+      *val = LIS2DH12_ODR_200Hz;
+      break;
+    case LIS2DH12_ODR_400Hz:
+      *val = LIS2DH12_ODR_400Hz;
+      break;
+    case LIS2DH12_ODR_1kHz620_LP:
+      *val = LIS2DH12_ODR_1kHz620_LP;
+      break;
+    case LIS2DH12_ODR_5kHz376_LP_1kHz344_NM_HP:
+      *val = LIS2DH12_ODR_5kHz376_LP_1kHz344_NM_HP;
+      break;
+    default:
+      *val = LIS2DH12_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_high_pass_on_outputs_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.fds = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_high_pass_on_outputs_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = (uint8_t)ctrl_reg2.fds;
+
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[set]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_high_pass_bandwidth_set(lis2dh12_ctx_t *ctx,
+                                         lis2dh12_hpcf_t val)
+{
+  lis2dh12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[get]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_high_pass_bandwidth_get(lis2dh12_ctx_t *ctx,
+                                         lis2dh12_hpcf_t *val)
+{
+  lis2dh12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpcf) {
+    case LIS2DH12_AGGRESSIVE:
+      *val = LIS2DH12_AGGRESSIVE;
+      break;
+    case LIS2DH12_STRONG:
+      *val = LIS2DH12_STRONG;
+      break;
+    case LIS2DH12_MEDIUM:
+      *val = LIS2DH12_MEDIUM;
+      break;
+    case LIS2DH12_LIGHT:
+      *val = LIS2DH12_LIGHT;
+      break;
+    default:
+      *val = LIS2DH12_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_high_pass_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t val)
+{
+  lis2dh12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_high_pass_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t *val)
+{
+  lis2dh12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpm) {
+    case LIS2DH12_NORMAL_WITH_RST:
+      *val = LIS2DH12_NORMAL_WITH_RST;
+      break;
+    case LIS2DH12_REFERENCE_MODE:
+      *val = LIS2DH12_REFERENCE_MODE;
+      break;
+    case LIS2DH12_NORMAL:
+      *val = LIS2DH12_NORMAL;
+      break;
+    case LIS2DH12_AUTORST_ON_INT:
+      *val = LIS2DH12_AUTORST_ON_INT;
+      break;
+    default:
+      *val = LIS2DH12_NORMAL_WITH_RST;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_full_scale_set(lis2dh12_ctx_t *ctx, lis2dh12_fs_t val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_full_scale_get(lis2dh12_ctx_t *ctx, lis2dh12_fs_t *val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.fs) {
+    case LIS2DH12_2g:
+      *val = LIS2DH12_2g;
+      break;
+    case LIS2DH12_4g:
+      *val = LIS2DH12_4g;
+      break;
+    case LIS2DH12_8g:
+      *val = LIS2DH12_8g;
+      break;
+    case LIS2DH12_16g:
+      *val = LIS2DH12_16g;
+      break;
+    default:
+      *val = LIS2DH12_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_block_data_update_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_block_data_update_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = (uint8_t)ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[set]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_filter_reference_set(lis2dh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dh12_write_reg(ctx, LIS2DH12_REFERENCE, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[get]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_filter_reference_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_REFERENCE, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_xl_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxor in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_xl_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxor;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_acceleration_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_OUT_X_L, buff, 6);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DH12_Common
+  * @brief     This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI .[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_device_id_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_WHO_AM_I, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Self Test.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_self_test_set(lis2dh12_ctx_t *ctx, lis2dh12_st_t val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Self Test.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_self_test_get(lis2dh12_ctx_t *ctx, lis2dh12_st_t *val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.st) {
+    case LIS2DH12_ST_DISABLE:
+      *val = LIS2DH12_ST_DISABLE;
+      break;
+    case LIS2DH12_ST_POSITIVE:
+      *val = LIS2DH12_ST_POSITIVE;
+      break;
+    case LIS2DH12_ST_NEGATIVE:
+      *val = LIS2DH12_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS2DH12_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ble in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_data_format_set(lis2dh12_ctx_t *ctx, lis2dh12_ble_t val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of ble in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_data_format_get(lis2dh12_ctx_t *ctx, lis2dh12_ble_t *val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.ble) {
+    case LIS2DH12_LSB_AT_LOW_ADD:
+      *val = LIS2DH12_LSB_AT_LOW_ADD;
+      break;
+    case LIS2DH12_MSB_AT_LOW_ADD:
+      *val = LIS2DH12_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LIS2DH12_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_boot_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.boot = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_boot_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_status_get(lis2dh12_ctx_t *ctx, lis2dh12_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DH12_Interrupts_generator_1
+  * @brief      This section group all the functions that manage the first
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_gen_conf_set(lis2dh12_ctx_t *ctx,
+                                   lis2dh12_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_write_reg(ctx, LIS2DH12_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_gen_conf_get(lis2dh12_ctx_t *ctx,
+                                   lis2dh12_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Registers INT1_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_gen_source_get(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_int1_src_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[set]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if (ret == 0) {
+    int1_ths.ths = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_INT1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = (uint8_t)int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  if (ret == 0) {
+    int1_duration.d = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  *val = (uint8_t)int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DH12_Interrupts_generator_2
+  * @brief      This section group all the functions that manage the second
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_gen_conf_set(lis2dh12_ctx_t *ctx,
+                                   lis2dh12_int2_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_write_reg(ctx, LIS2DH12_INT2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_gen_conf_get(lis2dh12_ctx_t *ctx,
+                                   lis2dh12_int2_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Interrupt generator 2 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_gen_source_get(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_int2_src_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief   User-defined threshold value for xl interrupt event on
+  *          generator 2.[set]
+  *          LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if (ret == 0) {
+    int2_ths.ths = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_INT2_THS, (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 2.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = (uint8_t)int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized .[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  if (ret == 0) {
+    int2_duration.d = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  *val = (uint8_t)int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DH12_Interrupt_pins
+  * @brief     This section group all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_high_pass_int_conf_set(lis2dh12_ctx_t *ctx,
+                                        lis2dh12_hp_t val)
+{
+  lis2dh12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hp = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_high_pass_int_conf_get(lis2dh12_ctx_t *ctx,
+                                        lis2dh12_hp_t *val)
+{
+  lis2dh12_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hp) {
+    case LIS2DH12_DISC_FROM_INT_GENERATOR:
+      *val = LIS2DH12_DISC_FROM_INT_GENERATOR;
+      break;
+    case LIS2DH12_ON_INT1_GEN:
+      *val = LIS2DH12_ON_INT1_GEN;
+      break;
+    case LIS2DH12_ON_INT2_GEN:
+      *val = LIS2DH12_ON_INT2_GEN;
+      break;
+    case LIS2DH12_ON_TAP_GEN:
+      *val = LIS2DH12_ON_TAP_GEN;
+      break;
+    case LIS2DH12_ON_INT1_INT2_GEN:
+      *val = LIS2DH12_ON_INT1_INT2_GEN;
+      break;
+    case LIS2DH12_ON_INT1_TAP_GEN:
+      *val = LIS2DH12_ON_INT1_TAP_GEN;
+      break;
+    case LIS2DH12_ON_INT2_TAP_GEN:
+      *val = LIS2DH12_ON_INT2_TAP_GEN;
+      break;
+    case LIS2DH12_ON_INT1_INT2_TAP_GEN:
+      *val = LIS2DH12_ON_INT1_INT2_TAP_GEN;
+      break;
+    default:
+      *val = LIS2DH12_DISC_FROM_INT_GENERATOR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_pin_int1_config_set(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_pin_int1_config_get(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  int2_pin_detect_4d: [set]  4D enable: 4D detection is enabled
+  *                                    on INT2 pin when 6D bit on
+  *                                    INT2_CFG (34h) is set to 1.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_int2 = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT2 pin when 6D bit on
+  *         INT2_CFG (34h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_int2;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
+                                                lis2dh12_lir_int2_t val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_int2 = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int2_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
+                                                lis2dh12_lir_int2_t *val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_int2) {
+    case LIS2DH12_INT2_PULSED:
+      *val = LIS2DH12_INT2_PULSED;
+      break;
+    case LIS2DH12_INT2_LATCHED:
+      *val = LIS2DH12_INT2_LATCHED;
+      break;
+    default:
+      *val = LIS2DH12_INT2_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit
+  *                    on INT1_CFG(30h) is set to 1.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_int1 = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit on
+  *         INT1_CFG(30h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_int1;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
+                                                lis2dh12_lir_int1_t val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_int1 = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_int1_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
+                                                lis2dh12_lir_int1_t *val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_int1) {
+    case LIS2DH12_INT1_PULSED:
+      *val = LIS2DH12_INT1_PULSED;
+      break;
+    case LIS2DH12_INT1_LATCHED:
+      *val = LIS2DH12_INT1_LATCHED;
+      break;
+    default:
+      *val = LIS2DH12_INT1_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_pin_int2_config_set(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_pin_int2_config_get(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DH12_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.fifo_en = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_watermark_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fth = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_watermark_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  *val = (uint8_t)fifo_ctrl_reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_trigger_event_set(lis2dh12_ctx_t *ctx,
+                                        lis2dh12_tr_t val)
+{
+  lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.tr = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_trigger_event_get(lis2dh12_ctx_t *ctx,
+                                        lis2dh12_tr_t *val)
+{
+  lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.tr) {
+    case LIS2DH12_INT1_GEN:
+      *val = LIS2DH12_INT1_GEN;
+      break;
+    case LIS2DH12_INT2_GEN:
+      *val = LIS2DH12_INT2_GEN;
+      break;
+    default:
+      *val = LIS2DH12_INT1_GEN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_fm_t val)
+{
+  lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fm = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_fm_t *val)
+{
+  lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.fm) {
+    case LIS2DH12_BYPASS_MODE:
+      *val = LIS2DH12_BYPASS_MODE;
+      break;
+    case LIS2DH12_FIFO_MODE:
+      *val = LIS2DH12_FIFO_MODE;
+      break;
+    case LIS2DH12_DYNAMIC_STREAM_MODE:
+      *val = LIS2DH12_DYNAMIC_STREAM_MODE;
+      break;
+    case LIS2DH12_STREAM_TO_FIFO_MODE:
+      *val = LIS2DH12_STREAM_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LIS2DH12_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_status_get(lis2dh12_ctx_t *ctx,
+                                 lis2dh12_fifo_src_reg_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_SRC_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fss in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_data_level_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.fss;
+
+  return ret;
+}
+/**
+  * @brief  Empty FIFO status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of empty in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_empty_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.empty;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ovrn_fifo in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_ovr_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.ovrn_fifo;
+
+  return ret;
+}
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_fifo_fth_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.wtm;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DH12_Tap_generator
+  * @brief     This section group all the functions that manage the tap and
+  *            double tap event generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_tap_conf_set(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_write_reg(ctx, LIS2DH12_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_tap_conf_get(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Tap/Double Tap generator source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_tap_source_get(lis2dh12_ctx_t *ctx, lis2dh12_click_src_t *val)
+{
+  int32_t ret;
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CLICK_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[set]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_tap_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.ths = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[get]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_tap_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  *val = (uint8_t)click_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+  *          for the duration of the latency window.
+  *          If the LIR_Click bit is set, the interrupt is kept high until the
+  *          CLICK_SRC(39h) register is read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_click in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_tap_notification_mode_set(lis2dh12_ctx_t *ctx,
+                                           lis2dh12_lir_click_t val)
+{
+  lis2dh12_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.lir_click = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+  *          for the duration of the latency window.
+  *          If the LIR_Click bit is set, the interrupt is kept high until the
+  *          CLICK_SRC(39h) register is read.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_click in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_tap_notification_mode_get(lis2dh12_ctx_t *ctx,
+                                           lis2dh12_lir_click_t *val)
+{
+  lis2dh12_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CLICK_THS, (uint8_t*)&click_ths, 1);
+  switch (click_ths.lir_click) {
+    case LIS2DH12_TAP_PULSED:
+      *val = LIS2DH12_TAP_PULSED;
+      break;
+    case LIS2DH12_TAP_LATCHED:
+      *val = LIS2DH12_TAP_LATCHED;
+      break;
+    default:
+      *val = LIS2DH12_TAP_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse
+  *         between the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_shock_dur_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  if (ret == 0) {
+    time_limit.tli = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse between
+  *         the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_shock_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  *val = (uint8_t)time_limit.tli;
+
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_quiet_dur_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  if (ret == 0) {
+    time_latency.tla = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_quiet_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  *val = (uint8_t)time_latency.tla;
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the click-detection
+  *         procedure can start, in cases where the device is configured
+  *         for double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_double_tap_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  if (ret == 0) {
+    time_window.tw = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the
+  *         click-detection procedure can start, in cases where the device
+  *         is configured for double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_double_tap_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  *val = (uint8_t)time_window.tw;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DH12_Activity_inactivity
+  * @brief     This section group all the functions concerning activity
+  *            inactivity functionality
+  * @{
+  *
+  */
+
+/**
+  * @brief    Sleep-to-wake, return-to-sleep activation threshold in
+  *           low-power mode.[set]
+  *           1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_act_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_ACT_THS, (uint8_t*)&act_ths, 1);
+  if (ret == 0) {
+    act_ths.acth = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_ACT_THS, (uint8_t*)&act_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep activation threshold in low-power
+  *         mode.[get]
+  *         1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_act_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_ACT_THS, (uint8_t*)&act_ths, 1);
+  *val = (uint8_t)act_ths.acth;
+
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[set]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_act_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val)
+{
+  lis2dh12_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  if (ret == 0) {
+    act_dur.actd = val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[get]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_act_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dh12_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  *val = (uint8_t)act_dur.actd;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DH12_Serial_interface
+  * @brief     This section group all the functions concerning serial
+  *            interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sdo_pu_disc in reg CTRL_REG0
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_pin_sdo_sa0_mode_set(lis2dh12_ctx_t *ctx,
+                                      lis2dh12_sdo_pu_disc_t val)
+{
+  lis2dh12_ctrl_reg0_t ctrl_reg0;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  if (ret == 0) {
+    ctrl_reg0.sdo_pu_disc = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sdo_pu_disc in reg CTRL_REG0
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_pin_sdo_sa0_mode_get(lis2dh12_ctx_t *ctx,
+                                      lis2dh12_sdo_pu_disc_t *val)
+{
+  lis2dh12_ctrl_reg0_t ctrl_reg0;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  switch (ctrl_reg0.sdo_pu_disc) {
+    case LIS2DH12_PULL_UP_DISCONNECT:
+      *val = LIS2DH12_PULL_UP_DISCONNECT;
+      break;
+    case LIS2DH12_PULL_UP_CONNECT:
+      *val = LIS2DH12_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LIS2DH12_PULL_UP_DISCONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_spi_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_sim_t val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = lis2dh12_write_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dh12_spi_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_sim_t *val)
+{
+  lis2dh12_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis2dh12_read_reg(ctx, LIS2DH12_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.sim) {
+    case LIS2DH12_SPI_4_WIRE:
+      *val = LIS2DH12_SPI_4_WIRE;
+      break;
+    case LIS2DH12_SPI_3_WIRE:
+      *val = LIS2DH12_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS2DH12_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2dh12_STdC/driver/lis2dh12_reg.h
+++ b/sensor/stmemsc/lis2dh12_STdC/driver/lis2dh12_reg.h
@@ -1,0 +1,763 @@
+/*
+ ******************************************************************************
+ * @file    lis2dh12_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis2dh12_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS2DH12_REGS_H
+#define LIS2DH12_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS2DH12
+  * @{
+  *
+  */
+
+/** @defgroup LIS2DH12_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup LIS3MDL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis2dh12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis2dh12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis2dh12_write_ptr  write_reg;
+  lis2dh12_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis2dh12_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS2DH12_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define LIS2DH12_I2C_ADD_L   0x31U
+#define LIS2DH12_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define LIS2DH12_ID          0x33U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS2DH12_STATUS_REG_AUX        0x07U
+typedef struct {
+  uint8_t not_used_01       : 2;
+  uint8_t tda               : 1;
+  uint8_t not_used_02       : 3;
+  uint8_t tor               : 1;
+  uint8_t not_used_03       : 1;
+} lis2dh12_status_reg_aux_t;
+
+#define LIS2DH12_OUT_TEMP_L            0x0CU
+#define LIS2DH12_OUT_TEMP_H            0x0DU
+#define LIS2DH12_WHO_AM_I              0x0FU
+
+#define LIS2DH12_CTRL_REG0             0x1EU
+typedef struct {
+  uint8_t not_used_01       : 7;
+  uint8_t sdo_pu_disc       : 1;
+} lis2dh12_ctrl_reg0_t;
+
+#define LIS2DH12_TEMP_CFG_REG          0x1FU
+typedef struct {
+  uint8_t not_used_01       : 6;
+  uint8_t temp_en           : 2;
+} lis2dh12_temp_cfg_reg_t;
+
+#define LIS2DH12_CTRL_REG1             0x20U
+typedef struct {
+  uint8_t xen               : 1;
+  uint8_t yen               : 1;
+  uint8_t zen               : 1;
+  uint8_t lpen              : 1;
+  uint8_t odr               : 4;
+} lis2dh12_ctrl_reg1_t;
+
+#define LIS2DH12_CTRL_REG2             0x21U
+typedef struct {
+  uint8_t hp                : 3; /* HPCLICK + HP_IA2 + HP_IA1 -> HP */
+  uint8_t fds               : 1;
+  uint8_t hpcf              : 2;
+  uint8_t hpm               : 2;
+} lis2dh12_ctrl_reg2_t;
+
+#define LIS2DH12_CTRL_REG3             0x22U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t i1_overrun        : 1;
+  uint8_t i1_wtm            : 1;
+  uint8_t not_used_02       : 1;
+  uint8_t i1_zyxda          : 1;
+  uint8_t i1_ia2            : 1;
+  uint8_t i1_ia1            : 1;
+  uint8_t i1_click          : 1;
+} lis2dh12_ctrl_reg3_t;
+
+#define LIS2DH12_CTRL_REG4             0x23U
+typedef struct {
+  uint8_t sim               : 1;
+  uint8_t st                : 2;
+  uint8_t hr                : 1;
+  uint8_t fs                : 2;
+  uint8_t ble               : 1;
+  uint8_t bdu               : 1;
+} lis2dh12_ctrl_reg4_t;
+
+#define LIS2DH12_CTRL_REG5             0x24U
+typedef struct {
+  uint8_t d4d_int2          : 1;
+  uint8_t lir_int2          : 1;
+  uint8_t d4d_int1          : 1;
+  uint8_t lir_int1          : 1;
+  uint8_t not_used_01       : 2;
+  uint8_t fifo_en           : 1;
+  uint8_t boot              : 1;
+} lis2dh12_ctrl_reg5_t;
+
+#define LIS2DH12_CTRL_REG6            0x25U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t int_polarity      : 1;
+  uint8_t not_used_02       : 1;
+  uint8_t i2_act            : 1;
+  uint8_t i2_boot           : 1;
+  uint8_t i2_ia2            : 1;
+  uint8_t i2_ia1            : 1;
+  uint8_t i2_click          : 1;
+} lis2dh12_ctrl_reg6_t;
+
+#define LIS2DH12_REFERENCE            0x26U
+#define LIS2DH12_STATUS_REG           0x27U
+typedef struct {
+  uint8_t xda               : 1;
+  uint8_t yda               : 1;
+  uint8_t zda               : 1;
+  uint8_t zyxda             : 1;
+  uint8_t _xor              : 1;
+  uint8_t yor               : 1;
+  uint8_t zor               : 1;
+  uint8_t zyxor             : 1;
+} lis2dh12_status_reg_t;
+
+#define LIS2DH12_OUT_X_L              0x28U
+#define LIS2DH12_OUT_X_H              0x29U
+#define LIS2DH12_OUT_Y_L              0x2AU
+#define LIS2DH12_OUT_Y_H              0x2BU
+#define LIS2DH12_OUT_Z_L              0x2CU
+#define LIS2DH12_OUT_Z_H              0x2DU
+#define LIS2DH12_FIFO_CTRL_REG        0x2EU
+typedef struct {
+  uint8_t fth               : 5;
+  uint8_t tr                : 1;
+  uint8_t fm                : 2;
+} lis2dh12_fifo_ctrl_reg_t;
+
+#define LIS2DH12_FIFO_SRC_REG         0x2FU
+typedef struct {
+  uint8_t fss               : 5;
+  uint8_t empty             : 1;
+  uint8_t ovrn_fifo         : 1;
+  uint8_t wtm               : 1;
+} lis2dh12_fifo_src_reg_t;
+
+#define LIS2DH12_INT1_CFG             0x30U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} lis2dh12_int1_cfg_t;
+
+#define LIS2DH12_INT1_SRC             0x31U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis2dh12_int1_src_t;
+
+#define LIS2DH12_INT1_THS             0x32U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} lis2dh12_int1_ths_t;
+
+#define LIS2DH12_INT1_DURATION        0x33U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} lis2dh12_int1_duration_t;
+
+#define LIS2DH12_INT2_CFG             0x34U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} lis2dh12_int2_cfg_t;
+
+#define LIS2DH12_INT2_SRC             0x35U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis2dh12_int2_src_t;
+
+#define LIS2DH12_INT2_THS             0x36U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} lis2dh12_int2_ths_t;
+
+#define LIS2DH12_INT2_DURATION        0x37U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} lis2dh12_int2_duration_t;
+
+#define LIS2DH12_CLICK_CFG            0x38U
+typedef struct {
+  uint8_t xs                : 1;
+  uint8_t xd                : 1;
+  uint8_t ys                : 1;
+  uint8_t yd                : 1;
+  uint8_t zs                : 1;
+  uint8_t zd                : 1;
+  uint8_t not_used_01       : 2;
+} lis2dh12_click_cfg_t;
+
+#define LIS2DH12_CLICK_SRC            0x39U
+typedef struct {
+  uint8_t x                 : 1;
+  uint8_t y                 : 1;
+  uint8_t z                 : 1;
+  uint8_t sign              : 1;
+  uint8_t sclick            : 1;
+  uint8_t dclick            : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis2dh12_click_src_t;
+
+#define LIS2DH12_CLICK_THS            0x3AU
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t lir_click         : 1;
+} lis2dh12_click_ths_t;
+
+#define LIS2DH12_TIME_LIMIT           0x3BU
+typedef struct {
+  uint8_t tli               : 7;
+  uint8_t not_used_01       : 1;
+} lis2dh12_time_limit_t;
+
+#define LIS2DH12_TIME_LATENCY         0x3CU
+typedef struct {
+  uint8_t tla               : 8;
+} lis2dh12_time_latency_t;
+
+#define LIS2DH12_TIME_WINDOW          0x3DU
+typedef struct {
+  uint8_t tw                : 8;
+} lis2dh12_time_window_t;
+
+#define LIS2DH12_ACT_THS              0x3EU
+typedef struct {
+  uint8_t acth              : 7;
+  uint8_t not_used_01       : 1;
+} lis2dh12_act_ths_t;
+
+#define LIS2DH12_ACT_DUR              0x3FU
+typedef struct {
+  uint8_t actd              : 8;
+} lis2dh12_act_dur_t;
+
+/**
+  * @defgroup LIS2DH12_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is usefull but not need by the driver.
+  *
+  *           REMOVING this union you are complient with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis2dh12_status_reg_aux_t status_reg_aux;
+  lis2dh12_ctrl_reg0_t      ctrl_reg0;
+  lis2dh12_temp_cfg_reg_t   temp_cfg_reg;
+  lis2dh12_ctrl_reg1_t      ctrl_reg1;
+  lis2dh12_ctrl_reg2_t      ctrl_reg2;
+  lis2dh12_ctrl_reg3_t      ctrl_reg3;
+  lis2dh12_ctrl_reg4_t      ctrl_reg4;
+  lis2dh12_ctrl_reg5_t      ctrl_reg5;
+  lis2dh12_ctrl_reg6_t      ctrl_reg6;
+  lis2dh12_status_reg_t     status_reg;
+  lis2dh12_fifo_ctrl_reg_t  fifo_ctrl_reg;
+  lis2dh12_fifo_src_reg_t   fifo_src_reg;
+  lis2dh12_int1_cfg_t       int1_cfg;
+  lis2dh12_int1_src_t       int1_src;
+  lis2dh12_int1_ths_t       int1_ths;
+  lis2dh12_int1_duration_t  int1_duration;
+  lis2dh12_int2_cfg_t       int2_cfg;
+  lis2dh12_int2_src_t       int2_src;
+  lis2dh12_int2_ths_t       int2_ths;
+  lis2dh12_int2_duration_t  int2_duration;
+  lis2dh12_click_cfg_t      click_cfg;
+  lis2dh12_click_src_t      click_src;
+  lis2dh12_click_ths_t      click_ths;
+  lis2dh12_time_limit_t     time_limit;
+  lis2dh12_time_latency_t   time_latency;
+  lis2dh12_time_window_t    time_window;
+  lis2dh12_act_ths_t        act_ths;
+  lis2dh12_act_dur_t        act_dur;
+  bitwise_t                 bitwise;
+  uint8_t                   byte;
+} lis2dh12_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis2dh12_read_reg(lis2dh12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lis2dh12_write_reg(lis2dh12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float lis2dh12_from_fs2_hr_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs4_hr_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs8_hr_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs16_hr_to_mg(int16_t lsb);
+extern float lis2dh12_from_lsb_hr_to_celsius(int16_t lsb);
+
+extern float lis2dh12_from_fs2_nm_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs4_nm_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs8_nm_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs16_nm_to_mg(int16_t lsb);
+extern float lis2dh12_from_lsb_nm_to_celsius(int16_t lsb);
+
+extern float lis2dh12_from_fs2_lp_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs4_lp_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs8_lp_to_mg(int16_t lsb);
+extern float lis2dh12_from_fs16_lp_to_mg(int16_t lsb);
+extern float lis2dh12_from_lsb_lp_to_celsius(int16_t lsb);
+
+int32_t lis2dh12_temp_status_reg_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dh12_temp_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_temp_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_temperature_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2DH12_TEMP_DISABLE  = 0,
+  LIS2DH12_TEMP_ENABLE   = 3,
+} lis2dh12_temp_en_t;
+int32_t lis2dh12_temperature_meas_set(lis2dh12_ctx_t *ctx,
+                                      lis2dh12_temp_en_t val);
+int32_t lis2dh12_temperature_meas_get(lis2dh12_ctx_t *ctx,
+                                      lis2dh12_temp_en_t *val);
+
+typedef enum {
+  LIS2DH12_HR_12bit   = 0,
+  LIS2DH12_NM_10bit   = 1,
+  LIS2DH12_LP_8bit    = 2,
+} lis2dh12_op_md_t;
+int32_t lis2dh12_operating_mode_set(lis2dh12_ctx_t *ctx,
+                                    lis2dh12_op_md_t val);
+int32_t lis2dh12_operating_mode_get(lis2dh12_ctx_t *ctx,
+                                    lis2dh12_op_md_t *val);
+
+typedef enum {
+  LIS2DH12_POWER_DOWN                      = 0x00,
+  LIS2DH12_ODR_1Hz                         = 0x01,
+  LIS2DH12_ODR_10Hz                        = 0x02,
+  LIS2DH12_ODR_25Hz                        = 0x03,
+  LIS2DH12_ODR_50Hz                        = 0x04,
+  LIS2DH12_ODR_100Hz                       = 0x05,
+  LIS2DH12_ODR_200Hz                       = 0x06,
+  LIS2DH12_ODR_400Hz                       = 0x07,
+  LIS2DH12_ODR_1kHz620_LP                  = 0x08,
+  LIS2DH12_ODR_5kHz376_LP_1kHz344_NM_HP    = 0x09,
+} lis2dh12_odr_t;
+int32_t lis2dh12_data_rate_set(lis2dh12_ctx_t *ctx, lis2dh12_odr_t val);
+int32_t lis2dh12_data_rate_get(lis2dh12_ctx_t *ctx, lis2dh12_odr_t *val);
+
+int32_t lis2dh12_high_pass_on_outputs_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_high_pass_on_outputs_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DH12_AGGRESSIVE  = 0,
+  LIS2DH12_STRONG      = 1,
+  LIS2DH12_MEDIUM      = 2,
+  LIS2DH12_LIGHT       = 3,
+} lis2dh12_hpcf_t;
+int32_t lis2dh12_high_pass_bandwidth_set(lis2dh12_ctx_t *ctx,
+                                         lis2dh12_hpcf_t val);
+int32_t lis2dh12_high_pass_bandwidth_get(lis2dh12_ctx_t *ctx,
+                                         lis2dh12_hpcf_t *val);
+
+typedef enum {
+  LIS2DH12_NORMAL_WITH_RST  = 0,
+  LIS2DH12_REFERENCE_MODE   = 1,
+  LIS2DH12_NORMAL           = 2,
+  LIS2DH12_AUTORST_ON_INT   = 3,
+} lis2dh12_hpm_t;
+int32_t lis2dh12_high_pass_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t val);
+int32_t lis2dh12_high_pass_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t *val);
+
+typedef enum {
+  LIS2DH12_2g   = 0,
+  LIS2DH12_4g   = 1,
+  LIS2DH12_8g   = 2,
+  LIS2DH12_16g  = 3,
+} lis2dh12_fs_t;
+int32_t lis2dh12_full_scale_set(lis2dh12_ctx_t *ctx, lis2dh12_fs_t val);
+int32_t lis2dh12_full_scale_get(lis2dh12_ctx_t *ctx, lis2dh12_fs_t *val);
+
+int32_t lis2dh12_block_data_update_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_block_data_update_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_filter_reference_set(lis2dh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dh12_filter_reference_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dh12_xl_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_xl_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_acceleration_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dh12_device_id_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2DH12_ST_DISABLE   = 0,
+  LIS2DH12_ST_POSITIVE  = 1,
+  LIS2DH12_ST_NEGATIVE  = 2,
+} lis2dh12_st_t;
+int32_t lis2dh12_self_test_set(lis2dh12_ctx_t *ctx, lis2dh12_st_t val);
+int32_t lis2dh12_self_test_get(lis2dh12_ctx_t *ctx, lis2dh12_st_t *val);
+
+typedef enum {
+  LIS2DH12_LSB_AT_LOW_ADD = 0,
+  LIS2DH12_MSB_AT_LOW_ADD = 1,
+} lis2dh12_ble_t;
+int32_t lis2dh12_data_format_set(lis2dh12_ctx_t *ctx, lis2dh12_ble_t val);
+int32_t lis2dh12_data_format_get(lis2dh12_ctx_t *ctx, lis2dh12_ble_t *val);
+
+int32_t lis2dh12_boot_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_boot_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_status_get(lis2dh12_ctx_t *ctx, lis2dh12_status_reg_t *val);
+
+int32_t lis2dh12_int1_gen_conf_set(lis2dh12_ctx_t *ctx,
+                                   lis2dh12_int1_cfg_t *val);
+int32_t lis2dh12_int1_gen_conf_get(lis2dh12_ctx_t *ctx,
+                                   lis2dh12_int1_cfg_t *val);
+
+int32_t lis2dh12_int1_gen_source_get(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_int1_src_t *val);
+
+int32_t lis2dh12_int1_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int1_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_int1_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int1_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_int2_gen_conf_set(lis2dh12_ctx_t *ctx,
+                                   lis2dh12_int2_cfg_t *val);
+int32_t lis2dh12_int2_gen_conf_get(lis2dh12_ctx_t *ctx,
+                                   lis2dh12_int2_cfg_t *val);
+
+int32_t lis2dh12_int2_gen_source_get(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_int2_src_t *val);
+
+int32_t lis2dh12_int2_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int2_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_int2_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int2_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DH12_DISC_FROM_INT_GENERATOR  = 0,
+  LIS2DH12_ON_INT1_GEN              = 1,
+  LIS2DH12_ON_INT2_GEN              = 2,
+  LIS2DH12_ON_TAP_GEN               = 4,
+  LIS2DH12_ON_INT1_INT2_GEN         = 3,
+  LIS2DH12_ON_INT1_TAP_GEN          = 5,
+  LIS2DH12_ON_INT2_TAP_GEN          = 6,
+  LIS2DH12_ON_INT1_INT2_TAP_GEN     = 7,
+} lis2dh12_hp_t;
+int32_t lis2dh12_high_pass_int_conf_set(lis2dh12_ctx_t *ctx,
+                                        lis2dh12_hp_t val);
+int32_t lis2dh12_high_pass_int_conf_get(lis2dh12_ctx_t *ctx,
+                                        lis2dh12_hp_t *val);
+
+int32_t lis2dh12_pin_int1_config_set(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_ctrl_reg3_t *val);
+int32_t lis2dh12_pin_int1_config_get(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_ctrl_reg3_t *val);
+
+int32_t lis2dh12_int2_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int2_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DH12_INT2_PULSED   = 0,
+  LIS2DH12_INT2_LATCHED  = 1,
+} lis2dh12_lir_int2_t;
+int32_t lis2dh12_int2_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
+                                                lis2dh12_lir_int2_t val);
+int32_t lis2dh12_int2_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
+                                                lis2dh12_lir_int2_t *val);
+
+int32_t lis2dh12_int1_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int1_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DH12_INT1_PULSED   = 0,
+  LIS2DH12_INT1_LATCHED  = 1,
+} lis2dh12_lir_int1_t;
+int32_t lis2dh12_int1_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
+                                                lis2dh12_lir_int1_t val);
+int32_t lis2dh12_int1_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
+                                                lis2dh12_lir_int1_t *val);
+
+int32_t lis2dh12_pin_int2_config_set(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_ctrl_reg6_t *val);
+int32_t lis2dh12_pin_int2_config_get(lis2dh12_ctx_t *ctx,
+                                     lis2dh12_ctrl_reg6_t *val);
+
+int32_t lis2dh12_fifo_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_fifo_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_fifo_watermark_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_fifo_watermark_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DH12_INT1_GEN = 0,
+  LIS2DH12_INT2_GEN = 1,
+} lis2dh12_tr_t;
+int32_t lis2dh12_fifo_trigger_event_set(lis2dh12_ctx_t *ctx,
+                                        lis2dh12_tr_t val);
+int32_t lis2dh12_fifo_trigger_event_get(lis2dh12_ctx_t *ctx,
+                                        lis2dh12_tr_t *val);
+
+typedef enum {
+  LIS2DH12_BYPASS_MODE           = 0,
+  LIS2DH12_FIFO_MODE             = 1,
+  LIS2DH12_DYNAMIC_STREAM_MODE   = 2,
+  LIS2DH12_STREAM_TO_FIFO_MODE   = 3,
+} lis2dh12_fm_t;
+int32_t lis2dh12_fifo_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_fm_t val);
+int32_t lis2dh12_fifo_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_fm_t *val);
+
+int32_t lis2dh12_fifo_status_get(lis2dh12_ctx_t *ctx,
+                                 lis2dh12_fifo_src_reg_t *val);
+
+int32_t lis2dh12_fifo_data_level_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_fifo_empty_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_fifo_ovr_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_fifo_fth_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_tap_conf_set(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val);
+int32_t lis2dh12_tap_conf_get(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val);
+
+int32_t lis2dh12_tap_source_get(lis2dh12_ctx_t *ctx,
+                                lis2dh12_click_src_t *val);
+
+int32_t lis2dh12_tap_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_tap_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DH12_TAP_PULSED   = 0,
+  LIS2DH12_TAP_LATCHED  = 1,
+} lis2dh12_lir_click_t;
+int32_t lis2dh12_tap_notification_mode_set(lis2dh12_ctx_t *ctx,
+                                           lis2dh12_lir_click_t val);
+int32_t lis2dh12_tap_notification_mode_get(lis2dh12_ctx_t *ctx,
+                                           lis2dh12_lir_click_t *val);
+
+int32_t lis2dh12_shock_dur_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_shock_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_quiet_dur_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_quiet_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_double_tap_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_double_tap_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_act_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_act_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dh12_act_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_act_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DH12_PULL_UP_DISCONNECT  = 0,
+  LIS2DH12_PULL_UP_CONNECT     = 1,
+} lis2dh12_sdo_pu_disc_t;
+int32_t lis2dh12_pin_sdo_sa0_mode_set(lis2dh12_ctx_t *ctx,
+                                      lis2dh12_sdo_pu_disc_t val);
+int32_t lis2dh12_pin_sdo_sa0_mode_get(lis2dh12_ctx_t *ctx,
+                                      lis2dh12_sdo_pu_disc_t *val);
+
+typedef enum {
+  LIS2DH12_SPI_4_WIRE = 0,
+  LIS2DH12_SPI_3_WIRE = 1,
+} lis2dh12_sim_t;
+int32_t lis2dh12_spi_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_sim_t val);
+int32_t lis2dh12_spi_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_sim_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS2DH12_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2ds12_STdC/driver/lis2ds12_reg.c
+++ b/sensor/stmemsc/lis2ds12_STdC/driver/lis2ds12_reg.c
@@ -1,0 +1,2693 @@
+/*
+ ******************************************************************************
+ * @file    lis2ds12_reg.c
+ * @author  MEMS Software Solution Team
+ * @brief   LIS2DS12 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis2ds12_reg.h"
+
+/**
+  * @addtogroup  lis2ds12
+  * @brief  This file provides a set of functions needed to drive the
+  *         lis2ds12 enanced inertial module.
+  * @{
+  */
+
+/**
+  * @addtogroup  interfaces_functions
+  * @brief  This section provide a set of functions used to read and write
+  *         a generic register of the device.
+  * @{
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  lis2ds12_ctx_t* ctx: read / write interface definitions
+  * @param  uint8_t reg: register to read
+  * @param  uint8_t* data: pointer to buffer that store the data read
+  * @param  uint16_t len: number of consecutive register to read
+  *
+  */
+int32_t lis2ds12_read_reg(lis2ds12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  return ctx->read_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t reg: register to write
+  * @param  uint8_t* data: pointer to data to write in register reg
+  * @param  uint16_t len: number of consecutive register to write
+  *
+*/
+int32_t lis2ds12_write_reg(lis2ds12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  return ctx->write_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  data_generation_c
+  * @brief   This section groups all the functions concerning data generation
+  * @{
+  */
+
+/**
+  * @brief  all_sources: [get] Read all the interrupt/status flag of
+  *                            the device.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_all_sources: FIFO_SRC, STATUS_DUP, WAKE_UP_SRC, TAP_SRC,
+  *                               6D_SRC, FUNC_CK_GATE, FUNC_SRC.
+  *
+  */
+int32_t lis2ds12_all_sources_get(lis2ds12_ctx_t *ctx,
+                                 lis2ds12_all_sources_t *val)
+{
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &(val->byte[0]), 1);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STATUS_DUP, &(val->byte[1]), 4);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE, &(val->byte[5]), 2);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [set] Blockdataupdate.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of bdu in reg CTRL1
+  *
+  */
+int32_t lis2ds12_block_data_update_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+  reg.ctrl1.bdu = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [get] Blockdataupdate.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of bdu in reg CTRL1
+  *
+  */
+int32_t lis2ds12_block_data_update_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+  *val = reg.ctrl1.bdu;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_full_scale: [set]   Accelerometer full-scale selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_fs_t: change the values of fs in reg CTRL1
+  *
+  */
+int32_t lis2ds12_xl_full_scale_set(lis2ds12_ctx_t *ctx, lis2ds12_fs_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+  reg.ctrl1.fs = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_full_scale: [get]   Accelerometer full-scale selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_fs_t: Get the values of fs in reg CTRL1
+  *
+  */
+int32_t lis2ds12_xl_full_scale_get(lis2ds12_ctx_t *ctx, lis2ds12_fs_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+  *val = (lis2ds12_fs_t) reg.ctrl1.fs;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_data_rate: [set]  Accelerometer data rate selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_odr_t: change the values of odr in reg CTRL1
+  *
+  */
+int32_t lis2ds12_xl_data_rate_set(lis2ds12_ctx_t *ctx, lis2ds12_odr_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+  reg.ctrl1.odr = val & 0x0F;
+  reg.ctrl1.hf_odr = (val & 0x10) >> 4;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_data_rate: [get]  Accelerometer data rate selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_odr_t: Get the values of odr in reg CTRL1
+  *
+  */
+int32_t lis2ds12_xl_data_rate_get(lis2ds12_ctx_t *ctx, lis2ds12_odr_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
+  *val = (lis2ds12_odr_t) ((reg.ctrl1.hf_odr << 4) + reg.ctrl1.odr);
+
+  return mm_error;
+}
+
+/**
+  * @brief  status_reg: [get]  The STATUS_REG register.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_status_reg_t: registers STATUS
+  *
+  */
+int32_t lis2ds12_status_reg_get(lis2ds12_ctx_t *ctx, lis2ds12_status_t *val)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_STATUS, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  xl_flag_data_ready: [get]  Accelerometer new data available.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of drdy in reg STATUS
+  *
+  */
+int32_t lis2ds12_xl_flag_data_ready_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STATUS, &reg.byte, 1);
+  *val = reg.status.drdy;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Dataoutput
+  * @brief   This section groups all the data output functions.
+  * @{
+  */
+
+/**
+  * @brief   acceleration_module_raw: [get]   Module output value (8-bit).
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lis2ds12_acceleration_module_raw_get(lis2ds12_ctx_t *ctx,
+                                             uint8_t *buff)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_MODULE_8BIT, buff, 1);
+}
+
+/**
+  * @brief  temperature_raw: [get] Temperature data output register (r).
+  *                                L and H registers together express a 16-bit
+  *                                word in two’s complement.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lis2ds12_temperature_raw_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_OUT_T, buff, 1);
+}
+
+/**
+  * @brief  acceleration_raw: [get] Linear acceleration output register.
+  *                                 The value is expressed as a 16-bit word
+  *                                 in two’s complement.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lis2ds12_acceleration_raw_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_OUT_X_L, buff, 6);
+}
+
+/**
+  * @brief  number_of_steps: [get] Number of steps detected by step
+  *                                counter routine.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lis2ds12_number_of_steps_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_L, buff, 2);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  common
+  * @brief   This section groups common usefull functions.
+  * @{
+  */
+
+/**
+  * @brief  device_id: [get] DeviceWhoamI.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lis2ds12_device_id_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_WHO_AM_I, buff, 1);
+}
+
+/**
+  * @brief  auto_increment: [set] Register address automatically
+  *                               incremented during a multiple byte
+  *                               access with a serial interface.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of if_add_inc in reg CTRL2
+  *
+  */
+int32_t lis2ds12_auto_increment_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  reg.ctrl2.if_add_inc = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  auto_increment: [get] Register address automatically incremented
+  *                               during a multiple byte access with a
+  *                               serial interface.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of if_add_inc in reg CTRL2
+  *
+  */
+int32_t lis2ds12_auto_increment_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  *val = reg.ctrl2.if_add_inc;
+
+  return mm_error;
+}
+
+/**
+  * @brief  mem_bank: [set] Enable access to the embedded functions/sensor
+  *                         hub configuration registers.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_func_cfg_en_t: change the values of func_cfg_en in
+  *                                 reg CTRL2
+  *
+  */
+int32_t lis2ds12_mem_bank_set(lis2ds12_ctx_t *ctx, lis2ds12_func_cfg_en_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  if (val == LIS2DS12_ADV_BANK){
+    mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+    reg.ctrl2.func_cfg_en = val;
+    mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  }
+  else {
+    mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2_ADV, &reg.byte, 1);
+    reg.ctrl2.func_cfg_en = val;
+    mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2_ADV, &reg.byte, 1);
+  }
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [set] Software reset. Restore the default values in
+  *                      user registers.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of soft_reset in reg CTRL2
+  *
+  */
+int32_t lis2ds12_reset_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  reg.ctrl2.soft_reset = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [get] Software reset. Restore the default values in
+  *                      user registers.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of soft_reset in reg CTRL2
+  *
+  */
+int32_t lis2ds12_reset_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  *val = reg.ctrl2.soft_reset;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [set] Reboot memory content. Reload the calibration
+  *                     parameters.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of boot in reg CTRL2
+  *
+  */
+int32_t lis2ds12_boot_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  reg.ctrl2.boot = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [get] Reboot memory content. Reload the calibration
+  *                     parameters.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of boot in reg CTRL2
+  *
+  */
+int32_t lis2ds12_boot_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  *val = reg.ctrl2.boot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_self_test: [set]
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_st_t: change the values of st in reg CTRL3
+  *
+  */
+int32_t lis2ds12_xl_self_test_set(lis2ds12_ctx_t *ctx, lis2ds12_st_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  reg.ctrl3.st = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_self_test: [get]
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_st_t: Get the values of st in reg CTRL3
+  *
+  */
+int32_t lis2ds12_xl_self_test_get(lis2ds12_ctx_t *ctx, lis2ds12_st_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  *val = (lis2ds12_st_t) reg.ctrl3.st;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_ready_mode: [set]
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_drdy_pulsed_t: change the values of drdy_pulsed in
+  *                                 reg CTRL5
+  *
+  */
+int32_t lis2ds12_data_ready_mode_set(lis2ds12_ctx_t *ctx,
+                                     lis2ds12_drdy_pulsed_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+  reg.ctrl5.drdy_pulsed = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_ready_mode: [get]
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_drdy_pulsed_t: Get the values of drdy_pulsed in reg CTRL5
+  *
+  */
+int32_t lis2ds12_data_ready_mode_get(lis2ds12_ctx_t *ctx,
+                                     lis2ds12_drdy_pulsed_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+  *val = (lis2ds12_drdy_pulsed_t) reg.ctrl5.drdy_pulsed;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Filters
+  * @brief   This section group all the functions concerning the filters
+  *          configuration.
+  * @{
+  */
+
+/**
+  * @brief  xl_hp_path: [set] High-pass filter data selection on output
+  *                           register and FIFO.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_fds_slope_t: change the values of fds_slope in reg CTRL2
+  *
+  */
+int32_t lis2ds12_xl_hp_path_set(lis2ds12_ctx_t *ctx, lis2ds12_fds_slope_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  reg.ctrl2.fds_slope = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_hp_path: [get] High-pass filter data selection on output
+  *                           register and FIFO.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_fds_slope_t: Get the values of fds_slope in reg CTRL2
+  *
+  */
+int32_t lis2ds12_xl_hp_path_get(lis2ds12_ctx_t *ctx,
+                                lis2ds12_fds_slope_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  *val = (lis2ds12_fds_slope_t) reg.ctrl2.fds_slope;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Auxiliary_interface
+  * @brief   This section groups all the functions concerning auxiliary
+  *          interface.
+  * @{
+  */
+
+/**
+  * @brief  spi_mode: [set]  SPI Serial Interface Mode selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_sim_t: change the values of sim in reg CTRL2
+  *
+  */
+int32_t lis2ds12_spi_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_sim_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  reg.ctrl2.sim = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  spi_mode: [get]  SPI Serial Interface Mode selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_sim_t: Get the values of sim in reg CTRL2
+  *
+  */
+int32_t lis2ds12_spi_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_sim_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  *val = (lis2ds12_sim_t) reg.ctrl2.sim;
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [set]  Disable / Enable I2C interface.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_i2c_disable_t: change the values of i2c_disable
+  *                                 in reg CTRL2
+  *
+  */
+int32_t lis2ds12_i2c_interface_set(lis2ds12_ctx_t *ctx,
+                                   lis2ds12_i2c_disable_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  reg.ctrl2.i2c_disable = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [get]  Disable / Enable I2C interface.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_i2c_disable_t: Get the values of i2c_disable in
+  *                                 reg CTRL2
+  *
+  */
+int32_t lis2ds12_i2c_interface_get(lis2ds12_ctx_t *ctx,
+                                   lis2ds12_i2c_disable_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+  *val = (lis2ds12_i2c_disable_t) reg.ctrl2.i2c_disable;
+
+  return mm_error;
+}
+
+/**
+  * @brief  cs_mode: [set]  Connect/Disconnects pull-up in if_cs pad.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_if_cs_pu_dis_t: change the values of if_cs_pu_dis
+  *                                  in reg FIFO_CTRL
+  *
+  */
+int32_t lis2ds12_cs_mode_set(lis2ds12_ctx_t *ctx,
+                             lis2ds12_if_cs_pu_dis_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+  reg.fifo_ctrl.if_cs_pu_dis = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  cs_mode: [get]  Connect/Disconnects pull-up in if_cs pad.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_if_cs_pu_dis_t: Get the values of if_cs_pu_dis in
+  *                                  reg FIFO_CTRL
+  *
+  */
+int32_t lis2ds12_cs_mode_get(lis2ds12_ctx_t *ctx,
+                             lis2ds12_if_cs_pu_dis_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+  *val = (lis2ds12_if_cs_pu_dis_t) reg.fifo_ctrl.if_cs_pu_dis;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   main_serial_interface
+  * @brief   This section groups all the functions concerning main serial
+  *          interface management (not auxiliary)
+  * @{
+  */
+
+/**
+  * @brief  pin_mode: [set]  Push-pull/open-drain selection on interrupt pad.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_pp_od_t: change the values of pp_od in reg CTRL3
+  *
+  */
+int32_t lis2ds12_pin_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_pp_od_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  reg.ctrl3.pp_od = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_mode: [get]  Push-pull/open-drain selection on interrupt pad.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_pp_od_t: Get the values of pp_od in reg CTRL3
+  *
+  */
+int32_t lis2ds12_pin_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_pp_od_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  *val = (lis2ds12_pp_od_t) reg.ctrl3.pp_od;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_polarity: [set]  Interrupt active-high/low.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_h_lactive_t: change the values of h_lactive in reg CTRL3
+  *
+  */
+int32_t lis2ds12_pin_polarity_set(lis2ds12_ctx_t *ctx,
+                                  lis2ds12_h_lactive_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  reg.ctrl3.h_lactive = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_polarity: [get]  Interrupt active-high/low.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_h_lactive_t: Get the values of h_lactive in reg CTRL3
+  *
+  */
+int32_t lis2ds12_pin_polarity_get(lis2ds12_ctx_t *ctx,
+                                  lis2ds12_h_lactive_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  *val = (lis2ds12_h_lactive_t) reg.ctrl3.h_lactive;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_notification: [set]  Latched/pulsed interrupt.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_lir_t: change the values of lir in reg CTRL3
+  *
+  */
+int32_t lis2ds12_int_notification_set(lis2ds12_ctx_t *ctx,
+                                      lis2ds12_lir_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  reg.ctrl3.lir = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_notification: [get]  Latched/pulsed interrupt.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_lir_t: Get the values of lir in reg CTRL3
+  *
+  */
+int32_t lis2ds12_int_notification_get(lis2ds12_ctx_t *ctx,
+                                      lis2ds12_lir_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  *val = (lis2ds12_lir_t) reg.ctrl3.lir;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int1_route: [set] Select the signal that need to route
+  *                               on int1 pad.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_pin_int1_route_t: union of registers from CTRL4 to
+  *
+  */
+int32_t lis2ds12_pin_int1_route_set(lis2ds12_ctx_t *ctx,
+                                    lis2ds12_pin_int1_route_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL4, &reg.byte, 1);
+  reg.ctrl4.int1_drdy         = val.int1_drdy;
+  reg.ctrl4.int1_fth          = val.int1_fth;
+  reg.ctrl4.int1_6d           = val.int1_6d;
+  reg.ctrl4.int1_tap          = val.int1_tap;
+  reg.ctrl4.int1_ff           = val.int1_ff;
+  reg.ctrl4.int1_wu           = val.int1_wu;
+  reg.ctrl4.int1_s_tap        = val.int1_s_tap;
+  reg.ctrl4.int1_master_drdy  = val.int1_master_drdy;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL4, &reg.byte, 1);
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+  reg.wake_up_dur.int1_fss7   = val.int1_fss7;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int1_route: [get] Select the signal that need to route on
+  *                               int1 pad.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_pin_int1_route_t: union of registers from CTRL4 to
+  *
+  */
+int32_t lis2ds12_pin_int1_route_get(lis2ds12_ctx_t *ctx,
+                                    lis2ds12_pin_int1_route_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL4, &reg.byte, 1);
+  val->int1_drdy          = reg.ctrl4.int1_drdy;
+  val->int1_fth           = reg.ctrl4.int1_fth;
+  val->int1_6d            = reg.ctrl4.int1_6d;
+  val->int1_tap           = reg.ctrl4.int1_tap;
+  val->int1_ff            = reg.ctrl4.int1_ff;
+  val->int1_wu            = reg.ctrl4.int1_wu;
+  val->int1_s_tap         = reg.ctrl4.int1_s_tap;
+  val->int1_master_drdy   = reg.ctrl4.int1_master_drdy;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+  val->int1_fss7 = reg.wake_up_dur.int1_fss7;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int2_route: [set] Select the signal that need to route on
+  *                               int2 pad.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_pin_int2_route_t: union of registers from CTRL5 to
+  *
+  */
+int32_t lis2ds12_pin_int2_route_set(lis2ds12_ctx_t *ctx,
+                                    lis2ds12_pin_int2_route_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+  reg.ctrl5.int2_boot       = val.int2_boot;
+  reg.ctrl5.int2_tilt       = val.int2_tilt;
+  reg.ctrl5.int2_sig_mot    = val.int2_sig_mot;
+  reg.ctrl5.int2_step_det   = val.int2_step_det;
+  reg.ctrl5.int2_fth        = val.int2_fth;
+  reg.ctrl5.int2_drdy       = val.int2_drdy;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int2_route: [get] Select the signal that need to route on
+  *                               int2 pad.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_pin_int2_route_t: union of registers from CTRL5 to
+  *
+  */
+int32_t lis2ds12_pin_int2_route_get(lis2ds12_ctx_t *ctx,
+                                    lis2ds12_pin_int2_route_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+  val->int2_boot     = reg.ctrl5.int2_boot;
+  val->int2_tilt     = reg.ctrl5.int2_tilt;
+  val->int2_sig_mot  = reg.ctrl5.int2_sig_mot;
+  val->int2_step_det = reg.ctrl5.int2_step_det;
+  val->int2_fth      = reg.ctrl5.int2_fth;
+  val->int2_drdy     = reg.ctrl5.int2_drdy;
+
+  return mm_error;
+}
+
+/**
+  * @brief  all_on_int1: [set] All interrupt signals become available on
+  *                            INT1 pin.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int2_on_int1 in reg CTRL5
+  *
+  */
+int32_t lis2ds12_all_on_int1_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+  reg.ctrl5.int2_on_int1 = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  all_on_int1: [get] All interrupt signals become available on
+  *                            INT1 pin.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int2_on_int1 in reg CTRL5
+  *
+  */
+int32_t lis2ds12_all_on_int1_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
+  *val = reg.ctrl5.int2_on_int1;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  interrupt_pins
+  * @brief   This section groups all the functions that manage interrup pins
+  * @{
+  */
+
+  /**
+  * @brief  sh_pin_mode: [set] Connect / Disconnect pull-up on auxiliary
+  *                            I2C line.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_tud_en_t: change the values of tud_en in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_sh_pin_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_tud_en_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  reg.func_ctrl.tud_en = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  sh_pin_mode: [get] Connect / Disconnect pull-up on auxiliary
+  *                            I2C line.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_tud_en_t: Get the values of tud_en in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_sh_pin_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_tud_en_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  *val = (lis2ds12_tud_en_t) reg.func_ctrl.tud_en;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Wake_Up_event
+  * @brief   This section groups all the functions that manage the Wake Up
+  *          event generation.
+  * @{
+  */
+
+  /**
+  * @brief  wkup_threshold: [set]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of wu_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t lis2ds12_wkup_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+  reg.wake_up_ths.wu_ths = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_threshold: [get]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of wu_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t lis2ds12_wkup_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+  *val = reg.wake_up_ths.wu_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_dur: [set]  Wakeup duration [1 LSb = 1 / ODR].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of wu_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lis2ds12_wkup_dur_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+  reg.wake_up_dur.wu_dur = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_dur: [get]  Wakeup duration [1 LSb = 1 / ODR].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of wu_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lis2ds12_wkup_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+  *val = reg.wake_up_dur.wu_dur;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Activity/Inactivity_detection
+  * @brief   This section groups all the functions concerning
+  *          activity/inactivity detection.
+  * @{
+  */
+/**
+  * @brief  sleep_mode: [set]  Enables Sleep mode.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sleep_on in reg WAKE_UP_THS
+  *
+  */
+int32_t lis2ds12_sleep_mode_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+  reg.wake_up_ths.sleep_on = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  sleep_mode: [get]  Enables Sleep mode.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sleep_on in reg WAKE_UP_THS
+  *
+  */
+int32_t lis2ds12_sleep_mode_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+  *val = reg.wake_up_ths.sleep_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief  act_sleep_dur: [set] Duration to go in sleep mode
+  *                              [1 LSb = 512 / ODR].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lis2ds12_act_sleep_dur_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+  reg.wake_up_dur.sleep_dur = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  act_sleep_dur: [get] Duration to go in sleep mode
+  *                              [1 LSb = 512 / ODR].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lis2ds12_act_sleep_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
+  *val = reg.wake_up_dur.sleep_dur;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  tap_generator
+  * @brief   This section groups all the functions that manage the tap and
+  *          double tap event generation.
+  * @{
+  */
+
+/**
+  * @brief  tap_detection_on_z: [set]  Enable Z direction in tap recognition.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_z_en in reg CTRL3
+  *
+  */
+int32_t lis2ds12_tap_detection_on_z_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  reg.ctrl3.tap_z_en = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_z: [get]  Enable Z direction in tap recognition.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_z_en in reg CTRL3
+  *
+  */
+int32_t lis2ds12_tap_detection_on_z_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  *val = reg.ctrl3.tap_z_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_y: [set]  Enable Y direction in tap recognition.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_y_en in reg CTRL3
+  *
+  */
+int32_t lis2ds12_tap_detection_on_y_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  reg.ctrl3.tap_y_en = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_y: [get]  Enable Y direction in tap recognition.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_y_en in reg CTRL3
+  *
+  */
+int32_t lis2ds12_tap_detection_on_y_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  *val = reg.ctrl3.tap_y_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_x: [set]  Enable X direction in tap recognition.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_x_en in reg CTRL3
+  *
+  */
+int32_t lis2ds12_tap_detection_on_x_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  reg.ctrl3.tap_x_en = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_x: [get]  Enable X direction in tap recognition.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_x_en in reg CTRL3
+  *
+  */
+int32_t lis2ds12_tap_detection_on_x_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
+  *val = reg.ctrl3.tap_x_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_threshold: [set] Threshold for tap recognition
+  *                              [1 LSb = FS/32].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_ths in reg TAP_6D_THS
+  *
+  */
+int32_t lis2ds12_tap_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+  reg.tap_6d_ths.tap_ths = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_threshold: [get] Threshold for tap recognition
+  *                              [1 LSb = FS/32].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_ths in reg TAP_6D_THS
+  *
+  */
+int32_t lis2ds12_tap_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+  *val = reg.tap_6d_ths.tap_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_shock: [set] Maximum duration is the maximum time of
+  *                          an overthreshold signal detection to be
+  *                          recognized as a tap event. The default value
+  *                          of these bits is 00b which corresponds to
+  *                          4*ODR_XL time. If the SHOCK[1:0] bits are set
+  *                          to a different value, 1LSB corresponds to
+  *                          8*ODR_XL time.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of shock in reg INT_DUR
+  *
+  */
+int32_t lis2ds12_tap_shock_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+  reg.int_dur.shock = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_shock: [get] Maximum duration is the maximum time of an
+  *                          overthreshold signal detection to be recognized
+  *                          as a tap event. The default value of these bits
+  *                          is 00b which corresponds to 4*ODR_XL time.
+  *                          If the SHOCK[1:0] bits are set to a different
+                             value, 1LSB corresponds to 8*ODR_XL time.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of shock in reg INT_DUR
+  *
+  */
+int32_t lis2ds12_tap_shock_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+  *val = reg.int_dur.shock;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_quiet: [set] Quiet time is the time after the first
+  *                          detected tap in which there must not be any
+  *                          overthreshold event. The default value of these
+  *                          bits is 00b which corresponds to 2*ODR_XL time.
+  *                          If the QUIET[1:0] bits are set to a different
+  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of quiet in reg INT_DUR
+  *
+  */
+int32_t lis2ds12_tap_quiet_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+  reg.int_dur.quiet = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_quiet: [get] Quiet time is the time after the first detected
+  *                          tap in which there must not be any overthreshold
+  *                          event. The default value of these bits is 00b
+  *                          which corresponds to 2*ODR_XL time.
+  *                          If the QUIET[1:0] bits are set to a different
+  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of quiet in reg INT_DUR
+  *
+  */
+int32_t lis2ds12_tap_quiet_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+  *val = reg.int_dur.quiet;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_dur: [set] When double tap recognition is enabled, this
+  *                        register expresses the maximum time between two
+  *                        consecutive detected taps to determine a double
+  *                        tap event. The default value of these bits is
+  *                        0000b which corresponds to 16*ODR_XL time.
+  *                        If the DUR[3:0] bits are set to a different value,
+  *                        1LSB corresponds to 32*ODR_XL time.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of lat in reg INT_DUR
+  *
+  */
+int32_t lis2ds12_tap_dur_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+  reg.int_dur.lat = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_dur: [get] When double tap recognition is enabled,
+  *                        this register expresses the maximum time
+  *                        between two consecutive detected taps to
+  *                        determine a double tap event. The default
+  *                        value of these bits is 0000b which corresponds
+  *                        to 16*ODR_XL time. If the DUR[3:0] bits are set
+  *                        to a different value, 1LSB corresponds to
+  *                        32*ODR_XL time.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of lat in reg INT_DUR
+  *
+  */
+int32_t lis2ds12_tap_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
+  *val = reg.int_dur.lat;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_mode: [set]  Single/double-tap event enable/disable.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_single_double_tap_t: change the values of
+  *                                       single_double_tap in regWAKE_UP_THS
+  *
+  */
+int32_t lis2ds12_tap_mode_set(lis2ds12_ctx_t *ctx,
+                              lis2ds12_single_double_tap_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+  reg.wake_up_ths.single_double_tap = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_mode: [get]  Single/double-tap event enable/disable.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_single_double_tap_t: Get the values of single_double_tap
+  *                                       in reg WAKE_UP_THS
+  *
+  */
+int32_t lis2ds12_tap_mode_get(lis2ds12_ctx_t *ctx,
+                              lis2ds12_single_double_tap_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
+  *val = (lis2ds12_single_double_tap_t) reg.wake_up_ths.single_double_tap;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_src: [get]  TAP source register
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_tap_src_t: registers TAP_SRC
+  *
+  */
+int32_t lis2ds12_tap_src_get(lis2ds12_ctx_t *ctx, lis2ds12_tap_src_t *val)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_TAP_SRC, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Six_position_detection(6D/4D)
+  * @brief   This section groups all the functions concerning six
+  *          position detection (6D).
+  * @{
+  */
+
+/**
+  * @brief  6d_threshold: [set]  Threshold for 4D/6D function.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_6d_ths_t: change the values of 6d_ths in reg TAP_6D_THS
+  *
+  */
+int32_t lis2ds12_6d_threshold_set(lis2ds12_ctx_t *ctx, lis2ds12_6d_ths_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+  reg.tap_6d_ths._6d_ths = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  6d_threshold: [get]  Threshold for 4D/6D function.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_6d_ths_t: Get the values of 6d_ths in reg TAP_6D_THS
+  *
+  */
+int32_t lis2ds12_6d_threshold_get(lis2ds12_ctx_t *ctx, lis2ds12_6d_ths_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+  *val = (lis2ds12_6d_ths_t) reg.tap_6d_ths._6d_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  4d_mode: [set]  4D orientation detection enable.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of 4d_en in reg TAP_6D_THS
+  *
+  */
+int32_t lis2ds12_4d_mode_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+  reg.tap_6d_ths._4d_en = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  4d_mode: [get]  4D orientation detection enable.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of 4d_en in reg TAP_6D_THS
+  *
+  */
+int32_t lis2ds12_4d_mode_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
+  *val = reg.tap_6d_ths._4d_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  6d_src: [get]  6D source register.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_6d_src_t: union of registers from 6D_SRC to
+  *
+  */
+int32_t lis2ds12_6d_src_get(lis2ds12_ctx_t *ctx, lis2ds12_6d_src_t *val)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_6D_SRC, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  free_fall
+  * @brief   This section group all the functions concerning the
+  *          free fall detection.
+  * @{
+  */
+
+/**
+  * @brief  ff_dur: [set]  Free-fall duration [1 LSb = 1 / ODR].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of ff_dur in reg
+  *                      WAKE_UP_DUR/FREE_FALL
+  *
+  */
+int32_t lis2ds12_ff_dur_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg[0].byte, 2);
+  reg[1].free_fall.ff_dur = 0x1F & val;
+  reg[0].wake_up_dur.ff_dur = (val & 0x20) >> 5;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg[0].byte, 2);
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_dur: [get]  Free-fall duration [1 LSb = 1 / ODR].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  *
+  */
+int32_t lis2ds12_ff_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg[0].byte, 2);
+  *val = (reg[0].wake_up_dur.ff_dur << 5) + reg[1].free_fall.ff_dur;
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_threshold: [set]  Free-fall threshold [1 LSB = 31.25 mg].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lis2ds12_ff_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FREE_FALL, &reg.byte, 1);
+  reg.free_fall.ff_ths = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FREE_FALL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_threshold: [get]  Free-fall threshold [1 LSB = 31.25 mg].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lis2ds12_ff_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FREE_FALL, &reg.byte, 1);
+  *val = reg.free_fall.ff_ths;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Fifo
+  * @brief   This section group all the functions concerning the fifo usage
+  * @{
+  */
+
+/**
+  * @brief   fifo_xl_module_batch: [set]  Module routine result is send to
+  *          FIFO instead of X,Y,Z acceleration data
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of module_to_fifo in reg FIFO_CTRL
+  *
+  */
+int32_t lis2ds12_fifo_xl_module_batch_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+  reg.fifo_ctrl.module_to_fifo = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_xl_module_batch: [get]  Module routine result is send to
+  *                                       FIFO instead of X,Y,Z acceleration
+  *                                       data
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of module_to_fifo in reg FIFO_CTRL
+  *
+  */
+int32_t lis2ds12_fifo_xl_module_batch_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+  *val = reg.fifo_ctrl.module_to_fifo;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [set]  FIFO mode selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_fmode_t: change the values of fmode in reg FIFO_CTRL
+  *
+  */
+int32_t lis2ds12_fifo_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_fmode_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+  reg.fifo_ctrl.fmode = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [get]  FIFO mode selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_fmode_t: Get the values of fmode in reg FIFO_CTRL
+  *
+  */
+int32_t lis2ds12_fifo_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_fmode_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
+  *val = (lis2ds12_fmode_t) reg.fifo_ctrl.fmode;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of fifo_watermark in reg FIFO_THS
+  *
+  */
+int32_t lis2ds12_fifo_watermark_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  int32_t mm_error;
+
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_THS, &val, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_watermark in reg FIFO_THS
+  *
+  */
+int32_t lis2ds12_fifo_watermark_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_THS, val, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_full_flag: [get]  FIFO full, 256 unread samples.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of diff in reg FIFO_SRC
+  *
+  */
+int32_t lis2ds12_fifo_full_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &reg.byte, 1);
+  *val = reg.fifo_src.diff;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_flag: [get]  FIFO overrun status.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_ovr in reg FIFO_SRC
+  *
+  */
+int32_t lis2ds12_fifo_ovr_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &reg.byte, 1);
+  *val = reg.fifo_src.fifo_ovr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_wtm_flag: [get]  FIFO threshold status.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fth in reg FIFO_SRC
+  *
+  */
+int32_t lis2ds12_fifo_wtm_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &reg.byte, 1);
+  *val = reg.fifo_src.fth;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_data_level: [get] The number of unread samples
+  *                                stored in FIFO.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint16_t: change the values of diff in reg FIFO_SAMPLES
+  *
+  */
+int32_t lis2ds12_fifo_data_level_get(lis2ds12_ctx_t *ctx, uint16_t *val)
+{
+  lis2ds12_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_THS, &reg[0].byte, 2);
+  *val = (reg[1].fifo_src.diff << 8) + reg[0].byte;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_src: [get] FIFO_SRCregister.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_fifo_src_t: registers FIFO_SRC
+  *
+  */
+int32_t lis2ds12_fifo_src_get(lis2ds12_ctx_t *ctx, lis2ds12_fifo_src_t *val)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Pedometer
+  * @brief   This section groups all the functions that manage pedometer.
+  * @{
+  */
+
+/**
+  * @brief  pedo_threshold: [set] Minimum threshold value for step
+  *                               counter routine.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sc_mths in
+  *                      reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lis2ds12_pedo_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                               &reg.byte, 1);
+  reg. step_counter_minths.sc_mths = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                                &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_threshold: [get] Minimum threshold value for step
+  *                               counter routine.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sc_mths in reg  STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lis2ds12_pedo_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                               &reg.byte, 1);
+  *val = reg. step_counter_minths.sc_mths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_full_scale: [set]  Pedometer data range.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_pedo4g_t: change the values of pedo4g in
+  *                            reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lis2ds12_pedo_full_scale_set(lis2ds12_ctx_t *ctx,
+                                     lis2ds12_pedo4g_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                               &reg.byte, 1);
+  reg. step_counter_minths.pedo4g = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                                &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_full_scale: [get]  Pedometer data range.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_pedo4g_t: Get the values of pedo4g in
+  *                            reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lis2ds12_pedo_full_scale_get(lis2ds12_ctx_t *ctx,
+                                     lis2ds12_pedo4g_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                               &reg.byte, 1);
+  *val = (lis2ds12_pedo4g_t) reg. step_counter_minths.pedo4g;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_step_reset: [set]  Reset pedometer step counter.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of rst_nstep in
+  *                      reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lis2ds12_pedo_step_reset_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                               &reg.byte, 1);
+  reg. step_counter_minths.rst_nstep = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                                &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_step_reset: [get]  Reset pedometer step counter.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of rst_nstep in
+  *                  reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lis2ds12_pedo_step_reset_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                               &reg.byte, 1);
+  *val = reg. step_counter_minths.rst_nstep;
+
+  return mm_error;
+}
+
+/**
+  * @brief   pedo_step_detect_flag: [get]  Step detection flag.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of step_detect in reg FUNC_CK_GATE
+  *
+  */
+int32_t lis2ds12_pedo_step_detect_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE, &reg.byte, 1);
+  *val = reg.func_ck_gate.step_detect;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_sens: [set]  Enable pedometer algorithm.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of step_cnt_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_pedo_sens_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  reg.func_ctrl.step_cnt_on = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_sens: [get]  Enable pedometer algorithm.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of step_cnt_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_pedo_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  *val = reg.func_ctrl.step_cnt_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief   pedo_debounce_steps: [set] Minimum number of steps to start
+  *                                     the increment step counter.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of deb_step in reg PEDO_DEB_REG
+  *
+  */
+int32_t lis2ds12_pedo_debounce_steps_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
+  reg.pedo_deb_reg.deb_step = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief   pedo_debounce_steps: [get] Minimum number of steps to start
+  *                                     the increment step counter.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of deb_step in reg PEDO_DEB_REG
+  *
+  */
+int32_t lis2ds12_pedo_debounce_steps_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
+  *val = reg.pedo_deb_reg.deb_step;
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_timeout: [set] Debounce time. If the time between two
+  *                             consecutive steps is greater than
+  *                             DEB_TIME*80ms, the debouncer is reactivated.
+  *                             Default value: 01101
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of deb_time in reg PEDO_DEB_REG
+  *
+  */
+int32_t lis2ds12_pedo_timeout_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
+  reg.pedo_deb_reg.deb_time = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_timeout: [get] Debounce time. If the time between two
+  *                             consecutive steps is greater than
+  *                             DEB_TIME*80ms, the debouncer is reactivated.
+  *                             Default value: 01101
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of deb_time in reg PEDO_DEB_REG
+  *
+  */
+int32_t lis2ds12_pedo_timeout_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
+  *val = reg.pedo_deb_reg.deb_time;
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_steps_period: [set] Period of time to detect at
+  *                                  least one step to generate step
+  *                                  recognition [1 LSb = 1.6384 s].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t lis2ds12_pedo_steps_period_set(lis2ds12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNT_DELTA, buff, 1);
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_steps_period: [get] Period of time to detect at least
+  *                                  one step to generate step recognition
+  *                                  [1 LSb = 1.6384 s].
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lis2ds12_pedo_steps_period_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNT_DELTA, buff, 1);
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  significant_motion
+  * @brief   This section groups all the functions that manage the
+  *          significant motion detection.
+  * @{
+  */
+
+/**
+  * @brief   motion_data_ready_flag: [get] Significant motion event
+  *                                        detection status.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sig_mot_detect in reg FUNC_CK_GATE
+  *
+  */
+int32_t lis2ds12_motion_data_ready_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE, &reg.byte, 1);
+  *val = reg.func_ck_gate.sig_mot_detect;
+
+  return mm_error;
+}
+
+/**
+  * @brief  motion_sens: [set]  Enable significant motion detection function.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sign_mot_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_motion_sens_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  reg.func_ctrl.sign_mot_on = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  motion_sens: [get]  Enable significant motion detection function.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sign_mot_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_motion_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  *val = reg.func_ctrl.sign_mot_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief  motion_threshold: [set] These bits define the threshold value
+  *                                 which corresponds to the number of steps
+  *                                 to be performed by the user upon a change
+  *                                 of location before the significant motion
+  *                                 interrupt is generated. It is expressed
+  *                                 as an 8-bit unsigned value.
+  *                                 The default value of this field is equal
+  *                                 to 6 (= 00000110b).
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sm_ths in reg SM_THS
+  *
+  */
+int32_t lis2ds12_motion_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_SM_THS, &reg.byte, 1);
+  reg.sm_ths.sm_ths = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SM_THS, &reg.byte, 1);
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  motion_threshold: [get] These bits define the threshold value
+  *                                 which corresponds to the number of steps
+  *                                 to be performed by the user upon a change
+  *                                 of location before the significant motion
+  *                                 interrupt is generated. It is expressed as
+  *                                 an 8-bit unsigned value. The default value
+  *                                 of this field is equal to 6 (= 00000110b).
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sm_ths in reg SM_THS
+  *
+  */
+int32_t lis2ds12_motion_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_SM_THS, &reg.byte, 1);
+  *val = reg.sm_ths.sm_ths;
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  tilt_detection
+  * @brief   This section groups all the functions that manage the tilt
+  *          event detection.
+  * @{
+  */
+
+/**
+  * @brief   tilt_data_ready_flag: [get]  Tilt event detection status.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tilt_int in reg FUNC_CK_GATE
+  *
+  */
+int32_t lis2ds12_tilt_data_ready_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE, &reg.byte, 1);
+  *val = reg.func_ck_gate.tilt_int;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tilt_sens: [set]  Enable tilt calculation.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tilt_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_tilt_sens_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  reg.func_ctrl.tilt_on = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tilt_sens: [get]  Enable tilt calculation.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tilt_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_tilt_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  *val = reg.func_ctrl.tilt_on;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  module
+  * @brief   This section groups all the functions that manage
+  *          module calculation
+  * @{
+  */
+
+/**
+  * @brief  module_sens: [set]  Module processing enable.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of module_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_module_sens_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  reg.func_ctrl.module_on = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  module_sens: [get]  Module processing enable.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of module_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_module_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  *val = reg.func_ctrl.module_on;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Sensor_hub
+  * @brief   This section groups all the functions that manage the sensor
+  *          hub functionality.
+  * @{
+  */
+
+/**
+  * @brief  sh_read_data_raw: [get]  Sensor hub output registers.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_sh_read_data_raw_t: registers from SENSORHUB1_REG
+  *                                      to SENSORHUB6_REG
+  *
+  */
+int32_t lis2ds12_sh_read_data_raw_get(lis2ds12_ctx_t *ctx,
+                                      lis2ds12_sh_read_data_raw_t *val)
+{
+  return lis2ds12_read_reg(ctx, LIS2DS12_SENSORHUB1_REG, (uint8_t*) val, 6);
+}
+
+/**
+  * @brief  sh_master: [set]  Sensor hub I2C master enable.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of master_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_sh_master_set(lis2ds12_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  reg.func_ctrl.master_on = val;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  sh_master: [get]  Sensor hub I2C master enable.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of master_on in reg FUNC_CTRL
+  *
+  */
+int32_t lis2ds12_sh_master_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
+  *val = reg.func_ctrl.master_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief  sh_cfg_write: Configure slave to perform a write.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_sh_cfg_write_t: a structure that contain
+  *                      - uint8_t slv_add;    8 bit i2c device address
+  *                      - uint8_t slv_subadd; 8 bit register device address
+  *                      - uint8_t slv_data;   8 bit data to write
+  *
+  */
+int32_t lis2ds12_sh_cfg_write(lis2ds12_ctx_t *ctx,
+                              lis2ds12_sh_cfg_write_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  reg.byte = val->slv_add;
+  reg.slv0_add.rw_0 = 0;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_ADD, &reg.byte, 1);
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_SUBADD,
+                               &(val->slv_subadd), 1);
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_DATAWRITE_SLV0,
+                              &(val->slv_data), 1);
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  sh_slv_cfg_read: [get] Configure slave 0 for perform a write/read.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  lis2ds12_sh_cfg_read_t: a structure that contain
+  *                      - uint8_t slv_add;    8 bit i2c device address
+  *                      - uint8_t slv_subadd; 8 bit register device address
+  *                      - uint8_t slv_len;    num of bit to read
+  *
+  */
+int32_t lis2ds12_sh_slv_cfg_read(lis2ds12_ctx_t *ctx,
+                                 lis2ds12_sh_cfg_read_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  reg.byte = val->slv_add;
+  reg.slv0_add.rw_0 = 1;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_ADD, &reg.byte, 1);
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_SUBADD,
+                               &(val->slv_subadd), 1);
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_SLV0_CONFIG, &reg.byte, 1);
+  reg.slv0_config.slave0_numop = val->slv_len;
+  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_CONFIG, &reg.byte, 1);
+  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  lis2ds12_sh_end_op_flag_get: [get] Sensor hub communication status.
+  *
+  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sensorhub_end_op
+  *
+  */
+int32_t lis2ds12_sh_end_op_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_SRC, &reg.byte, 1);
+  *val = reg.func_src.sensorhub_end_op;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2ds12_STdC/driver/lis2ds12_reg.h
+++ b/sensor/stmemsc/lis2ds12_STdC/driver/lis2ds12_reg.h
@@ -1,0 +1,915 @@
+/*
+ ******************************************************************************
+ * @file    lis2ds12_reg.h
+ * @author  MEMS Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis2ds12_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __LIS2DS12_DRIVER__H
+#define __LIS2DS12_DRIVER__H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS2DS12
+  * @{
+  *
+  */
+
+/** @defgroup LIS2DS12_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup lis2ds12_interface
+  * @{
+  */
+
+typedef int32_t (*lis2ds12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis2ds12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis2ds12_write_ptr  write_reg;
+  lis2ds12_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis2ds12_ctx_t;
+
+/**
+  * @}
+  */
+
+/** @defgroup lis2ds12_Infos
+  * @{
+  */
+  /** I2C Device Address 8 bit format  if SA0=0 -> 0x3D if SA0=1 -> 0x3B **/
+#define LIS2DS12_I2C_ADD_L     0x3D
+#define LIS2DS12_I2C_ADD_H     0x3B
+
+/** Device Identification (Who am I) **/
+#define LIS2DS12_ID            0x43
+
+/**
+  * @}
+  */
+
+/**
+  * @defgroup lis2ds12_Sensitivity
+  * @{
+  */
+
+#define LIS2DS12_FROM_FS_2g_TO_mg(lsb)    (float)(lsb *  61.0f) / 1000.0f
+#define LIS2DS12_FROM_FS_4g_TO_mg(lsb)    (float)(lsb * 122.0f) / 1000.0f
+#define LIS2DS12_FROM_FS_8g_TO_mg(lsb)    (float)(lsb * 244.0f) / 1000.0f
+#define LIS2DS12_FROM_FS_16g_TO_mg(lsb)   (float)(lsb * 488.0f) / 1000.0f
+
+#define LIS2DS12_FROM_LSB_TO_degC(lsb)  ((float)((int16_t)lsb>>8)*1.0f + 25.0f)
+
+/**
+  * @}
+  */
+
+#define LIS2DS12_SENSORHUB1_REG        0x06
+typedef struct {
+  uint8_t bit0                : 1;
+  uint8_t bit1                : 1;
+  uint8_t bit2                : 1;
+  uint8_t bit3                : 1;
+  uint8_t bit4                : 1;
+  uint8_t bit5                : 1;
+  uint8_t bit6                : 1;
+  uint8_t bit7                : 1;
+} lis2ds12_sensorhub1_reg_t;
+
+#define LIS2DS12_SENSORHUB2_REG        0x07
+typedef struct {
+  uint8_t bit0                : 1;
+  uint8_t bit1                : 1;
+  uint8_t bit2                : 1;
+  uint8_t bit3                : 1;
+  uint8_t bit4                : 1;
+  uint8_t bit5                : 1;
+  uint8_t bit6                : 1;
+  uint8_t bit7                : 1;
+} lis2ds12_sensorhub2_reg_t;
+
+#define LIS2DS12_SENSORHUB3_REG        0x08
+typedef struct {
+  uint8_t bit0                : 1;
+  uint8_t bit1                : 1;
+  uint8_t bit2                : 1;
+  uint8_t bit3                : 1;
+  uint8_t bit4                : 1;
+  uint8_t bit5                : 1;
+  uint8_t bit6                : 1;
+  uint8_t bit7                : 1;
+} lis2ds12_sensorhub3_reg_t;
+
+#define LIS2DS12_SENSORHUB4_REG        0x09
+typedef struct {
+  uint8_t bit0                : 1;
+  uint8_t bit1                : 1;
+  uint8_t bit2                : 1;
+  uint8_t bit3                : 1;
+  uint8_t bit4                : 1;
+  uint8_t bit5                : 1;
+  uint8_t bit6                : 1;
+  uint8_t bit7                : 1;
+} lis2ds12_sensorhub4_reg_t;
+
+#define LIS2DS12_SENSORHUB5_REG        0x0A
+typedef struct {
+  uint8_t bit0                : 1;
+  uint8_t bit1                : 1;
+  uint8_t bit2                : 1;
+  uint8_t bit3                : 1;
+  uint8_t bit4                : 1;
+  uint8_t bit5                : 1;
+  uint8_t bit6                : 1;
+  uint8_t bit7                : 1;
+} lis2ds12_sensorhub5_reg_t;
+
+#define LIS2DS12_SENSORHUB6_REG        0x0B
+typedef struct {
+  uint8_t bit0                : 1;
+  uint8_t bit1                : 1;
+  uint8_t bit2                : 1;
+  uint8_t bit3                : 1;
+  uint8_t bit4                : 1;
+  uint8_t bit5                : 1;
+  uint8_t bit6                : 1;
+  uint8_t bit7                : 1;
+} lis2ds12_sensorhub6_reg_t;
+
+#define LIS2DS12_MODULE_8BIT           0x0C
+#define LIS2DS12_WHO_AM_I              0x0F
+#define LIS2DS12_CTRL1                 0x20
+typedef struct {
+  uint8_t bdu                 : 1;
+  uint8_t hf_odr              : 1;
+  uint8_t fs                  : 2;
+  uint8_t odr                 : 4;
+} lis2ds12_ctrl1_t;
+
+#define LIS2DS12_CTRL2                 0x21
+typedef struct {
+  uint8_t sim                 : 1;
+  uint8_t i2c_disable         : 1;
+  uint8_t if_add_inc          : 1;
+  uint8_t fds_slope           : 1;
+  uint8_t func_cfg_en         : 1;
+  uint8_t not_used_01         : 1;
+  uint8_t soft_reset          : 1;
+  uint8_t boot                : 1;
+} lis2ds12_ctrl2_t;
+
+#define LIS2DS12_CTRL3                 0x22
+typedef struct {
+  uint8_t pp_od               : 1;
+  uint8_t h_lactive           : 1;
+  uint8_t lir                 : 1;
+  uint8_t tap_z_en            : 1;
+  uint8_t tap_y_en            : 1;
+  uint8_t tap_x_en            : 1;
+  uint8_t st                  : 2;
+} lis2ds12_ctrl3_t;
+
+#define LIS2DS12_CTRL4                 0x23
+typedef struct {
+  uint8_t int1_drdy           : 1;
+  uint8_t int1_fth            : 1;
+  uint8_t int1_6d             : 1;
+  uint8_t int1_tap            : 1;
+  uint8_t int1_ff             : 1;
+  uint8_t int1_wu             : 1;
+  uint8_t int1_s_tap          : 1;
+  uint8_t int1_master_drdy    : 1;
+} lis2ds12_ctrl4_t;
+
+#define LIS2DS12_CTRL5                 0x24
+typedef struct {
+  uint8_t int2_drdy           : 1;
+  uint8_t int2_fth            : 1;
+  uint8_t int2_step_det       : 1;
+  uint8_t int2_sig_mot        : 1;
+  uint8_t int2_tilt           : 1;
+  uint8_t int2_on_int1        : 1;
+  uint8_t int2_boot           : 1;
+  uint8_t drdy_pulsed         : 1;
+} lis2ds12_ctrl5_t;
+
+#define LIS2DS12_FIFO_CTRL             0x25
+typedef struct {
+  uint8_t if_cs_pu_dis        : 1;
+  uint8_t not_used_01         : 2;
+  uint8_t module_to_fifo      : 1;
+  uint8_t int2_step_count_ov  : 1;
+  uint8_t fmode               : 3;
+} lis2ds12_fifo_ctrl_t;
+
+#define LIS2DS12_OUT_T                 0x26
+#define LIS2DS12_STATUS                0x27
+typedef struct {
+  uint8_t drdy                : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t single_tap          : 1;
+  uint8_t double_tap          : 1;
+  uint8_t sleep_state         : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t fifo_ths            : 1;
+} lis2ds12_status_t;
+
+#define LIS2DS12_OUT_X_L               0x28
+#define LIS2DS12_OUT_X_H               0x29
+#define LIS2DS12_OUT_Y_L               0x2A
+#define LIS2DS12_OUT_Y_H               0x2B
+#define LIS2DS12_OUT_Z_L               0x2C
+#define LIS2DS12_OUT_Z_H               0x2D
+#define LIS2DS12_FIFO_THS              0x2E
+#define LIS2DS12_FIFO_SRC              0x2F
+typedef struct {
+  uint8_t not_used_01         : 5;
+  uint8_t diff                : 1;
+  uint8_t fifo_ovr            : 1;
+  uint8_t fth                 : 1;
+} lis2ds12_fifo_src_t;
+
+#define LIS2DS12_FIFO_SAMPLES          0x30
+#define LIS2DS12_TAP_6D_THS            0x31
+typedef struct {
+  uint8_t tap_ths             : 5;
+  uint8_t _6d_ths             : 2;
+  uint8_t _4d_en              : 1;
+} lis2ds12_tap_6d_ths_t;
+
+#define LIS2DS12_INT_DUR               0x32
+typedef struct {
+  uint8_t shock               : 2;
+  uint8_t quiet               : 2;
+  uint8_t lat                 : 4;
+} lis2ds12_int_dur_t;
+
+#define LIS2DS12_WAKE_UP_THS           0x33
+typedef struct {
+  uint8_t wu_ths              : 6;
+  uint8_t sleep_on            : 1;
+  uint8_t single_double_tap   : 1;
+} lis2ds12_wake_up_ths_t;
+
+#define LIS2DS12_WAKE_UP_DUR           0x34
+typedef struct {
+  uint8_t sleep_dur           : 4;
+  uint8_t int1_fss7           : 1;
+  uint8_t wu_dur              : 2;
+  uint8_t ff_dur              : 1;
+} lis2ds12_wake_up_dur_t;
+
+#define LIS2DS12_FREE_FALL             0x35
+typedef struct {
+  uint8_t ff_ths              : 3;
+  uint8_t ff_dur              : 5;
+} lis2ds12_free_fall_t;
+
+#define LIS2DS12_STATUS_DUP            0x36
+typedef struct {
+  uint8_t drdy                : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t single_tap          : 1;
+  uint8_t double_tap          : 1;
+  uint8_t sleep_state         : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t ovr                 : 1;
+} lis2ds12_status_dup_t;
+
+#define LIS2DS12_WAKE_UP_SRC           0x37
+typedef struct {
+  uint8_t z_wu                : 1;
+  uint8_t y_wu                : 1;
+  uint8_t x_wu                : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t sleep_state_ia      : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t not_used_01         : 2;
+} lis2ds12_wake_up_src_t;
+
+#define LIS2DS12_TAP_SRC               0x38
+typedef struct {
+  uint8_t z_tap               : 1;
+  uint8_t y_tap               : 1;
+  uint8_t x_tap               : 1;
+  uint8_t tap_sign            : 1;
+  uint8_t double_tap          : 1;
+  uint8_t single_tap          : 1;
+  uint8_t tap_ia              : 1;
+  uint8_t not_used_01         : 1;
+} lis2ds12_tap_src_t;
+
+#define LIS2DS12_6D_SRC                0x39
+typedef struct {
+  uint8_t xl                  : 1;
+  uint8_t xh                  : 1;
+  uint8_t yl                  : 1;
+  uint8_t yh                  : 1;
+  uint8_t zl                  : 1;
+  uint8_t zh                  : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t not_used_01         : 1;
+} lis2ds12_6d_src_t;
+
+#define LIS2DS12_STEP_COUNTER_MINTHS   0x3A
+typedef struct {
+  uint8_t sc_mths             : 6;
+  uint8_t pedo4g              : 1;
+  uint8_t rst_nstep           : 1;
+} lis2ds12_step_counter_minths_t;
+
+#define LIS2DS12_STEP_COUNTER_L        0x3B
+#define LIS2DS12_STEP_COUNTER_H        0x3C
+#define LIS2DS12_FUNC_CK_GATE          0x3D
+typedef struct {
+  uint8_t ck_gate_func        : 1;
+  uint8_t step_detect         : 1;
+  uint8_t rst_pedo            : 1;
+  uint8_t rst_sign_mot        : 1;
+  uint8_t sig_mot_detect      : 1;
+  uint8_t fs_src              : 2;
+  uint8_t tilt_int            : 1;
+} lis2ds12_func_ck_gate_t;
+
+#define LIS2DS12_FUNC_SRC              0x3E
+typedef struct {
+  uint8_t sensorhub_end_op    : 1;
+  uint8_t module_ready        : 1;
+  uint8_t rst_tilt            : 1;
+  uint8_t not_used_01         : 5;
+} lis2ds12_func_src_t;
+
+#define LIS2DS12_FUNC_CTRL             0x3F
+typedef struct {
+  uint8_t step_cnt_on         : 1;
+  uint8_t sign_mot_on         : 1;
+  uint8_t master_on           : 1;
+  uint8_t tud_en              : 1;
+  uint8_t tilt_on             : 1;
+  uint8_t module_on           : 1;
+  uint8_t not_used_01         : 2;
+} lis2ds12_func_ctrl_t;
+
+#define LIS2DS12_PEDO_DEB_REG          0x2B
+typedef struct {
+  uint8_t deb_step            : 3;
+  uint8_t deb_time            : 5;
+} lis2ds12_pedo_deb_reg_t;
+
+#define LIS2DS12_SLV0_ADD              0x30
+typedef struct {
+  uint8_t rw_0                : 1;
+  uint8_t slave0_add          : 7;
+} lis2ds12_slv0_add_t;
+
+#define LIS2DS12_SLV0_SUBADD           0x31
+typedef struct {
+  uint8_t slave0_reg          : 8;
+} lis2ds12_slv0_subadd_t;
+
+#define LIS2DS12_SLV0_CONFIG           0x32
+typedef struct {
+  uint8_t slave0_numop        : 3;
+  uint8_t not_used_01         : 5;
+} lis2ds12_slv0_config_t;
+
+#define LIS2DS12_DATAWRITE_SLV0        0x33
+typedef struct {
+  uint8_t slave_dataw         : 8;
+} lis2ds12_datawrite_slv0_t;
+
+#define LIS2DS12_SM_THS                0x34
+typedef struct {
+  uint8_t sm_ths              : 8;
+} lis2ds12_sm_ths_t;
+
+#define LIS2DS12_STEP_COUNT_DELTA      0x3A
+typedef struct {
+  uint8_t step_count_d        : 8;
+} lis2ds12_step_count_delta_t;
+
+#define LIS2DS12_CTRL2_ADV             0x3F
+typedef struct {
+  uint8_t sim                 : 1;
+  uint8_t i2c_disable         : 1;
+  uint8_t if_add_inc          : 1;
+  uint8_t fds_slope           : 1;
+  uint8_t func_cfg_en         : 1;
+  uint8_t not_used_01         : 1;
+  uint8_t soft_reset          : 1;
+  uint8_t boot                : 1;
+} lis2ds12_ctrl2_adv_t;
+
+typedef union{
+  lis2ds12_sensorhub1_reg_t            sensorhub1_reg;
+  lis2ds12_sensorhub2_reg_t            sensorhub2_reg;
+  lis2ds12_sensorhub3_reg_t            sensorhub3_reg;
+  lis2ds12_sensorhub4_reg_t            sensorhub4_reg;
+  lis2ds12_sensorhub5_reg_t            sensorhub5_reg;
+  lis2ds12_sensorhub6_reg_t            sensorhub6_reg;
+  lis2ds12_ctrl1_t                     ctrl1;
+  lis2ds12_ctrl2_t                     ctrl2;
+  lis2ds12_ctrl3_t                     ctrl3;
+  lis2ds12_ctrl4_t                     ctrl4;
+  lis2ds12_ctrl5_t                     ctrl5;
+  lis2ds12_fifo_ctrl_t                 fifo_ctrl;
+  lis2ds12_status_t                    status;
+  lis2ds12_fifo_src_t                  fifo_src;
+  lis2ds12_tap_6d_ths_t                tap_6d_ths;
+  lis2ds12_int_dur_t                   int_dur;
+  lis2ds12_wake_up_ths_t               wake_up_ths;
+  lis2ds12_wake_up_dur_t               wake_up_dur;
+  lis2ds12_free_fall_t                 free_fall;
+  lis2ds12_status_dup_t                status_dup;
+  lis2ds12_wake_up_src_t               wake_up_src;
+  lis2ds12_tap_src_t                   tap_src;
+  lis2ds12_6d_src_t                    _6d_src;
+  lis2ds12_step_counter_minths_t       step_counter_minths;
+  lis2ds12_func_ck_gate_t              func_ck_gate;
+  lis2ds12_func_src_t                  func_src;
+  lis2ds12_func_ctrl_t                 func_ctrl;
+  lis2ds12_pedo_deb_reg_t              pedo_deb_reg;
+  lis2ds12_slv0_add_t                  slv0_add;
+  lis2ds12_slv0_subadd_t               slv0_subadd;
+  lis2ds12_slv0_config_t               slv0_config;
+  lis2ds12_datawrite_slv0_t            datawrite_slv0;
+  lis2ds12_sm_ths_t                    sm_ths;
+  lis2ds12_step_count_delta_t          step_count_delta;
+  lis2ds12_ctrl2_adv_t                 ctrl2_adv;
+  bitwise_t                            bitwise;
+  uint8_t                              byte;
+} lis2ds12_reg_t;
+int32_t lis2ds12_read_reg(lis2ds12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lis2ds12_write_reg(lis2ds12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+typedef union {
+  struct {
+  lis2ds12_fifo_src_t       fifo_src;
+  lis2ds12_status_dup_t     status_dup;
+  lis2ds12_wake_up_src_t    wake_up_src;
+  lis2ds12_tap_src_t        tap_src;
+  lis2ds12_6d_src_t         _6d_src;
+  lis2ds12_func_ck_gate_t   func_ck_gate;
+  lis2ds12_func_src_t       func_src;
+  } reg;
+  uint8_t byte[7];
+} lis2ds12_all_sources_t;
+int32_t lis2ds12_all_sources_get(lis2ds12_ctx_t *ctx,
+                                 lis2ds12_all_sources_t *val);
+
+
+int32_t lis2ds12_block_data_update_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_block_data_update_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DS12_2g = 0,
+  LIS2DS12_16g = 1,
+  LIS2DS12_4g = 2,
+  LIS2DS12_8g = 3,
+} lis2ds12_fs_t;
+int32_t lis2ds12_xl_full_scale_set(lis2ds12_ctx_t *ctx, lis2ds12_fs_t val);
+int32_t lis2ds12_xl_full_scale_get(lis2ds12_ctx_t *ctx, lis2ds12_fs_t *val);
+
+typedef enum {
+  LIS2DS12_XL_ODR_OFF         = 0x00,
+  LIS2DS12_XL_ODR_1Hz_LP      = 0x08,
+  LIS2DS12_XL_ODR_12Hz5_LP    = 0x09,
+  LIS2DS12_XL_ODR_25Hz_LP     = 0x0A,
+  LIS2DS12_XL_ODR_50Hz_LP     = 0x0B,
+  LIS2DS12_XL_ODR_100Hz_LP    = 0x0C,
+  LIS2DS12_XL_ODR_200Hz_LP    = 0x0D,
+  LIS2DS12_XL_ODR_400Hz_LP    = 0x0E,
+  LIS2DS12_XL_ODR_800Hz_LP    = 0x0F,
+  LIS2DS12_XL_ODR_12Hz5_HR    = 0x01,
+  LIS2DS12_XL_ODR_25Hz_HR     = 0x02,
+  LIS2DS12_XL_ODR_50Hz_HR     = 0x03,
+  LIS2DS12_XL_ODR_100Hz_HR    = 0x04,
+  LIS2DS12_XL_ODR_200Hz_HR    = 0x05,
+  LIS2DS12_XL_ODR_400Hz_HR    = 0x06,
+  LIS2DS12_XL_ODR_800Hz_HR    = 0x07,
+  LIS2DS12_XL_ODR_1k6Hz_HF    = 0x15,
+  LIS2DS12_XL_ODR_3k2Hz_HF    = 0x16,
+  LIS2DS12_XL_ODR_6k4Hz_HF    = 0x17,
+} lis2ds12_odr_t;
+int32_t lis2ds12_xl_data_rate_set(lis2ds12_ctx_t *ctx, lis2ds12_odr_t val);
+int32_t lis2ds12_xl_data_rate_get(lis2ds12_ctx_t *ctx, lis2ds12_odr_t *val);
+
+int32_t lis2ds12_status_reg_get(lis2ds12_ctx_t *ctx, lis2ds12_status_t *val);
+
+int32_t lis2ds12_xl_flag_data_ready_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_acceleration_module_raw_get(lis2ds12_ctx_t *ctx,
+                                             uint8_t *buff);
+
+int32_t lis2ds12_temperature_raw_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2ds12_acceleration_raw_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2ds12_number_of_steps_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2ds12_device_id_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2ds12_auto_increment_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_auto_increment_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DS12_USER_BANK   = 0,
+  LIS2DS12_ADV_BANK    = 1,
+} lis2ds12_func_cfg_en_t;
+int32_t lis2ds12_mem_bank_set(lis2ds12_ctx_t *ctx,
+                              lis2ds12_func_cfg_en_t val);
+
+int32_t lis2ds12_reset_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_reset_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_boot_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_boot_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DS12_XL_ST_DISABLE     = 0,
+  LIS2DS12_XL_ST_POSITIVE    = 1,
+  LIS2DS12_XL_ST_NEGATIVE    = 2,
+} lis2ds12_st_t;
+int32_t lis2ds12_xl_self_test_set(lis2ds12_ctx_t *ctx, lis2ds12_st_t val);
+int32_t lis2ds12_xl_self_test_get(lis2ds12_ctx_t *ctx, lis2ds12_st_t *val);
+
+typedef enum {
+  LIS2DS12_DRDY_LATCHED   = 0,
+  LIS2DS12_DRDY_PULSED    = 1,
+} lis2ds12_drdy_pulsed_t;
+int32_t lis2ds12_data_ready_mode_set(lis2ds12_ctx_t *ctx,
+                                     lis2ds12_drdy_pulsed_t val);
+int32_t lis2ds12_data_ready_mode_get(lis2ds12_ctx_t *ctx,
+                                     lis2ds12_drdy_pulsed_t *val);
+
+typedef enum {
+  LIS2DS12_HP_INTERNAL_ONLY  = 0,
+  LIS2DS12_HP_ON_OUTPUTS     = 1,
+} lis2ds12_fds_slope_t;
+int32_t lis2ds12_xl_hp_path_set(lis2ds12_ctx_t *ctx,
+                                lis2ds12_fds_slope_t val);
+int32_t lis2ds12_xl_hp_path_get(lis2ds12_ctx_t *ctx,
+                                lis2ds12_fds_slope_t *val);
+
+typedef enum {
+  LIS2DS12_SPI_4_WIRE   = 0,
+  LIS2DS12_SPI_3_WIRE   = 1,
+} lis2ds12_sim_t;
+int32_t lis2ds12_spi_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_sim_t val);
+int32_t lis2ds12_spi_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_sim_t *val);
+
+typedef enum {
+  LIS2DS12_I2C_ENABLE   = 0,
+  LIS2DS12_I2C_DISABLE  = 1,
+} lis2ds12_i2c_disable_t;
+int32_t lis2ds12_i2c_interface_set(lis2ds12_ctx_t *ctx,
+                                   lis2ds12_i2c_disable_t val);
+int32_t lis2ds12_i2c_interface_get(lis2ds12_ctx_t *ctx,
+                                   lis2ds12_i2c_disable_t *val);
+
+typedef enum {
+  LIS2DS12_PULL_UP_CONNECTED     = 0,
+  LIS2DS12_PULL_UP_DISCONNECTED  = 1,
+} lis2ds12_if_cs_pu_dis_t;
+int32_t lis2ds12_cs_mode_set(lis2ds12_ctx_t *ctx,
+                             lis2ds12_if_cs_pu_dis_t val);
+int32_t lis2ds12_cs_mode_get(lis2ds12_ctx_t *ctx,
+                             lis2ds12_if_cs_pu_dis_t *val);
+
+typedef enum {
+  LIS2DS12_PUSH_PULL   = 0,
+  LIS2DS12_OPEN_DRAIN  = 1,
+} lis2ds12_pp_od_t;
+int32_t lis2ds12_pin_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_pp_od_t val);
+int32_t lis2ds12_pin_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_pp_od_t *val);
+
+typedef enum {
+  LIS2DS12_ACTIVE_HIGH  = 0,
+  LIS2DS12_ACTIVE_LOW   = 1,
+} lis2ds12_h_lactive_t;
+int32_t lis2ds12_pin_polarity_set(lis2ds12_ctx_t *ctx,
+                                  lis2ds12_h_lactive_t val);
+int32_t lis2ds12_pin_polarity_get(lis2ds12_ctx_t *ctx,
+                                  lis2ds12_h_lactive_t *val);
+
+typedef enum {
+  LIS2DS12_INT_PULSED   = 0,
+  LIS2DS12_INT_LATCHED  = 1,
+} lis2ds12_lir_t;
+int32_t lis2ds12_int_notification_set(lis2ds12_ctx_t *ctx,
+                                      lis2ds12_lir_t val);
+int32_t lis2ds12_int_notification_get(lis2ds12_ctx_t *ctx,
+                                      lis2ds12_lir_t *val);
+
+typedef struct{
+  uint8_t int1_drdy               : 1;
+  uint8_t int1_fth                : 1;
+  uint8_t int1_6d                 : 1;
+  uint8_t int1_tap                : 1;
+  uint8_t int1_ff                 : 1;
+  uint8_t int1_wu                 : 1;
+  uint8_t int1_s_tap              : 1;
+  uint8_t int1_master_drdy        : 1;
+  uint8_t int1_fss7               : 1;
+} lis2ds12_pin_int1_route_t;
+int32_t lis2ds12_pin_int1_route_set(lis2ds12_ctx_t *ctx,
+                                    lis2ds12_pin_int1_route_t val);
+int32_t lis2ds12_pin_int1_route_get(lis2ds12_ctx_t *ctx,
+                                    lis2ds12_pin_int1_route_t *val);
+
+typedef struct{
+  uint8_t int2_boot               : 1;
+  uint8_t int2_tilt               : 1;
+  uint8_t int2_sig_mot            : 1;
+  uint8_t int2_step_det           : 1;
+  uint8_t int2_fth                : 1;
+  uint8_t int2_drdy               : 1;
+} lis2ds12_pin_int2_route_t;
+int32_t lis2ds12_pin_int2_route_set(lis2ds12_ctx_t *ctx,
+                                    lis2ds12_pin_int2_route_t val);
+int32_t lis2ds12_pin_int2_route_get(lis2ds12_ctx_t *ctx,
+                                    lis2ds12_pin_int2_route_t *val);
+
+int32_t lis2ds12_all_on_int1_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_all_on_int1_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_wkup_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_wkup_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_wkup_dur_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_wkup_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_sleep_mode_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_sleep_mode_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_act_sleep_dur_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_act_sleep_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tap_detection_on_z_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_detection_on_z_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tap_detection_on_y_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_detection_on_y_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tap_detection_on_x_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_detection_on_x_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tap_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tap_shock_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_shock_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tap_quiet_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_quiet_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tap_dur_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DS12_ONLY_SINGLE  = 0,
+  LIS2DS12_ONLY_DOUBLE  = 1,
+} lis2ds12_single_double_tap_t;
+int32_t lis2ds12_tap_mode_set(lis2ds12_ctx_t *ctx,
+                              lis2ds12_single_double_tap_t val);
+int32_t lis2ds12_tap_mode_get(lis2ds12_ctx_t *ctx,
+                              lis2ds12_single_double_tap_t *val);
+
+int32_t lis2ds12_tap_src_get(lis2ds12_ctx_t *ctx, lis2ds12_tap_src_t *val);
+
+typedef enum {
+  LIS2DS12_DEG_80   = 0,
+  LIS2DS12_DEG_70   = 1,
+  LIS2DS12_DEG_60   = 2,
+  LIS2DS12_DEG_50   = 3,
+} lis2ds12_6d_ths_t;
+int32_t lis2ds12_6d_threshold_set(lis2ds12_ctx_t *ctx, lis2ds12_6d_ths_t val);
+int32_t lis2ds12_6d_threshold_get(lis2ds12_ctx_t *ctx, lis2ds12_6d_ths_t *val);
+
+int32_t lis2ds12_4d_mode_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_4d_mode_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_6d_src_get(lis2ds12_ctx_t *ctx, lis2ds12_6d_src_t *val);
+
+int32_t lis2ds12_ff_dur_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_ff_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_ff_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_ff_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_fifo_xl_module_batch_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_fifo_xl_module_batch_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DS12_BYPASS_MODE            = 0,
+  LIS2DS12_FIFO_MODE              = 1,
+  LIS2DS12_STREAM_TO_FIFO_MODE    = 3,
+  LIS2DS12_BYPASS_TO_STREAM_MODE  = 4,
+  LIS2DS12_STREAM_MODE            = 6,
+} lis2ds12_fmode_t;
+int32_t lis2ds12_fifo_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_fmode_t val);
+int32_t lis2ds12_fifo_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_fmode_t *val);
+
+int32_t lis2ds12_fifo_watermark_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_fifo_watermark_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_fifo_full_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_fifo_ovr_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_fifo_wtm_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_fifo_data_level_get(lis2ds12_ctx_t *ctx, uint16_t *val);
+
+int32_t lis2ds12_fifo_src_get(lis2ds12_ctx_t *ctx, lis2ds12_fifo_src_t *val);
+
+int32_t lis2ds12_pedo_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DS12_PEDO_AT_2g  = 0,
+  LIS2DS12_PEDO_AT_4g  = 1,
+} lis2ds12_pedo4g_t;
+int32_t lis2ds12_pedo_full_scale_set(lis2ds12_ctx_t *ctx,
+                                     lis2ds12_pedo4g_t val);
+int32_t lis2ds12_pedo_full_scale_get(lis2ds12_ctx_t *ctx,
+                                     lis2ds12_pedo4g_t *val);
+
+int32_t lis2ds12_pedo_step_reset_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_step_reset_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_pedo_step_detect_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_pedo_sens_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_pedo_debounce_steps_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_debounce_steps_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_pedo_timeout_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_timeout_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_pedo_steps_period_set(lis2ds12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2ds12_pedo_steps_period_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2ds12_motion_data_ready_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_motion_sens_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_motion_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_motion_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_motion_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tilt_data_ready_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_tilt_sens_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tilt_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_module_sens_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_module_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+typedef union {
+  struct {
+    lis2ds12_sensorhub1_reg_t  sensorhub1_reg;
+    lis2ds12_sensorhub2_reg_t  sensorhub2_reg;
+    lis2ds12_sensorhub3_reg_t  sensorhub3_reg;
+    lis2ds12_sensorhub4_reg_t  sensorhub4_reg;
+    lis2ds12_sensorhub5_reg_t  sensorhub5_reg;
+    lis2ds12_sensorhub6_reg_t  sensorhub6_reg;
+  } reg;
+  uint8_t byte[6];
+} lis2ds12_sh_read_data_raw_t;
+int32_t lis2ds12_sh_read_data_raw_get(lis2ds12_ctx_t *ctx,
+                                      lis2ds12_sh_read_data_raw_t *val);
+
+int32_t lis2ds12_sh_master_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_sh_master_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DS12_EXT_PULL_UP        = 0,
+  LIS2DS12_INTERNAL_PULL_UP   = 1,
+} lis2ds12_tud_en_t;
+int32_t lis2ds12_sh_pin_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_tud_en_t val);
+int32_t lis2ds12_sh_pin_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_tud_en_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_data;
+} lis2ds12_sh_cfg_write_t;
+int32_t lis2ds12_sh_cfg_write(lis2ds12_ctx_t *ctx,
+                              lis2ds12_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} lis2ds12_sh_cfg_read_t;
+int32_t lis2ds12_sh_slv_cfg_read(lis2ds12_ctx_t *ctx,
+                                 lis2ds12_sh_cfg_read_t *val);
+
+int32_t lis2ds12_sh_slv0_cfg_read_set(lis2ds12_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_sh_slv0_cfg_read_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2ds12_sh_end_op_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__LIS2DS12_DRIVER__H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.c
+++ b/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.c
@@ -1,0 +1,2911 @@
+/*
+ ******************************************************************************
+ * @file    lis2dw12_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS2DW12 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis2dw12_reg.h"
+
+/**
+  * @defgroup  LIS2DW12
+  * @brief     This file provides a set of functions needed to drive the
+  *            lis2dw12 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_read_reg(lis2dw12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_write_reg(lis2dw12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2DW12_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lis2dw12_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lis2dw12_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t lis2dw12_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t lis2dw12_from_fs16_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) *0.488f;
+}
+
+float_t lis2dw12_from_fs2_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lis2dw12_from_fs4_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t lis2dw12_from_fs8_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t lis2dw12_from_fs16_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.488f;
+}
+
+float_t lis2dw12_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 16.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Data_Generation
+  * @brief     This section groups all the functions concerning
+  *            data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select accelerometer operating modes.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mode / lp_mode in reg CTRL1
+  *                  and low_noise in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_power_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_mode_t val)
+{
+  lis2dw12_ctrl1_t ctrl1;
+  lis2dw12_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ctrl1.mode = ( (uint8_t) val & 0x0CU ) >> 2;
+    ctrl1.lp_mode = (uint8_t) val & 0x03U ;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  }
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  }
+  if (ret == 0) {
+    ctrl6.low_noise = ( (uint8_t) val & 0x10U ) >> 4;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select accelerometer operating modes.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mode / lp_mode in reg CTRL1
+  *                  and low_noise in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_power_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_mode_t *val)
+{
+  lis2dw12_ctrl1_t ctrl1;
+  lis2dw12_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+
+    switch (((ctrl6.low_noise << 4) + (ctrl1.mode << 2) +
+            ctrl1.lp_mode)) {
+      case LIS2DW12_HIGH_PERFORMANCE:
+        *val = LIS2DW12_HIGH_PERFORMANCE;
+        break;
+      case LIS2DW12_CONT_LOW_PWR_4:
+        *val = LIS2DW12_CONT_LOW_PWR_4;
+        break;
+      case LIS2DW12_CONT_LOW_PWR_3:
+        *val = LIS2DW12_CONT_LOW_PWR_3;
+        break;
+      case LIS2DW12_CONT_LOW_PWR_2:
+        *val = LIS2DW12_CONT_LOW_PWR_2;
+        break;
+      case LIS2DW12_CONT_LOW_PWR_12bit:
+        *val = LIS2DW12_CONT_LOW_PWR_12bit;
+        break;
+      case LIS2DW12_SINGLE_LOW_PWR_4:
+        *val = LIS2DW12_SINGLE_LOW_PWR_4;
+        break;
+      case LIS2DW12_SINGLE_LOW_PWR_3:
+        *val = LIS2DW12_SINGLE_LOW_PWR_3;
+        break;
+      case LIS2DW12_SINGLE_LOW_PWR_2:
+        *val = LIS2DW12_SINGLE_LOW_PWR_2;
+        break;
+      case LIS2DW12_SINGLE_LOW_PWR_12bit:
+        *val = LIS2DW12_SINGLE_LOW_PWR_12bit;
+        break;
+      case LIS2DW12_HIGH_PERFORMANCE_LOW_NOISE:
+        *val = LIS2DW12_HIGH_PERFORMANCE_LOW_NOISE;
+        break;
+      case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_4:
+        *val = LIS2DW12_CONT_LOW_PWR_LOW_NOISE_4;
+        break;
+      case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_3:
+        *val = LIS2DW12_CONT_LOW_PWR_LOW_NOISE_3;
+        break;
+      case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_2:
+        *val = LIS2DW12_CONT_LOW_PWR_LOW_NOISE_2;
+        break;
+      case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit:
+        *val = LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit;
+        break;
+      case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_4:
+        *val = LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_4;
+        break;
+      case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_3:
+        *val = LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_3;
+        break;
+      case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2:
+        *val = LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2;
+        break;
+      case LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit:
+        *val = LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit;
+        break;
+      default:
+        *val = LIS2DW12_HIGH_PERFORMANCE;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_data_rate_set(lis2dw12_ctx_t *ctx, lis2dw12_odr_t val)
+{
+  lis2dw12_ctrl1_t ctrl1;
+  lis2dw12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ctrl1.odr = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  }
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &ctrl3, 1);
+  }
+  if (ret == 0) {
+    ctrl3.slp_mode = ( (uint8_t) val & 0x30U ) >> 4;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr in reg CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_data_rate_get(lis2dw12_ctx_t *ctx, lis2dw12_odr_t *val)
+{
+  lis2dw12_ctrl1_t ctrl1;
+  lis2dw12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &ctrl3, 1);
+
+    switch ((ctrl3.slp_mode << 4) + ctrl1.odr) {
+      case LIS2DW12_XL_ODR_OFF:
+        *val = LIS2DW12_XL_ODR_OFF;
+        break;
+      case LIS2DW12_XL_ODR_1Hz6_LP_ONLY:
+        *val = LIS2DW12_XL_ODR_1Hz6_LP_ONLY;
+        break;
+      case LIS2DW12_XL_ODR_12Hz5:
+        *val = LIS2DW12_XL_ODR_12Hz5;
+        break;
+      case LIS2DW12_XL_ODR_25Hz:
+        *val = LIS2DW12_XL_ODR_25Hz;
+        break;
+       case LIS2DW12_XL_ODR_50Hz:
+        *val = LIS2DW12_XL_ODR_50Hz;
+        break;
+      case LIS2DW12_XL_ODR_100Hz:
+        *val = LIS2DW12_XL_ODR_100Hz;
+        break;
+      case LIS2DW12_XL_ODR_200Hz:
+        *val = LIS2DW12_XL_ODR_200Hz;
+        break;
+      case LIS2DW12_XL_ODR_400Hz:
+        *val = LIS2DW12_XL_ODR_400Hz;
+        break;
+       case LIS2DW12_XL_ODR_800Hz:
+        *val = LIS2DW12_XL_ODR_800Hz;
+        break;
+      case LIS2DW12_XL_ODR_1k6Hz:
+        *val = LIS2DW12_XL_ODR_1k6Hz;
+        break;
+      case LIS2DW12_XL_SET_SW_TRIG:
+        *val = LIS2DW12_XL_SET_SW_TRIG;
+        break;
+      case LIS2DW12_XL_SET_PIN_TRIG:
+        *val = LIS2DW12_XL_SET_PIN_TRIG;
+        break;
+      default:
+        *val = LIS2DW12_XL_ODR_OFF;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_block_data_update_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_block_data_update_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_full_scale_set(lis2dw12_ctx_t *ctx, lis2dw12_fs_t val)
+{
+  lis2dw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fs = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_full_scale_get(lis2dw12_ctx_t *ctx, lis2dw12_fs_t *val)
+{
+  lis2dw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+
+  switch (reg.fs) {
+    case LIS2DW12_2g:
+      *val = LIS2DW12_2g;
+      break;
+    case LIS2DW12_4g:
+      *val = LIS2DW12_4g;
+      break;
+    case LIS2DW12_8g:
+      *val = LIS2DW12_8g;
+      break;
+    case LIS2DW12_16g:
+      *val = LIS2DW12_16g;
+      break;
+    default:
+      *val = LIS2DW12_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_status_reg_get(lis2dw12_ctx_t *ctx, lis2dw12_status_t *val)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_STATUS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_flag_data_ready_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_status_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_STATUS,(uint8_t*) &reg, 1);
+  *val = reg.drdy;
+
+  return ret;
+}
+/**
+  * @brief   Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers STATUS_DUP, WAKE_UP_SRC,
+  *                  TAP_SRC, SIXD_SRC, ALL_INT_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_all_sources_get(lis2dw12_ctx_t *ctx,
+                                 lis2dw12_all_sources_t *val)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_STATUS_DUP, (uint8_t*) val, 5);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_usr_offset_x_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_write_reg(ctx, LIS2DW12_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_usr_offset_x_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_usr_offset_y_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_write_reg(ctx, LIS2DW12_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_usr_offset_y_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_usr_offset_z_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_write_reg(ctx, LIS2DW12_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_usr_offset_z_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR,
+  *         Y_OFS_USR, Z_OFS_USR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_w in
+  *                               reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_offset_weight_set(lis2dw12_ctx_t *ctx,
+                                   lis2dw12_usr_off_w_t val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.usr_off_w = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR,
+  *         Y_OFS_USR, Z_OFS_USR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of usr_off_w in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_offset_weight_get(lis2dw12_ctx_t *ctx,
+                                   lis2dw12_usr_off_w_t *val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  switch (reg.usr_off_w) {
+    case LIS2DW12_LSb_977ug:
+      *val = LIS2DW12_LSb_977ug;
+      break;
+    case LIS2DW12_LSb_15mg6:
+      *val = LIS2DW12_LSb_15mg6;
+      break;
+    default:
+      *val = LIS2DW12_LSb_977ug;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Data_Output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data output register (r). L and H registers
+  *         together express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_temperature_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_OUT_T_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as
+  *         a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_acceleration_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Common
+  * @brief     This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_device_id_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_auto_increment_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.if_add_inc = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during multiple
+  *         byte access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_auto_increment_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_reset in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_reset_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.soft_reset = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_reset in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_reset_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.soft_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_boot_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.boot = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_boot_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_self_test_set(lis2dw12_ctx_t *ctx, lis2dw12_st_t val)
+{
+  lis2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.st = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor self-test enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_self_test_get(lis2dw12_ctx_t *ctx, lis2dw12_st_t *val)
+{
+  lis2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.st) {
+    case LIS2DW12_XL_ST_DISABLE:
+      *val = LIS2DW12_XL_ST_DISABLE;
+      break;
+    case LIS2DW12_XL_ST_POSITIVE:
+      *val = LIS2DW12_XL_ST_POSITIVE;
+      break;
+    case LIS2DW12_XL_ST_NEGATIVE:
+      *val = LIS2DW12_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS2DW12_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_pulsed in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_data_ready_mode_set(lis2dw12_ctx_t *ctx,
+                                     lis2dw12_drdy_pulsed_t val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.drdy_pulsed = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of drdy_pulsed in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_data_ready_mode_get(lis2dw12_ctx_t *ctx,
+                                     lis2dw12_drdy_pulsed_t *val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.drdy_pulsed) {
+    case LIS2DW12_DRDY_LATCHED:
+      *val = LIS2DW12_DRDY_LATCHED;
+      break;
+    case LIS2DW12_DRDY_PULSED:
+      *val = LIS2DW12_DRDY_PULSED;
+      break;
+    default:
+      *val = LIS2DW12_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Filters
+  * @brief     This section group all the functions concerning the filters
+  *            configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer filtering path for outputs.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_filter_path_set(lis2dw12_ctx_t *ctx, lis2dw12_fds_t val)
+{
+  lis2dw12_ctrl6_t ctrl6;
+  lis2dw12_ctrl_reg7_t ctrl_reg7;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  if (ret == 0) {
+    ctrl6.fds = ( (uint8_t) val & 0x10U ) >> 4;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  }
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+  }
+  if (ret == 0) {
+    ctrl_reg7.usr_off_on_out = (uint8_t) val & 0x01U;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer filtering path for outputs.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fds in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_filter_path_get(lis2dw12_ctx_t *ctx, lis2dw12_fds_t *val)
+{
+  lis2dw12_ctrl6_t ctrl6;
+  lis2dw12_ctrl_reg7_t ctrl_reg7;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  if (ret == 0) {
+   ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+
+    switch ((ctrl6.fds << 4 ) + ctrl_reg7.usr_off_on_out) {
+      case LIS2DW12_LPF_ON_OUT:
+        *val = LIS2DW12_LPF_ON_OUT;
+        break;
+      case LIS2DW12_USER_OFFSET_ON_OUT:
+        *val = LIS2DW12_USER_OFFSET_ON_OUT;
+        break;
+      case LIS2DW12_HIGH_PASS_ON_OUT:
+        *val = LIS2DW12_HIGH_PASS_ON_OUT;
+        break;
+      default:
+        *val = LIS2DW12_LPF_ON_OUT;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer cutoff filter frequency. Valid for low and high
+  *          pass filter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bw_filt in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_filter_bandwidth_set(lis2dw12_ctx_t *ctx,
+                                         lis2dw12_bw_filt_t val)
+{
+  lis2dw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bw_filt = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer cutoff filter frequency. Valid for low and
+  *          high pass filter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of bw_filt in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_filter_bandwidth_get(lis2dw12_ctx_t *ctx,
+                                         lis2dw12_bw_filt_t *val)
+{
+  lis2dw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+
+  switch (reg.bw_filt) {
+    case LIS2DW12_ODR_DIV_2:
+      *val = LIS2DW12_ODR_DIV_2;
+      break;
+    case LIS2DW12_ODR_DIV_4:
+      *val = LIS2DW12_ODR_DIV_4;
+      break;
+    case LIS2DW12_ODR_DIV_10:
+      *val = LIS2DW12_ODR_DIV_10;
+      break;
+    case LIS2DW12_ODR_DIV_20:
+      *val = LIS2DW12_ODR_DIV_20;
+      break;
+    default:
+      *val = LIS2DW12_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_ref_mode in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_reference_mode_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.hp_ref_mode = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_ref_mode in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_reference_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  *val = reg.hp_ref_mode;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DW12_Serial_Interface
+  * @brief      This section groups all the functions concerning main serial
+  *             interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_spi_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sim_t val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sim = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_spi_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sim_t *val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.sim) {
+    case LIS2DW12_SPI_4_WIRE:
+      *val = LIS2DW12_SPI_4_WIRE;
+      break;
+    case LIS2DW12_SPI_3_WIRE:
+      *val = LIS2DW12_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS2DW12_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_disable in
+  *                                 reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_i2c_interface_set(lis2dw12_ctx_t *ctx,
+                                   lis2dw12_i2c_disable_t val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i2c_disable = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_disable in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_i2c_interface_get(lis2dw12_ctx_t *ctx,
+                                   lis2dw12_i2c_disable_t *val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.i2c_disable) {
+    case LIS2DW12_I2C_ENABLE:
+      *val = LIS2DW12_I2C_ENABLE;
+      break;
+    case LIS2DW12_I2C_DISABLE:
+      *val = LIS2DW12_I2C_DISABLE;
+      break;
+    default:
+      *val = LIS2DW12_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disconnect CS pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of cs_pu_disc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_cs_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.cs_pu_disc = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disconnect CS pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of cs_pu_disc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_cs_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t *val)
+{
+  lis2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.cs_pu_disc) {
+    case LIS2DW12_PULL_UP_CONNECT:
+      *val = LIS2DW12_PULL_UP_CONNECT;
+      break;
+    case LIS2DW12_PULL_UP_DISCONNECT:
+      *val = LIS2DW12_PULL_UP_DISCONNECT;
+      break;
+    default:
+      *val = LIS2DW12_PULL_UP_CONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Interrupt_Pins
+  * @brief     This section groups all the functions that manage interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of h_lactive in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_pin_polarity_set(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_h_lactive_t val)
+{
+  lis2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.h_lactive = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of h_lactive in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_pin_polarity_get(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_h_lactive_t *val)
+{
+  lis2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.h_lactive) {
+    case LIS2DW12_ACTIVE_HIGH:
+      *val = LIS2DW12_ACTIVE_HIGH;
+      break;
+    case LIS2DW12_ACTIVE_LOW:
+      *val = LIS2DW12_ACTIVE_LOW;
+      break;
+    default:
+      *val = LIS2DW12_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_int_notification_set(lis2dw12_ctx_t *ctx,
+                                      lis2dw12_lir_t val)
+{
+  lis2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lir = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_int_notification_get(lis2dw12_ctx_t *ctx,
+                                      lis2dw12_lir_t *val)
+{
+  lis2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.lir) {
+    case LIS2DW12_INT_PULSED:
+      *val = LIS2DW12_INT_PULSED;
+      break;
+    case LIS2DW12_INT_LATCHED:
+      *val = LIS2DW12_INT_LATCHED;
+      break;
+    default:
+      *val = LIS2DW12_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pp_od in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_pin_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t val)
+{
+  lis2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.pp_od = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pp_od in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_pin_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t *val)
+{
+  lis2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.pp_od) {
+    case LIS2DW12_PUSH_PULL:
+      *val = LIS2DW12_PUSH_PULL;
+      break;
+    case LIS2DW12_OPEN_DRAIN:
+      *val = LIS2DW12_OPEN_DRAIN;
+      break;
+    default:
+      *val = LIS2DW12_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL4_INT1_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_pin_int1_route_set(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_ctrl4_int1_pad_ctrl_t *val)
+{
+  lis2dw12_ctrl5_int2_pad_ctrl_t ctrl5_int2_pad_ctrl;
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL5_INT2_PAD_CTRL,
+                          (uint8_t*)&ctrl5_int2_pad_ctrl, 1);
+
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  if (ret == 0) {
+    if ((val->int1_tap |
+         val->int1_ff |
+         val->int1_wu |
+         val->int1_single_tap |
+         val->int1_6d |
+         ctrl5_int2_pad_ctrl.int2_sleep_state |
+         ctrl5_int2_pad_ctrl.int2_sleep_chg ) != PROPERTY_DISABLE){
+      reg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      reg.interrupts_enable = PROPERTY_DISABLE;
+    }
+
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL,
+                                (uint8_t*) val, 1);
+  } if (ret == 0) {
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL4_INT1_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_pin_int1_route_get(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_ctrl4_int1_pad_ctrl_t *val)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL,
+                          (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief   Select the signal that need to route on int2 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL5_INT2_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_pin_int2_route_set(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_ctrl5_int2_pad_ctrl_t *val)
+{
+  lis2dw12_ctrl4_int1_pad_ctrl_t ctrl4_int1_pad_ctrl;
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL,
+                          (uint8_t*) &ctrl4_int1_pad_ctrl, 1);
+
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  if (ret == 0) {
+    if ((ctrl4_int1_pad_ctrl.int1_tap |
+         ctrl4_int1_pad_ctrl.int1_ff |
+         ctrl4_int1_pad_ctrl.int1_wu |
+         ctrl4_int1_pad_ctrl.int1_single_tap |
+         ctrl4_int1_pad_ctrl.int1_6d |
+         val->int2_sleep_state | val->int2_sleep_chg ) != PROPERTY_DISABLE) {
+        reg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      reg.interrupts_enable = PROPERTY_DISABLE;
+    }
+
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL5_INT2_PAD_CTRL,
+                             (uint8_t*) val, 1);
+  }
+  if (ret == 0) {
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL5_INT2_PAD_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_pin_int2_route_get(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_ctrl5_int2_pad_ctrl_t *val)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL5_INT2_PAD_CTRL,
+                          (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_all_on_int1_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.int2_on_int1 = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_all_on_int1_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  *val = reg.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Wake_Up_Event
+  * @brief     This section groups all the functions that manage the Wake
+  *            Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_wkup_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wk_ths = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_wkup_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  *val = reg.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_wkup_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wake_dur = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_wkup_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  *val = reg.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Data sent to wake-up interrupt function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_wu in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_wkup_feed_data_set(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_usr_off_on_wu_t val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.usr_off_on_wu = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data sent to wake-up interrupt function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of usr_off_on_wu in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_wkup_feed_data_get(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_usr_off_on_wu_t *val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.usr_off_on_wu) {
+    case LIS2DW12_HP_FEED:
+      *val = LIS2DW12_HP_FEED;
+      break;
+    case LIS2DW12_USER_OFFSET_FEED:
+      *val = LIS2DW12_USER_OFFSET_FEED;
+      break;
+    default:
+      *val = LIS2DW12_HP_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DW12_Activity/Inactivity_Detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Config activity / inactivity or
+  *         stationary / motion detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_on / stationary in
+  *                  reg WAKE_UP_THS / WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_act_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t val)
+{
+  lis2dw12_wake_up_ths_t wake_up_ths;
+  lis2dw12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  }
+  if (ret == 0) {
+    wake_up_ths.sleep_on = (uint8_t) val & 0x01U;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  }
+  if (ret == 0) {
+    wake_up_dur.stationary = ((uint8_t)val & 0x02U) >> 1;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Config activity / inactivity or
+  *         stationary / motion detection. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sleep_on in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_act_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t *val)
+{
+  lis2dw12_wake_up_ths_t wake_up_ths;
+  lis2dw12_wake_up_dur_t wake_up_dur;;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+
+    switch ((wake_up_dur.stationary << 1) + wake_up_ths.sleep_on){
+      case LIS2DW12_NO_DETECTION:
+        *val = LIS2DW12_NO_DETECTION;
+        break;
+      case LIS2DW12_DETECT_ACT_INACT:
+        *val = LIS2DW12_DETECT_ACT_INACT;
+        break;
+      case LIS2DW12_DETECT_STAT_MOTION:
+        *val = LIS2DW12_DETECT_STAT_MOTION;
+        break;
+      default:
+        *val = LIS2DW12_NO_DETECTION;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_act_sleep_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sleep_dur = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_act_sleep_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  *val = reg.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Tap_Generator
+  * @brief     This section groups all the functions that manage the tap
+  *            and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsx in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_threshold_x_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsx = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsx in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_threshold_x_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsx;
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsy in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_threshold_y_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsy = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsy in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_threshold_y_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsy;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_prior in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_axis_priority_set(lis2dw12_ctx_t *ctx,
+                                       lis2dw12_tap_prior_t val)
+{
+  lis2dw12_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_prior = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tap_prior in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_axis_priority_get(lis2dw12_ctx_t *ctx,
+                                       lis2dw12_tap_prior_t *val)
+{
+  lis2dw12_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+
+  switch (reg.tap_prior) {
+    case LIS2DW12_XYZ:
+      *val = LIS2DW12_XYZ;
+      break;
+    case LIS2DW12_YXZ:
+      *val = LIS2DW12_YXZ;
+      break;
+    case LIS2DW12_XZY:
+      *val = LIS2DW12_XZY;
+      break;
+    case LIS2DW12_ZYX:
+      *val = LIS2DW12_ZYX;
+      break;
+    case LIS2DW12_YZX:
+      *val = LIS2DW12_YZX;
+      break;
+    case LIS2DW12_ZXY:
+      *val = LIS2DW12_ZXY;
+      break;
+    default:
+      *val = LIS2DW12_XYZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsz in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_threshold_z_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsz = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsz in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_threshold_z_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsz;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_detection_on_z_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_z_en = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_detection_on_z_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_detection_on_y_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_y_en = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_detection_on_y_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_detection_on_x_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_x_en = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_detection_on_x_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value
+  *         of these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_shock_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.shock = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value
+  *         of these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_shock_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds
+  *         to 2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_quiet_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.quiet = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds
+  *         to 2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_quiet_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses
+  *         the maximum time between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which corresponds
+  *         to 16*ODR_XL time. If the DUR[3:0] bits are set to a different
+  *         value, 1LSB corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of latency in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.latency = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses
+  *         the maximum time between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which corresponds
+  *         to 16*ODR_XL time. If the DUR[3:0] bits are set to a different
+  *         value, 1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of latency in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.latency;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of single_double_tap in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_mode_set(lis2dw12_ctx_t *ctx,
+                              lis2dw12_single_double_tap_t val)
+{
+  lis2dw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.single_double_tap = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of single_double_tap in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_mode_get(lis2dw12_ctx_t *ctx,
+                              lis2dw12_single_double_tap_t *val)
+{
+  lis2dw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+
+  switch (reg.single_double_tap) {
+    case LIS2DW12_ONLY_SINGLE:
+      *val = LIS2DW12_ONLY_SINGLE;
+      break;
+    case LIS2DW12_BOTH_SINGLE_DOUBLE:
+      *val = LIS2DW12_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LIS2DW12_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Read the tap / double tap source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  lis2dw12_tap_src: union of registers from TAP_SRC to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_tap_src_get(lis2dw12_ctx_t *ctx, lis2dw12_tap_src_t *val)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DW12_Six_Position_Detection(6D/4D)
+  * @brief      This section groups all the functions concerning six
+  *             position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 6d_ths in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_6d_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg._6d_ths = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 6d_ths in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_6d_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg._6d_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4d_en in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_4d_mode_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg._4d_en = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4d_en in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_4d_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg._4d_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Read the 6D tap source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from SIXD_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_6d_src_get(lis2dw12_ctx_t *ctx, lis2dw12_sixd_src_t *val)
+{
+  int32_t ret;
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_SIXD_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Data sent to 6D interrupt function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpass_on6d in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_6d_feed_data_set(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_lpass_on6d_t val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lpass_on6d = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data sent to 6D interrupt function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lpass_on6d in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_6d_feed_data_get(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_lpass_on6d_t *val)
+{
+  lis2dw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.lpass_on6d) {
+    case LIS2DW12_ODR_DIV_2_FEED:
+      *val = LIS2DW12_ODR_DIV_2_FEED;
+      break;
+    case LIS2DW12_LPF2_FEED:
+      *val = LIS2DW12_LPF2_FEED;
+      break;
+    default:
+      *val = LIS2DW12_ODR_DIV_2_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Free_Fall
+  * @brief     This section group all the functions concerning
+  *            the free fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in reg
+  *                  WAKE_UP_DUR /F REE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_ff_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_wake_up_dur_t wake_up_dur;
+  lis2dw12_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+  }
+  if(ret == 0) {
+    wake_up_dur.ff_dur = ( (uint8_t) val & 0x20U) >> 5;
+    free_fall.ff_dur = (uint8_t) val & 0x1FU;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  }
+  if(ret == 0) {
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in
+  *                  reg WAKE_UP_DUR /F REE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_ff_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_wake_up_dur_t wake_up_dur;
+  lis2dw12_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  if (ret == 0) {
+    ret = lis2dw12_read_reg(ctx, LIS2DW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+    *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_ths in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_ff_threshold_set(lis2dw12_ctx_t *ctx, lis2dw12_ff_ths_t val)
+{
+  lis2dw12_free_fall_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FREE_FALL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.ff_ths = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_FREE_FALL,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ff_ths in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_ff_threshold_get(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_ff_ths_t *val)
+{
+  lis2dw12_free_fall_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FREE_FALL,(uint8_t*) &reg, 1);
+
+  switch (reg.ff_ths) {
+    case LIS2DW12_FF_TSH_5LSb_FS2g:
+      *val = LIS2DW12_FF_TSH_5LSb_FS2g;
+      break;
+    case LIS2DW12_FF_TSH_7LSb_FS2g:
+      *val = LIS2DW12_FF_TSH_7LSb_FS2g;
+      break;
+    case LIS2DW12_FF_TSH_8LSb_FS2g:
+      *val = LIS2DW12_FF_TSH_8LSb_FS2g;
+      break;
+    case LIS2DW12_FF_TSH_10LSb_FS2g:
+      *val = LIS2DW12_FF_TSH_10LSb_FS2g;
+      break;
+    case LIS2DW12_FF_TSH_11LSb_FS2g:
+      *val = LIS2DW12_FF_TSH_11LSb_FS2g;
+      break;
+    case LIS2DW12_FF_TSH_13LSb_FS2g:
+      *val = LIS2DW12_FF_TSH_13LSb_FS2g;
+      break;
+    case LIS2DW12_FF_TSH_15LSb_FS2g:
+      *val = LIS2DW12_FF_TSH_15LSb_FS2g;
+      break;
+    case LIS2DW12_FF_TSH_16LSb_FS2g:
+      *val = LIS2DW12_FF_TSH_16LSb_FS2g;
+      break;
+    default:
+      *val = LIS2DW12_FF_TSH_5LSb_FS2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DW12_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_fifo_watermark_set(lis2dw12_ctx_t *ctx, uint8_t val)
+{
+  lis2dw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fth = val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_fifo_watermark_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  *val = reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fmode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_fifo_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t val)
+{
+  lis2dw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fmode = (uint8_t) val;
+    ret = lis2dw12_write_reg(ctx, LIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fmode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_fifo_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t *val)
+{
+  lis2dw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+
+  switch (reg.fmode) {
+    case LIS2DW12_BYPASS_MODE:
+      *val = LIS2DW12_BYPASS_MODE;
+      break;
+    case LIS2DW12_FIFO_MODE:
+      *val = LIS2DW12_FIFO_MODE;
+      break;
+    case LIS2DW12_STREAM_TO_FIFO_MODE:
+      *val = LIS2DW12_STREAM_TO_FIFO_MODE;
+      break;
+    case LIS2DW12_BYPASS_TO_STREAM_MODE:
+      *val = LIS2DW12_BYPASS_TO_STREAM_MODE;
+      break;
+    case LIS2DW12_STREAM_MODE:
+      *val = LIS2DW12_STREAM_MODE;
+      break;
+    default:
+      *val = LIS2DW12_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of unread samples stored in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of diff in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_fifo_data_level_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.diff;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_ovr in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_fifo_ovr_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.fifo_ovr;
+
+  return ret;
+}
+/**
+  * @brief  FIFO threshold status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_fth in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dw12_fifo_wtm_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+{
+  lis2dw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = lis2dw12_read_reg(ctx, LIS2DW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.fifo_fth;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.h
+++ b/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.h
@@ -1,0 +1,781 @@
+/*
+ ******************************************************************************
+ * @file    lis2dw12_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis2dw12_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS2DW12_REGS_H
+#define LIS2DW12_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS2DW12
+  * @{
+  *
+  */
+
+/** @defgroup LIS2DW12_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LIS2DW12_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis2dw12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis2dw12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis2dw12_write_ptr  write_reg;
+  lis2dw12_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis2dw12_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS2DW12_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define LIS2DW12_I2C_ADD_L   0x31U
+#define LIS2DW12_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define LIS2DW12_ID            0x44U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS2DW12_OUT_T_L                     0x0DU
+#define LIS2DW12_OUT_T_H                     0x0EU
+#define LIS2DW12_WHO_AM_I                    0x0FU
+#define LIS2DW12_CTRL1                       0x20U
+typedef struct {
+  uint8_t lp_mode                    : 2;
+  uint8_t mode                       : 2;
+  uint8_t odr                        : 4;
+} lis2dw12_ctrl1_t;
+
+#define LIS2DW12_CTRL2                       0x21U
+typedef struct {
+  uint8_t sim                        : 1;
+  uint8_t i2c_disable                : 1;
+  uint8_t if_add_inc                 : 1;
+  uint8_t bdu                        : 1;
+  uint8_t cs_pu_disc                 : 1;
+  uint8_t not_used_01                : 1;
+  uint8_t soft_reset                 : 1;
+  uint8_t boot                       : 1;
+} lis2dw12_ctrl2_t;
+
+#define LIS2DW12_CTRL3                       0x22U
+typedef struct {
+  uint8_t slp_mode                   : 2;  /* slp_mode_sel + slp_mode_1 */
+  uint8_t not_used_01                : 1;
+  uint8_t h_lactive                  : 1;
+  uint8_t lir                        : 1;
+  uint8_t pp_od                      : 1;
+  uint8_t st                         : 2;
+} lis2dw12_ctrl3_t;
+
+#define LIS2DW12_CTRL4_INT1_PAD_CTRL         0x23U
+typedef struct {
+  uint8_t int1_drdy                  : 1;
+  uint8_t int1_fth                   : 1;
+  uint8_t int1_diff5                 : 1;
+  uint8_t int1_tap                   : 1;
+  uint8_t int1_ff                    : 1;
+  uint8_t int1_wu                    : 1;
+  uint8_t int1_single_tap            : 1;
+  uint8_t int1_6d                    : 1;
+} lis2dw12_ctrl4_int1_pad_ctrl_t;
+
+#define LIS2DW12_CTRL5_INT2_PAD_CTRL         0x24U
+typedef struct {
+  uint8_t int2_drdy                  : 1;
+  uint8_t int2_fth                   : 1;
+  uint8_t int2_diff5                 : 1;
+  uint8_t int2_ovr                   : 1;
+  uint8_t int2_drdy_t                : 1;
+  uint8_t int2_boot                  : 1;
+  uint8_t int2_sleep_chg             : 1;
+  uint8_t int2_sleep_state           : 1;
+} lis2dw12_ctrl5_int2_pad_ctrl_t;
+
+#define LIS2DW12_CTRL6                       0x25U
+typedef struct {
+  uint8_t not_used_01                : 2;
+  uint8_t low_noise                  : 1;
+  uint8_t fds                        : 1;
+  uint8_t fs                         : 2;
+  uint8_t bw_filt                    : 2;
+} lis2dw12_ctrl6_t;
+
+#define LIS2DW12_OUT_T                       0x26U
+#define LIS2DW12_STATUS                      0x27U
+typedef struct {
+  uint8_t drdy                       : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t sleep_state                : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t fifo_ths                   : 1;
+} lis2dw12_status_t;
+
+#define LIS2DW12_OUT_X_L                     0x28U
+#define LIS2DW12_OUT_X_H                     0x29U
+#define LIS2DW12_OUT_Y_L                     0x2AU
+#define LIS2DW12_OUT_Y_H                     0x2BU
+#define LIS2DW12_OUT_Z_L                     0x2CU
+#define LIS2DW12_OUT_Z_H                     0x2DU
+#define LIS2DW12_FIFO_CTRL                   0x2EU
+typedef struct {
+  uint8_t fth                        : 5;
+  uint8_t fmode                      : 3;
+} lis2dw12_fifo_ctrl_t;
+
+#define LIS2DW12_FIFO_SAMPLES                0x2FU
+typedef struct {
+  uint8_t diff                       : 6;
+  uint8_t fifo_ovr                   : 1;
+  uint8_t fifo_fth                   : 1;
+} lis2dw12_fifo_samples_t;
+
+#define LIS2DW12_TAP_THS_X                   0x30U
+typedef struct {
+  uint8_t tap_thsx                    : 5;
+  uint8_t _6d_ths                     : 2;
+  uint8_t _4d_en                      : 1;
+} lis2dw12_tap_ths_x_t;
+
+#define LIS2DW12_TAP_THS_Y                   0x31U
+typedef struct {
+  uint8_t tap_thsy                   : 5;
+  uint8_t tap_prior                  : 3;
+} lis2dw12_tap_ths_y_t;
+
+#define LIS2DW12_TAP_THS_Z                   0x32U
+typedef struct {
+  uint8_t tap_thsz                   : 5;
+  uint8_t tap_z_en                   : 1;
+  uint8_t tap_y_en                   : 1;
+  uint8_t tap_x_en                   : 1;
+} lis2dw12_tap_ths_z_t;
+
+#define LIS2DW12_INT_DUR                     0x33U
+typedef struct {
+  uint8_t shock                      : 2;
+  uint8_t quiet                      : 2;
+  uint8_t latency                    : 4;
+} lis2dw12_int_dur_t;
+
+#define LIS2DW12_WAKE_UP_THS                 0x34U
+typedef struct {
+  uint8_t wk_ths                     : 6;
+  uint8_t sleep_on                   : 1;
+  uint8_t single_double_tap          : 1;
+} lis2dw12_wake_up_ths_t;
+
+#define LIS2DW12_WAKE_UP_DUR                 0x35U
+typedef struct {
+  uint8_t sleep_dur                  : 4;
+  uint8_t stationary                 : 1;
+  uint8_t wake_dur                   : 2;
+  uint8_t ff_dur                     : 1;
+} lis2dw12_wake_up_dur_t;
+
+#define LIS2DW12_FREE_FALL                   0x36U
+typedef struct {
+  uint8_t ff_ths                     : 3;
+  uint8_t ff_dur                     : 5;
+} lis2dw12_free_fall_t;
+
+#define LIS2DW12_STATUS_DUP                  0x37U
+typedef struct {
+  uint8_t drdy                       : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t sleep_state_ia             : 1;
+  uint8_t drdy_t                     : 1;
+  uint8_t ovr                        : 1;
+} lis2dw12_status_dup_t;
+
+#define LIS2DW12_WAKE_UP_SRC                 0x38U
+typedef struct {
+  uint8_t z_wu                       : 1;
+  uint8_t y_wu                       : 1;
+  uint8_t x_wu                       : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t sleep_state_ia             : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t not_used_01                : 2;
+} lis2dw12_wake_up_src_t;
+
+#define LIS2DW12_TAP_SRC                     0x39U
+typedef struct {
+  uint8_t z_tap                      : 1;
+  uint8_t y_tap                      : 1;
+  uint8_t x_tap                      : 1;
+  uint8_t tap_sign                   : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t tap_ia                     : 1;
+  uint8_t not_used_01                : 1;
+} lis2dw12_tap_src_t;
+
+#define LIS2DW12_SIXD_SRC                    0x3AU
+typedef struct {
+  uint8_t xl                         : 1;
+  uint8_t xh                         : 1;
+  uint8_t yl                         : 1;
+  uint8_t yh                         : 1;
+  uint8_t zl                         : 1;
+  uint8_t zh                         : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t not_used_01                : 1;
+} lis2dw12_sixd_src_t;
+
+#define LIS2DW12_ALL_INT_SRC                 0x3BU
+typedef struct {
+  uint8_t ff_ia                      : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t sleep_change_ia            : 1;
+  uint8_t not_used_01                : 2;
+} lis2dw12_all_int_src_t;
+
+#define LIS2DW12_X_OFS_USR                   0x3CU
+#define LIS2DW12_Y_OFS_USR                   0x3DU
+#define LIS2DW12_Z_OFS_USR                   0x3EU
+#define LIS2DW12_CTRL_REG7                   0x3FU
+typedef struct {
+  uint8_t lpass_on6d                 : 1;
+  uint8_t hp_ref_mode                : 1;
+  uint8_t usr_off_w                  : 1;
+  uint8_t usr_off_on_wu              : 1;
+  uint8_t usr_off_on_out             : 1;
+  uint8_t interrupts_enable          : 1;
+  uint8_t int2_on_int1               : 1;
+  uint8_t drdy_pulsed                : 1;
+} lis2dw12_ctrl_reg7_t;
+
+/**
+  * @defgroup LIS2DW12_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis2dw12_ctrl1_t                   ctrl1;
+  lis2dw12_ctrl2_t                   ctrl2;
+  lis2dw12_ctrl3_t                   ctrl3;
+  lis2dw12_ctrl4_int1_pad_ctrl_t     ctrl4_int1_pad_ctrl;
+  lis2dw12_ctrl5_int2_pad_ctrl_t     ctrl5_int2_pad_ctrl;
+  lis2dw12_ctrl6_t                   ctrl6;
+  lis2dw12_status_t                  status;
+  lis2dw12_fifo_ctrl_t               fifo_ctrl;
+  lis2dw12_fifo_samples_t            fifo_samples;
+  lis2dw12_tap_ths_x_t               tap_ths_x;
+  lis2dw12_tap_ths_y_t               tap_ths_y;
+  lis2dw12_tap_ths_z_t               tap_ths_z;
+  lis2dw12_int_dur_t                 int_dur;
+  lis2dw12_wake_up_ths_t             wake_up_ths;
+  lis2dw12_wake_up_dur_t             wake_up_dur;
+  lis2dw12_free_fall_t               free_fall;
+  lis2dw12_status_dup_t              status_dup;
+  lis2dw12_wake_up_src_t             wake_up_src;
+  lis2dw12_tap_src_t                 tap_src;
+  lis2dw12_sixd_src_t                sixd_src;
+  lis2dw12_all_int_src_t             all_int_src;
+  lis2dw12_ctrl_reg7_t               ctrl_reg7;
+  bitwise_t                          bitwise;
+  uint8_t                            byte;
+} lis2dw12_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis2dw12_read_reg(lis2dw12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lis2dw12_write_reg(lis2dw12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t lis2dw12_from_fs2_to_mg(int16_t lsb);
+extern float_t lis2dw12_from_fs4_to_mg(int16_t lsb);
+extern float_t lis2dw12_from_fs8_to_mg(int16_t lsb);
+extern float_t lis2dw12_from_fs16_to_mg(int16_t lsb);
+extern float_t lis2dw12_from_fs2_lp1_to_mg(int16_t lsb);
+extern float_t lis2dw12_from_fs4_lp1_to_mg(int16_t lsb);
+extern float_t lis2dw12_from_fs8_lp1_to_mg(int16_t lsb);
+extern float_t lis2dw12_from_fs16_lp1_to_mg(int16_t lsb);
+extern float_t lis2dw12_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  LIS2DW12_HIGH_PERFORMANCE                    = 0x04,
+  LIS2DW12_CONT_LOW_PWR_4                      = 0x03,
+  LIS2DW12_CONT_LOW_PWR_3                      = 0x02,
+  LIS2DW12_CONT_LOW_PWR_2                      = 0x01,
+  LIS2DW12_CONT_LOW_PWR_12bit                  = 0x00,
+  LIS2DW12_SINGLE_LOW_PWR_4                    = 0x0B,
+  LIS2DW12_SINGLE_LOW_PWR_3                    = 0x0A,
+  LIS2DW12_SINGLE_LOW_PWR_2                    = 0x09,
+  LIS2DW12_SINGLE_LOW_PWR_12bit                = 0x08,
+  LIS2DW12_HIGH_PERFORMANCE_LOW_NOISE          = 0x14,
+  LIS2DW12_CONT_LOW_PWR_LOW_NOISE_4            = 0x13,
+  LIS2DW12_CONT_LOW_PWR_LOW_NOISE_3            = 0x12,
+  LIS2DW12_CONT_LOW_PWR_LOW_NOISE_2            = 0x11,
+  LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit        = 0x10,
+  LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_4          = 0x1B,
+  LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_3          = 0x1A,
+  LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2          = 0x19,
+  LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit      = 0x18,
+} lis2dw12_mode_t;
+int32_t lis2dw12_power_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_mode_t val);
+int32_t lis2dw12_power_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_mode_t *val);
+
+typedef enum {
+  LIS2DW12_XL_ODR_OFF            = 0x00,
+  LIS2DW12_XL_ODR_1Hz6_LP_ONLY   = 0x01,
+  LIS2DW12_XL_ODR_12Hz5          = 0x02,
+  LIS2DW12_XL_ODR_25Hz           = 0x03,
+  LIS2DW12_XL_ODR_50Hz           = 0x04,
+  LIS2DW12_XL_ODR_100Hz          = 0x05,
+  LIS2DW12_XL_ODR_200Hz          = 0x06,
+  LIS2DW12_XL_ODR_400Hz          = 0x07,
+  LIS2DW12_XL_ODR_800Hz          = 0x08,
+  LIS2DW12_XL_ODR_1k6Hz          = 0x09,
+  LIS2DW12_XL_SET_SW_TRIG        = 0x10,  /* Use this only in SINGLE mode */
+  LIS2DW12_XL_SET_PIN_TRIG       = 0x20,  /* Use this only in SINGLE mode */
+} lis2dw12_odr_t;
+int32_t lis2dw12_data_rate_set(lis2dw12_ctx_t *ctx, lis2dw12_odr_t val);
+int32_t lis2dw12_data_rate_get(lis2dw12_ctx_t *ctx, lis2dw12_odr_t *val);
+
+int32_t lis2dw12_block_data_update_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_block_data_update_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DW12_2g     = 0,
+  LIS2DW12_4g     = 1,
+  LIS2DW12_8g     = 2,
+  LIS2DW12_16g    = 3,
+} lis2dw12_fs_t;
+int32_t lis2dw12_full_scale_set(lis2dw12_ctx_t *ctx, lis2dw12_fs_t val);
+int32_t lis2dw12_full_scale_get(lis2dw12_ctx_t *ctx, lis2dw12_fs_t *val);
+
+int32_t lis2dw12_status_reg_get(lis2dw12_ctx_t *ctx, lis2dw12_status_t *val);
+
+int32_t lis2dw12_flag_data_ready_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef struct{
+  lis2dw12_status_dup_t   status_dup;
+  lis2dw12_wake_up_src_t  wake_up_src;
+  lis2dw12_tap_src_t      tap_src;
+  lis2dw12_sixd_src_t     sixd_src;
+  lis2dw12_all_int_src_t  all_int_src;
+} lis2dw12_all_sources_t;
+int32_t lis2dw12_all_sources_get(lis2dw12_ctx_t *ctx,
+                                 lis2dw12_all_sources_t *val);
+
+int32_t lis2dw12_usr_offset_x_set(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_x_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dw12_usr_offset_y_set(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_y_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dw12_usr_offset_z_set(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_z_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2DW12_LSb_977ug    = 0,
+  LIS2DW12_LSb_15mg6    = 1,
+} lis2dw12_usr_off_w_t;
+int32_t lis2dw12_offset_weight_set(lis2dw12_ctx_t *ctx,
+                                      lis2dw12_usr_off_w_t val);
+int32_t lis2dw12_offset_weight_get(lis2dw12_ctx_t *ctx,
+                                      lis2dw12_usr_off_w_t *val);
+
+int32_t lis2dw12_temperature_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dw12_acceleration_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dw12_device_id_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dw12_auto_increment_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_auto_increment_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_reset_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_reset_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_boot_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_boot_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DW12_XL_ST_DISABLE      = 0,
+  LIS2DW12_XL_ST_POSITIVE     = 1,
+  LIS2DW12_XL_ST_NEGATIVE     = 2,
+} lis2dw12_st_t;
+int32_t lis2dw12_self_test_set(lis2dw12_ctx_t *ctx, lis2dw12_st_t val);
+int32_t lis2dw12_self_test_get(lis2dw12_ctx_t *ctx, lis2dw12_st_t *val);
+
+typedef enum {
+  LIS2DW12_DRDY_LATCHED   = 0,
+  LIS2DW12_DRDY_PULSED    = 1,
+} lis2dw12_drdy_pulsed_t;
+int32_t lis2dw12_data_ready_mode_set(lis2dw12_ctx_t *ctx,
+                                     lis2dw12_drdy_pulsed_t val);
+int32_t lis2dw12_data_ready_mode_get(lis2dw12_ctx_t *ctx,
+                                     lis2dw12_drdy_pulsed_t *val);
+
+typedef enum {
+  LIS2DW12_LPF_ON_OUT         = 0x00,
+  LIS2DW12_USER_OFFSET_ON_OUT  = 0x01,
+  LIS2DW12_HIGH_PASS_ON_OUT    = 0x10,
+} lis2dw12_fds_t;
+int32_t lis2dw12_filter_path_set(lis2dw12_ctx_t *ctx, lis2dw12_fds_t val);
+int32_t lis2dw12_filter_path_get(lis2dw12_ctx_t *ctx, lis2dw12_fds_t *val);
+
+typedef enum {
+  LIS2DW12_ODR_DIV_2     = 0,
+  LIS2DW12_ODR_DIV_4     = 1,
+  LIS2DW12_ODR_DIV_10    = 2,
+  LIS2DW12_ODR_DIV_20    = 3,
+} lis2dw12_bw_filt_t;
+int32_t lis2dw12_filter_bandwidth_set(lis2dw12_ctx_t *ctx,
+                                         lis2dw12_bw_filt_t val);
+int32_t lis2dw12_filter_bandwidth_get(lis2dw12_ctx_t *ctx,
+                                         lis2dw12_bw_filt_t *val);
+
+int32_t lis2dw12_reference_mode_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_reference_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DW12_SPI_4_WIRE   = 0,
+  LIS2DW12_SPI_3_WIRE   = 1,
+} lis2dw12_sim_t;
+int32_t lis2dw12_spi_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sim_t val);
+int32_t lis2dw12_spi_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sim_t *val);
+
+typedef enum {
+  LIS2DW12_I2C_ENABLE    = 0,
+  LIS2DW12_I2C_DISABLE   = 1,
+} lis2dw12_i2c_disable_t;
+int32_t lis2dw12_i2c_interface_set(lis2dw12_ctx_t *ctx,
+                                   lis2dw12_i2c_disable_t val);
+int32_t lis2dw12_i2c_interface_get(lis2dw12_ctx_t *ctx,
+                                   lis2dw12_i2c_disable_t *val);
+
+typedef enum {
+  LIS2DW12_PULL_UP_CONNECT     = 0,
+  LIS2DW12_PULL_UP_DISCONNECT  = 1,
+} lis2dw12_cs_pu_disc_t;
+int32_t lis2dw12_cs_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t val);
+int32_t lis2dw12_cs_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t *val);
+
+typedef enum {
+  LIS2DW12_ACTIVE_HIGH  = 0,
+  LIS2DW12_ACTIVE_LOW   = 1,
+} lis2dw12_h_lactive_t;
+int32_t lis2dw12_pin_polarity_set(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_h_lactive_t val);
+int32_t lis2dw12_pin_polarity_get(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_h_lactive_t *val);
+
+typedef enum {
+  LIS2DW12_INT_PULSED   = 0,
+  LIS2DW12_INT_LATCHED  = 1,
+} lis2dw12_lir_t;
+int32_t lis2dw12_int_notification_set(lis2dw12_ctx_t *ctx,
+                                      lis2dw12_lir_t val);
+int32_t lis2dw12_int_notification_get(lis2dw12_ctx_t *ctx,
+                                      lis2dw12_lir_t *val);
+
+typedef enum {
+  LIS2DW12_PUSH_PULL   = 0,
+  LIS2DW12_OPEN_DRAIN  = 1,
+} lis2dw12_pp_od_t;
+int32_t lis2dw12_pin_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t val);
+int32_t lis2dw12_pin_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t *val);
+
+int32_t lis2dw12_pin_int1_route_set(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_ctrl4_int1_pad_ctrl_t *val);
+int32_t lis2dw12_pin_int1_route_get(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_ctrl4_int1_pad_ctrl_t *val);
+
+int32_t lis2dw12_pin_int2_route_set(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_ctrl5_int2_pad_ctrl_t *val);
+int32_t lis2dw12_pin_int2_route_get(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_ctrl5_int2_pad_ctrl_t *val);
+
+int32_t lis2dw12_all_on_int1_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_all_on_int1_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_wkup_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_wkup_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_wkup_dur_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_wkup_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DW12_HP_FEED           = 0,
+  LIS2DW12_USER_OFFSET_FEED  = 1,
+} lis2dw12_usr_off_on_wu_t;
+int32_t lis2dw12_wkup_feed_data_set(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_usr_off_on_wu_t val);
+int32_t lis2dw12_wkup_feed_data_get(lis2dw12_ctx_t *ctx,
+                                    lis2dw12_usr_off_on_wu_t *val);
+
+typedef enum {
+  LIS2DW12_NO_DETECTION        = 0,
+  LIS2DW12_DETECT_ACT_INACT    = 1,
+  LIS2DW12_DETECT_STAT_MOTION  = 3,
+} lis2dw12_sleep_on_t;
+int32_t lis2dw12_act_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t val);
+int32_t lis2dw12_act_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t *val);
+
+int32_t lis2dw12_act_sleep_dur_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_act_sleep_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_tap_threshold_x_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_threshold_x_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_tap_threshold_y_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_threshold_y_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DW12_XYZ    = 0,
+  LIS2DW12_YXZ    = 1,
+  LIS2DW12_XZY    = 2,
+  LIS2DW12_ZYX    = 3,
+  LIS2DW12_YZX    = 5,
+  LIS2DW12_ZXY    = 6,
+} lis2dw12_tap_prior_t;
+int32_t lis2dw12_tap_axis_priority_set(lis2dw12_ctx_t *ctx,
+                                       lis2dw12_tap_prior_t val);
+int32_t lis2dw12_tap_axis_priority_get(lis2dw12_ctx_t *ctx,
+                                       lis2dw12_tap_prior_t *val);
+
+int32_t lis2dw12_tap_threshold_z_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_threshold_z_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_tap_detection_on_z_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_detection_on_z_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_tap_detection_on_y_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_detection_on_y_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_tap_detection_on_x_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_detection_on_x_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_tap_shock_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_shock_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_tap_quiet_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_quiet_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_tap_dur_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DW12_ONLY_SINGLE          = 0,
+  LIS2DW12_BOTH_SINGLE_DOUBLE   = 1,
+} lis2dw12_single_double_tap_t;
+int32_t lis2dw12_tap_mode_set(lis2dw12_ctx_t *ctx,
+                              lis2dw12_single_double_tap_t val);
+int32_t lis2dw12_tap_mode_get(lis2dw12_ctx_t *ctx,
+                              lis2dw12_single_double_tap_t *val);
+
+int32_t lis2dw12_tap_src_get(lis2dw12_ctx_t *ctx, lis2dw12_tap_src_t *val);
+
+int32_t lis2dw12_6d_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_6d_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_4d_mode_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_4d_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_6d_src_get(lis2dw12_ctx_t *ctx, lis2dw12_sixd_src_t *val);
+
+typedef enum {
+  LIS2DW12_ODR_DIV_2_FEED   = 0,
+  LIS2DW12_LPF2_FEED        = 1,
+} lis2dw12_lpass_on6d_t;
+int32_t lis2dw12_6d_feed_data_set(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_lpass_on6d_t val);
+int32_t lis2dw12_6d_feed_data_get(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_lpass_on6d_t *val);
+
+int32_t lis2dw12_ff_dur_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_ff_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DW12_FF_TSH_5LSb_FS2g  = 0,
+  LIS2DW12_FF_TSH_7LSb_FS2g  = 1,
+  LIS2DW12_FF_TSH_8LSb_FS2g  = 2,
+  LIS2DW12_FF_TSH_10LSb_FS2g = 3,
+  LIS2DW12_FF_TSH_11LSb_FS2g = 4,
+  LIS2DW12_FF_TSH_13LSb_FS2g = 5,
+  LIS2DW12_FF_TSH_15LSb_FS2g = 6,
+  LIS2DW12_FF_TSH_16LSb_FS2g = 7,
+} lis2dw12_ff_ths_t;
+int32_t lis2dw12_ff_threshold_set(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_ff_ths_t val);
+int32_t lis2dw12_ff_threshold_get(lis2dw12_ctx_t *ctx,
+                                  lis2dw12_ff_ths_t *val);
+
+int32_t lis2dw12_fifo_watermark_set(lis2dw12_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_fifo_watermark_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DW12_BYPASS_MODE             = 0,
+  LIS2DW12_FIFO_MODE               = 1,
+  LIS2DW12_STREAM_TO_FIFO_MODE     = 3,
+  LIS2DW12_BYPASS_TO_STREAM_MODE   = 4,
+  LIS2DW12_STREAM_MODE             = 6,
+} lis2dw12_fmode_t;
+int32_t lis2dw12_fifo_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t val);
+int32_t lis2dw12_fifo_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t *val);
+
+int32_t lis2dw12_fifo_data_level_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_fifo_ovr_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dw12_fifo_wtm_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*LIS2DW12_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2hh12_STdC/driver/lis2hh12_reg.c
+++ b/sensor/stmemsc/lis2hh12_STdC/driver/lis2hh12_reg.c
@@ -1,0 +1,2192 @@
+/*
+ ******************************************************************************
+ * @file    lis2hh12_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS2HH12 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "lis2hh12_reg.h"
+
+/**
+  * @defgroup    LIS2HH12
+  * @brief       This file provides a set of functions needed to drive the
+  *              lis2hh12 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2hh12_read_reg(lis2hh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2hh12_write_reg(lis2hh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lis2hh12_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.061f);
+}
+
+float_t lis2hh12_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.122f);
+}
+
+float_t lis2hh12_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.244f);
+}
+
+float_t lis2hh12_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 8.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Data_generation
+  * @brief       This section groups all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief   Enable accelerometer axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer’s X-axis output enable.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_axis_set(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t val)
+{
+  lis2hh12_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0) {
+    ctrl1.xen  = val.xen;
+    ctrl1.yen  = val.yen;
+    ctrl1.zen  = val.zen;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable accelerometer axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer’s X-axis output enable.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_axis_get(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t *val)
+{
+  lis2hh12_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  val->xen = ctrl1.xen;
+  val->yen = ctrl1.yen;
+  val->zen = ctrl1.zen;
+
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_block_data_update_set(lis2hh12_ctx_t *ctx, uint8_t val)
+{
+  lis2hh12_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ctrl1.bdu = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_block_data_update_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2hh12_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  *val = (uint8_t)ctrl1.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "odr" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_data_rate_set(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_xl_data_rate_t val)
+{
+  lis2hh12_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ctrl1.odr = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_data_rate_get(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_xl_data_rate_t *val)
+{
+  lis2hh12_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  switch (ctrl1.odr){
+    case LIS2HH12_XL_ODR_OFF:
+      *val = LIS2HH12_XL_ODR_OFF;
+      break;
+    case LIS2HH12_XL_ODR_10Hz:
+      *val = LIS2HH12_XL_ODR_10Hz;
+      break;
+    case LIS2HH12_XL_ODR_50Hz:
+      *val = LIS2HH12_XL_ODR_50Hz;
+      break;
+    case LIS2HH12_XL_ODR_100Hz:
+      *val = LIS2HH12_XL_ODR_100Hz;
+      break;
+    case LIS2HH12_XL_ODR_200Hz:
+      *val = LIS2HH12_XL_ODR_200Hz;
+      break;
+    case LIS2HH12_XL_ODR_400Hz:
+      *val = LIS2HH12_XL_ODR_400Hz;
+      break;
+    case LIS2HH12_XL_ODR_800Hz:
+      *val = LIS2HH12_XL_ODR_800Hz;
+      break;
+    default:
+      *val = LIS2HH12_XL_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fs" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_full_scale_set(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_xl_fs_t val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.fs = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_full_scale_get(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_xl_fs_t *val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch (ctrl4.fs){
+    case LIS2HH12_2g:
+      *val = LIS2HH12_2g;
+      break;
+    case LIS2HH12_4g:
+      *val = LIS2HH12_4g;
+      break;
+    case LIS2HH12_8g:
+      *val = LIS2HH12_8g;
+      break;
+    default:
+      *val = LIS2HH12_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Decimation of acceleration data on OUT REG and FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dec" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_decimation_set(lis2hh12_ctx_t *ctx, lis2hh12_dec_t val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.dec = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Decimation of acceleration data on OUT REG and FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dec in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_decimation_get(lis2hh12_ctx_t *ctx, lis2hh12_dec_t *val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  switch (ctrl5.dec){
+    case LIS2HH12_NO_DECIMATION:
+      *val = LIS2HH12_NO_DECIMATION;
+      break;
+    case LIS2HH12_EVERY_2_SAMPLES:
+      *val = LIS2HH12_EVERY_2_SAMPLES;
+      break;
+    case LIS2HH12_EVERY_4_SAMPLES:
+      *val = LIS2HH12_EVERY_4_SAMPLES;
+      break;
+    case LIS2HH12_EVERY_8_SAMPLES:
+      *val = LIS2HH12_EVERY_8_SAMPLES;
+      break;
+    default:
+      *val = LIS2HH12_NO_DECIMATION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   New data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "zyxda" in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_flag_data_ready_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2hh12_status_t status;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_STATUS, (uint8_t*)&status, 1);
+  *val = status.zyxda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Dataoutput
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Temperature data output register (r). L and H registers together
+  *          express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_temperature_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief   Linear acceleration output register. The value is expressed
+  *          as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_acceleration_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_OUT_X_L, buff,
+                            6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_dev_id_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_WHO_AM_I, buff,
+                            1);
+  return ret;
+}
+
+/**
+  * @brief   Software reset. Restore the default values
+  *          in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of soft_reset in reg CTRL5.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_dev_reset_set(lis2hh12_ctx_t *ctx, uint8_t val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.soft_reset = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Software reset. Restore the default values in
+  *          user registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of soft_reset in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_dev_reset_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  *val = (uint8_t)ctrl5.soft_reset;
+
+  return ret;
+}
+
+/**
+  * @brief   Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL6.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_dev_boot_set(lis2hh12_ctx_t *ctx, uint8_t val)
+{
+  lis2hh12_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL6, (uint8_t*)&ctrl6, 1);
+  if(ret == 0){
+    ctrl6.boot = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL6, (uint8_t*)&ctrl6, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL6.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_dev_boot_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2hh12_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL6, (uint8_t*)&ctrl6, 1);
+  *val = (uint8_t)ctrl6.boot;
+
+  return ret;
+}
+
+/**
+  * @brief   Device status register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     X-axis new data available.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_dev_status_get(lis2hh12_ctx_t *ctx,
+                                lis2hh12_status_reg_t *val)
+{
+  lis2hh12_status_t status;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_STATUS, (uint8_t*)&status, 1);
+  val->xda = status.xda;
+  val->yda = status.yda;
+  val->zda = status.zda;
+  val->zyxda = status.zyxda;
+  val->_xor = status._xor;
+  val->yor = status.yor;
+  val->zor = status.zor;
+  val->zyxor = status.zyxor;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Filters
+  * @brief       This section group all the functions concerning the
+  *              filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief   Accelerometer filter routing on interrupt generators.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "hpis" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_int_path_set(lis2hh12_ctx_t *ctx,
+                                        lis2hh12_xl_hp_path_t val)
+{
+  lis2hh12_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.hpis = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer filter routing on interrupt generators.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpis in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_int_path_get(lis2hh12_ctx_t *ctx,
+                                        lis2hh12_xl_hp_path_t *val)
+{
+  lis2hh12_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  switch (ctrl2.hpis){
+    case LIS2HH12_HP_DISABLE:
+      *val = LIS2HH12_HP_DISABLE;
+      break;
+    case LIS2HH12_HP_ON_INT_GEN_1:
+      *val = LIS2HH12_HP_ON_INT_GEN_1;
+      break;
+    case LIS2HH12_HP_ON_INT_GEN_2:
+      *val = LIS2HH12_HP_ON_INT_GEN_2;
+      break;
+    default:
+      *val = LIS2HH12_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer output filter path configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fds" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_out_path_set(lis2hh12_ctx_t *ctx,
+                                        lis2hh12_xl_out_path_t val)
+{
+  lis2hh12_ctrl1_t ctrl1;
+  lis2hh12_ctrl2_t ctrl2;
+
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+
+  if(ret == 0){
+    ctrl1.hr = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  if(ret == 0){
+    ctrl2.fds = ( (uint8_t) val & 0x02U ) >> 1;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer output filter path configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fds in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_out_path_get(lis2hh12_ctx_t *ctx,
+                                        lis2hh12_xl_out_path_t *val)
+{
+  lis2hh12_ctrl1_t ctrl1;
+  lis2hh12_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+
+    switch ((ctrl2.fds << 1) | ctrl1.hr){
+      case LIS2HH12_BYPASSED:
+        *val = LIS2HH12_BYPASSED;
+        break;
+      case LIS2HH12_FILT_HP:
+        *val = LIS2HH12_FILT_HP;
+        break;
+      case LIS2HH12_FILT_LP:
+        *val = LIS2HH12_FILT_LP;
+        break;
+      default:
+        *val = LIS2HH12_BYPASSED;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer digital filter high pass cutoff
+  *          frequency selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "hpm" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_hp_bandwidth_set(lis2hh12_ctx_t *ctx,
+                                            lis2hh12_xl_hp_bw_t val)
+{
+  lis2hh12_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.hpm = (uint8_t) val & 0x01U;
+    ctrl2.dfc = (((uint8_t) val  & 0x30U )>> 4);
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer digital filter high pass cutoff frequency
+  *          selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpm in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_hp_bandwidth_get(lis2hh12_ctx_t *ctx,
+                                            lis2hh12_xl_hp_bw_t *val)
+{
+  lis2hh12_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  switch ((ctrl2.dfc << 4) | ctrl2.hpm){
+    case LIS2HH12_HP_ODR_DIV_50:
+      *val = LIS2HH12_HP_ODR_DIV_50;
+      break;
+    case LIS2HH12_HP_ODR_DIV_100:
+      *val = LIS2HH12_HP_ODR_DIV_100;
+      break;
+    case LIS2HH12_HP_ODR_DIV_9:
+      *val = LIS2HH12_HP_ODR_DIV_9;
+      break;
+    case LIS2HH12_HP_ODR_DIV_400:
+      *val = LIS2HH12_HP_ODR_DIV_400;
+      break;
+    case LIS2HH12_HP_ODR_DIV_50_REF_MD:
+      *val = LIS2HH12_HP_ODR_DIV_50_REF_MD;
+      break;
+    case LIS2HH12_HP_ODR_DIV_100_REF_MD:
+      *val = LIS2HH12_HP_ODR_DIV_100_REF_MD;
+      break;
+    case LIS2HH12_HP_ODR_DIV_9_REF_MD:
+      *val = LIS2HH12_HP_ODR_DIV_9_REF_MD;
+      break;
+    case LIS2HH12_HP_ODR_DIV_400_REF_MD:
+      *val = LIS2HH12_HP_ODR_DIV_400_REF_MD;
+      break;
+    default:
+      *val = LIS2HH12_HP_ODR_DIV_50;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer digital filter low pass cutoff frequency
+  *          selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dfc" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_low_bandwidth_set(lis2hh12_ctx_t *ctx,
+                                             lis2hh12_xl_lp_bw_t val)
+{
+  lis2hh12_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.dfc = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer digital filter low pass cutoff frequency
+  *          selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dfc in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_low_bandwidth_get(lis2hh12_ctx_t *ctx,
+                                             lis2hh12_xl_lp_bw_t *val)
+{
+  lis2hh12_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL2, (uint8_t*)&ctrl2, 1);
+  switch (ctrl2.dfc){
+    case LIS2HH12_LP_ODR_DIV_50:
+      *val = LIS2HH12_LP_ODR_DIV_50;
+      break;
+    case LIS2HH12_LP_ODR_DIV_100:
+      *val = LIS2HH12_LP_ODR_DIV_100;
+      break;
+    case LIS2HH12_LP_ODR_DIV_9:
+      *val = LIS2HH12_LP_ODR_DIV_9;
+      break;
+    case LIS2HH12_LP_ODR_DIV_400:
+      *val = LIS2HH12_LP_ODR_DIV_400;
+      break;
+    default:
+      *val = LIS2HH12_LP_ODR_DIV_50;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Set anti-aliasing filter bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "bw_scale_odr" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_aalias_bandwidth_set(lis2hh12_ctx_t *ctx,
+                                                lis2hh12_xl_filt_aa_bw_t val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.bw_scale_odr = ((( uint8_t) val & 0x10U ) >> 4);
+    ctrl4.bw = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Set anti-aliasing filter bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bw_scale_odr in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_aalias_bandwidth_get(lis2hh12_ctx_t *ctx,
+                                                lis2hh12_xl_filt_aa_bw_t *val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch ( (ctrl4.bw_scale_odr << 4) | ctrl4.bw){
+    case LIS2HH12_AUTO:
+      *val = LIS2HH12_AUTO;
+      break;
+    case LIS2HH12_408Hz:
+      *val = LIS2HH12_408Hz;
+      break;
+    case LIS2HH12_211Hz:
+      *val = LIS2HH12_211Hz;
+      break;
+    case LIS2HH12_105Hz:
+      *val = LIS2HH12_105Hz;
+      break;
+    case LIS2HH12_50Hz:
+      *val = LIS2HH12_50Hz;
+      break;     
+    default:
+      *val = LIS2HH12_AUTO;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Reference value for acelerometer digital high-pass filter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data to be write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_reference_set(lis2hh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2hh12_write_reg(ctx, LIS2HH12_XL_REFERENCE, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief   Reference value for acelerometer digital high-pass filter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_filter_reference_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_XL_REFERENCE, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Serial_interface
+  * @brief       This section groups all the functions concerning main
+  *              serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief   SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "sim" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_spi_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_sim_t val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.sim = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_spi_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_sim_t *val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch (ctrl4.sim){
+    case LIS2HH12_SPI_4_WIRE:
+      *val = LIS2HH12_SPI_4_WIRE;
+      break;
+    case LIS2HH12_SPI_3_WIRE:
+      *val = LIS2HH12_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS2HH12_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Disable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "i2c_disable" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_i2c_interface_set(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_i2c_dis_t val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.i2c_disable = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Disable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_disable in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_i2c_interface_get(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_i2c_dis_t *val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch (ctrl4.i2c_disable){
+    case LIS2HH12_I2C_ENABLE:
+      *val = LIS2HH12_I2C_ENABLE;
+      break;
+    case LIS2HH12_I2C_DISABLE:
+      *val = LIS2HH12_I2C_DISABLE;
+      break;
+    default:
+      *val = LIS2HH12_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Register address automatically incremented during a
+  *          multiple byte access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "if_add_inc" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_auto_increment_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_auto_inc_t val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.if_add_inc = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Register address automatically incremented during a multiple
+  *          byte access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_add_inc in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_auto_increment_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_auto_inc_t *val)
+{
+  lis2hh12_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch (ctrl4.if_add_inc){
+    case LIS2HH12_DISABLE:
+      *val = LIS2HH12_DISABLE;
+      break;
+    case LIS2HH12_ENABLE:
+      *val = LIS2HH12_ENABLE;
+      break;
+    default:
+      *val = LIS2HH12_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Interrupt_pins
+  * @brief       This section groups all the functions that manage
+  *              interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief   Route a signal on INT 1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer data ready on INT 1 pin.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_int1_route_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_pin_int1_route_t val)
+{
+  lis2hh12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0) {
+    ctrl3.int1_drdy  = val.int1_drdy;
+    ctrl3.int1_fth  = val.int1_fth;
+    ctrl3.int1_ovr  = val.int1_ovr;
+    ctrl3.int1_ig1  = val.int1_ig1;
+    ctrl3.int1_ig2  = val.int1_ig2;
+    ctrl3.int1_inact  = val.int1_inact;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Route a signal on INT 1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer data ready on INT 1 pin.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_int1_route_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_pin_int1_route_t *val)
+{
+  lis2hh12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL3, (uint8_t*)&ctrl3, 1);
+  val->int1_drdy = ctrl3.int1_drdy;
+  val->int1_fth = ctrl3.int1_fth;
+  val->int1_ovr = ctrl3.int1_ovr;
+  val->int1_ig1 = ctrl3.int1_ig1;
+  val->int1_ig2 = ctrl3.int1_ig2;
+  val->int1_inact = ctrl3.int1_inact;
+
+  return ret;
+}
+
+/**
+  * @brief   Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "pp_od" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.pp_od = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t *val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  switch (ctrl5.pp_od){
+    case LIS2HH12_PUSH_PULL:
+      *val = LIS2HH12_PUSH_PULL;
+      break;
+    case LIS2HH12_OPEN_DRAIN:
+      *val = LIS2HH12_OPEN_DRAIN;
+      break;
+    default:
+      *val = LIS2HH12_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt active-high/low.Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "h_lactive" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_polarity_set(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_pin_pol_t val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.h_lactive = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt active-high/low.Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_polarity_get(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_pin_pol_t *val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  switch (ctrl5.h_lactive){
+    case LIS2HH12_ACTIVE_HIGH:
+      *val = LIS2HH12_ACTIVE_HIGH;
+      break;
+    case LIS2HH12_ACTIVE_LOW:
+      *val = LIS2HH12_ACTIVE_LOW;
+      break;
+    default:
+      *val = LIS2HH12_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Route a signal on INT 2 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer data ready on INT2 pin.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_int2_route_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_pin_int2_route_t val)
+{
+  lis2hh12_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL6, (uint8_t*)&ctrl6, 1);
+  if(ret == 0) {
+    ctrl6.int2_drdy   = val.int2_drdy;
+    ctrl6.int2_fth    = val.int2_fth;
+    ctrl6.int2_empty  = val.int2_empty;
+    ctrl6.int2_ig1    = val.int2_ig1;
+    ctrl6.int2_ig2    = val.int2_ig2;
+    ctrl6.int2_boot   = val.int2_boot;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL6, (uint8_t*)&ctrl6, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Route a signal on INT 2 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer data ready on INT2 pin.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_int2_route_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_pin_int2_route_t *val)
+{
+  lis2hh12_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL6, (uint8_t*)&ctrl6, 1);
+  val->int2_drdy  = ctrl6.int2_drdy;
+  val->int2_fth   = ctrl6.int2_fth;
+  val->int2_empty = ctrl6.int2_empty;
+  val->int2_ig1   = ctrl6.int2_ig1;
+  val->int2_ig2   = ctrl6.int2_ig2;
+  val->int2_boot  = ctrl6.int2_boot;
+  return ret;
+}
+
+/**
+  * @brief    Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "lir" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_notification_set(lis2hh12_ctx_t *ctx,
+                                      lis2hh12_lir_t val)
+{
+  lis2hh12_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  if(ret == 0){
+    ctrl7.lir = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg CTRL7.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_notification_get(lis2hh12_ctx_t *ctx,
+                                      lis2hh12_lir_t *val)
+{
+  lis2hh12_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  switch (ctrl7.lir){
+    case LIS2HH12_INT_PULSED:
+      *val = LIS2HH12_INT_PULSED;
+      break;
+    case LIS2HH12_INT_LATCHED:
+      *val = LIS2HH12_INT_LATCHED;
+      break;
+    default:
+      *val = LIS2HH12_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of accelerometer’s interrupt events.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "aoi" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_logic_set(lis2hh12_ctx_t *ctx,
+                               lis2hh12_pin_logic_t val)
+{
+  lis2hh12_ig_cfg1_t ig_cfg1;
+  lis2hh12_ig_cfg2_t ig_cfg2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG1, (uint8_t*)&ig_cfg1, 1);
+  if(ret == 0){
+    ig_cfg1.aoi = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_CFG1, (uint8_t*)&ig_cfg1, 1);
+  }
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+  if(ret == 0){
+    ig_cfg2.aoi = (((uint8_t) val & 0x02U) >> 1);
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of accelerometer’s interrupt events.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of aoi in reg IG_CFG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_pin_logic_get(lis2hh12_ctx_t *ctx,
+                               lis2hh12_pin_logic_t *val)
+{
+  lis2hh12_ig_cfg1_t ig_cfg1;
+  lis2hh12_ig_cfg2_t ig_cfg2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG1, (uint8_t*)&ig_cfg1, 1);
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+
+  switch ( (ig_cfg2.aoi << 1) |  ig_cfg1.aoi){
+    case LIS2HH12_IG1_OR_IG2_OR:
+      *val = LIS2HH12_IG1_OR_IG2_OR;
+      break;
+    case LIS2HH12_IG1_AND_IG2_OR:
+      *val = LIS2HH12_IG1_AND_IG2_OR;
+      break;
+    case LIS2HH12_IG1_OR_IG2_AND:
+      *val = LIS2HH12_IG1_OR_IG2_AND;
+      break;
+    case LIS2HH12_IG1_AND_IG2_AND:
+      *val = LIS2HH12_IG1_AND_IG2_AND;
+      break;
+    default:
+      *val = LIS2HH12_IG1_OR_IG2_OR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Interrupt_on_threshold
+  * @brief       This section group all the functions concerning the
+  *              interrupt on threshold configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief   Decrement or reset counter mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dcrm" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_mode_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_dcrm_t val)
+{
+  lis2hh12_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  if(ret == 0){
+    ctrl7.dcrm = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Decrement or reset counter mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dcrm in reg CTRL7.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_mode_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_dcrm_t *val)
+{
+  lis2hh12_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  switch (ctrl7.dcrm){
+    case LIS2HH12_RESET_MODE:
+      *val = LIS2HH12_RESET_MODE;
+      break;
+    case LIS2HH12_DECREMENT_MODE:
+      *val = LIS2HH12_DECREMENT_MODE;
+      break;
+    default:
+      *val = LIS2HH12_RESET_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable interrupt generation on threshold event.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Enable interrupt generation on accelerometer’s
+  *                X-axis low event.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_axis_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_xl_trshld_en_t val)
+{
+  lis2hh12_ig_cfg1_t ig_cfg1;
+  lis2hh12_ig_cfg2_t ig_cfg2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG1, (uint8_t*)&ig_cfg1, 1);
+  if(ret == 0) {
+    ig_cfg1.xlie  = (uint8_t)val.ig1_xlie;
+    ig_cfg1.xhie  = (uint8_t)val.ig1_xhie;
+    ig_cfg1.ylie  = (uint8_t)val.ig1_ylie;
+    ig_cfg1.yhie  = (uint8_t)val.ig1_yhie;
+    ig_cfg1.zlie  = (uint8_t)val.ig1_zlie;
+    ig_cfg1.zhie  = (uint8_t)val.ig1_zhie;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_CFG1, (uint8_t*)&ig_cfg1, 1);
+  }
+  if(ret == 0) {
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+  if(ret == 0) {
+    ig_cfg2.xlie  = (uint8_t)val.ig2_xlie;
+    ig_cfg2.xhie  = (uint8_t)val.ig2_xhie;
+    ig_cfg2.ylie  = (uint8_t)val.ig2_ylie;
+    ig_cfg2.yhie  = (uint8_t)val.ig2_yhie;
+    ig_cfg2.zlie  = (uint8_t)val.ig2_zlie;
+    ig_cfg2.zhie  = (uint8_t)val.ig2_zhie;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable interrupt generation on threshold event.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Enable interrupt generation on accelerometer’s
+  *                X-axis low event.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_axis_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_xl_trshld_en_t *val)
+{
+  lis2hh12_ig_cfg1_t ig_cfg1;
+  lis2hh12_ig_cfg2_t ig_cfg2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG1,(uint8_t*)&ig_cfg1, 1);
+
+  if(ret == 0) {
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+  val->ig1_xlie = ig_cfg1.xlie;
+  val->ig1_xhie = ig_cfg1.xhie;
+  val->ig1_ylie = ig_cfg1.ylie;
+  val->ig1_yhie = ig_cfg1.yhie;
+  val->ig1_zlie = ig_cfg1.zlie;
+  val->ig1_zhie = ig_cfg1.zhie;
+
+  val->ig2_xlie = ig_cfg2.xlie;
+  val->ig2_xhie = ig_cfg2.xhie;
+  val->ig2_ylie = ig_cfg2.ylie;
+  val->ig2_yhie = ig_cfg2.yhie;
+  val->ig2_zlie = ig_cfg2.zlie;
+  val->ig2_zhie = ig_cfg2.zhie;
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer interrupt on threshold source.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer’s X low. event.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_src_get(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_xl_trshld_src_t *val)
+{
+  lis2hh12_ig_src1_t ig_src1;
+  lis2hh12_ig_src2_t ig_src2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_SRC1, (uint8_t*)&ig_src1, 1);
+  if(ret == 0) {
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_SRC2, (uint8_t*)&ig_src2, 1);
+  }
+  val->ig1_xl = ig_src1.xl;
+  val->ig1_xh = ig_src1.xh;
+  val->ig1_yl = ig_src1.yl;
+  val->ig1_yh = ig_src1.yh;
+  val->ig1_zl = ig_src1.zl;
+  val->ig1_zh = ig_src1.zh;
+  val->ig1_ia = ig_src1.ia;
+  val->ig2_xl = ig_src2.xl;
+  val->ig2_xh = ig_src2.xh;
+  val->ig2_yl = ig_src2.yl;
+  val->ig2_yh = ig_src2.yh;
+  val->ig2_zl = ig_src2.zl;
+  val->ig2_zh = ig_src2.zh;
+  val->ig2_ia = ig_src2.ia;
+
+  return ret;
+}
+
+/**
+  * @brief   Axis interrupt threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data to be write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_set(lis2hh12_ctx_t *ctx, uint8_t ig1_x,
+                               uint8_t ig1_y, uint8_t ig1_z,
+                               uint8_t ig2_xyz)
+{
+  int32_t ret;
+
+  ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_THS_X1, &ig1_x, 1);
+  if(ret == 0) {
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_THS_Y1, &ig1_y, 1);
+  }
+  if(ret == 0) {
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_THS_Z1, &ig1_z, 1);
+  }
+  if(ret == 0) {
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_THS2, &ig2_xyz, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Axis interrupt threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_get(lis2hh12_ctx_t *ctx, uint8_t *ig1_x,
+                               uint8_t *ig1_y, uint8_t *ig1_z,
+                               uint8_t *ig2_xyz)
+{
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_THS_X1, ig1_x, 1);
+  if(ret == 0) {
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_THS_Y1, ig1_y, 1);
+  }
+  if(ret == 0) {
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_THS_Z1, ig1_z, 1);
+  }
+  if(ret == 0) {
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_THS2, ig2_xyz, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enter/exit interrupt duration value.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dur1 in reg IG_DUR1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_min_sample_set(lis2hh12_ctx_t *ctx,
+                                          uint8_t ig1_sam, uint8_t ig2_sam)
+{
+  lis2hh12_ig_dur1_t ig_dur1;
+  lis2hh12_ig_dur2_t ig_dur2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_DUR1, (uint8_t*)&ig_dur1, 1);
+  if(ret == 0){
+    if (ig1_sam == 0x00U){
+      ig_dur1.wait1 = PROPERTY_DISABLE;
+    }
+    else{
+      ig_dur1.wait1 = PROPERTY_ENABLE;
+    }
+    ig_dur1.dur1 = ig1_sam;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_DUR1, (uint8_t*)&ig_dur1, 1);
+  }
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_DUR2, (uint8_t*)&ig_dur2, 1);
+  }
+  if(ret == 0){
+    if (ig2_sam == 0x00U){
+      ig_dur2.wait2 = PROPERTY_DISABLE;
+    }
+    else{
+      ig_dur2.wait2 = PROPERTY_ENABLE;
+    }
+    ig_dur2.dur2 = ig2_sam;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_DUR2, (uint8_t*)&ig_dur2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enter/exit interrupt duration value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dur1 in reg IG_DUR1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_trshld_min_sample_get(lis2hh12_ctx_t *ctx,
+                                          uint8_t *ig1_sam, uint8_t *ig2_sam)
+{
+  lis2hh12_ig_dur1_t ig_dur1;
+  lis2hh12_ig_dur2_t ig_dur2;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_DUR1, (uint8_t*)&ig_dur1, 1);
+  *ig1_sam = (uint8_t)ig_dur1.dur1;
+
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_DUR2, (uint8_t*)&ig_dur2, 1);
+    *ig2_sam = (uint8_t)ig_dur2.dur2;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Activity/Inactivity_detection
+  * @brief       This section groups all the functions concerning
+  *              activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Inactivity threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ths in reg ACT_THS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_act_threshold_set(lis2hh12_ctx_t *ctx, uint8_t val)
+{
+  lis2hh12_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_ACT_THS, (uint8_t*)&act_ths, 1);
+  if(ret == 0){
+    act_ths.ths = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_ACT_THS, (uint8_t*)&act_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Inactivity threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ths in reg ACT_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_act_threshold_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2hh12_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_ACT_THS, (uint8_t*)&act_ths, 1);
+  *val = (uint8_t)act_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief   Inactivity duration in number of sample.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dur in reg ACT_DUR.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_act_duration_set(lis2hh12_ctx_t *ctx, uint8_t val)
+{
+  lis2hh12_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  if(ret == 0){
+    act_dur.dur = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Inactivity duration in number of sample.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dur in reg ACT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_act_duration_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+{
+  lis2hh12_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_ACT_DUR, (uint8_t*)&act_dur, 1);
+  *val = (uint8_t)act_dur.dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Six_position_detection(6D/4D).
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief   6D feature working mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Configure 6D feature working mode.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_6d_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t val)
+{
+  lis2hh12_ig_cfg1_t ig_cfg1;
+  lis2hh12_ig_cfg2_t ig_cfg2;
+  lis2hh12_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  if(ret == 0){
+    ctrl7._4d_ig = ((uint8_t)val & 0x10U) >> 4;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  }
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+  if(ret == 0){
+    ig_cfg2._6d = ((uint8_t)val & 0x02U) >> 1;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG1, (uint8_t*)&ig_cfg1, 1);
+  }
+  if(ret == 0){
+    ig_cfg1._6d = (uint8_t)val & 0x01U;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_IG_CFG1, (uint8_t*)&ig_cfg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   6D feature working mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the configuration of 6D feature.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_6d_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t *val)
+{
+  lis2hh12_ig_cfg1_t ig_cfg1;
+  lis2hh12_ig_cfg2_t ig_cfg2;
+  lis2hh12_ctrl7_t ctrl7;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL7, (uint8_t*)&ctrl7, 1);
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG2, (uint8_t*)&ig_cfg2, 1);
+  }
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_IG_CFG1, (uint8_t*)&ig_cfg1, 1);
+  }
+
+  switch ( (ctrl7._4d_ig << 4) | (ig_cfg2._6d << 1) | ig_cfg1._6d){
+    case LIS2HH12_6D_4D_DISABLE:
+      *val = LIS2HH12_6D_4D_DISABLE;
+      break;
+    case LIS2HH12_ENABLE_ON_IG1_6D:
+      *val = LIS2HH12_ENABLE_ON_IG1_6D;
+      break;
+    case LIS2HH12_ENABLE_ON_IG2_6D:
+      *val = LIS2HH12_ENABLE_ON_IG2_6D;
+      break;
+    case LIS2HH12_ENABLE_ON_IG1_4D:
+      *val = LIS2HH12_ENABLE_ON_IG1_4D;
+      break;
+    case LIS2HH12_ENABLE_ON_IG2_4D:
+      *val = LIS2HH12_ENABLE_ON_IG2_4D;
+      break;
+    default:
+      *val = LIS2HH12_6D_4D_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Fifo
+  * @brief       This section group all the functions concerning
+  *              the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief   FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_fth in reg CTRL3.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_fifo_watermark_set(lis2hh12_ctx_t *ctx, uint8_t val)
+{
+  lis2hh12_fifo_ctrl_t fifo_ctrl;
+  lis2hh12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+
+  if(ret == 0){
+    if (val == 0x00U){
+      ctrl3.stop_fth = PROPERTY_DISABLE;
+    }
+    else{
+      ctrl3.stop_fth = PROPERTY_ENABLE;
+
+    }
+    fifo_ctrl.fth = val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of stop_fth in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_fifo_watermark_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+{
+
+  lis2hh12_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = (uint8_t)fifo_ctrl.fth;
+
+  return ret;
+}
+
+/**
+  * @brief   FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fifo_en" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_fifo_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t val)
+{
+  lis2hh12_fifo_ctrl_t fifo_ctrl;
+  lis2hh12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.fifo_en = (( (uint8_t) val & 0x10U) >> 4);
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl.fmode = ((uint8_t)val & 0x0FU);
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_fifo_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t *val)
+{
+  lis2hh12_fifo_ctrl_t fifo_ctrl;
+  lis2hh12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ret = lis2hh12_read_reg(ctx, LIS2HH12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+
+  switch ( (ctrl3.fifo_en << 4) | fifo_ctrl.fmode ){
+    case LIS2HH12_FIFO_OFF:
+      *val = LIS2HH12_FIFO_OFF;
+      break;
+    case LIS2HH12_BYPASS_MODE:
+      *val = LIS2HH12_BYPASS_MODE;
+      break;
+    case LIS2HH12_FIFO_MODE:
+      *val = LIS2HH12_FIFO_MODE;
+      break;
+    case LIS2HH12_STREAM_MODE:
+      *val = LIS2HH12_STREAM_MODE;
+      break;
+    case LIS2HH12_STREAM_TO_FIFO_MODE:
+      *val = LIS2HH12_STREAM_TO_FIFO_MODE;
+      break;
+    case LIS2HH12_BYPASS_TO_STREAM_MODE:
+      *val = LIS2HH12_BYPASS_TO_STREAM_MODE;
+      break;
+    case LIS2HH12_BYPASS_TO_FIFO_MODE:
+      *val = LIS2HH12_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LIS2HH12_FIFO_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFOstatus.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    FIFOfullflag.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_fifo_status_get(lis2hh12_ctx_t *ctx,
+                                 lis2hh12_fifo_stat_t *val)
+{
+  lis2hh12_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  val->fss = fifo_src.fss;
+  val->empty = fifo_src.empty;
+  val->ovr = fifo_src.ovr;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2HH12_Self_test
+  * @brief       This section groups all the functions that manage
+  *              self test configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief   Enable/disable self-test mode for accelerometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "st" in reg LIS2HH12.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_self_test_set(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_xl_st_t val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.st = (uint8_t)val;
+    ret = lis2hh12_write_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable/disable self-test mode for accelerometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2hh12_xl_self_test_get(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_xl_st_t *val)
+{
+  lis2hh12_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = lis2hh12_read_reg(ctx, LIS2HH12_CTRL5, (uint8_t*)&ctrl5, 1);
+  switch (ctrl5.st){
+    case LIS2HH12_ST_DISABLE:
+      *val = LIS2HH12_ST_DISABLE;
+      break;
+    case LIS2HH12_ST_POSITIVE:
+      *val = LIS2HH12_ST_POSITIVE;
+      break;
+    case LIS2HH12_ST_NEGATIVE:
+      *val = LIS2HH12_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS2HH12_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2hh12_STdC/driver/lis2hh12_reg.h
+++ b/sensor/stmemsc/lis2hh12_STdC/driver/lis2hh12_reg.h
@@ -1,0 +1,737 @@
+/*
+ ******************************************************************************
+ * @file    lis2hh12_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis2hh12_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS2HH12_REGS_H
+#define LIS2HH12_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS2HH12
+  * @{
+  *
+  */
+
+/** @defgroup LIS2HH12_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LIS2HH12_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis2hh12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis2hh12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis2hh12_write_ptr  write_reg;
+  lis2hh12_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis2hh12_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS2HH12_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0x3D if SA0=1 -> 0x3B **/
+#define LIS2HH12_I2C_ADD_L                   0x3DU
+#define LIS2HH12_I2C_ADD_H                   0x3BU
+/** Device Identification (Who am I) **/
+#define LIS2HH12_ID                          0x41U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS2HH12_TEMP_L                      0x0BU
+#define LIS2HH12_TEMP_H                      0x0CU
+#define LIS2HH12_WHO_AM_I                    0x0FU
+#define LIS2HH12_ACT_THS                     0x1EU
+typedef struct {
+  uint8_t ths              : 7;
+  uint8_t not_used_01      : 1;
+} lis2hh12_act_ths_t;
+
+#define LIS2HH12_ACT_DUR                     0x1FU
+typedef struct {
+  uint8_t dur      : 8;
+} lis2hh12_act_dur_t;
+
+#define LIS2HH12_CTRL1                       0x20U
+typedef struct {
+  uint8_t xen              : 1;
+  uint8_t yen              : 1;
+  uint8_t zen              : 1;
+  uint8_t bdu              : 1;
+  uint8_t odr              : 3;
+  uint8_t hr               : 1;
+} lis2hh12_ctrl1_t;
+
+#define LIS2HH12_CTRL2                       0x21U
+typedef struct {
+  uint8_t hpis             : 2;
+  uint8_t fds              : 1;
+  uint8_t hpm              : 2;
+  uint8_t dfc              : 2;
+  uint8_t not_used_01      : 1;
+} lis2hh12_ctrl2_t;
+
+#define LIS2HH12_CTRL3                       0x22U
+typedef struct {
+  uint8_t int1_drdy        : 1;
+  uint8_t int1_fth         : 1;
+  uint8_t int1_ovr         : 1;
+  uint8_t int1_ig1         : 1;
+  uint8_t int1_ig2         : 1;
+  uint8_t int1_inact       : 1;
+  uint8_t stop_fth         : 1;
+  uint8_t fifo_en          : 1;
+} lis2hh12_ctrl3_t;
+
+#define LIS2HH12_CTRL4                       0x23U
+typedef struct {
+  uint8_t sim              : 1;
+  uint8_t i2c_disable      : 1;
+  uint8_t if_add_inc       : 1;
+  uint8_t bw_scale_odr     : 1;
+  uint8_t fs               : 2;
+  uint8_t bw               : 2;
+} lis2hh12_ctrl4_t;
+
+#define LIS2HH12_CTRL5                       0x24U
+typedef struct {
+  uint8_t pp_od            : 1;
+  uint8_t h_lactive        : 1;
+  uint8_t st               : 2;
+  uint8_t dec              : 2;
+  uint8_t soft_reset       : 1;
+  uint8_t debug            : 1;
+} lis2hh12_ctrl5_t;
+
+#define LIS2HH12_CTRL6                       0x25U
+typedef struct {
+  uint8_t int2_drdy        : 1;
+  uint8_t int2_fth         : 1;
+  uint8_t int2_empty       : 1;
+  uint8_t int2_ig1         : 1;
+  uint8_t int2_ig2         : 1;
+  uint8_t int2_boot        : 1;
+  uint8_t not_used_01      : 1;
+  uint8_t boot             : 1;
+} lis2hh12_ctrl6_t;
+
+#define LIS2HH12_CTRL7                       0x26U
+typedef struct {
+  uint8_t _4d_ig           : 2;
+  uint8_t lir              : 2;
+  uint8_t dcrm             : 2;
+  uint8_t not_used_01      : 2;
+} lis2hh12_ctrl7_t;
+
+#define LIS2HH12_STATUS                      0x27U
+typedef struct {
+  uint8_t xda              : 1;
+  uint8_t yda              : 1;
+  uint8_t zda              : 1;
+  uint8_t zyxda            : 1;
+  uint8_t _xor             : 1;
+  uint8_t yor              : 1;
+  uint8_t zor              : 1;
+  uint8_t zyxor            : 1;
+} lis2hh12_status_t;
+
+#define LIS2HH12_OUT_X_L                     0x28U
+#define LIS2HH12_OUT_X_H                     0x29U
+#define LIS2HH12_OUT_Y_L                     0x2AU
+#define LIS2HH12_OUT_Y_H                     0x2BU
+#define LIS2HH12_OUT_Z_L                     0x2CU
+#define LIS2HH12_OUT_Z_H                     0x2DU
+#define LIS2HH12_FIFO_CTRL                   0x2EU
+typedef struct {
+  uint8_t fth              : 5;
+  uint8_t fmode            : 3;
+} lis2hh12_fifo_ctrl_t;
+
+#define LIS2HH12_FIFO_SRC                    0x2FU
+typedef struct {
+  uint8_t fss              : 5;
+  uint8_t empty            : 1;
+  uint8_t ovr              : 1;
+  uint8_t fth              : 1;
+} lis2hh12_fifo_src_t;
+
+#define LIS2HH12_IG_CFG1                     0x30U
+typedef struct {
+  uint8_t xlie             : 1;
+  uint8_t xhie             : 1;
+  uint8_t ylie             : 1;
+  uint8_t yhie             : 1;
+  uint8_t zlie             : 1;
+  uint8_t zhie             : 1;
+  uint8_t _6d              : 1;
+  uint8_t aoi              : 1;
+} lis2hh12_ig_cfg1_t;
+
+#define LIS2HH12_IG_SRC1                     0x31U
+typedef struct {
+  uint8_t xl               : 1;
+  uint8_t xh               : 1;
+  uint8_t yl               : 1;
+  uint8_t yh               : 1;
+  uint8_t zl               : 1;
+  uint8_t zh               : 1;
+  uint8_t ia               : 1;
+  uint8_t not_used_01      : 1;
+} lis2hh12_ig_src1_t;
+
+#define LIS2HH12_IG_THS_X1                   0x32U
+#define LIS2HH12_IG_THS_Y1                   0x33U
+#define LIS2HH12_IG_THS_Z1                   0x34U
+#define LIS2HH12_IG_DUR1                     0x35U
+typedef struct {
+  uint8_t dur1             : 7;
+  uint8_t wait1            : 1;
+} lis2hh12_ig_dur1_t;
+
+#define LIS2HH12_IG_CFG2                     0x36U
+typedef struct {
+  uint8_t xlie             : 1;
+  uint8_t xhie             : 1;
+  uint8_t ylie             : 1;
+  uint8_t yhie             : 1;
+  uint8_t zlie             : 1;
+  uint8_t zhie             : 1;
+  uint8_t _6d              : 1;
+  uint8_t aoi              : 1;
+} lis2hh12_ig_cfg2_t;
+
+#define LIS2HH12_IG_SRC2                     0x37U
+typedef struct {
+  uint8_t xl               : 1;
+  uint8_t xh               : 1;
+  uint8_t yl               : 1;
+  uint8_t yh               : 1;
+  uint8_t zl               : 1;
+  uint8_t zh               : 1;
+  uint8_t ia               : 1;
+  uint8_t not_used_01      : 1;
+} lis2hh12_ig_src2_t;
+
+#define LIS2HH12_IG_THS2                     0x38U
+#define LIS2HH12_IG_DUR2                     0x39U
+typedef struct {
+  uint8_t dur2             : 7;
+  uint8_t wait2            : 1;
+} lis2hh12_ig_dur2_t;
+
+#define LIS2HH12_XL_REFERENCE                0x3AU
+#define LIS2HH12_XH_REFERENCE                0x3BU
+#define LIS2HH12_YL_REFERENCE                0x3CU
+#define LIS2HH12_YH_REFERENCE                0x3DU
+#define LIS2HH12_ZL_REFERENCE                0x3EU
+#define LIS2HH12_ZH_REFERENCE                0x3FU
+
+/**
+  * @defgroup LIS2HH12_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis2hh12_act_ths_t       act_ths;
+  lis2hh12_act_dur_t       act_dur;
+  lis2hh12_ctrl1_t         ctrl1;
+  lis2hh12_ctrl2_t         ctrl2;
+  lis2hh12_ctrl3_t         ctrl3;
+  lis2hh12_ctrl4_t         ctrl4;
+  lis2hh12_ctrl5_t         ctrl5;
+  lis2hh12_ctrl6_t         ctrl6;
+  lis2hh12_ctrl7_t         ctrl7;
+  lis2hh12_status_t        status;
+  lis2hh12_fifo_ctrl_t     fifo_ctrl;
+  lis2hh12_fifo_src_t      fifo_src;
+  lis2hh12_ig_cfg1_t       ig_cfg1;
+  lis2hh12_ig_src1_t       ig_src1;
+  lis2hh12_ig_dur1_t       ig_dur1;
+  lis2hh12_ig_cfg2_t       ig_cfg2;
+  lis2hh12_ig_src2_t       ig_src2;
+  lis2hh12_ig_dur2_t       ig_dur2;
+  bitwise_t                bitwise;
+  uint8_t                  byte;
+} lis2hh12_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis2hh12_read_reg(lis2hh12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lis2hh12_write_reg(lis2hh12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t lis2hh12_from_fs2g_to_mg(int16_t lsb);
+extern float_t lis2hh12_from_fs4g_to_mg(int16_t lsb);
+extern float_t lis2hh12_from_fs8g_to_mg(int16_t lsb);
+extern float_t lis2hh12_from_lsb_to_celsius(int16_t lsb);
+
+typedef struct {
+  uint8_t xen              : 1;
+  uint8_t yen              : 1;
+  uint8_t zen              : 1;
+} lis2hh12_xl_axis_t;
+int32_t lis2hh12_xl_axis_set(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t val);
+int32_t lis2hh12_xl_axis_get(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t *val);
+
+int32_t lis2hh12_block_data_update_set(lis2hh12_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_block_data_update_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2HH12_XL_ODR_OFF      = 0x00,
+  LIS2HH12_XL_ODR_10Hz     = 0x01,
+  LIS2HH12_XL_ODR_50Hz     = 0x02,
+  LIS2HH12_XL_ODR_100Hz    = 0x03,
+  LIS2HH12_XL_ODR_200Hz    = 0x04,
+  LIS2HH12_XL_ODR_400Hz    = 0x05,
+  LIS2HH12_XL_ODR_800Hz    = 0x06,
+} lis2hh12_xl_data_rate_t;
+int32_t lis2hh12_xl_data_rate_set(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_xl_data_rate_t val);
+int32_t lis2hh12_xl_data_rate_get(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_xl_data_rate_t *val);
+
+typedef enum {
+  LIS2HH12_2g              = 0x00,
+  LIS2HH12_16g             = 0x01,
+  LIS2HH12_4g              = 0x02,
+  LIS2HH12_8g              = 0x03,
+} lis2hh12_xl_fs_t;
+int32_t lis2hh12_xl_full_scale_set(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_xl_fs_t val);
+int32_t lis2hh12_xl_full_scale_get(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_xl_fs_t *val);
+
+typedef enum {
+  LIS2HH12_NO_DECIMATION   = 0x00,
+  LIS2HH12_EVERY_2_SAMPLES = 0x01,
+  LIS2HH12_EVERY_4_SAMPLES = 0x02,
+  LIS2HH12_EVERY_8_SAMPLES = 0x03,
+} lis2hh12_dec_t;
+int32_t lis2hh12_xl_decimation_set(lis2hh12_ctx_t *ctx, lis2hh12_dec_t val);
+int32_t lis2hh12_xl_decimation_get(lis2hh12_ctx_t *ctx, lis2hh12_dec_t *val);
+
+int32_t lis2hh12_xl_flag_data_ready_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2hh12_temperature_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2hh12_acceleration_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2hh12_dev_id_get(lis2hh12_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2hh12_dev_reset_set(lis2hh12_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_dev_reset_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2hh12_dev_boot_set(lis2hh12_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_dev_boot_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t xda              : 1;
+  uint8_t yda              : 1;
+  uint8_t zda              : 1;
+  uint8_t zyxda            : 1;
+  uint8_t _xor             : 1;
+  uint8_t yor              : 1;
+  uint8_t zor              : 1;
+  uint8_t zyxor            : 1;
+} lis2hh12_status_reg_t;
+int32_t lis2hh12_dev_status_get(lis2hh12_ctx_t *ctx,
+                                lis2hh12_status_reg_t *val);
+
+typedef enum {
+  LIS2HH12_HP_DISABLE      = 0x00,
+  LIS2HH12_HP_ON_INT_GEN_1 = 0x02,
+  LIS2HH12_HP_ON_INT_GEN_2 = 0x01,
+  LIS2HH12_HP_ON_BOTH_GEN  = 0x03,
+} lis2hh12_xl_hp_path_t;
+int32_t lis2hh12_xl_filter_int_path_set(lis2hh12_ctx_t *ctx,
+                                        lis2hh12_xl_hp_path_t val);
+int32_t lis2hh12_xl_filter_int_path_get(lis2hh12_ctx_t *ctx,
+                                        lis2hh12_xl_hp_path_t *val);
+
+typedef enum {
+  LIS2HH12_BYPASSED        = 0x00,
+  LIS2HH12_FILT_HP         = 0x02,
+  LIS2HH12_FILT_LP         = 0x01,
+} lis2hh12_xl_out_path_t;
+int32_t lis2hh12_xl_filter_out_path_set(lis2hh12_ctx_t *ctx,
+                                        lis2hh12_xl_out_path_t val);
+int32_t lis2hh12_xl_filter_out_path_get(lis2hh12_ctx_t *ctx,
+                                        lis2hh12_xl_out_path_t *val);
+
+typedef enum {
+  LIS2HH12_HP_ODR_DIV_50          = 0x00,
+  LIS2HH12_HP_ODR_DIV_100         = 0x10,
+  LIS2HH12_HP_ODR_DIV_9           = 0x20,
+  LIS2HH12_HP_ODR_DIV_400         = 0x30,
+  LIS2HH12_HP_ODR_DIV_50_REF_MD   = 0x01,
+  LIS2HH12_HP_ODR_DIV_100_REF_MD  = 0x11,
+  LIS2HH12_HP_ODR_DIV_9_REF_MD    = 0x21,
+  LIS2HH12_HP_ODR_DIV_400_REF_MD  = 0x31,
+} lis2hh12_xl_hp_bw_t;
+int32_t lis2hh12_xl_filter_hp_bandwidth_set(lis2hh12_ctx_t *ctx,
+                                            lis2hh12_xl_hp_bw_t val);
+int32_t lis2hh12_xl_filter_hp_bandwidth_get(lis2hh12_ctx_t *ctx,
+                                            lis2hh12_xl_hp_bw_t *val);
+
+typedef enum {
+  LIS2HH12_LP_ODR_DIV_50   = 0,
+  LIS2HH12_LP_ODR_DIV_100  = 1,
+  LIS2HH12_LP_ODR_DIV_9    = 2,
+  LIS2HH12_LP_ODR_DIV_400  = 3,
+} lis2hh12_xl_lp_bw_t;
+int32_t lis2hh12_xl_filter_low_bandwidth_set(lis2hh12_ctx_t *ctx,
+                                             lis2hh12_xl_lp_bw_t val);
+int32_t lis2hh12_xl_filter_low_bandwidth_get(lis2hh12_ctx_t *ctx,
+                                             lis2hh12_xl_lp_bw_t *val);
+
+typedef enum {
+  LIS2HH12_AUTO      = 0x00,
+  LIS2HH12_408Hz     = 0x10,
+  LIS2HH12_211Hz     = 0x11,
+  LIS2HH12_105Hz     = 0x12,
+  LIS2HH12_50Hz      = 0x13,
+} lis2hh12_xl_filt_aa_bw_t;
+int32_t lis2hh12_xl_filter_aalias_bandwidth_set(lis2hh12_ctx_t *ctx,
+                                                lis2hh12_xl_filt_aa_bw_t val);
+int32_t lis2hh12_xl_filter_aalias_bandwidth_get(lis2hh12_ctx_t *ctx,
+                                                lis2hh12_xl_filt_aa_bw_t *val);
+
+int32_t lis2hh12_xl_filter_reference_set(lis2hh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2hh12_xl_filter_reference_get(lis2hh12_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2HH12_SPI_4_WIRE = 0x00,
+  LIS2HH12_SPI_3_WIRE = 0x01,
+} lis2hh12_sim_t;
+int32_t lis2hh12_spi_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_sim_t val);
+int32_t lis2hh12_spi_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_sim_t *val);
+
+typedef enum {
+  LIS2HH12_I2C_ENABLE  = 0x00,
+  LIS2HH12_I2C_DISABLE = 0x01,
+} lis2hh12_i2c_dis_t;
+int32_t lis2hh12_i2c_interface_set(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_i2c_dis_t val);
+int32_t lis2hh12_i2c_interface_get(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_i2c_dis_t *val);
+
+typedef enum {
+  LIS2HH12_DISABLE = 0x00,
+  LIS2HH12_ENABLE  = 0x01,
+} lis2hh12_auto_inc_t;
+int32_t lis2hh12_auto_increment_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_auto_inc_t val);
+int32_t lis2hh12_auto_increment_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_auto_inc_t *val);
+
+typedef struct {
+  uint8_t int1_drdy            : 1;
+  uint8_t int1_fth             : 1;
+  uint8_t int1_ovr             : 1;
+  uint8_t int1_ig1             : 1;
+  uint8_t int1_ig2             : 1;
+  uint8_t int1_inact           : 1;
+} lis2hh12_pin_int1_route_t;
+int32_t lis2hh12_pin_int1_route_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_pin_int1_route_t val);
+int32_t lis2hh12_pin_int1_route_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_pin_int1_route_t *val);
+
+typedef enum {
+  LIS2HH12_PUSH_PULL       = 0x00,
+  LIS2HH12_OPEN_DRAIN      = 0x01,
+} lis2hh12_pp_od_t;
+int32_t lis2hh12_pin_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t val);
+int32_t lis2hh12_pin_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t *val);
+
+typedef enum {
+  LIS2HH12_ACTIVE_HIGH     = 0x00,
+  LIS2HH12_ACTIVE_LOW      = 0x01,
+} lis2hh12_pin_pol_t;
+int32_t lis2hh12_pin_polarity_set(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_pin_pol_t val);
+int32_t lis2hh12_pin_polarity_get(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_pin_pol_t *val);
+
+typedef struct {
+  uint8_t int2_drdy            : 1;
+  uint8_t int2_fth             : 1;
+  uint8_t int2_empty           : 1;
+  uint8_t int2_ig1             : 1;
+  uint8_t int2_ig2             : 1;
+  uint8_t int2_boot            : 1;
+} lis2hh12_pin_int2_route_t;
+int32_t lis2hh12_pin_int2_route_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_pin_int2_route_t val);
+int32_t lis2hh12_pin_int2_route_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_pin_int2_route_t *val);
+
+typedef enum {
+  LIS2HH12_INT_PULSED      = 0x00,
+  LIS2HH12_INT_LATCHED     = 0x01,
+} lis2hh12_lir_t;
+int32_t lis2hh12_pin_notification_set(lis2hh12_ctx_t *ctx,
+                                      lis2hh12_lir_t val);
+int32_t lis2hh12_pin_notification_get(lis2hh12_ctx_t *ctx,
+                                      lis2hh12_lir_t *val);
+typedef enum {
+  LIS2HH12_IG1_OR_IG2_OR   = 0x00,
+  LIS2HH12_IG1_AND_IG2_OR  = 0x01,
+  LIS2HH12_IG1_OR_IG2_AND  = 0x10,
+  LIS2HH12_IG1_AND_IG2_AND = 0x11,
+} lis2hh12_pin_logic_t;
+int32_t lis2hh12_pin_logic_set(lis2hh12_ctx_t *ctx,
+                               lis2hh12_pin_logic_t val);
+int32_t lis2hh12_pin_logic_get(lis2hh12_ctx_t *ctx,
+                               lis2hh12_pin_logic_t *val);
+
+typedef enum {
+  LIS2HH12_RESET_MODE      = 0x00,
+  LIS2HH12_DECREMENT_MODE  = 0x01,
+} lis2hh12_dcrm_t;
+int32_t lis2hh12_xl_trshld_mode_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_dcrm_t val);
+int32_t lis2hh12_xl_trshld_mode_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_dcrm_t *val);
+
+typedef struct {
+  uint16_t ig1_xlie             : 1;
+  uint16_t ig1_xhie             : 1;
+  uint16_t ig1_ylie             : 1;
+  uint16_t ig1_yhie             : 1;
+  uint16_t ig1_zlie             : 1;
+  uint16_t ig1_zhie             : 1;
+  uint16_t ig2_xlie             : 1;
+  uint16_t ig2_xhie             : 1;
+  uint16_t ig2_ylie             : 1;
+  uint16_t ig2_yhie             : 1;
+  uint16_t ig2_zlie             : 1;
+  uint16_t ig2_zhie             : 1;
+} lis2hh12_xl_trshld_en_t;
+int32_t lis2hh12_xl_trshld_axis_set(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_xl_trshld_en_t val);
+int32_t lis2hh12_xl_trshld_axis_get(lis2hh12_ctx_t *ctx,
+                                    lis2hh12_xl_trshld_en_t *val);
+
+typedef struct {
+  uint16_t ig1_xl             : 1;
+  uint16_t ig1_xh             : 1;
+  uint16_t ig1_yl             : 1;
+  uint16_t ig1_yh             : 1;
+  uint16_t ig1_zl             : 1;
+  uint16_t ig1_zh             : 1;
+  uint16_t ig1_ia             : 1;
+  uint16_t ig2_xl             : 1;
+  uint16_t ig2_xh             : 1;
+  uint16_t ig2_yl             : 1;
+  uint16_t ig2_yh             : 1;
+  uint16_t ig2_zl             : 1;
+  uint16_t ig2_zh             : 1;
+  uint16_t ig2_ia             : 1;
+} lis2hh12_xl_trshld_src_t;
+int32_t lis2hh12_xl_trshld_src_get(lis2hh12_ctx_t *ctx,
+                                   lis2hh12_xl_trshld_src_t *val);
+
+int32_t lis2hh12_xl_trshld_set(lis2hh12_ctx_t *ctx, uint8_t ig1_x,
+                               uint8_t ig1_y, uint8_t ig1_z,
+                               uint8_t ig2_xyz);
+int32_t lis2hh12_xl_trshld_get(lis2hh12_ctx_t *ctx, uint8_t *ig1_x,
+                               uint8_t *ig1_y, uint8_t *ig1_z,
+                               uint8_t *ig2_xyz);
+
+int32_t lis2hh12_xl_trshld_min_sample_set(lis2hh12_ctx_t *ctx,
+                                          uint8_t ig1_sam, uint8_t ig2_sam);
+int32_t lis2hh12_xl_trshld_min_sample_get(lis2hh12_ctx_t *ctx,
+                                          uint8_t *ig1_sam, uint8_t *ig2_sam);
+
+int32_t lis2hh12_act_threshold_set(lis2hh12_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_act_threshold_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2hh12_act_duration_set(lis2hh12_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_act_duration_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2HH12_6D_4D_DISABLE       = 0x00,
+  LIS2HH12_ENABLE_ON_IG1_6D    = 0x01,
+  LIS2HH12_ENABLE_ON_IG2_6D    = 0x02,
+  LIS2HH12_ENABLE_ON_IG1_4D    = 0x11,
+  LIS2HH12_ENABLE_ON_IG2_4D    = 0x12,
+} lis2hh12_6d_mode_t;
+int32_t lis2hh12_6d_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t val);
+int32_t lis2hh12_6d_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t *val);
+
+int32_t lis2hh12_fifo_watermark_set(lis2hh12_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_fifo_watermark_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2HH12_FIFO_OFF               = 0x00,
+  LIS2HH12_BYPASS_MODE            = 0x10,
+  LIS2HH12_FIFO_MODE              = 0x11,
+  LIS2HH12_STREAM_MODE            = 0x12,
+  LIS2HH12_STREAM_TO_FIFO_MODE   = 0x13,
+  LIS2HH12_BYPASS_TO_STREAM_MODE = 0x14,
+  LIS2HH12_BYPASS_TO_FIFO_MODE   = 0x17,
+} lis2hh12_fifo_md_t;
+int32_t lis2hh12_fifo_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t val);
+int32_t lis2hh12_fifo_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t *val);
+
+typedef struct {
+  uint8_t fss             : 1;
+  uint8_t empty           : 1;
+  uint8_t ovr             : 1;
+} lis2hh12_fifo_stat_t;
+int32_t lis2hh12_fifo_status_get(lis2hh12_ctx_t *ctx,
+                                 lis2hh12_fifo_stat_t *val);
+
+typedef enum {
+  LIS2HH12_ST_DISABLE    = 0x00,
+  LIS2HH12_ST_POSITIVE   = 0x01,
+  LIS2HH12_ST_NEGATIVE   = 0x02,
+} lis2hh12_xl_st_t;
+int32_t lis2hh12_xl_self_test_set(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_xl_st_t val);
+int32_t lis2hh12_xl_self_test_get(lis2hh12_ctx_t *ctx,
+                                  lis2hh12_xl_st_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS2HH12_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2mdl_STdC/driver/lis2mdl_reg.c
+++ b/sensor/stmemsc/lis2mdl_STdC/driver/lis2mdl_reg.c
@@ -1,0 +1,1156 @@
+/*
+ ******************************************************************************
+ * @file    lis2mdl_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS2MDL driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+#include "lis2mdl_reg.h"
+
+/**
+  * @defgroup    LIS2MDL
+  * @brief       This file provides a set of functions needed to drive the
+  *              lis2mdl enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LIS2MDL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_read_reg(lis2mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_write_reg(lis2mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    LIS2MDL_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+float_t lis2mdl_from_lsb_to_mgauss(int16_t lsb)
+{
+  return ((float_t)lsb * 1.5f);
+}
+
+float_t lis2mdl_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 8.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2MDL_data_generation
+  * @brief       This section group all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  These registers comprise a 3 group of 16-bit number and represent
+  *         hard-iron offset in order to compensate environmental effects.
+  *         Data format is the same of output data raw: two’s complement
+  *         with 1LSb = 1.5mG. These values act on the magnetic output data
+  *         value in order to delete the environmental offset.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  buff  buffer that contains data to write
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_mag_user_offset_set(lis2mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2mdl_write_reg(ctx, LIS2MDL_OFFSET_X_REG_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  These registers comprise a 3 group of 16-bit number and represent
+  *         hard-iron offset in order to compensate environmental effects.
+  *         Data format is the same of output data raw: two’s complement
+  *         with 1LSb = 1.5mG. These values act on the magnetic output data
+  *         value in order to delete the environmental offset.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  buff  that stores data read
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_mag_user_offset_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_OFFSET_X_REG_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[set]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of md in reg CFG_REG_A
+  * @retval        interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_operating_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_md_t val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.md = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   Get the values of md in reg CFG_REG_A.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_operating_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_md_t *val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  switch (reg.md){
+    case LIS2MDL_POWER_DOWN:
+      *val = LIS2MDL_POWER_DOWN;
+      break;
+    case LIS2MDL_CONTINUOUS_MODE:
+      *val = LIS2MDL_CONTINUOUS_MODE;
+      break;
+    case LIS2MDL_SINGLE_TRIGGER:
+      *val = LIS2MDL_SINGLE_TRIGGER;
+      break;
+    default:
+      *val = LIS2MDL_POWER_DOWN;
+      break;
+  }  
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set] 
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of odr in reg CFG_REG_A
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_data_rate_set(lis2mdl_ctx_t *ctx, lis2mdl_odr_t val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.odr = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get] 
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   Get the values of odr in reg CFG_REG_A.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_data_rate_get(lis2mdl_ctx_t *ctx, lis2mdl_odr_t *val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  switch (reg.odr){
+    case LIS2MDL_ODR_10Hz:
+      *val = LIS2MDL_ODR_10Hz;
+      break;
+    case LIS2MDL_ODR_20Hz:
+      *val = LIS2MDL_ODR_20Hz;
+      break;
+    case LIS2MDL_ODR_50Hz:
+      *val = LIS2MDL_ODR_50Hz;
+      break;
+    case LIS2MDL_ODR_100Hz:
+      *val = LIS2MDL_ODR_100Hz;
+      break;
+    default:
+      *val = LIS2MDL_ODR_10Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables high-resolution/low-power mode.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of lp in reg CFG_REG_A
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_power_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_lp_t val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.lp = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Enables high-resolution/low-power mode.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   Get the values of lp in reg CFG_REG_A.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_power_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_lp_t *val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  switch (reg.lp){
+    case LIS2MDL_HIGH_RESOLUTION:
+      *val = LIS2MDL_HIGH_RESOLUTION;
+      break;
+    case LIS2MDL_LOW_POWER:
+      *val = LIS2MDL_LOW_POWER;
+      break;
+    default:
+      *val = LIS2MDL_HIGH_RESOLUTION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the magnetometer temperature compensation.[set] 
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of comp_temp_en in reg CFG_REG_A
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_offset_temp_comp_set(lis2mdl_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.comp_temp_en = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Enables the magnetometer temperature compensation.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of comp_temp_en in reg CFG_REG_A.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_offset_temp_comp_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  *val = reg.comp_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of lpf in reg CFG_REG_B
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_low_pass_bandwidth_set(lis2mdl_ctx_t *ctx,
+                                       lis2mdl_lpf_t val)
+{
+  lis2mdl_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.lpf = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   Get the values of lpf in reg CFG_REG_B.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_low_pass_bandwidth_get(lis2mdl_ctx_t *ctx,
+                                       lis2mdl_lpf_t *val)
+{
+  lis2mdl_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  switch (reg.lpf){
+    case LIS2MDL_ODR_DIV_2:
+      *val = LIS2MDL_ODR_DIV_2;
+      break;
+    case LIS2MDL_ODR_DIV_4:
+      *val = LIS2MDL_ODR_DIV_4;
+      break;
+    default:
+      *val = LIS2MDL_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset mode.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of set_rst in reg CFG_REG_B
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_set_rst_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_set_rst_t val)
+{
+  lis2mdl_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.set_rst = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Reset mode.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   Get the values of set_rst in reg CFG_REG_B.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_set_rst_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_set_rst_t *val)
+{
+  lis2mdl_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  switch (reg.set_rst){
+    case LIS2MDL_SET_SENS_ODR_DIV_63:
+      *val = LIS2MDL_SET_SENS_ODR_DIV_63;
+      break;
+    case LIS2MDL_SENS_OFF_CANC_EVERY_ODR:
+      *val = LIS2MDL_SENS_OFF_CANC_EVERY_ODR;
+      break;
+    case LIS2MDL_SET_SENS_ONLY_AT_POWER_ON:
+      *val = LIS2MDL_SET_SENS_ONLY_AT_POWER_ON;
+      break;
+    default:
+      *val = LIS2MDL_SET_SENS_ODR_DIV_63;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables offset cancellation in single measurement mode. 
+  *         The OFF_CANC bit must be set to 1 when enabling offset
+  *         cancellation in single measurement mode this means a
+  *         call function: set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
+  *         is need.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of off_canc_one_shot in reg CFG_REG_B
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_set_rst_sensor_single_set(lis2mdl_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.off_canc_one_shot = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Enables offset cancellation in single measurement mode. 
+  *         The OFF_CANC bit must be set to 1 when enabling offset
+  *         cancellation in single measurement mode this means a
+  *         call function: set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
+  *         is need.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of off_canc_one_shot in reg CFG_REG_B.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_set_rst_sensor_single_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  *val = reg.off_canc_one_shot;
+
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of bdu in reg CFG_REG_C
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_block_data_update_set(lis2mdl_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.bdu = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of bdu in reg CFG_REG_C.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_block_data_update_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic set of data available.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of zyxda in reg STATUS_REG.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_mag_data_ready_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_status_reg_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.zyxda;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic set of data overrun.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of zyxor in reg STATUS_REG.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_mag_data_ovr_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_status_reg_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.zyxor;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic output value.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  buff  that stores data read
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_magnetic_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_OUTX_L_REG, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  buff  that stores data read
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_temperature_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_TEMP_OUT_L_REG, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2MDL_common
+  * @brief       This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  buff  that stores data read
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_device_id_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of soft_rst in reg CFG_REG_A
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_reset_set(lis2mdl_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.soft_rst = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of soft_rst in reg CFG_REG_A.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_reset_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  *val = reg.soft_rst;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set] 
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of reboot in reg CFG_REG_A
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_boot_set(lis2mdl_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.reboot = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of reboot in reg CFG_REG_A.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_boot_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_a_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
+  *val = reg.reboot;
+
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of self_test in reg CFG_REG_C
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_self_test_set(lis2mdl_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.self_test = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of self_test in reg CFG_REG_C.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_self_test_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  *val = reg.self_test;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of ble in reg CFG_REG_C
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_data_format_set(lis2mdl_ctx_t *ctx, lis2mdl_ble_t val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.ble = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   Get the values of ble in reg CFG_REG_C.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_data_format_get(lis2mdl_ctx_t *ctx, lis2mdl_ble_t *val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  switch (reg.ble){
+    case LIS2MDL_LSB_AT_LOW_ADD:
+      *val = LIS2MDL_LSB_AT_LOW_ADD;
+      break;
+    case LIS2MDL_MSB_AT_LOW_ADD:
+      *val = LIS2MDL_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LIS2MDL_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   registers STATUS_REG.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_status_get(lis2mdl_ctx_t *ctx, lis2mdl_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2MDL_interrupts
+  * @brief       This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  The interrupt block recognition checks data after/before the
+  *         hard-iron correction to discover the interrupt.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of int_on_dataoff in reg CFG_REG_B
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_offset_int_conf_set(lis2mdl_ctx_t *ctx,
+                                    lis2mdl_int_on_dataoff_t val)
+{
+  lis2mdl_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.int_on_dataoff = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  The interrupt block recognition checks data after/before the
+  *         hard-iron correction to discover the interrupt.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   Get the values of int_on_dataoff in reg CFG_REG_B.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_offset_int_conf_get(lis2mdl_ctx_t *ctx,
+                                    lis2mdl_int_on_dataoff_t *val)
+{
+  lis2mdl_cfg_reg_b_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
+  switch (reg.int_on_dataoff){
+    case LIS2MDL_CHECK_BEFORE:
+      *val = LIS2MDL_CHECK_BEFORE;
+      break;
+    case LIS2MDL_CHECK_AFTER:
+      *val = LIS2MDL_CHECK_AFTER;
+      break;
+    default:
+      *val = LIS2MDL_CHECK_BEFORE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of drdy_on_pin in reg CFG_REG_C
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_drdy_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.drdy_on_pin = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of drdy_on_pin in reg CFG_REG_C.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_drdy_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  *val = reg.drdy_on_pin;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of int_on_pin in reg CFG_REG_C
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_int_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.int_on_pin = val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Interrupt signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of int_on_pin in reg CFG_REG_C.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_int_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  *val = reg.int_on_pin;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator configuration register.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   registers INT_CRTL_REG.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_int_gen_conf_set(lis2mdl_ctx_t *ctx,
+                                 lis2mdl_int_crtl_reg_t *val)
+{
+  int32_t ret;
+  ret = lis2mdl_write_reg(ctx, LIS2MDL_INT_CRTL_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator configuration register.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   registers INT_CRTL_REG.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_int_gen_conf_get(lis2mdl_ctx_t *ctx,
+                                 lis2mdl_int_crtl_reg_t *val)
+{
+  int32_t ret;
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_INT_CRTL_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator source register.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   registers INT_SOURCE_REG.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_int_gen_source_get(lis2mdl_ctx_t *ctx,
+                                   lis2mdl_int_source_reg_t *val)
+{
+  int32_t ret;
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_INT_SOURCE_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  buff  that contains data to write
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_int_gen_treshold_set(lis2mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2mdl_write_reg(ctx, LIS2MDL_INT_THS_L_REG, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  buff  that stores data read
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_int_gen_treshold_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_INT_THS_L_REG, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS2MDL_serial_interface
+  * @brief       This section group all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable/Disable I2C interface.[set]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   change the values of i2c_dis in reg CFG_REG_C
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_i2c_interface_set(lis2mdl_ctx_t *ctx, lis2mdl_i2c_dis_t val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  
+  if(ret == 0){
+    reg.i2c_dis = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  }
+  
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable I2C interface.[get]
+  *
+  * @param  ctx   read / write interface definitions.(ptr)
+  * @param  val   Get the values of i2c_dis in reg CFG_REG_C.(ptr)
+  * @retval       interface status.(MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_i2c_interface_get(lis2mdl_ctx_t *ctx, lis2mdl_i2c_dis_t *val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  switch (reg.i2c_dis){
+    case LIS2MDL_I2C_ENABLE:
+      *val = LIS2MDL_I2C_ENABLE;
+      break;
+    case LIS2MDL_I2C_DISABLE:
+      *val = LIS2MDL_I2C_DISABLE;
+      break;
+    default:
+      *val = LIS2MDL_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2mdl_STdC/driver/lis2mdl_reg.h
+++ b/sensor/stmemsc/lis2mdl_STdC/driver/lis2mdl_reg.h
@@ -1,0 +1,411 @@
+/*
+ ******************************************************************************
+ * @file    lis2mdl_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis2mdl_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS2MDL_REGS_H
+#define LIS2MDL_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS2MDL
+  * @{
+  *
+  */
+
+/** @defgroup LIS2MDL_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+  /** @addtogroup  LIS2MDL_Interfaces_Functions
+    * @brief       This section provide a set of functions used to read and
+    *              write a generic register of the device.
+    *              MANDATORY: return 0 -> no Error.
+    * @{
+    *
+    */
+
+typedef int32_t (*lis2mdl_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis2mdl_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis2mdl_write_ptr  write_reg;
+  lis2mdl_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis2mdl_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM9DS1_Infos
+  * @{
+  *
+  */
+
+  /** I2C Device Address 8 bit format **/
+#define LIS2MDL_I2C_ADD                 0x3DU
+
+/** Device Identification (Who am I) **/
+#define LIS2MDL_ID                      0x40U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS2MDL_OFFSET_X_REG_L          0x45U
+#define LIS2MDL_OFFSET_X_REG_H          0x46U
+#define LIS2MDL_OFFSET_Y_REG_L          0x47U
+#define LIS2MDL_OFFSET_Y_REG_H          0x48U
+#define LIS2MDL_OFFSET_Z_REG_L          0x49U
+#define LIS2MDL_OFFSET_Z_REG_H          0x4AU
+#define LIS2MDL_WHO_AM_I                0x4FU
+#define LIS2MDL_CFG_REG_A               0x60U
+typedef struct {
+  uint8_t md                     : 2;
+  uint8_t odr                    : 2;
+  uint8_t lp                     : 1;
+  uint8_t soft_rst               : 1;
+  uint8_t reboot                 : 1;
+  uint8_t comp_temp_en           : 1;
+} lis2mdl_cfg_reg_a_t;
+
+#define LIS2MDL_CFG_REG_B               0x61U
+typedef struct {
+  uint8_t lpf                    : 1;
+  uint8_t set_rst                : 2; /* OFF_CANC + Set_FREQ */
+  uint8_t int_on_dataoff         : 1;
+  uint8_t off_canc_one_shot      : 1;
+  uint8_t not_used_01            : 3;
+} lis2mdl_cfg_reg_b_t;
+
+#define LIS2MDL_CFG_REG_C               0x62U
+typedef struct {
+  uint8_t drdy_on_pin            : 1;
+  uint8_t self_test              : 1;
+  uint8_t not_used_01            : 1;
+  uint8_t ble                    : 1;
+  uint8_t bdu                    : 1;
+  uint8_t i2c_dis                : 1;
+  uint8_t int_on_pin             : 1;
+  uint8_t not_used_02            : 1;
+} lis2mdl_cfg_reg_c_t;
+
+#define LIS2MDL_INT_CRTL_REG            0x63U
+typedef struct {
+  uint8_t ien                    : 1;
+  uint8_t iel                    : 1;
+  uint8_t iea                    : 1;
+  uint8_t not_used_01            : 2;
+  uint8_t zien                   : 1;
+  uint8_t yien                   : 1;
+  uint8_t xien                   : 1;
+} lis2mdl_int_crtl_reg_t;
+
+#define LIS2MDL_INT_SOURCE_REG          0x64U
+typedef struct {
+  uint8_t _int                    : 1;
+  uint8_t mroi                   : 1;
+  uint8_t n_th_s_z               : 1;
+  uint8_t n_th_s_y               : 1;
+  uint8_t n_th_s_x               : 1;
+  uint8_t p_th_s_z               : 1;
+  uint8_t p_th_s_y               : 1;
+  uint8_t p_th_s_x               : 1;
+} lis2mdl_int_source_reg_t;
+
+#define LIS2MDL_INT_THS_L_REG           0x65U
+#define LIS2MDL_INT_THS_H_REG           0x66U
+#define LIS2MDL_STATUS_REG              0x67U
+typedef struct {
+  uint8_t xda                    : 1;
+  uint8_t yda                    : 1;
+  uint8_t zda                    : 1;
+  uint8_t zyxda                  : 1;
+  uint8_t _xor                    : 1;
+  uint8_t yor                    : 1;
+  uint8_t zor                    : 1;
+  uint8_t zyxor                  : 1;
+} lis2mdl_status_reg_t;
+
+#define LIS2MDL_OUTX_L_REG              0x68U
+#define LIS2MDL_OUTX_H_REG              0x69U
+#define LIS2MDL_OUTY_L_REG              0x6AU
+#define LIS2MDL_OUTY_H_REG              0x6BU
+#define LIS2MDL_OUTZ_L_REG              0x6CU
+#define LIS2MDL_OUTZ_H_REG              0x6DU
+#define LIS2MDL_TEMP_OUT_L_REG          0x6EU
+#define LIS2MDL_TEMP_OUT_H_REG          0x6FU
+
+/**
+  * @defgroup LIS2MDL_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis2mdl_cfg_reg_a_t            cfg_reg_a;
+  lis2mdl_cfg_reg_b_t            cfg_reg_b;
+  lis2mdl_cfg_reg_c_t            cfg_reg_c;
+  lis2mdl_int_crtl_reg_t         int_crtl_reg;
+  lis2mdl_int_source_reg_t       int_source_reg;
+  lis2mdl_status_reg_t           status_reg;
+  bitwise_t                      bitwise;
+  uint8_t                        byte;
+} lis2mdl_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis2mdl_read_reg(lis2mdl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lis2mdl_write_reg(lis2mdl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+                          
+extern float_t lis2mdl_from_lsb_to_mgauss(int16_t lsb);
+extern float_t lis2mdl_from_lsb_to_celsius(int16_t lsb);
+
+int32_t lis2mdl_mag_user_offset_set(lis2mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_mag_user_offset_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2MDL_CONTINUOUS_MODE  = 0,
+  LIS2MDL_SINGLE_TRIGGER   = 1,
+  LIS2MDL_POWER_DOWN       = 2,
+} lis2mdl_md_t;
+int32_t lis2mdl_operating_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_md_t val);
+int32_t lis2mdl_operating_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_md_t *val);
+
+typedef enum {
+  LIS2MDL_ODR_10Hz   = 0,
+  LIS2MDL_ODR_20Hz   = 1,
+  LIS2MDL_ODR_50Hz   = 2,
+  LIS2MDL_ODR_100Hz  = 3,
+} lis2mdl_odr_t;
+int32_t lis2mdl_data_rate_set(lis2mdl_ctx_t *ctx, lis2mdl_odr_t val);
+int32_t lis2mdl_data_rate_get(lis2mdl_ctx_t *ctx, lis2mdl_odr_t *val);
+
+typedef enum {
+  LIS2MDL_HIGH_RESOLUTION  = 0,
+  LIS2MDL_LOW_POWER        = 1,
+} lis2mdl_lp_t;
+int32_t lis2mdl_power_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_lp_t val);
+int32_t lis2mdl_power_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_lp_t *val);
+
+int32_t lis2mdl_offset_temp_comp_set(lis2mdl_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_offset_temp_comp_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2MDL_ODR_DIV_2  = 0,
+  LIS2MDL_ODR_DIV_4  = 1,
+} lis2mdl_lpf_t;
+int32_t lis2mdl_low_pass_bandwidth_set(lis2mdl_ctx_t *ctx,
+                                       lis2mdl_lpf_t val);
+int32_t lis2mdl_low_pass_bandwidth_get(lis2mdl_ctx_t *ctx,
+                                       lis2mdl_lpf_t *val);
+
+typedef enum {
+  LIS2MDL_SET_SENS_ODR_DIV_63        = 0,
+  LIS2MDL_SENS_OFF_CANC_EVERY_ODR    = 1,
+  LIS2MDL_SET_SENS_ONLY_AT_POWER_ON  = 2,
+} lis2mdl_set_rst_t;
+int32_t lis2mdl_set_rst_mode_set(lis2mdl_ctx_t *ctx,
+                                 lis2mdl_set_rst_t val);
+int32_t lis2mdl_set_rst_mode_get(lis2mdl_ctx_t *ctx,
+                                 lis2mdl_set_rst_t *val);
+
+int32_t lis2mdl_set_rst_sensor_single_set(lis2mdl_ctx_t *ctx,
+                                          uint8_t val);
+int32_t lis2mdl_set_rst_sensor_single_get(lis2mdl_ctx_t *ctx,
+                                          uint8_t *val);
+
+int32_t lis2mdl_block_data_update_set(lis2mdl_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_block_data_update_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2mdl_mag_data_ready_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2mdl_mag_data_ovr_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2mdl_magnetic_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2mdl_temperature_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2mdl_device_id_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2mdl_reset_set(lis2mdl_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_reset_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2mdl_boot_set(lis2mdl_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_boot_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2mdl_self_test_set(lis2mdl_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_self_test_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2MDL_LSB_AT_LOW_ADD  = 0,
+  LIS2MDL_MSB_AT_LOW_ADD  = 1,
+} lis2mdl_ble_t;
+int32_t lis2mdl_data_format_set(lis2mdl_ctx_t *ctx, lis2mdl_ble_t val);
+int32_t lis2mdl_data_format_get(lis2mdl_ctx_t *ctx, lis2mdl_ble_t *val);
+
+int32_t lis2mdl_status_get(lis2mdl_ctx_t *ctx, lis2mdl_status_reg_t *val);
+
+typedef enum {
+  LIS2MDL_CHECK_BEFORE  = 0,
+  LIS2MDL_CHECK_AFTER   = 1,
+} lis2mdl_int_on_dataoff_t;
+int32_t lis2mdl_offset_int_conf_set(lis2mdl_ctx_t *ctx,
+                                    lis2mdl_int_on_dataoff_t val);
+int32_t lis2mdl_offset_int_conf_get(lis2mdl_ctx_t *ctx,
+                                    lis2mdl_int_on_dataoff_t *val);
+
+int32_t lis2mdl_drdy_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_drdy_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2mdl_int_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_int_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2mdl_int_gen_conf_set(lis2mdl_ctx_t *ctx,
+                                 lis2mdl_int_crtl_reg_t *val);
+int32_t lis2mdl_int_gen_conf_get(lis2mdl_ctx_t *ctx,
+                                 lis2mdl_int_crtl_reg_t *val);
+
+int32_t lis2mdl_int_gen_source_get(lis2mdl_ctx_t *ctx,
+                                   lis2mdl_int_source_reg_t *val);
+
+int32_t lis2mdl_int_gen_treshold_set(lis2mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_int_gen_treshold_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2MDL_I2C_ENABLE   = 0,
+  LIS2MDL_I2C_DISABLE  = 1,
+} lis2mdl_i2c_dis_t;
+int32_t lis2mdl_i2c_interface_set(lis2mdl_ctx_t *ctx,
+                                  lis2mdl_i2c_dis_t val);
+int32_t lis2mdl_i2c_interface_get(lis2mdl_ctx_t *ctx,
+                                  lis2mdl_i2c_dis_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS2MDL_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis331dlh_STdC/driver/lis331dlh_reg.c
+++ b/sensor/stmemsc/lis331dlh_STdC/driver/lis331dlh_reg.c
@@ -1,0 +1,2001 @@
+/*
+ ******************************************************************************
+ * @file    lis331dlh_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS331DLH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis331dlh_reg.h"
+
+/**
+  * @defgroup    LIS331DLH
+  * @brief       This file provides a set of functions needed to drive the
+  *              lis331dlh enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis331dlh_read_reg(lis331dlh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis331dlh_write_reg(lis331dlh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    LIS331DLH_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float lis331dlh_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float)lsb / 16.0f);
+}
+
+float lis331dlh_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 2.0f / 16.0f);
+}
+
+float lis331dlh_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float)lsb * 3.9f / 16.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Data_Generation
+  * @brief       This section group all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  X axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t lis331dlh_axis_x_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.xen = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of xen in reg CTRL_REG1
+  *
+  */
+int32_t lis331dlh_axis_x_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.xen;
+
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t lis331dlh_axis_y_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.yen = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of yen in reg CTRL_REG1
+  *
+  */
+int32_t lis331dlh_axis_y_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.yen;
+
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t lis331dlh_axis_z_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.zen = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z axis enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zen in reg CTRL_REG1
+  *
+  */
+int32_t lis331dlh_axis_z_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.zen;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t lis331dlh_data_rate_set(lis331dlh_ctx_t *ctx, lis331dlh_dr_t val)
+{
+  lis331dlh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0) {
+    ctrl_reg1.pm = (uint8_t)val & 0x07U;
+    ctrl_reg1.dr = ( (uint8_t)val & 0x30U ) >> 4;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG1,
+                              (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of dr in reg CTRL_REG1
+  *
+  */
+int32_t lis331dlh_data_rate_get(lis331dlh_ctx_t *ctx, lis331dlh_dr_t *val)
+{
+  lis331dlh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG1,
+                           (uint8_t*)&ctrl_reg1, 1);
+
+  switch ((ctrl_reg1.dr << 4) + ctrl_reg1.pm)
+  {
+    case LIS331DLH_ODR_OFF:
+      *val = LIS331DLH_ODR_OFF;
+      break;
+    case LIS331DLH_ODR_Hz5:
+      *val = LIS331DLH_ODR_Hz5;
+      break;
+    case LIS331DLH_ODR_1Hz:
+      *val = LIS331DLH_ODR_1Hz;
+      break;
+    case LIS331DLH_ODR_2Hz:
+      *val = LIS331DLH_ODR_2Hz;
+      break;
+    case LIS331DLH_ODR_5Hz:
+      *val = LIS331DLH_ODR_5Hz;
+      break;
+    case LIS331DLH_ODR_10Hz:
+      *val = LIS331DLH_ODR_10Hz;
+      break;
+    case LIS331DLH_ODR_50Hz:
+      *val = LIS331DLH_ODR_50Hz;
+      break;
+    case LIS331DLH_ODR_100Hz:
+      *val = LIS331DLH_ODR_100Hz;
+      break;
+    case LIS331DLH_ODR_400Hz:
+      *val = LIS331DLH_ODR_400Hz;
+      break;
+    case LIS331DLH_ODR_1kHz:
+      *val = LIS331DLH_ODR_1kHz;
+      break;
+    default:
+      *val = LIS331DLH_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t lis331dlh_reference_mode_set(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_hpm_t val)
+{
+  lis331dlh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter mode selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpm in reg CTRL_REG2
+  *
+  */
+int32_t lis331dlh_reference_mode_get(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_hpm_t *val)
+{
+  lis331dlh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG2,
+                           (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpm)
+  {
+    case LIS331DLH_NORMAL_MODE:
+      *val = LIS331DLH_NORMAL_MODE;
+      break;
+    case LIS331DLH_REF_MODE_ENABLE:
+      *val = LIS331DLH_REF_MODE_ENABLE;
+      break;
+    default:
+      *val = LIS331DLH_NORMAL_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_full_scale_set(lis331dlh_ctx_t *ctx, lis331dlh_fs_t val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of fs in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_full_scale_get(lis331dlh_ctx_t *ctx, lis331dlh_fs_t *val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.fs)
+  {
+    case LIS331DLH_2g:
+      *val = LIS331DLH_2g;
+      break;
+    case LIS331DLH_4g:
+      *val = LIS331DLH_4g;
+      break;
+    case LIS331DLH_8g:
+      *val = LIS331DLH_8g;
+      break;
+    default:
+      *val = LIS331DLH_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_block_data_update_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of bdu in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_block_data_update_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers STATUS_REG
+  *
+  */
+int32_t lis331dlh_status_reg_get(lis331dlh_ctx_t *ctx,
+                                 lis331dlh_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of zyxda in reg STATUS_REG
+  *
+  */
+int32_t lis331dlh_flag_data_ready_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Data_Output
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lis331dlh_acceleration_raw_get(lis331dlh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Common
+  * @brief       This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lis331dlh_device_id_get(lis331dlh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t lis331dlh_boot_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.boot = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t lis331dlh_boot_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of st in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_self_test_set(lis331dlh_ctx_t *ctx, lis331dlh_st_t val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of st in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_self_test_get(lis331dlh_ctx_t *ctx, lis331dlh_st_t *val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.st)
+  {
+    case LIS331DLH_ST_DISABLE:
+      *val = LIS331DLH_ST_DISABLE;
+      break;
+    case LIS331DLH_ST_POSITIVE:
+      *val = LIS331DLH_ST_POSITIVE;
+      break;
+    case LIS331DLH_ST_NEGATIVE:
+      *val = LIS331DLH_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS331DLH_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_data_format_set(lis331dlh_ctx_t *ctx, lis331dlh_ble_t val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ble in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_data_format_get(lis331dlh_ctx_t *ctx, lis331dlh_ble_t *val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.ble)
+  {
+    case LIS331DLH_LSB_AT_LOW_ADD:
+      *val = LIS331DLH_LSB_AT_LOW_ADD;
+      break;
+    case LIS331DLH_MSB_AT_LOW_ADD:
+      *val = LIS331DLH_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LIS331DLH_LSB_AT_LOW_ADD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Filters
+  * @brief       This section group all the functions concerning the
+  *              filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t lis331dlh_hp_bandwidth_set(lis331dlh_ctx_t *ctx, lis331dlh_hpcf_t val)
+{
+  lis331dlh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass filter cut-off frequency configuration.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpcf in reg CTRL_REG2
+  *
+  */
+int32_t lis331dlh_hp_bandwidth_get(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_hpcf_t *val)
+{
+  lis331dlh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+
+  switch (ctrl_reg2.hpcf)
+  {
+    case LIS331DLH_CUT_OFF_8Hz:
+      *val = LIS331DLH_CUT_OFF_8Hz;
+      break;
+    case LIS331DLH_CUT_OFF_16Hz:
+      *val = LIS331DLH_CUT_OFF_16Hz;
+      break;
+    case LIS331DLH_CUT_OFF_32Hz:
+      *val = LIS331DLH_CUT_OFF_32Hz;
+      break;
+    case LIS331DLH_CUT_OFF_64Hz:
+      *val = LIS331DLH_CUT_OFF_64Hz;
+      break;
+    default:
+      *val = LIS331DLH_CUT_OFF_8Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t lis331dlh_hp_path_set(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t val)
+{
+  lis331dlh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0) {
+    ctrl_reg2.hpen = (uint8_t)val & 0x03U;
+    ctrl_reg2.fds = ((uint8_t)val & 0x04U) >> 2;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG2,
+                              (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select High Pass filter path.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of hpen in reg CTRL_REG2
+  *
+  */
+int32_t lis331dlh_hp_path_get(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t *val)
+{
+  lis331dlh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+
+  switch ( (ctrl_reg2.fds << 2) + ctrl_reg2.hpen )
+  {
+    case LIS331DLH_HP_DISABLE:
+      *val = LIS331DLH_HP_DISABLE;
+      break;
+    case LIS331DLH_HP_ON_OUT:
+      *val = LIS331DLH_HP_ON_OUT;
+      break;
+    case LIS331DLH_HP_ON_INT1:
+      *val = LIS331DLH_HP_ON_INT1;
+      break;
+    case LIS331DLH_HP_ON_INT2:
+      *val = LIS331DLH_HP_ON_INT2;
+      break;
+    case LIS331DLH_HP_ON_INT1_INT2:
+      *val = LIS331DLH_HP_ON_INT1_INT2;
+      break;
+    case LIS331DLH_HP_ON_INT1_INT2_OUT:
+      *val = LIS331DLH_HP_ON_INT1_INT2_OUT;
+      break;
+    case LIS331DLH_HP_ON_INT2_OUT:
+      *val = LIS331DLH_HP_ON_INT2_OUT;
+      break;
+    case LIS331DLH_HP_ON_INT1_OUT:
+      *val = LIS331DLH_HP_ON_INT1_OUT;
+      break;
+    default:
+      *val = LIS331DLH_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reading at this address zeroes instantaneously
+  *         the content of the internal high pass-filter.
+  *         If the high pass filter is enabled all three axes
+  *         are instantaneously set to 0g. This allows to
+  *         overcome the settling time of the high pass
+  *         filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  *
+  */
+int32_t lis331dlh_hp_reset_get(lis331dlh_ctx_t *ctx)
+{
+  uint8_t dummy;
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_HP_FILTER_RESET,
+                           (uint8_t*)&dummy, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t lis331dlh_hp_reference_value_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  ret = lis331dlh_write_reg(ctx, LIS331DLH_REFERENCE, (uint8_t*)&val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for high-pass filter.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ref in reg REFERENCE
+  *
+  */
+int32_t lis331dlh_hp_reference_value_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_REFERENCE, val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Serial_Interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_spi_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_sim_t val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG4,
+                              (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI 3- or 4-wire interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of sim in reg CTRL_REG4
+  *
+  */
+int32_t lis331dlh_spi_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_sim_t *val)
+{
+  lis331dlh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch ( ctrl_reg4.sim )
+  {
+    case LIS331DLH_SPI_4_WIRE:
+      *val = LIS331DLH_SPI_4_WIRE;
+      break;
+    case LIS331DLH_SPI_3_WIRE:
+      *val = LIS331DLH_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS331DLH_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Interrupt_Pins
+  * @brief       This section groups all the functions that manage
+  *              interrupt pins.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_pin_int1_route_set(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_i1_cfg_t val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i1_cfg = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 1 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i1_cfg in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_pin_int1_route_get(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_i1_cfg_t *val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i1_cfg )
+  {
+    case LIS331DLH_PAD1_INT1_SRC:
+      *val = LIS331DLH_PAD1_INT1_SRC;
+      break;
+    case LIS331DLH_PAD1_INT1_OR_INT2_SRC:
+      *val = LIS331DLH_PAD1_INT1_OR_INT2_SRC;
+      break;
+    case LIS331DLH_PAD1_DRDY:
+      *val = LIS331DLH_PAD1_DRDY;
+      break;
+    case LIS331DLH_PAD1_BOOT:
+      *val = LIS331DLH_PAD1_BOOT;
+      break;
+    default:
+      *val = LIS331DLH_PAD1_INT1_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_int1_notification_set(lis331dlh_ctx_t *ctx,
+                                        lis331dlh_lir1_t val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir1 = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC register, with INT1_SRC
+  *         register cleared by reading INT1_SRC register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir1 in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_int1_notification_get(lis331dlh_ctx_t *ctx,
+                                        lis331dlh_lir1_t *val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir1 )
+  {
+    case LIS331DLH_INT1_PULSED:
+      *val = LIS331DLH_INT1_PULSED;
+      break;
+    case LIS331DLH_INT1_LATCHED:
+      *val = LIS331DLH_INT1_LATCHED;
+      break;
+    default:
+      *val = LIS331DLH_INT1_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_pin_int2_route_set(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_i2_cfg_t val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.i2_cfg = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT 2 pad control bits.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of i2_cfg in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_pin_int2_route_get(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_i2_cfg_t *val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.i2_cfg )
+  {
+    case LIS331DLH_PAD2_INT2_SRC:
+      *val = LIS331DLH_PAD2_INT2_SRC;
+      break;
+    case LIS331DLH_PAD2_INT1_OR_INT2_SRC:
+      *val = LIS331DLH_PAD2_INT1_OR_INT2_SRC;
+      break;
+    case LIS331DLH_PAD2_DRDY:
+      *val = LIS331DLH_PAD2_DRDY;
+      break;
+    case LIS331DLH_PAD2_BOOT:
+      *val = LIS331DLH_PAD2_BOOT;
+      break;
+    default:
+      *val = LIS331DLH_PAD2_INT2_SRC;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_int2_notification_set(lis331dlh_ctx_t *ctx,
+                                        lis331dlh_lir2_t val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.lir2 = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC register, with INT2_SRC
+  *         register cleared by reading INT2_SRC itself.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of lir2 in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_int2_notification_get(lis331dlh_ctx_t *ctx,
+                                        lis331dlh_lir2_t *val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.lir2 )
+  {
+    case LIS331DLH_INT2_PULSED:
+      *val = LIS331DLH_INT2_PULSED;
+      break;
+    case LIS331DLH_INT2_LATCHED:
+      *val = LIS331DLH_INT2_LATCHED;
+      break;
+    default:
+      *val = LIS331DLH_INT2_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_pin_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_pin_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t *val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.pp_od )
+  {
+    case LIS331DLH_PUSH_PULL:
+      *val = LIS331DLH_PUSH_PULL;
+      break;
+    case LIS331DLH_OPEN_DRAIN:
+      *val = LIS331DLH_OPEN_DRAIN;
+      break;
+    default:
+      *val = LIS331DLH_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_pin_polarity_set(lis331dlh_ctx_t *ctx, lis331dlh_ihl_t val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0) {
+    ctrl_reg3.ihl = (uint8_t)val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG3,
+                              (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of ihl in reg CTRL_REG3
+  *
+  */
+int32_t lis331dlh_pin_polarity_get(lis331dlh_ctx_t *ctx, lis331dlh_ihl_t *val)
+{
+  lis331dlh_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+
+  switch ( ctrl_reg3.ihl )
+  {
+    case LIS331DLH_ACTIVE_HIGH:
+      *val = LIS331DLH_ACTIVE_HIGH;
+      break;
+    case LIS331DLH_ACTIVE_LOW:
+      *val = LIS331DLH_ACTIVE_LOW;
+      break;
+    default:
+      *val = LIS331DLH_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_interrupt_on_threshold
+  * @brief       This section groups all the functions that manage
+  *              the interrupt on threshold event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the interrupt 1 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t lis331dlh_int1_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
+                                              int1_on_th_conf_t val)
+{
+  lis331dlh_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.xlie  = val.int1_xlie;
+    int1_cfg.xhie  = val.int1_xhie;
+    int1_cfg.ylie  = val.int1_ylie;
+    int1_cfg.yhie  = val.int1_yhie;
+    int1_cfg.zlie  = val.int1_zlie;
+    int1_cfg.zhie  = val.int1_zhie;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Configure the interrupt 1 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t lis331dlh_int1_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
+                                             int1_on_th_conf_t *val)
+{
+  lis331dlh_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  val->int1_xlie = int1_cfg.xlie;
+  val->int1_xhie = int1_cfg.xhie;
+  val->int1_ylie = int1_cfg.ylie;
+  val->int1_yhie = int1_cfg.yhie;
+  val->int1_zlie = int1_cfg.zlie;
+  val->int1_zhie = int1_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 1 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t lis331dlh_int1_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
+                                             lis331dlh_int1_aoi_t val)
+{
+  lis331dlh_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg.aoi = (uint8_t) val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT1_CFG,
+                              (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 1 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT1_CFG
+  *
+  */
+int32_t lis331dlh_int1_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
+                                             lis331dlh_int1_aoi_t *val)
+{
+  lis331dlh_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ( int1_cfg.aoi )
+  {
+    case LIS331DLH_INT1_ON_THRESHOLD_OR:
+      *val = LIS331DLH_INT1_ON_THRESHOLD_OR;
+      break;
+    case LIS331DLH_INT1_ON_THRESHOLD_AND:
+      *val = LIS331DLH_INT1_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = LIS331DLH_INT1_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t lis331dlh_int1_src_get(lis331dlh_ctx_t *ctx,
+                               lis331dlh_int1_src_t *val)
+{
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t lis331dlh_int1_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT1_THS,
+                              (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t lis331dlh_int1_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t lis331dlh_int1_dur_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  if(ret == 0) {
+    int1_duration.d = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT1_DURATION,
+                              (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT1_DURATION
+  *
+  */
+int32_t lis331dlh_int1_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_DURATION,
+                           (uint8_t*)&int1_duration, 1);
+  *val = int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t lis331dlh_int2_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
+                                              int2_on_th_conf_t val)
+{
+  lis331dlh_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_CFG,
+                           (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.xlie  = val.int2_xlie;
+    int2_cfg.xhie  = val.int2_xhie;
+    int2_cfg.ylie  = val.int2_ylie;
+    int2_cfg.yhie  = val.int2_yhie;
+    int2_cfg.zlie  = val.int2_zlie;
+    int2_cfg.zhie  = val.int2_zhie;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt 2 threshold sign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         enable sign and axis for interrupt on threshold
+  *
+  */
+int32_t lis331dlh_int2_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
+                                              int2_on_th_conf_t *val)
+{
+  lis331dlh_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  val->int2_xlie = int2_cfg.xlie;
+  val->int2_xhie = int2_cfg.xhie;
+  val->int2_ylie = int2_cfg.ylie;
+  val->int2_yhie = int2_cfg.yhie;
+  val->int2_zlie = int2_cfg.zlie;
+  val->int2_zhie = int2_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of Interrupt 2 events.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t lis331dlh_int2_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
+                                             lis331dlh_int2_aoi_t val)
+{
+  lis331dlh_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg.aoi = (uint8_t) val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   AND/OR combination of Interrupt 2 events.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of aoi in reg INT2_CFG
+  *
+  */
+int32_t lis331dlh_int2_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
+                                             lis331dlh_int2_aoi_t *val)
+{
+  lis331dlh_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ( int2_cfg.aoi )
+  {
+    case LIS331DLH_INT2_ON_THRESHOLD_OR:
+      *val = LIS331DLH_INT2_ON_THRESHOLD_OR;
+      break;
+    case LIS331DLH_INT2_ON_THRESHOLD_AND:
+      *val = LIS331DLH_INT2_ON_THRESHOLD_AND;
+      break;
+    default:
+      *val = LIS331DLH_INT2_ON_THRESHOLD_OR;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 on threshold source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t lis331dlh_int2_src_get(lis331dlh_ctx_t *ctx,
+                               lis331dlh_int2_src_t *val)
+{
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t lis331dlh_int2_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t lis331dlh_int2_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Duration value for interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t lis331dlh_int2_dur_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  if(ret == 0) {
+    int2_duration.d = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT2_DURATION,
+                              (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Duration value for interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of d in reg INT2_DURATION
+  *
+  */
+int32_t lis331dlh_int2_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_DURATION,
+                           (uint8_t*)&int2_duration, 1);
+  *val = int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Wake_Up_Event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t lis331dlh_wkup_to_sleep_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0) {
+    ctrl_reg5.turnon = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_CTRL_REG5,
+                              (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Turn-on mode selection for sleep to wake function.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of turnon in reg CTRL_REG5
+  *
+  */
+int32_t lis331dlh_wkup_to_sleep_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.turnon;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS331DLH_Six_Position_Detection
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Configure the 6d on interrupt 1 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of 6d in reg INT1_CFG
+  *
+  */
+int32_t lis331dlh_int1_6d_mode_set(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_int1_6d_t val)
+{
+  lis331dlh_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  if(ret == 0) {
+    int1_cfg._6d = (uint8_t)val & 0x01U;
+    int1_cfg.aoi = ((uint8_t)val & 0x02U) >> 1;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 1 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of 6d in reg INT1_CFG
+  *
+  */
+int32_t lis331dlh_int1_6d_mode_get(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_int1_6d_t *val)
+{
+  lis331dlh_int1_cfg_t int1_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_CFG, (uint8_t*)&int1_cfg, 1);
+
+  switch ((int1_cfg.aoi << 1) + int1_cfg._6d)
+  {
+    case LIS331DLH_6D_INT1_DISABLE:
+      *val = LIS331DLH_6D_INT1_DISABLE;
+      break;
+    case LIS331DLH_6D_INT1_MOVEMENT:
+      *val = LIS331DLH_6D_INT1_MOVEMENT;
+      break;
+     case LIS331DLH_6D_INT1_POSITION:
+      *val = LIS331DLH_6D_INT1_POSITION;
+      break;
+    default:
+      *val = LIS331DLH_6D_INT1_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  6D on interrupt generator 1 source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT1_SRC
+  *
+  */
+int32_t lis331dlh_int1_6d_src_get(lis331dlh_ctx_t *ctx,
+                                  lis331dlh_int1_src_t *val)
+{
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t lis331dlh_int1_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if(ret == 0) {
+    int1_ths.ths = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 1 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT1_THS
+  *
+  */
+int32_t lis331dlh_int1_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 2 generator.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of 6d in reg INT2_CFG
+  *
+  */
+int32_t lis331dlh_int2_6d_mode_set(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_int2_6d_t val)
+{
+  lis331dlh_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+  if(ret == 0) {
+    int2_cfg._6d = (uint8_t)val & 0x01U;
+    int2_cfg.aoi = ((uint8_t)val & 0x02U) >> 1;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT2_CFG,
+                              (uint8_t*)&int2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure the 6d on interrupt 2 generator.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Get the values of 6d in reg INT2_CFG
+  *
+  */
+int32_t lis331dlh_int2_6d_mode_get(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_int2_6d_t *val)
+{
+  lis331dlh_int2_cfg_t int2_cfg;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_CFG, (uint8_t*)&int2_cfg, 1);
+
+  switch ((int2_cfg.aoi << 1) + int2_cfg._6d)
+  {
+    case LIS331DLH_6D_INT2_DISABLE:
+      *val = LIS331DLH_6D_INT2_DISABLE;
+      break;
+    case LIS331DLH_6D_INT2_MOVEMENT:
+      *val = LIS331DLH_6D_INT2_MOVEMENT;
+      break;
+     case LIS331DLH_6D_INT2_POSITION:
+      *val = LIS331DLH_6D_INT2_POSITION;
+      break;
+    default:
+      *val = LIS331DLH_6D_INT2_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  6D on interrupt generator 2 source register.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         registers INT2_SRC
+  *
+  */
+int32_t lis331dlh_int2_6d_src_get(lis331dlh_ctx_t *ctx,
+                                  lis331dlh_int2_src_t *val)
+{
+  int32_t ret;
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t lis331dlh_int2_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
+{
+  lis331dlh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if(ret == 0) {
+    int2_ths.ths = val;
+    ret = lis331dlh_write_reg(ctx, LIS331DLH_INT2_THS,
+                              (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt 2 threshold.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of ths in reg INT2_THS
+  *
+  */
+int32_t lis331dlh_int2_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+{
+  lis331dlh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis331dlh_read_reg(ctx, LIS331DLH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis331dlh_STdC/driver/lis331dlh_reg.h
+++ b/sensor/stmemsc/lis331dlh_STdC/driver/lis331dlh_reg.h
@@ -1,0 +1,640 @@
+/*
+ ******************************************************************************
+ * @file    lis331dlh_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis331dlh_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS331DLH_REGS_H
+#define LIS331DLH_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS331DLH
+  * @{
+  *
+  */
+
+/** @defgroup LIS331DLH_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LIS331DLH_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis331dlh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis331dlh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis331dlh_write_ptr  write_reg;
+  lis331dlh_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis331dlh_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+
+/** @defgroup LIS331DLH_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0x31 if SA0=1 -> 0x33 **/
+#define LIS331DLH_I2C_ADD_L     0x31U
+#define LIS331DLH_I2C_ADD_H     0x33U
+
+/** Device Identification (Who am I) **/
+#define LIS331DLH_ID            0x32U
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  LIS331DLH_Sensitivity
+  * @brief       These macro are maintained for back compatibility.
+  *              in order to convert data into engineering units please
+  *              use functions:
+  *                -> _from_fs2_to_mg(int16_t lsb);
+  *                -> _from_fs4_to_mg(int16_t lsb);
+  *                -> _from_fs8_to_mg(int16_t lsb);
+  *
+  *              REMOVING the MACRO you are compliant with:
+  *              MISRA-C 2012 [Dir 4.9] -> " avoid function-like macros "
+  * @{
+  *
+  */
+
+#define LIS331DLH_FROM_FS_2g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 1.0f )
+#define LIS331DLH_FROM_FS_4g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 2.0f )
+#define LIS331DLH_FROM_FS_8g_TO_mg(lsb)    (float)( (lsb >> 4 ) * 3.9f )
+
+/**
+  * @}
+  *
+  */
+
+#define LIS331DLH_WHO_AM_I                  0x0FU
+#define LIS331DLH_CTRL_REG1                 0x20U
+typedef struct {
+  uint8_t xen                      : 1;
+  uint8_t yen                      : 1;
+  uint8_t zen                      : 1;
+  uint8_t dr                       : 2;
+  uint8_t pm                       : 3;
+} lis331dlh_ctrl_reg1_t;
+
+#define LIS331DLH_CTRL_REG2                 0x21U
+typedef struct {
+  uint8_t hpcf                     : 2;
+  uint8_t hpen                     : 2;
+  uint8_t fds                      : 1;
+  uint8_t hpm                      : 2;
+  uint8_t boot                     : 1;
+} lis331dlh_ctrl_reg2_t;
+
+#define LIS331DLH_CTRL_REG3                 0x22U
+typedef struct {
+  uint8_t i1_cfg                   : 2;
+  uint8_t lir1                     : 1;
+  uint8_t i2_cfg                   : 2;
+  uint8_t lir2                     : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t ihl                      : 1;
+} lis331dlh_ctrl_reg3_t;
+
+#define LIS331DLH_CTRL_REG4                 0x23U
+typedef struct {
+  uint8_t sim                      : 1;
+  uint8_t st                       : 3; /* STsign + ST */
+  uint8_t fs                       : 2;
+  uint8_t ble                      : 1;
+  uint8_t bdu                      : 1;
+} lis331dlh_ctrl_reg4_t;
+
+#define LIS331DLH_CTRL_REG5                 0x24U
+typedef struct {
+  uint8_t turnon                   : 2;
+  uint8_t not_used_01              : 6;
+} lis331dlh_ctrl_reg5_t;
+
+#define LIS331DLH_HP_FILTER_RESET           0x25U
+#define LIS331DLH_REFERENCE                 0x26U
+#define LIS331DLH_STATUS_REG                0x27U
+typedef struct {
+  uint8_t xda                      : 1;
+  uint8_t yda                      : 1;
+  uint8_t zda                      : 1;
+  uint8_t zyxda                    : 1;
+  uint8_t _xor                     : 1;
+  uint8_t yor                      : 1;
+  uint8_t zor                      : 1;
+  uint8_t zyxor                    : 1;
+} lis331dlh_status_reg_t;
+
+#define LIS331DLH_OUT_X_L                   0x28U
+#define LIS331DLH_OUT_X_H                   0x29U
+#define LIS331DLH_OUT_Y_L                   0x2AU
+#define LIS331DLH_OUT_Y_H                   0x2BU
+#define LIS331DLH_OUT_Z_L                   0x2CU
+#define LIS331DLH_OUT_Z_H                   0x2DU
+#define LIS331DLH_INT1_CFG                  0x30U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi                      : 1;
+} lis331dlh_int1_cfg_t;
+
+#define LIS331DLH_INT1_SRC                  0x31U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} lis331dlh_int1_src_t;
+
+#define LIS331DLH_INT1_THS                  0x32U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} lis331dlh_int1_ths_t;
+
+#define LIS331DLH_INT1_DURATION             0x33U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} lis331dlh_int1_duration_t;
+
+#define LIS331DLH_INT2_CFG                  0x34U
+typedef struct {
+  uint8_t xlie                     : 1;
+  uint8_t xhie                     : 1;
+  uint8_t ylie                     : 1;
+  uint8_t yhie                     : 1;
+  uint8_t zlie                     : 1;
+  uint8_t zhie                     : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi                      : 1;
+} lis331dlh_int2_cfg_t;
+
+#define LIS331DLH_INT2_SRC                  0x35U
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t ia                       : 1;
+  uint8_t not_used_01              : 1;
+} lis331dlh_int2_src_t;
+
+#define LIS331DLH_INT2_THS                  0x36U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} lis331dlh_int2_ths_t;
+
+#define LIS331DLH_INT2_DURATION             0x37U
+typedef struct {
+  uint8_t d                        : 7;
+  uint8_t not_used_01              : 1;
+} lis331dlh_int2_duration_t;
+
+/**
+  * @defgroup LIS331DLH_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis331dlh_ctrl_reg1_t                     ctrl_reg1;
+  lis331dlh_ctrl_reg2_t                     ctrl_reg2;
+  lis331dlh_ctrl_reg3_t                     ctrl_reg3;
+  lis331dlh_ctrl_reg4_t                     ctrl_reg4;
+  lis331dlh_ctrl_reg5_t                     ctrl_reg5;
+  lis331dlh_status_reg_t                    status_reg;
+  lis331dlh_int1_cfg_t                      int1_cfg;
+  lis331dlh_int1_src_t                      int1_src;
+  lis331dlh_int1_ths_t                      int1_ths;
+  lis331dlh_int1_duration_t                 int1_duration;
+  lis331dlh_int2_cfg_t                      int2_cfg;
+  lis331dlh_int2_src_t                      int2_src;
+  lis331dlh_int2_ths_t                      int2_ths;
+  lis331dlh_int2_duration_t                 int2_duration;
+  bitwise_t                                 bitwise;
+  uint8_t                                   byte;
+} lis331dlh_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis331dlh_read_reg(lis331dlh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+int32_t lis331dlh_write_reg(lis331dlh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len);
+
+extern float lis331dlh_from_fs2_to_mg(int16_t lsb);
+extern float lis331dlh_from_fs4_to_mg(int16_t lsb);
+extern float lis331dlh_from_fs8_to_mg(int16_t lsb);
+
+int32_t lis331dlh_axis_x_data_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_axis_x_data_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis331dlh_axis_y_data_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_axis_y_data_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis331dlh_axis_z_data_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_axis_z_data_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS331DLH_ODR_OFF   = 0x00,
+  LIS331DLH_ODR_Hz5   = 0x02,
+  LIS331DLH_ODR_1Hz   = 0x03,
+  LIS331DLH_ODR_2Hz   = 0x04,
+  LIS331DLH_ODR_5Hz   = 0x05,
+  LIS331DLH_ODR_10Hz  = 0x06,
+  LIS331DLH_ODR_50Hz  = 0x01,
+  LIS331DLH_ODR_100Hz = 0x11,
+  LIS331DLH_ODR_400Hz = 0x21,
+  LIS331DLH_ODR_1kHz  = 0x31,
+} lis331dlh_dr_t;
+int32_t lis331dlh_data_rate_set(lis331dlh_ctx_t *ctx, lis331dlh_dr_t val);
+int32_t lis331dlh_data_rate_get(lis331dlh_ctx_t *ctx, lis331dlh_dr_t *val);
+
+typedef enum {
+  LIS331DLH_NORMAL_MODE      = 0,
+  LIS331DLH_REF_MODE_ENABLE  = 1,
+} lis331dlh_hpm_t;
+int32_t lis331dlh_reference_mode_set(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_hpm_t val);
+int32_t lis331dlh_reference_mode_get(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_hpm_t *val);
+
+typedef enum {
+  LIS331DLH_2g  = 0,
+  LIS331DLH_4g  = 1,
+  LIS331DLH_8g  = 3,
+} lis331dlh_fs_t;
+int32_t lis331dlh_full_scale_set(lis331dlh_ctx_t *ctx, lis331dlh_fs_t val);
+int32_t lis331dlh_full_scale_get(lis331dlh_ctx_t *ctx, lis331dlh_fs_t *val);
+
+int32_t lis331dlh_block_data_update_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_block_data_update_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis331dlh_status_reg_get(lis331dlh_ctx_t *ctx,
+                                 lis331dlh_status_reg_t *val);
+
+int32_t lis331dlh_flag_data_ready_get(lis331dlh_ctx_t *ctx,
+                                      uint8_t *val);
+
+int32_t lis331dlh_acceleration_raw_get(lis331dlh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis331dlh_device_id_get(lis331dlh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis331dlh_boot_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_boot_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS331DLH_ST_DISABLE   = 0,
+  LIS331DLH_ST_POSITIVE  = 1,
+  LIS331DLH_ST_NEGATIVE  = 5,
+} lis331dlh_st_t;
+int32_t lis331dlh_self_test_set(lis331dlh_ctx_t *ctx, lis331dlh_st_t val);
+int32_t lis331dlh_self_test_get(lis331dlh_ctx_t *ctx, lis331dlh_st_t *val);
+
+typedef enum {
+  LIS331DLH_LSB_AT_LOW_ADD  = 0,
+  LIS331DLH_MSB_AT_LOW_ADD  = 1,
+} lis331dlh_ble_t;
+int32_t lis331dlh_data_format_set(lis331dlh_ctx_t *ctx, lis331dlh_ble_t val);
+int32_t lis331dlh_data_format_get(lis331dlh_ctx_t *ctx, lis331dlh_ble_t *val);
+
+typedef enum {
+  LIS331DLH_CUT_OFF_8Hz   = 0,
+  LIS331DLH_CUT_OFF_16Hz  = 1,
+  LIS331DLH_CUT_OFF_32Hz  = 2,
+  LIS331DLH_CUT_OFF_64Hz  = 3,
+} lis331dlh_hpcf_t;
+int32_t lis331dlh_hp_bandwidth_set(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_hpcf_t val);
+int32_t lis331dlh_hp_bandwidth_get(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_hpcf_t *val);
+
+typedef enum {
+  LIS331DLH_HP_DISABLE            = 0,
+  LIS331DLH_HP_ON_OUT             = 4,
+  LIS331DLH_HP_ON_INT1            = 1,
+  LIS331DLH_HP_ON_INT2            = 2,
+  LIS331DLH_HP_ON_INT1_INT2       = 3,
+  LIS331DLH_HP_ON_INT1_INT2_OUT   = 7,
+  LIS331DLH_HP_ON_INT2_OUT        = 6,
+  LIS331DLH_HP_ON_INT1_OUT        = 5,
+} lis331dlh_hpen_t;
+int32_t lis331dlh_hp_path_set(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t val);
+int32_t lis331dlh_hp_path_get(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t *val);
+
+int32_t lis331dlh_hp_reset_get(lis331dlh_ctx_t *ctx);
+
+int32_t lis331dlh_hp_reference_value_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_hp_reference_value_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS331DLH_SPI_4_WIRE  = 0,
+  LIS331DLH_SPI_3_WIRE  = 1,
+} lis331dlh_sim_t;
+int32_t lis331dlh_spi_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_sim_t val);
+int32_t lis331dlh_spi_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_sim_t *val);
+
+typedef enum {
+  LIS331DLH_PAD1_INT1_SRC           = 0,
+  LIS331DLH_PAD1_INT1_OR_INT2_SRC   = 1,
+  LIS331DLH_PAD1_DRDY               = 2,
+  LIS331DLH_PAD1_BOOT               = 3,
+} lis331dlh_i1_cfg_t;
+int32_t lis331dlh_pin_int1_route_set(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_i1_cfg_t val);
+int32_t lis331dlh_pin_int1_route_get(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_i1_cfg_t *val);
+
+typedef enum {
+  LIS331DLH_INT1_PULSED   = 0,
+  LIS331DLH_INT1_LATCHED  = 1,
+} lis331dlh_lir1_t;
+int32_t lis331dlh_int1_notification_set(lis331dlh_ctx_t *ctx,
+                                        lis331dlh_lir1_t val);
+int32_t lis331dlh_int1_notification_get(lis331dlh_ctx_t *ctx,
+                                        lis331dlh_lir1_t *val);
+
+typedef enum {
+  LIS331DLH_PAD2_INT2_SRC           = 0,
+  LIS331DLH_PAD2_INT1_OR_INT2_SRC   = 1,
+  LIS331DLH_PAD2_DRDY               = 2,
+  LIS331DLH_PAD2_BOOT               = 3,
+} lis331dlh_i2_cfg_t;
+int32_t lis331dlh_pin_int2_route_set(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_i2_cfg_t val);
+int32_t lis331dlh_pin_int2_route_get(lis331dlh_ctx_t *ctx,
+                                     lis331dlh_i2_cfg_t *val);
+
+typedef enum {
+  LIS331DLH_INT2_PULSED   = 0,
+  LIS331DLH_INT2_LATCHED  = 1,
+} lis331dlh_lir2_t;
+int32_t lis331dlh_int2_notification_set(lis331dlh_ctx_t *ctx,
+                                        lis331dlh_lir2_t val);
+int32_t lis331dlh_int2_notification_get(lis331dlh_ctx_t *ctx,
+                                        lis331dlh_lir2_t *val);
+
+typedef enum {
+  LIS331DLH_PUSH_PULL   = 0,
+  LIS331DLH_OPEN_DRAIN  = 1,
+} lis331dlh_pp_od_t;
+int32_t lis331dlh_pin_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t val);
+int32_t lis331dlh_pin_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t *val);
+
+typedef enum {
+  LIS331DLH_ACTIVE_HIGH  = 0,
+  LIS331DLH_ACTIVE_LOW   = 1,
+} lis331dlh_ihl_t;
+int32_t lis331dlh_pin_polarity_set(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_ihl_t val);
+int32_t lis331dlh_pin_polarity_get(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_ihl_t *val);
+
+typedef struct {
+  uint8_t int1_xlie             : 1;
+  uint8_t int1_xhie             : 1;
+  uint8_t int1_ylie             : 1;
+  uint8_t int1_yhie             : 1;
+  uint8_t int1_zlie             : 1;
+  uint8_t int1_zhie             : 1;
+} int1_on_th_conf_t;
+int32_t lis331dlh_int1_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
+                                             int1_on_th_conf_t val);
+int32_t lis331dlh_int1_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
+                                             int1_on_th_conf_t *val);
+
+typedef enum {
+  LIS331DLH_INT1_ON_THRESHOLD_OR   = 0,
+  LIS331DLH_INT1_ON_THRESHOLD_AND  = 1,
+} lis331dlh_int1_aoi_t;
+int32_t lis331dlh_int1_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
+                                             lis331dlh_int1_aoi_t val);
+int32_t lis331dlh_int1_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
+                                             lis331dlh_int1_aoi_t *val);
+
+int32_t lis331dlh_int1_src_get(lis331dlh_ctx_t *ctx,
+                               lis331dlh_int1_src_t *val);
+
+int32_t lis331dlh_int1_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int1_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis331dlh_int1_dur_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int1_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t int2_xlie             : 1;
+  uint8_t int2_xhie             : 1;
+  uint8_t int2_ylie             : 1;
+  uint8_t int2_yhie             : 1;
+  uint8_t int2_zlie             : 1;
+  uint8_t int2_zhie             : 1;
+} int2_on_th_conf_t;
+int32_t lis331dlh_int2_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
+                                             int2_on_th_conf_t val);
+int32_t lis331dlh_int2_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
+                                             int2_on_th_conf_t *val);
+
+typedef enum {
+  LIS331DLH_INT2_ON_THRESHOLD_OR   = 0,
+  LIS331DLH_INT2_ON_THRESHOLD_AND  = 1,
+} lis331dlh_int2_aoi_t;
+int32_t lis331dlh_int2_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
+                                             lis331dlh_int2_aoi_t val);
+int32_t lis331dlh_int2_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
+                                             lis331dlh_int2_aoi_t *val);
+
+int32_t lis331dlh_int2_src_get(lis331dlh_ctx_t *ctx,
+                               lis331dlh_int2_src_t *val);
+
+int32_t lis331dlh_int2_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int2_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis331dlh_int2_dur_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int2_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis331dlh_wkup_to_sleep_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_wkup_to_sleep_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS331DLH_6D_INT1_DISABLE   = 0,
+  LIS331DLH_6D_INT1_MOVEMENT  = 1,
+  LIS331DLH_6D_INT1_POSITION  = 3,
+} lis331dlh_int1_6d_t;
+int32_t lis331dlh_int1_6d_mode_set(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_int1_6d_t val);
+int32_t lis331dlh_int1_6d_mode_get(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_int1_6d_t *val);
+
+int32_t lis331dlh_int1_6d_src_get(lis331dlh_ctx_t *ctx,
+                                  lis331dlh_int1_src_t *val);
+
+int32_t lis331dlh_int1_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int1_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS331DLH_6D_INT2_DISABLE   = 0,
+  LIS331DLH_6D_INT2_MOVEMENT  = 1,
+  LIS331DLH_6D_INT2_POSITION  = 3,
+} lis331dlh_int2_6d_t;
+int32_t lis331dlh_int2_6d_mode_set(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_int2_6d_t val);
+int32_t lis331dlh_int2_6d_mode_get(lis331dlh_ctx_t *ctx,
+                                   lis331dlh_int2_6d_t *val);
+
+int32_t lis331dlh_int2_6d_src_get(lis331dlh_ctx_t *ctx,
+                                  lis331dlh_int2_src_t *val);
+
+int32_t lis331dlh_int2_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int2_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS331DLH_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis3de_STdC/driver/lis3de_reg.c
+++ b/sensor/stmemsc/lis3de_STdC/driver/lis3de_reg.c
@@ -1,0 +1,2264 @@
+/*
+ ******************************************************************************
+ * @file    lis3de_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS3DE driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis3de_reg.h"
+
+/**
+  * @defgroup  LIS3DE
+  * @brief     This file provides a set of functions needed to drive the
+  *            lis3de enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LIS3DE_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_read_reg(lis3de_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_write_reg(lis3de_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    LIS3DE_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float lis3de_from_fs2_to_mg(int16_t lsb)
+{
+  return ( (float)lsb ) * 15.6f;
+}
+
+float lis3de_from_fs4_to_mg(int16_t lsb)
+{
+  return ( (float)lsb ) * 31.2f;
+}
+
+float lis3de_from_fs8_to_mg(int16_t lsb)
+{
+  return ( (float)lsb ) * 62.5f;
+}
+
+float lis3de_from_fs16_to_mg(int16_t lsb)
+{
+  return ( (float)lsb ) * 187.5f;
+}
+
+float lis3de_from_lsb_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb ) * 1.0f ) + 25.0f;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DE_Data_generation
+  * @brief     This section group all the functions concerning data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_temp_status_reg_get(lis3de_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_STATUS_REG_AUX, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tda in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_temp_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_STATUS_REG_AUX,
+                          (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux._3da;
+
+  return ret;
+}
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tor in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_temp_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_STATUS_REG_AUX,
+                          (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux._3or;
+
+  return ret;
+}
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_temperature_raw_get(lis3de_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_OUT_ADC1_H, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  ADC output value.[get]
+  *         Sample frequency: the same as the ODR CTRL_REG1
+  *         The resolution:
+  *                    10bit if LPen bit in CTRL_REG1 (20h) is clear
+  *                     8bit if LPen bit in CTRL_REG1 (20h) is set
+  *         Data Format:
+  *                     Outputs are Left Justified in 2’ complements
+  *                     range 800mV
+  *                     code zero means an analogue value of about 1.2V
+  *                     Voltage values smaller than centre values are positive
+  *                           (Example:  800mV = 7Fh / 127 dec)
+  *                     Voltage values bigger than centre values are negative
+  *                           (Example: 1600mV = 80h / -128 dec)
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_adc_raw_get(lis3de_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_OUT_ADC1_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Auxiliary ADC.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      configure the auxiliary ADC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_aux_adc_set(lis3de_ctx_t *ctx, lis3de_temp_en_t val)
+{
+  lis3de_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  if (ret == 0) {
+    if (val != LIS3DE_AUX_DISABLE){
+      /* Required in order to use auxiliary adc */
+      ret = lis3de_block_data_update_set(ctx, PROPERTY_ENABLE);
+    }
+  } 
+  if (ret == 0) {
+    temp_cfg_reg.temp_en = ( (uint8_t) val & 0x02U) >> 1;
+    temp_cfg_reg.adc_pd  = (uint8_t) val &  0x01U;
+    ret = lis3de_write_reg(ctx, LIS3DE_TEMP_CFG_REG,
+                           (uint8_t*)&temp_cfg_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Auxiliary ADC.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      configure the auxiliary ADC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_aux_adc_get(lis3de_ctx_t *ctx, lis3de_temp_en_t *val)
+{
+  lis3de_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  if ( ( temp_cfg_reg.temp_en & temp_cfg_reg.adc_pd ) == PROPERTY_ENABLE ){
+    *val = LIS3DE_AUX_ON_TEMPERATURE;
+  } 
+  if ( ( temp_cfg_reg.temp_en  == PROPERTY_DISABLE ) &&
+              ( temp_cfg_reg.adc_pd == PROPERTY_ENABLE ) ) {
+    *val = LIS3DE_AUX_ON_PADS;
+  } else {
+    *val = LIS3DE_AUX_DISABLE;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpen in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_operating_mode_set(lis3de_ctx_t *ctx, lis3de_op_md_t val)
+{
+  lis3de_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ctrl_reg1.lpen = (uint8_t) val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpen in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_operating_mode_get(lis3de_ctx_t *ctx, lis3de_op_md_t *val)
+{
+  lis3de_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+
+    if ( ctrl_reg1.lpen == PROPERTY_ENABLE ) {
+      *val = LIS3DE_LP;
+    }
+    else {
+      *val = LIS3DE_NM;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_data_rate_set(lis3de_ctx_t *ctx, lis3de_odr_t val)
+{
+  lis3de_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ctrl_reg1.odr = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_data_rate_get(lis3de_ctx_t *ctx, lis3de_odr_t *val)
+{
+  lis3de_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.odr) {
+    case LIS3DE_POWER_DOWN:
+      *val = LIS3DE_POWER_DOWN;
+      break;
+    case LIS3DE_ODR_1Hz:
+      *val = LIS3DE_ODR_1Hz;
+      break;
+    case LIS3DE_ODR_10Hz:
+      *val = LIS3DE_ODR_10Hz;
+      break;
+    case LIS3DE_ODR_25Hz:
+      *val = LIS3DE_ODR_25Hz;
+      break;
+    case LIS3DE_ODR_50Hz:
+      *val = LIS3DE_ODR_50Hz;
+      break;
+    case LIS3DE_ODR_100Hz:
+      *val = LIS3DE_ODR_100Hz;
+      break;
+    case LIS3DE_ODR_200Hz:
+      *val = LIS3DE_ODR_200Hz;
+      break;
+    case LIS3DE_ODR_400Hz:
+      *val = LIS3DE_ODR_400Hz;
+      break;
+    case LIS3DE_ODR_1kHz6:
+      *val = LIS3DE_ODR_1kHz6;
+      break;
+    case LIS3DE_ODR_5kHz376_LP_1kHz344_NM:
+      *val = LIS3DE_ODR_5kHz376_LP_1kHz344_NM;
+      break;
+    default:
+      *val = LIS3DE_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_high_pass_on_outputs_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.fds = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_high_pass_on_outputs_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = (uint8_t)ctrl_reg2.fds;
+
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[set]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_high_pass_bandwidth_set(lis3de_ctx_t *ctx,
+                                         lis3de_hpcf_t val)
+{
+  lis3de_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[get]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_high_pass_bandwidth_get(lis3de_ctx_t *ctx,
+                                         lis3de_hpcf_t *val)
+{
+  lis3de_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpcf) {
+    case LIS3DE_AGGRESSIVE:
+      *val = LIS3DE_AGGRESSIVE;
+      break;
+    case LIS3DE_STRONG:
+      *val = LIS3DE_STRONG;
+      break;
+    case LIS3DE_MEDIUM:
+      *val = LIS3DE_MEDIUM;
+      break;
+    case LIS3DE_LIGHT:
+      *val = LIS3DE_LIGHT;
+      break;
+    default:
+      *val = LIS3DE_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_high_pass_mode_set(lis3de_ctx_t *ctx, lis3de_hpm_t val)
+{
+  lis3de_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_high_pass_mode_get(lis3de_ctx_t *ctx, lis3de_hpm_t *val)
+{
+  lis3de_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpm) {
+    case LIS3DE_NORMAL_WITH_RST:
+      *val = LIS3DE_NORMAL_WITH_RST;
+      break;
+    case LIS3DE_REFERENCE_MODE:
+      *val = LIS3DE_REFERENCE_MODE;
+      break;
+    case LIS3DE_NORMAL:
+      *val = LIS3DE_NORMAL;
+      break;
+    case LIS3DE_AUTORST_ON_INT:
+      *val = LIS3DE_AUTORST_ON_INT;
+      break;
+    default:
+      *val = LIS3DE_NORMAL_WITH_RST;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_full_scale_set(lis3de_ctx_t *ctx, lis3de_fs_t val)
+{
+  lis3de_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_full_scale_get(lis3de_ctx_t *ctx, lis3de_fs_t *val)
+{
+  lis3de_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.fs) {
+    case LIS3DE_2g:
+      *val = LIS3DE_2g;
+      break;
+    case LIS3DE_4g:
+      *val = LIS3DE_4g;
+      break;
+    case LIS3DE_8g:
+      *val = LIS3DE_8g;
+      break;
+    case LIS3DE_16g:
+      *val = LIS3DE_16g;
+      break;
+    default:
+      *val = LIS3DE_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_block_data_update_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_block_data_update_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = (uint8_t)ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[set]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_filter_reference_set(lis3de_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3de_write_reg(ctx, LIS3DE_REFERENCE, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[get]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_filter_reference_get(lis3de_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_REFERENCE, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_xl_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxor in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_xl_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxor;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_acceleration_raw_get(lis3de_ctx_t *ctx, int16_t *buff)
+{
+  int32_t ret;
+  int8_t dummy;
+  ret = lis3de_read_reg(ctx, LIS3DE_OUT_X, (uint8_t*)&dummy  , 1);
+  buff[0] = dummy;
+  if (ret == 0) {
+    ret = lis3de_read_reg(ctx, LIS3DE_OUT_Y, (uint8_t*)&dummy, 1);
+    buff[1] = dummy;
+  } 
+  if (ret == 0) {
+    ret = lis3de_read_reg(ctx, LIS3DE_OUT_Z, (uint8_t*)&dummy, 1);
+    buff[2] = dummy;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DE_Common
+  * @brief     This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI .[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_device_id_get(lis3de_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_WHO_AM_I, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Self Test.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_self_test_set(lis3de_ctx_t *ctx, lis3de_st_t val)
+{
+  lis3de_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Self Test.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_self_test_get(lis3de_ctx_t *ctx, lis3de_st_t *val)
+{
+  lis3de_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.st) {
+    case LIS3DE_ST_DISABLE:
+      *val = LIS3DE_ST_DISABLE;
+      break;
+    case LIS3DE_ST_POSITIVE:
+      *val = LIS3DE_ST_POSITIVE;
+      break;
+    case LIS3DE_ST_NEGATIVE:
+      *val = LIS3DE_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS3DE_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_boot_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.boot = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_boot_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_status_get(lis3de_ctx_t *ctx, lis3de_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS3DE_Interrupts_generator_1
+  * @brief      This section group all the functions that manage the first
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_gen_conf_set(lis3de_ctx_t *ctx,
+                                   lis3de_ig1_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3de_write_reg(ctx, LIS3DE_IG1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_gen_conf_get(lis3de_ctx_t *ctx,
+                                   lis3de_ig1_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_IG1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Registers INT1_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_gen_source_get(lis3de_ctx_t *ctx,
+                                     lis3de_ig1_source_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_IG1_SOURCE, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[set]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ig1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_IG1_THS, (uint8_t*)&int1_ths, 1);
+  if (ret == 0) {
+    int1_ths.ths = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_IG1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ig1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_IG1_THS, (uint8_t*)&int1_ths, 1);
+  *val = (uint8_t)int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ig1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_IG1_DURATION, (uint8_t*)&int1_duration, 1);
+  if (ret == 0) {
+    int1_duration.d = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_IG1_DURATION, (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ig1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_IG1_DURATION, (uint8_t*)&int1_duration, 1);
+  *val = (uint8_t)int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS3DE_Interrupts_generator_2
+  * @brief      This section group all the functions that manage the second
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers IG2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_gen_conf_set(lis3de_ctx_t *ctx,
+                                   lis3de_ig2_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3de_write_reg(ctx, LIS3DE_IG2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers IG2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_gen_conf_get(lis3de_ctx_t *ctx,
+                                   lis3de_ig2_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_IG2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Interrupt generator 2 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_gen_source_get(lis3de_ctx_t *ctx,
+                                     lis3de_ig2_source_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_IG2_SOURCE, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief   User-defined threshold value for xl interrupt event on
+  *          generator 2.[set]
+  *          LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ig2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_IG2_THS, (uint8_t*)&int2_ths, 1);
+  if (ret == 0) {
+    int2_ths.ths = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_IG2_THS, (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 2.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ig2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_IG2_THS, (uint8_t*)&int2_ths, 1);
+  *val = (uint8_t)int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized .[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ig2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_IG2_DURATION, (uint8_t*)&int2_duration, 1);
+  if (ret == 0) {
+    int2_duration.d = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_IG2_DURATION, (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ig2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_IG2_DURATION, (uint8_t*)&int2_duration, 1);
+  *val = (uint8_t)int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DE_Interrupt_pins
+  * @brief     This section group all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_high_pass_int_conf_set(lis3de_ctx_t *ctx,
+                                        lis3de_hp_t val)
+{
+  lis3de_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hp = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_high_pass_int_conf_get(lis3de_ctx_t *ctx,
+                                        lis3de_hp_t *val)
+{
+  lis3de_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hp) {
+    case LIS3DE_DISC_FROM_INT_GENERATOR:
+      *val = LIS3DE_DISC_FROM_INT_GENERATOR;
+      break;
+    case LIS3DE_ON_INT1_GEN:
+      *val = LIS3DE_ON_INT1_GEN;
+      break;
+    case LIS3DE_ON_INT2_GEN:
+      *val = LIS3DE_ON_INT2_GEN;
+      break;
+    case LIS3DE_ON_TAP_GEN:
+      *val = LIS3DE_ON_TAP_GEN;
+      break;
+    case LIS3DE_ON_INT1_INT2_GEN:
+      *val = LIS3DE_ON_INT1_INT2_GEN;
+      break;
+    case LIS3DE_ON_INT1_TAP_GEN:
+      *val = LIS3DE_ON_INT1_TAP_GEN;
+      break;
+    case LIS3DE_ON_INT2_TAP_GEN:
+      *val = LIS3DE_ON_INT2_TAP_GEN;
+      break;
+    case LIS3DE_ON_INT1_INT2_TAP_GEN:
+      *val = LIS3DE_ON_INT1_INT2_TAP_GEN;
+      break;
+    default:
+      *val = LIS3DE_DISC_FROM_INT_GENERATOR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_pin_int1_config_set(lis3de_ctx_t *ctx,
+                                     lis3de_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_pin_int1_config_get(lis3de_ctx_t *ctx,
+                                     lis3de_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  int2_pin_detect_4d: [set]  4D enable: 4D detection is enabled
+  *                                    on INT2 pin when 6D bit on
+  *                                    IG2_CFG (34h) is set to 1.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_ig2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_ig2 = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT2 pin when 6D bit on
+  *         IG2_CFG (34h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_ig2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_ig2;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_ig2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_pin_notification_mode_set(lis3de_ctx_t *ctx,
+                                                lis3de_lir_int2_t val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_ig2 = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_ig2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int2_pin_notification_mode_get(lis3de_ctx_t *ctx,
+                                                lis3de_lir_int2_t *val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_ig2) {
+    case LIS3DE_INT2_PULSED:
+      *val = LIS3DE_INT2_PULSED;
+      break;
+    case LIS3DE_INT2_LATCHED:
+      *val = LIS3DE_INT2_LATCHED;
+      break;
+    default:
+      *val = LIS3DE_INT2_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit
+  *                    on INT1_CFG(30h) is set to 1.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_ig1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_ig1 = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit on
+  *         INT1_CFG(30h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_ig1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_ig1;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_ig1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_pin_notification_mode_set(lis3de_ctx_t *ctx,
+                                                lis3de_lir_int1_t val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_ig1 = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_ig1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_int1_pin_notification_mode_get(lis3de_ctx_t *ctx,
+                                                lis3de_lir_int1_t *val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_ig1) {
+    case LIS3DE_INT1_PULSED:
+      *val = LIS3DE_INT1_PULSED;
+      break;
+    case LIS3DE_INT1_LATCHED:
+      *val = LIS3DE_INT1_LATCHED;
+      break;
+    default:
+      *val = LIS3DE_INT1_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_pin_int2_config_set(lis3de_ctx_t *ctx,
+                                     lis3de_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_pin_int2_config_get(lis3de_ctx_t *ctx,
+                                     lis3de_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DE_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.fifo_en = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_watermark_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fth = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_watermark_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  *val = (uint8_t)fifo_ctrl_reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_trigger_event_set(lis3de_ctx_t *ctx,
+                                        lis3de_tr_t val)
+{
+  lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.tr = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_trigger_event_get(lis3de_ctx_t *ctx,
+                                        lis3de_tr_t *val)
+{
+  lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.tr) {
+    case LIS3DE_INT1_GEN:
+      *val = LIS3DE_INT1_GEN;
+      break;
+    case LIS3DE_INT2_GEN:
+      *val = LIS3DE_INT2_GEN;
+      break;
+    default:
+      *val = LIS3DE_INT1_GEN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_mode_set(lis3de_ctx_t *ctx, lis3de_fm_t val)
+{
+  lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fm = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_mode_get(lis3de_ctx_t *ctx, lis3de_fm_t *val)
+{
+  lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.fm) {
+    case LIS3DE_BYPASS_MODE:
+      *val = LIS3DE_BYPASS_MODE;
+      break;
+    case LIS3DE_FIFO_MODE:
+      *val = LIS3DE_FIFO_MODE;
+      break;
+    case LIS3DE_DYNAMIC_STREAM_MODE:
+      *val = LIS3DE_DYNAMIC_STREAM_MODE;
+      break;
+    case LIS3DE_STREAM_TO_FIFO_MODE:
+      *val = LIS3DE_STREAM_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LIS3DE_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_status_get(lis3de_ctx_t *ctx,
+                                 lis3de_fifo_src_reg_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_SRC_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fss in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_data_level_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.fss;
+
+  return ret;
+}
+/**
+  * @brief  Empty FIFO status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of empty in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_empty_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.empty;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ovrn_fifo in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_ovr_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.ovrn_fifo;
+
+  return ret;
+}
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_fifo_fth_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.wtm;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DE_Tap_generator
+  * @brief     This section group all the functions that manage the tap and
+  *            double tap event generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_tap_conf_set(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3de_write_reg(ctx, LIS3DE_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_tap_conf_get(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Tap/Double Tap generator source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_tap_source_get(lis3de_ctx_t *ctx, lis3de_click_src_t *val)
+{
+  int32_t ret;
+  ret = lis3de_read_reg(ctx, LIS3DE_CLICK_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[set]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_tap_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.ths = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[get]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_tap_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CLICK_THS, (uint8_t*)&click_ths, 1);
+  *val = (uint8_t)click_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+  *          for the duration of the latency window.
+  *          If the LIR_Click bit is set, the interrupt is kept high until the
+  *          CLICK_SRC(39h) register is read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_tap_notification_mode_set(lis3de_ctx_t *ctx,
+                                           lis3de_lir_t val)
+{
+  lis3de_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.lir = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+  *          for the duration of the latency window.
+  *          If the LIR_Click bit is set, the interrupt is kept high until the
+  *          CLICK_SRC(39h) register is read.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_tap_notification_mode_get(lis3de_ctx_t *ctx,
+                                           lis3de_lir_t *val)
+{
+  lis3de_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CLICK_THS, (uint8_t*)&click_ths, 1);
+  switch (click_ths.lir) {
+    case LIS3DE_TAP_PULSED:
+      *val = LIS3DE_TAP_PULSED;
+      break;
+    case LIS3DE_TAP_LATCHED:
+      *val = LIS3DE_TAP_LATCHED;
+      break;
+    default:
+      *val = LIS3DE_TAP_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse
+  *         between the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_shock_dur_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  if (ret == 0) {
+    time_limit.tli = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse between
+  *         the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_shock_dur_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  *val = (uint8_t)time_limit.tli;
+
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_quiet_dur_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  if (ret == 0) {
+    time_latency.tla = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_quiet_dur_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  *val = (uint8_t)time_latency.tla;
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the click-detection
+  *         procedure can start, in cases where the device is configured
+  *         for double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_double_tap_timeout_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  if (ret == 0) {
+    time_window.tw = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the
+  *         click-detection procedure can start, in cases where the device
+  *         is configured for double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_double_tap_timeout_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  *val = (uint8_t)time_window.tw;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DE_Activity_inactivity
+  * @brief     This section group all the functions concerning activity
+  *            inactivity functionality
+  * @{
+  *
+  */
+
+/**
+  * @brief    Sleep-to-wake, return-to-sleep activation threshold in
+  *           low-power mode.[set]
+  *           1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_act_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_ACT_THS, (uint8_t*)&act_ths, 1);
+  if (ret == 0) {
+    act_ths.acth = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_ACT_THS, (uint8_t*)&act_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep activation threshold in low-power
+  *         mode.[get]
+  *         1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_act_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_ACT_THS, (uint8_t*)&act_ths, 1);
+  *val = (uint8_t)act_ths.acth;
+
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[set]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_act_timeout_set(lis3de_ctx_t *ctx, uint8_t val)
+{
+  lis3de_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_ACT_DUR, (uint8_t*)&act_dur, 1);
+  if (ret == 0) {
+    act_dur.actd = val;
+    ret = lis3de_write_reg(ctx, LIS3DE_ACT_DUR, (uint8_t*)&act_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[get]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_act_timeout_get(lis3de_ctx_t *ctx, uint8_t *val)
+{
+  lis3de_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_ACT_DUR, (uint8_t*)&act_dur, 1);
+  *val = (uint8_t)act_dur.actd;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DE_Serial_interface
+  * @brief     This section group all the functions concerning serial
+  *            interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_spi_mode_set(lis3de_ctx_t *ctx, lis3de_sim_t val)
+{
+  lis3de_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = lis3de_write_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3de_spi_mode_get(lis3de_ctx_t *ctx, lis3de_sim_t *val)
+{
+  lis3de_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3de_read_reg(ctx, LIS3DE_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.sim) {
+    case LIS3DE_SPI_4_WIRE:
+      *val = LIS3DE_SPI_4_WIRE;
+      break;
+    case LIS3DE_SPI_3_WIRE:
+      *val = LIS3DE_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS3DE_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis3de_STdC/driver/lis3de_reg.h
+++ b/sensor/stmemsc/lis3de_STdC/driver/lis3de_reg.h
@@ -1,0 +1,731 @@
+/*
+ ******************************************************************************
+ * @file    lis3de_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis3de_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS3DE_REGS_H
+#define LIS3DE_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS3DE
+  * @{
+  *
+  */
+
+/** @defgroup LIS3DE_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup LIS3MDL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis3de_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis3de_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis3de_write_ptr  write_reg;
+  lis3de_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis3de_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS3DE_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define LIS3DE_I2C_ADD_L   0x31U
+#define LIS3DE_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define LIS3DE_ID          0x33U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS3DE_STATUS_REG_AUX        0x07U
+typedef struct {
+  uint8_t _1da              : 1;
+  uint8_t _2da              : 1;
+  uint8_t _3da              : 1;
+  uint8_t _321da            : 1;
+  uint8_t _1or              : 1;
+  uint8_t _2or              : 1;
+  uint8_t _3or              : 1;
+  uint8_t _321or            : 1;
+} lis3de_status_reg_aux_t;
+
+#define LIS3DE_OUT_ADC1_L            0x08U
+#define LIS3DE_OUT_ADC1_H            0x09U
+#define LIS3DE_OUT_ADC2_L            0x0AU
+#define LIS3DE_OUT_ADC2_H            0x0BU
+#define LIS3DE_OUT_ADC3_L            0x0CU
+#define LIS3DE_OUT_ADC3_H            0x0DU
+#define LIS3DE_INT_COUNTER_REG       0x0EU
+#define LIS3DE_WHO_AM_I              0x0FU
+
+#define LIS3DE_TEMP_CFG_REG          0x1FU
+typedef struct {
+  uint8_t not_used_01       : 6;
+  uint8_t adc_pd            : 1;
+  uint8_t temp_en           : 1;
+} lis3de_temp_cfg_reg_t;
+
+#define LIS3DE_CTRL_REG1             0x20U
+typedef struct {
+  uint8_t xen               : 1;
+  uint8_t yen               : 1;
+  uint8_t zen               : 1;
+  uint8_t lpen              : 1;
+  uint8_t odr               : 4;
+} lis3de_ctrl_reg1_t;
+
+#define LIS3DE_CTRL_REG2             0x21U
+typedef struct {
+  uint8_t hp                : 3; /* HPCLICK + HP_IA2 + HP_IA1 -> HP */
+  uint8_t fds               : 1;
+  uint8_t hpcf              : 2;
+  uint8_t hpm               : 2;
+} lis3de_ctrl_reg2_t;
+
+#define LIS3DE_CTRL_REG3             0x22U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t int1_overrun      : 1;
+  uint8_t int1_wtm          : 1;
+  uint8_t int1_drdy2        : 1;
+  uint8_t int1_drdy1        : 1;
+  uint8_t int1_ig2          : 1;
+  uint8_t int1_ig1          : 1;
+  uint8_t int1_click        : 1;
+} lis3de_ctrl_reg3_t;
+
+#define LIS3DE_CTRL_REG4             0x23U
+typedef struct {
+  uint8_t sim               : 1;
+  uint8_t st                : 2;
+  uint8_t not_used_01       : 1;
+  uint8_t fs                : 2;
+  uint8_t not_used_02       : 1;
+  uint8_t bdu               : 1;
+} lis3de_ctrl_reg4_t;
+
+#define LIS3DE_CTRL_REG5             0x24U
+typedef struct {
+  uint8_t d4d_ig2           : 1;
+  uint8_t lir_ig2           : 1;
+  uint8_t d4d_ig1           : 1;
+  uint8_t lir_ig1           : 1;
+  uint8_t not_used_01       : 2;
+  uint8_t fifo_en           : 1;
+  uint8_t boot              : 1;
+} lis3de_ctrl_reg5_t;
+
+#define LIS3DE_CTRL_REG6             0x25U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t h_lactive         : 1;
+  uint8_t not_used_02       : 1;
+  uint8_t int2_act          : 1;
+  uint8_t int2_boot         : 1;
+  uint8_t int2_ig2          : 1;
+  uint8_t int2_ig1          : 1;
+  uint8_t int2_click        : 1;
+} lis3de_ctrl_reg6_t;
+
+#define LIS3DE_REFERENCE             0x26U
+#define LIS3DE_STATUS_REG            0x27U
+typedef struct {
+  uint8_t xda               : 1;
+  uint8_t yda               : 1;
+  uint8_t zda               : 1;
+  uint8_t zyxda             : 1;
+  uint8_t _xor              : 1;
+  uint8_t yor               : 1;
+  uint8_t zor               : 1;
+  uint8_t zyxor             : 1;
+} lis3de_status_reg_t;
+
+#define LIS3DE_OUT_X                 0x29U
+#define LIS3DE_OUT_Y                 0x2BU
+#define LIS3DE_OUT_Z                 0x2DU
+#define LIS3DE_FIFO_CTRL_REG         0x2EU
+typedef struct {
+  uint8_t fth               : 5;
+  uint8_t tr                : 1;
+  uint8_t fm                : 2;
+} lis3de_fifo_ctrl_reg_t;
+
+#define LIS3DE_FIFO_SRC_REG          0x2FU
+typedef struct {
+  uint8_t fss               : 5;
+  uint8_t empty             : 1;
+  uint8_t ovrn_fifo         : 1;
+  uint8_t wtm               : 1;
+} lis3de_fifo_src_reg_t;
+
+#define LIS3DE_IG1_CFG               0x30U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} lis3de_ig1_cfg_t;
+
+#define LIS3DE_IG1_SOURCE            0x31U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis3de_ig1_source_t;
+
+#define LIS3DE_IG1_THS               0x32U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} lis3de_ig1_ths_t;
+
+#define LIS3DE_IG1_DURATION          0x33U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} lis3de_ig1_duration_t;
+
+#define LIS3DE_IG2_CFG               0x34U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} lis3de_ig2_cfg_t;
+
+#define LIS3DE_IG2_SOURCE            0x35U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis3de_ig2_source_t;
+
+#define LIS3DE_IG2_THS               0x36U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} lis3de_ig2_ths_t;
+
+#define LIS3DE_IG2_DURATION          0x37U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} lis3de_ig2_duration_t;
+
+#define LIS3DE_CLICK_CFG             0x38U
+typedef struct {
+  uint8_t xs                : 1;
+  uint8_t xd                : 1;
+  uint8_t ys                : 1;
+  uint8_t yd                : 1;
+  uint8_t zs                : 1;
+  uint8_t zd                : 1;
+  uint8_t not_used_01       : 2;
+} lis3de_click_cfg_t;
+
+#define LIS3DE_CLICK_SRC             0x39U
+typedef struct {
+  uint8_t x                 : 1;
+  uint8_t y                 : 1;
+  uint8_t z                 : 1;
+  uint8_t sign              : 1;
+  uint8_t sclick            : 1;
+  uint8_t dclick            : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis3de_click_src_t;
+
+#define LIS3DE_CLICK_THS             0x3AU
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t lir               : 1;
+} lis3de_click_ths_t;
+
+#define LIS3DE_TIME_LIMIT            0x3BU
+typedef struct {
+  uint8_t tli               : 7;
+  uint8_t not_used_01       : 1;
+} lis3de_time_limit_t;
+
+#define LIS3DE_TIME_LATENCY          0x3CU
+typedef struct {
+  uint8_t tla               : 8;
+} lis3de_time_latency_t;
+
+#define LIS3DE_TIME_WINDOW           0x3DU
+typedef struct {
+  uint8_t tw                : 8;
+} lis3de_time_window_t;
+
+#define LIS3DE_ACT_THS               0x3EU
+typedef struct {
+  uint8_t acth              : 7;
+  uint8_t not_used_01       : 1;
+} lis3de_act_ths_t;
+
+#define LIS3DE_ACT_DUR               0x3FU
+typedef struct {
+  uint8_t actd              : 8;
+} lis3de_act_dur_t;
+
+/**
+  * @defgroup LIS3DE_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is usefull but not need by the driver.
+  *
+  *           REMOVING this union you are complient with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis3de_status_reg_aux_t status_reg_aux;
+  lis3de_temp_cfg_reg_t   temp_cfg_reg;
+  lis3de_ctrl_reg1_t      ctrl_reg1;
+  lis3de_ctrl_reg2_t      ctrl_reg2;
+  lis3de_ctrl_reg3_t      ctrl_reg3;
+  lis3de_ctrl_reg4_t      ctrl_reg4;
+  lis3de_ctrl_reg5_t      ctrl_reg5;
+  lis3de_ctrl_reg6_t      ctrl_reg6;
+  lis3de_status_reg_t     status_reg;
+  lis3de_fifo_ctrl_reg_t  fifo_ctrl_reg;
+  lis3de_fifo_src_reg_t   fifo_src_reg;
+  lis3de_ig1_cfg_t        int1_cfg;
+  lis3de_ig1_source_t     int1_src;
+  lis3de_ig1_ths_t        int1_ths;
+  lis3de_ig1_duration_t   int1_duration;
+  lis3de_ig2_cfg_t        int2_cfg;
+  lis3de_ig2_source_t     int2_src;
+  lis3de_ig2_ths_t        int2_ths;
+  lis3de_ig2_duration_t   int2_duration;
+  lis3de_click_cfg_t      click_cfg;
+  lis3de_click_src_t      click_src;
+  lis3de_click_ths_t      click_ths;
+  lis3de_time_limit_t     time_limit;
+  lis3de_time_latency_t   time_latency;
+  lis3de_time_window_t    time_window;
+  lis3de_act_ths_t        act_ths;
+  lis3de_act_dur_t        act_dur;
+  bitwise_t               bitwise;
+  uint8_t                 byte;
+} lis3de_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis3de_read_reg(lis3de_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lis3de_write_reg(lis3de_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float lis3de_from_fs2_to_mg(int16_t lsb);
+extern float lis3de_from_fs4_to_mg(int16_t lsb);
+extern float lis3de_from_fs8_to_mg(int16_t lsb);
+extern float lis3de_from_fs16_to_mg(int16_t lsb);
+extern float lis3de_from_lsb_to_celsius(int16_t lsb);
+
+int32_t lis3de_temp_status_reg_get(lis3de_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_temp_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_temp_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_temperature_raw_get(lis3de_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_adc_raw_get(lis3de_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS3DE_AUX_DISABLE          = 0,
+  LIS3DE_AUX_ON_TEMPERATURE   = 3,
+  LIS3DE_AUX_ON_PADS          = 1,
+} lis3de_temp_en_t;
+int32_t lis3de_aux_adc_set(lis3de_ctx_t *ctx, lis3de_temp_en_t val);
+int32_t lis3de_aux_adc_get(lis3de_ctx_t *ctx, lis3de_temp_en_t *val);
+
+typedef enum {
+  LIS3DE_NM    = 0,
+  LIS3DE_LP    = 1,
+} lis3de_op_md_t;
+int32_t lis3de_operating_mode_set(lis3de_ctx_t *ctx, lis3de_op_md_t val);
+int32_t lis3de_operating_mode_get(lis3de_ctx_t *ctx, lis3de_op_md_t *val);
+
+typedef enum {
+  LIS3DE_POWER_DOWN                      = 0x00,
+  LIS3DE_ODR_1Hz                         = 0x01,
+  LIS3DE_ODR_10Hz                        = 0x02,
+  LIS3DE_ODR_25Hz                        = 0x03,
+  LIS3DE_ODR_50Hz                        = 0x04,
+  LIS3DE_ODR_100Hz                       = 0x05,
+  LIS3DE_ODR_200Hz                       = 0x06,
+  LIS3DE_ODR_400Hz                       = 0x07,
+  LIS3DE_ODR_1kHz6                       = 0x08,
+  LIS3DE_ODR_5kHz376_LP_1kHz344_NM       = 0x09,
+} lis3de_odr_t;
+int32_t lis3de_data_rate_set(lis3de_ctx_t *ctx, lis3de_odr_t val);
+int32_t lis3de_data_rate_get(lis3de_ctx_t *ctx, lis3de_odr_t *val);
+
+int32_t lis3de_high_pass_on_outputs_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_high_pass_on_outputs_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DE_AGGRESSIVE  = 0,
+  LIS3DE_STRONG      = 1,
+  LIS3DE_MEDIUM      = 2,
+  LIS3DE_LIGHT       = 3,
+} lis3de_hpcf_t;
+int32_t lis3de_high_pass_bandwidth_set(lis3de_ctx_t *ctx,
+                                         lis3de_hpcf_t val);
+int32_t lis3de_high_pass_bandwidth_get(lis3de_ctx_t *ctx,
+                                         lis3de_hpcf_t *val);
+
+typedef enum {
+  LIS3DE_NORMAL_WITH_RST  = 0,
+  LIS3DE_REFERENCE_MODE   = 1,
+  LIS3DE_NORMAL           = 2,
+  LIS3DE_AUTORST_ON_INT   = 3,
+} lis3de_hpm_t;
+int32_t lis3de_high_pass_mode_set(lis3de_ctx_t *ctx, lis3de_hpm_t val);
+int32_t lis3de_high_pass_mode_get(lis3de_ctx_t *ctx, lis3de_hpm_t *val);
+
+typedef enum {
+  LIS3DE_2g   = 0,
+  LIS3DE_4g   = 1,
+  LIS3DE_8g   = 2,
+  LIS3DE_16g  = 3,
+} lis3de_fs_t;
+int32_t lis3de_full_scale_set(lis3de_ctx_t *ctx, lis3de_fs_t val);
+int32_t lis3de_full_scale_get(lis3de_ctx_t *ctx, lis3de_fs_t *val);
+
+int32_t lis3de_block_data_update_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_block_data_update_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_filter_reference_set(lis3de_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_filter_reference_get(lis3de_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3de_xl_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_xl_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_acceleration_raw_get(lis3de_ctx_t *ctx, int16_t *buff);
+
+int32_t lis3de_device_id_get(lis3de_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS3DE_ST_DISABLE   = 0,
+  LIS3DE_ST_POSITIVE  = 1,
+  LIS3DE_ST_NEGATIVE  = 2,
+} lis3de_st_t;
+int32_t lis3de_self_test_set(lis3de_ctx_t *ctx, lis3de_st_t val);
+int32_t lis3de_self_test_get(lis3de_ctx_t *ctx, lis3de_st_t *val);
+
+int32_t lis3de_boot_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_boot_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_status_get(lis3de_ctx_t *ctx, lis3de_status_reg_t *val);
+
+int32_t lis3de_int1_gen_conf_set(lis3de_ctx_t *ctx,
+                                   lis3de_ig1_cfg_t *val);
+int32_t lis3de_int1_gen_conf_get(lis3de_ctx_t *ctx,
+                                   lis3de_ig1_cfg_t *val);
+
+int32_t lis3de_int1_gen_source_get(lis3de_ctx_t *ctx,
+                                     lis3de_ig1_source_t *val);
+
+int32_t lis3de_int1_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int1_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_int1_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int1_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_int2_gen_conf_set(lis3de_ctx_t *ctx,
+                                   lis3de_ig2_cfg_t *val);
+int32_t lis3de_int2_gen_conf_get(lis3de_ctx_t *ctx,
+                                   lis3de_ig2_cfg_t *val);
+
+int32_t lis3de_int2_gen_source_get(lis3de_ctx_t *ctx,
+                                     lis3de_ig2_source_t *val);
+
+int32_t lis3de_int2_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int2_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_int2_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int2_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DE_DISC_FROM_INT_GENERATOR  = 0,
+  LIS3DE_ON_INT1_GEN              = 1,
+  LIS3DE_ON_INT2_GEN              = 2,
+  LIS3DE_ON_TAP_GEN               = 4,
+  LIS3DE_ON_INT1_INT2_GEN         = 3,
+  LIS3DE_ON_INT1_TAP_GEN          = 5,
+  LIS3DE_ON_INT2_TAP_GEN          = 6,
+  LIS3DE_ON_INT1_INT2_TAP_GEN     = 7,
+} lis3de_hp_t;
+int32_t lis3de_high_pass_int_conf_set(lis3de_ctx_t *ctx,
+                                        lis3de_hp_t val);
+int32_t lis3de_high_pass_int_conf_get(lis3de_ctx_t *ctx,
+                                        lis3de_hp_t *val);
+
+int32_t lis3de_pin_int1_config_set(lis3de_ctx_t *ctx,
+                                     lis3de_ctrl_reg3_t *val);
+int32_t lis3de_pin_int1_config_get(lis3de_ctx_t *ctx,
+                                     lis3de_ctrl_reg3_t *val);
+
+int32_t lis3de_int2_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int2_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DE_INT2_PULSED   = 0,
+  LIS3DE_INT2_LATCHED  = 1,
+} lis3de_lir_int2_t;
+int32_t lis3de_int2_pin_notification_mode_set(lis3de_ctx_t *ctx,
+                                                lis3de_lir_int2_t val);
+int32_t lis3de_int2_pin_notification_mode_get(lis3de_ctx_t *ctx,
+                                                lis3de_lir_int2_t *val);
+
+int32_t lis3de_int1_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int1_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DE_INT1_PULSED   = 0,
+  LIS3DE_INT1_LATCHED  = 1,
+} lis3de_lir_int1_t;
+int32_t lis3de_int1_pin_notification_mode_set(lis3de_ctx_t *ctx,
+                                                lis3de_lir_int1_t val);
+int32_t lis3de_int1_pin_notification_mode_get(lis3de_ctx_t *ctx,
+                                                lis3de_lir_int1_t *val);
+
+int32_t lis3de_pin_int2_config_set(lis3de_ctx_t *ctx,
+                                     lis3de_ctrl_reg6_t *val);
+int32_t lis3de_pin_int2_config_get(lis3de_ctx_t *ctx,
+                                     lis3de_ctrl_reg6_t *val);
+
+int32_t lis3de_fifo_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_fifo_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_fifo_watermark_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_fifo_watermark_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DE_INT1_GEN = 0,
+  LIS3DE_INT2_GEN = 1,
+} lis3de_tr_t;
+int32_t lis3de_fifo_trigger_event_set(lis3de_ctx_t *ctx,
+                                        lis3de_tr_t val);
+int32_t lis3de_fifo_trigger_event_get(lis3de_ctx_t *ctx,
+                                        lis3de_tr_t *val);
+
+typedef enum {
+  LIS3DE_BYPASS_MODE           = 0,
+  LIS3DE_FIFO_MODE             = 1,
+  LIS3DE_DYNAMIC_STREAM_MODE   = 2,
+  LIS3DE_STREAM_TO_FIFO_MODE   = 3,
+} lis3de_fm_t;
+int32_t lis3de_fifo_mode_set(lis3de_ctx_t *ctx, lis3de_fm_t val);
+int32_t lis3de_fifo_mode_get(lis3de_ctx_t *ctx, lis3de_fm_t *val);
+
+int32_t lis3de_fifo_status_get(lis3de_ctx_t *ctx,
+                                 lis3de_fifo_src_reg_t *val);
+
+int32_t lis3de_fifo_data_level_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_fifo_empty_flag_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_fifo_ovr_flag_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_fifo_fth_flag_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_tap_conf_set(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val);
+int32_t lis3de_tap_conf_get(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val);
+
+int32_t lis3de_tap_source_get(lis3de_ctx_t *ctx,
+                                lis3de_click_src_t *val);
+
+int32_t lis3de_tap_threshold_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_tap_threshold_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DE_TAP_PULSED   = 0,
+  LIS3DE_TAP_LATCHED  = 1,
+} lis3de_lir_t;
+int32_t lis3de_tap_notification_mode_set(lis3de_ctx_t *ctx,
+                                           lis3de_lir_t val);
+int32_t lis3de_tap_notification_mode_get(lis3de_ctx_t *ctx,
+                                           lis3de_lir_t *val);
+
+int32_t lis3de_shock_dur_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_shock_dur_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_quiet_dur_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_quiet_dur_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_double_tap_timeout_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_double_tap_timeout_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_act_threshold_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_act_threshold_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3de_act_timeout_set(lis3de_ctx_t *ctx, uint8_t val);
+int32_t lis3de_act_timeout_get(lis3de_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DE_SPI_4_WIRE = 0,
+  LIS3DE_SPI_3_WIRE = 1,
+} lis3de_sim_t;
+int32_t lis3de_spi_mode_set(lis3de_ctx_t *ctx, lis3de_sim_t val);
+int32_t lis3de_spi_mode_get(lis3de_ctx_t *ctx, lis3de_sim_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS3DE_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis3dh_STdC/driver/lis3dh_reg.c
+++ b/sensor/stmemsc/lis3dh_STdC/driver/lis3dh_reg.c
@@ -1,0 +1,2426 @@
+/*
+ ******************************************************************************
+ * @file    lis3dh_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS3DH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis3dh_reg.h"
+
+/**
+  * @defgroup  LIS3DH
+  * @brief     This file provides a set of functions needed to drive the
+  *            lis3dh enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LIS3DH_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_read_reg(lis3dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_write_reg(lis3dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    LIS3DH_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float lis3dh_from_fs2_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 1.0f;
+}
+
+float lis3dh_from_fs4_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) *  2.0f;
+}
+
+float lis3dh_from_fs8_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 4.0f;
+}
+
+float lis3dh_from_fs16_hr_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 16.0f ) * 12.0f;
+}
+
+float lis3dh_from_lsb_hr_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 64.0f ) / 4.0f ) + 25.0f;
+}
+
+float lis3dh_from_fs2_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) *  4.0f;
+}
+
+float lis3dh_from_fs4_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) *  8.0f;
+}
+
+float lis3dh_from_fs8_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) * 16.0f;
+}
+
+float lis3dh_from_fs16_nm_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 64.0f ) * 48.0f;
+}
+
+float lis3dh_from_lsb_nm_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 64.0f ) / 4.0f ) + 25.0f;
+}
+
+float lis3dh_from_fs2_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 16.0f;
+}
+
+float lis3dh_from_fs4_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 32.0f;
+}
+
+float lis3dh_from_fs8_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 64.0f;
+}
+
+float lis3dh_from_fs16_lp_to_mg(int16_t lsb)
+{
+  return ( (float)lsb / 256.0f ) * 192.0f;
+}
+
+float lis3dh_from_lsb_lp_to_celsius(int16_t lsb)
+{
+  return ( ( (float)lsb / 256.0f ) * 1.0f ) + 25.0f;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DH_Data_generation
+  * @brief     This section group all the functions concerning data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_temp_status_reg_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG_AUX, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tda in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_temp_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG_AUX,
+                          (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux._3da;
+
+  return ret;
+}
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tor in reg STATUS_REG_AUX
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_temp_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_status_reg_aux_t status_reg_aux;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG_AUX,
+                          (uint8_t*)&status_reg_aux, 1);
+  *val = status_reg_aux._3or;
+
+  return ret;
+}
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_temperature_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_OUT_ADC1_H, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  ADC output value.[get]
+  *         Sample frequency: the same as the ODR CTRL_REG1
+  *         The resolution:
+  *                    10bit if LPen bit in CTRL_REG1 (20h) is clear
+  *                     8bit if LPen bit in CTRL_REG1 (20h) is set
+  *         Data Format:
+  *                     Outputs are Left Justified in 2’ complements
+  *                     range 800mV
+  *                     code zero means an analogue value of about 1.2V
+  *                     Voltage values smaller than centre values are positive
+  *                           (Example:  800mV = 7Fh / 127 dec)
+  *                     Voltage values bigger than centre values are negative
+  *                           (Example: 1600mV = 80h / -128 dec)
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_adc_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_OUT_ADC1_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Auxiliary ADC.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      configure the auxiliary ADC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_aux_adc_set(lis3dh_ctx_t *ctx, lis3dh_temp_en_t val)
+{
+  lis3dh_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  if (ret == 0) {
+    if (val != LIS3DH_AUX_DISABLE){
+      /* Required in order to use auxiliary adc */
+      ret = lis3dh_block_data_update_set(ctx, PROPERTY_ENABLE);
+    }
+  } 
+  if (ret == 0) {
+    temp_cfg_reg.temp_en = ( (uint8_t) val & 0x02U) >> 1;
+    temp_cfg_reg.adc_pd  = (uint8_t) val &  0x01U;
+    ret = lis3dh_write_reg(ctx, LIS3DH_TEMP_CFG_REG,
+                           (uint8_t*)&temp_cfg_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Auxiliary ADC.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      configure the auxiliary ADC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_aux_adc_get(lis3dh_ctx_t *ctx, lis3dh_temp_en_t *val)
+{
+  lis3dh_temp_cfg_reg_t temp_cfg_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TEMP_CFG_REG, (uint8_t*)&temp_cfg_reg, 1);
+  if ( ( temp_cfg_reg.temp_en & temp_cfg_reg.adc_pd ) == PROPERTY_ENABLE ){
+    *val = LIS3DH_AUX_ON_TEMPERATURE;
+  } 
+  if ( ( temp_cfg_reg.temp_en  == PROPERTY_DISABLE ) &&
+              ( temp_cfg_reg.adc_pd == PROPERTY_ENABLE ) ) {
+    *val = LIS3DH_AUX_ON_PADS;
+  } else {
+    *val = LIS3DH_AUX_DISABLE;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpen in reg CTRL_REG1
+  *                  and HR in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_operating_mode_set(lis3dh_ctx_t *ctx, lis3dh_op_md_t val)
+{
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG1,
+                          (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  } 
+  if (ret == 0) {
+    if ( val == LIS3DH_HR_12bit ) {
+      ctrl_reg1.lpen = 0;
+      ctrl_reg4.hr   = 1;
+    }
+    if (val == LIS3DH_NM_10bit) {
+      ctrl_reg1.lpen = 0;
+      ctrl_reg4.hr   = 0;
+    }
+    if (val == LIS3DH_LP_8bit) {
+      ctrl_reg1.lpen = 1;
+      ctrl_reg4.hr   = 0;
+    }
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  } 
+  if (ret == 0) {
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpen in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_operating_mode_get(lis3dh_ctx_t *ctx, lis3dh_op_md_t *val)
+{
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+    if ( ctrl_reg1.lpen == PROPERTY_ENABLE ) {
+      *val = LIS3DH_LP_8bit;
+    } else if (ctrl_reg4.hr == PROPERTY_ENABLE ) {
+      *val = LIS3DH_HR_12bit;
+    } else {
+      *val = LIS3DH_NM_10bit;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_data_rate_set(lis3dh_ctx_t *ctx, lis3dh_odr_t val)
+{
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ctrl_reg1.odr = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_data_rate_get(lis3dh_ctx_t *ctx, lis3dh_odr_t *val)
+{
+  lis3dh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.odr) {
+    case LIS3DH_POWER_DOWN:
+      *val = LIS3DH_POWER_DOWN;
+      break;
+    case LIS3DH_ODR_1Hz:
+      *val = LIS3DH_ODR_1Hz;
+      break;
+    case LIS3DH_ODR_10Hz:
+      *val = LIS3DH_ODR_10Hz;
+      break;
+    case LIS3DH_ODR_25Hz:
+      *val = LIS3DH_ODR_25Hz;
+      break;
+    case LIS3DH_ODR_50Hz:
+      *val = LIS3DH_ODR_50Hz;
+      break;
+    case LIS3DH_ODR_100Hz:
+      *val = LIS3DH_ODR_100Hz;
+      break;
+    case LIS3DH_ODR_200Hz:
+      *val = LIS3DH_ODR_200Hz;
+      break;
+    case LIS3DH_ODR_400Hz:
+      *val = LIS3DH_ODR_400Hz;
+      break;
+    case LIS3DH_ODR_1kHz620_LP:
+      *val = LIS3DH_ODR_1kHz620_LP;
+      break;
+    case LIS3DH_ODR_5kHz376_LP_1kHz344_NM_HP:
+      *val = LIS3DH_ODR_5kHz376_LP_1kHz344_NM_HP;
+      break;
+    default:
+      *val = LIS3DH_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_high_pass_on_outputs_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.fds = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register
+  *          and FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_high_pass_on_outputs_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = (uint8_t)ctrl_reg2.fds;
+
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[set]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_high_pass_bandwidth_set(lis3dh_ctx_t *ctx,
+                                         lis3dh_hpcf_t val)
+{
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpcf = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High-pass filter cutoff frequency selection.[get]
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpcf in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_high_pass_bandwidth_get(lis3dh_ctx_t *ctx,
+                                         lis3dh_hpcf_t *val)
+{
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpcf) {
+    case LIS3DH_AGGRESSIVE:
+      *val = LIS3DH_AGGRESSIVE;
+      break;
+    case LIS3DH_STRONG:
+      *val = LIS3DH_STRONG;
+      break;
+    case LIS3DH_MEDIUM:
+      *val = LIS3DH_MEDIUM;
+      break;
+    case LIS3DH_LIGHT:
+      *val = LIS3DH_LIGHT;
+      break;
+    default:
+      *val = LIS3DH_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_high_pass_mode_set(lis3dh_ctx_t *ctx, lis3dh_hpm_t val)
+{
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hpm = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of hpm in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_high_pass_mode_get(lis3dh_ctx_t *ctx, lis3dh_hpm_t *val)
+{
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hpm) {
+    case LIS3DH_NORMAL_WITH_RST:
+      *val = LIS3DH_NORMAL_WITH_RST;
+      break;
+    case LIS3DH_REFERENCE_MODE:
+      *val = LIS3DH_REFERENCE_MODE;
+      break;
+    case LIS3DH_NORMAL:
+      *val = LIS3DH_NORMAL;
+      break;
+    case LIS3DH_AUTORST_ON_INT:
+      *val = LIS3DH_AUTORST_ON_INT;
+      break;
+    default:
+      *val = LIS3DH_NORMAL_WITH_RST;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_full_scale_set(lis3dh_ctx_t *ctx, lis3dh_fs_t val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.fs = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of fs in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_full_scale_get(lis3dh_ctx_t *ctx, lis3dh_fs_t *val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.fs) {
+    case LIS3DH_2g:
+      *val = LIS3DH_2g;
+      break;
+    case LIS3DH_4g:
+      *val = LIS3DH_4g;
+      break;
+    case LIS3DH_8g:
+      *val = LIS3DH_8g;
+      break;
+    case LIS3DH_16g:
+      *val = LIS3DH_16g;
+      break;
+    default:
+      *val = LIS3DH_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_block_data_update_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.bdu = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_block_data_update_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = (uint8_t)ctrl_reg4.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[set]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_filter_reference_set(lis3dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dh_write_reg(ctx, LIS3DH_REFERENCE, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[get]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_filter_reference_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_REFERENCE, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_xl_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxda;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration set of data overrun.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of zyxor in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_xl_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.zyxor;
+
+  return ret;
+}
+/**
+  * @brief  Acceleration output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_acceleration_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_OUT_X_L, buff, 6);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DH_Common
+  * @brief     This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI .[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_device_id_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_WHO_AM_I, buff, 1);
+  return ret;
+}
+/**
+  * @brief  Self Test.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_self_test_set(lis3dh_ctx_t *ctx, lis3dh_st_t val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.st = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Self Test.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_self_test_get(lis3dh_ctx_t *ctx, lis3dh_st_t *val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.st) {
+    case LIS3DH_ST_DISABLE:
+      *val = LIS3DH_ST_DISABLE;
+      break;
+    case LIS3DH_ST_POSITIVE:
+      *val = LIS3DH_ST_POSITIVE;
+      break;
+    case LIS3DH_ST_NEGATIVE:
+      *val = LIS3DH_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS3DH_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ble in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_data_format_set(lis3dh_ctx_t *ctx, lis3dh_ble_t val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of ble in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_data_format_get(lis3dh_ctx_t *ctx, lis3dh_ble_t *val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.ble) {
+    case LIS3DH_LSB_AT_LOW_ADD:
+      *val = LIS3DH_LSB_AT_LOW_ADD;
+      break;
+    case LIS3DH_MSB_AT_LOW_ADD:
+      *val = LIS3DH_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LIS3DH_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_boot_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.boot = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_boot_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_status_get(lis3dh_ctx_t *ctx, lis3dh_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS3DH_Interrupts_generator_1
+  * @brief      This section group all the functions that manage the first
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_gen_conf_set(lis3dh_ctx_t *ctx,
+                                   lis3dh_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_write_reg(ctx, LIS3DH_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register INT1_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_gen_conf_get(lis3dh_ctx_t *ctx,
+                                   lis3dh_int1_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Registers INT1_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_gen_source_get(lis3dh_ctx_t *ctx,
+                                     lis3dh_int1_src_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[set]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  if (ret == 0) {
+    int1_ths.ths = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 1.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT1_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_int1_ths_t int1_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_THS, (uint8_t*)&int1_ths, 1);
+  *val = (uint8_t)int1_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  if (ret == 0) {
+    int1_duration.d = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT1_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_int1_duration_t int1_duration;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT1_DURATION, (uint8_t*)&int1_duration, 1);
+  *val = (uint8_t)int1_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS3DH_Interrupts_generator_2
+  * @brief      This section group all the functions that manage the second
+  *             interrupts generator
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_gen_conf_set(lis3dh_ctx_t *ctx,
+                                   lis3dh_int2_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_write_reg(ctx, LIS3DH_INT2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_gen_conf_get(lis3dh_ctx_t *ctx,
+                                   lis3dh_int2_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Interrupt generator 2 source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers INT2_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_gen_source_get(lis3dh_ctx_t *ctx,
+                                     lis3dh_int2_src_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief   User-defined threshold value for xl interrupt event on
+  *          generator 2.[set]
+  *          LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  if (ret == 0) {
+    int2_ths.ths = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on
+  *         generator 2.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg INT2_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_int2_ths_t int2_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_THS, (uint8_t*)&int2_ths, 1);
+  *val = (uint8_t)int2_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized .[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  if (ret == 0) {
+    int2_duration.d = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d in reg INT2_DURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_int2_duration_t int2_duration;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_INT2_DURATION, (uint8_t*)&int2_duration, 1);
+  *val = (uint8_t)int2_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DH_Interrupt_pins
+  * @brief     This section group all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_high_pass_int_conf_set(lis3dh_ctx_t *ctx,
+                                        lis3dh_hp_t val)
+{
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if (ret == 0) {
+    ctrl_reg2.hp = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_high_pass_int_conf_get(lis3dh_ctx_t *ctx,
+                                        lis3dh_hp_t *val)
+{
+  lis3dh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.hp) {
+    case LIS3DH_DISC_FROM_INT_GENERATOR:
+      *val = LIS3DH_DISC_FROM_INT_GENERATOR;
+      break;
+    case LIS3DH_ON_INT1_GEN:
+      *val = LIS3DH_ON_INT1_GEN;
+      break;
+    case LIS3DH_ON_INT2_GEN:
+      *val = LIS3DH_ON_INT2_GEN;
+      break;
+    case LIS3DH_ON_TAP_GEN:
+      *val = LIS3DH_ON_TAP_GEN;
+      break;
+    case LIS3DH_ON_INT1_INT2_GEN:
+      *val = LIS3DH_ON_INT1_INT2_GEN;
+      break;
+    case LIS3DH_ON_INT1_TAP_GEN:
+      *val = LIS3DH_ON_INT1_TAP_GEN;
+      break;
+    case LIS3DH_ON_INT2_TAP_GEN:
+      *val = LIS3DH_ON_INT2_TAP_GEN;
+      break;
+    case LIS3DH_ON_INT1_INT2_TAP_GEN:
+      *val = LIS3DH_ON_INT1_INT2_TAP_GEN;
+      break;
+    default:
+      *val = LIS3DH_DISC_FROM_INT_GENERATOR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_pin_int1_config_set(lis3dh_ctx_t *ctx,
+                                     lis3dh_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_pin_int1_config_get(lis3dh_ctx_t *ctx,
+                                     lis3dh_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  int2_pin_detect_4d: [set]  4D enable: 4D detection is enabled
+  *                                    on INT2 pin when 6D bit on
+  *                                    INT2_CFG (34h) is set to 1.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_int2 = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT2 pin when 6D bit on
+  *         INT2_CFG (34h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_int2;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_pin_notification_mode_set(lis3dh_ctx_t *ctx,
+                                                lis3dh_lir_int2_t val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_int2 = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT2_SRC (35h) register, with
+  *          INT2_SRC (35h) register cleared by reading INT2_SRC(35h)
+  *          itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_int2 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int2_pin_notification_mode_get(lis3dh_ctx_t *ctx,
+                                                lis3dh_lir_int2_t *val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_int2) {
+    case LIS3DH_INT2_PULSED:
+      *val = LIS3DH_INT2_PULSED;
+      break;
+    case LIS3DH_INT2_LATCHED:
+      *val = LIS3DH_INT2_LATCHED;
+      break;
+    default:
+      *val = LIS3DH_INT2_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit
+  *                    on INT1_CFG(30h) is set to 1.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.d4d_int1 = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D enable: 4D detection is enabled on INT1 pin when 6D bit on
+  *         INT1_CFG(30h) is set to 1.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.d4d_int1;
+
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_pin_notification_mode_set(lis3dh_ctx_t *ctx,
+                                                lis3dh_lir_int1_t val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.lir_int1 = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latch interrupt request on INT1_SRC (31h), with INT1_SRC(31h)
+  *          register cleared by reading INT1_SRC (31h) itself.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_int1 in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_int1_pin_notification_mode_get(lis3dh_ctx_t *ctx,
+                                                lis3dh_lir_int1_t *val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  switch (ctrl_reg5.lir_int1) {
+    case LIS3DH_INT1_PULSED:
+      *val = LIS3DH_INT1_PULSED;
+      break;
+    case LIS3DH_INT1_LATCHED:
+      *val = LIS3DH_INT1_LATCHED;
+      break;
+    default:
+      *val = LIS3DH_INT1_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_pin_int2_config_set(lis3dh_ctx_t *ctx,
+                                     lis3dh_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_pin_int2_config_get(lis3dh_ctx_t *ctx,
+                                     lis3dh_ctrl_reg6_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG6, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DH_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if (ret == 0) {
+    ctrl_reg5.fifo_en = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_en in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_watermark_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fth = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_watermark_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  *val = (uint8_t)fifo_ctrl_reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_trigger_event_set(lis3dh_ctx_t *ctx,
+                                        lis3dh_tr_t val)
+{
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.tr = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tr in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_trigger_event_get(lis3dh_ctx_t *ctx,
+                                        lis3dh_tr_t *val)
+{
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.tr) {
+    case LIS3DH_INT1_GEN:
+      *val = LIS3DH_INT1_GEN;
+      break;
+    case LIS3DH_INT2_GEN:
+      *val = LIS3DH_INT2_GEN;
+      break;
+    default:
+      *val = LIS3DH_INT1_GEN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_mode_set(lis3dh_ctx_t *ctx, lis3dh_fm_t val)
+{
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  if (ret == 0) {
+    fifo_ctrl_reg.fm = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fm in reg FIFO_CTRL_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_mode_get(lis3dh_ctx_t *ctx, lis3dh_fm_t *val)
+{
+  lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_CTRL_REG, (uint8_t*)&fifo_ctrl_reg, 1);
+  switch (fifo_ctrl_reg.fm) {
+    case LIS3DH_BYPASS_MODE:
+      *val = LIS3DH_BYPASS_MODE;
+      break;
+    case LIS3DH_FIFO_MODE:
+      *val = LIS3DH_FIFO_MODE;
+      break;
+    case LIS3DH_DYNAMIC_STREAM_MODE:
+      *val = LIS3DH_DYNAMIC_STREAM_MODE;
+      break;
+    case LIS3DH_STREAM_TO_FIFO_MODE:
+      *val = LIS3DH_STREAM_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LIS3DH_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO status register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_status_get(lis3dh_ctx_t *ctx,
+                                 lis3dh_fifo_src_reg_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fss in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_data_level_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.fss;
+
+  return ret;
+}
+/**
+  * @brief  Empty FIFO status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of empty in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_empty_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.empty;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ovrn_fifo in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_ovr_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.ovrn_fifo;
+
+  return ret;
+}
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_SRC_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_fifo_fth_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_fifo_src_reg_t fifo_src_reg;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_FIFO_SRC_REG, (uint8_t*)&fifo_src_reg, 1);
+  *val = (uint8_t)fifo_src_reg.wtm;
+
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DH_Tap_generator
+  * @brief     This section group all the functions that manage the tap and
+  *            double tap event generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_tap_conf_set(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_write_reg(ctx, LIS3DH_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_tap_conf_get(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_CFG, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Tap/Double Tap generator source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CLICK_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_tap_source_get(lis3dh_ctx_t *ctx, lis3dh_click_src_t *val)
+{
+  int32_t ret;
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[set]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_tap_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.ths = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.[get]
+  *         1 LSB = full scale/128
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ths in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_tap_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  *val = (uint8_t)click_ths.ths;
+
+  return ret;
+}
+
+/**
+  * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+  *          for the duration of the latency window.
+  *          If the LIR_Click bit is set, the interrupt is kept high until the
+  *          CLICK_SRC(39h) register is read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir_click in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_tap_notification_mode_set(lis3dh_ctx_t *ctx,
+                                           lis3dh_lir_click_t val)
+{
+  lis3dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  if (ret == 0) {
+    click_ths.lir_click = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   If the LIR_Click bit is not set, the interrupt is kept high
+  *          for the duration of the latency window.
+  *          If the LIR_Click bit is set, the interrupt is kept high until the
+  *          CLICK_SRC(39h) register is read.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir_click in reg CLICK_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_tap_notification_mode_get(lis3dh_ctx_t *ctx,
+                                           lis3dh_lir_click_t *val)
+{
+  lis3dh_click_ths_t click_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_THS, (uint8_t*)&click_ths, 1);
+  switch (click_ths.lir_click) {
+    case LIS3DH_TAP_PULSED:
+      *val = LIS3DH_TAP_PULSED;
+      break;
+    case LIS3DH_TAP_LATCHED:
+      *val = LIS3DH_TAP_LATCHED;
+      break;
+    default:
+      *val = LIS3DH_TAP_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse
+  *         between the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_shock_dur_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  if (ret == 0) {
+    time_limit.tli = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can elapse between
+  *         the start of the click-detection procedure and when the
+  *         acceleration falls back below the threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tli in reg TIME_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_shock_dur_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_time_limit_t time_limit;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_LIMIT, (uint8_t*)&time_limit, 1);
+  *val = (uint8_t)time_limit.tli;
+
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_quiet_dur_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  if (ret == 0) {
+    time_latency.tla = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first
+  *         click detection where the click-detection procedure is
+  *         disabled, in cases where the device is configured for
+  *         double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tla in reg TIME_LATENCY
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_quiet_dur_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_time_latency_t time_latency;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_LATENCY, (uint8_t*)&time_latency, 1);
+  *val = (uint8_t)time_latency.tla;
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the click-detection
+  *         procedure can start, in cases where the device is configured
+  *         for double-click detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_double_tap_timeout_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  if (ret == 0) {
+    time_window.tw = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse
+  *         after the end of the latency interval in which the
+  *         click-detection procedure can start, in cases where the device
+  *         is configured for double-click detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tw in reg TIME_WINDOW
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_double_tap_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_time_window_t time_window;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_TIME_WINDOW, (uint8_t*)&time_window, 1);
+  *val = (uint8_t)time_window.tw;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DH_Activity_inactivity
+  * @brief     This section group all the functions concerning activity
+  *            inactivity functionality
+  * @{
+  *
+  */
+
+/**
+  * @brief    Sleep-to-wake, return-to-sleep activation threshold in
+  *           low-power mode.[set]
+  *           1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_act_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_ACT_THS, (uint8_t*)&act_ths, 1);
+  if (ret == 0) {
+    act_ths.acth = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_ACT_THS, (uint8_t*)&act_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep activation threshold in low-power
+  *         mode.[get]
+  *         1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of acth in reg ACT_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_act_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_ACT_THS, (uint8_t*)&act_ths, 1);
+  *val = (uint8_t)act_ths.acth;
+
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[set]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_act_timeout_set(lis3dh_ctx_t *ctx, uint8_t val)
+{
+  lis3dh_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_ACT_DUR, (uint8_t*)&act_dur, 1);
+  if (ret == 0) {
+    act_dur.actd = val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_ACT_DUR, (uint8_t*)&act_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep.[get]
+  *         duration = (8*1[LSb]+1)/ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of actd in reg ACT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_act_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dh_act_dur_t act_dur;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_ACT_DUR, (uint8_t*)&act_dur, 1);
+  *val = (uint8_t)act_dur.actd;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DH_Serial_interface
+  * @brief     This section group all the functions concerning serial
+  *            interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sdo_pu_disc in reg CTRL_REG0
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_pin_sdo_sa0_mode_set(lis3dh_ctx_t *ctx,
+                                      lis3dh_sdo_pu_disc_t val)
+{
+  lis3dh_ctrl_reg0_t ctrl_reg0;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  if (ret == 0) {
+    ctrl_reg0.sdo_pu_disc = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sdo_pu_disc in reg CTRL_REG0
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_pin_sdo_sa0_mode_get(lis3dh_ctx_t *ctx,
+                                      lis3dh_sdo_pu_disc_t *val)
+{
+  lis3dh_ctrl_reg0_t ctrl_reg0;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG0, (uint8_t*)&ctrl_reg0, 1);
+  switch (ctrl_reg0.sdo_pu_disc) {
+    case LIS3DH_PULL_UP_DISCONNECT:
+      *val = LIS3DH_PULL_UP_DISCONNECT;
+      break;
+    case LIS3DH_PULL_UP_CONNECT:
+      *val = LIS3DH_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LIS3DH_PULL_UP_DISCONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_spi_mode_set(lis3dh_ctx_t *ctx, lis3dh_sim_t val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if (ret == 0) {
+    ctrl_reg4.sim = (uint8_t)val;
+    ret = lis3dh_write_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dh_spi_mode_get(lis3dh_ctx_t *ctx, lis3dh_sim_t *val)
+{
+  lis3dh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dh_read_reg(ctx, LIS3DH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.sim) {
+    case LIS3DH_SPI_4_WIRE:
+      *val = LIS3DH_SPI_4_WIRE;
+      break;
+    case LIS3DH_SPI_3_WIRE:
+      *val = LIS3DH_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS3DH_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis3dh_STdC/driver/lis3dh_reg.h
+++ b/sensor/stmemsc/lis3dh_STdC/driver/lis3dh_reg.h
@@ -1,0 +1,772 @@
+/*
+ ******************************************************************************
+ * @file    lis3dh_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis3dh_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS3DH_REGS_H
+#define LIS3DH_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS3DH
+  * @{
+  *
+  */
+
+/** @defgroup LIS3DH_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup LIS3MDL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis3dh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis3dh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis3dh_write_ptr  write_reg;
+  lis3dh_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis3dh_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS3DH_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define LIS3DH_I2C_ADD_L   0x31U
+#define LIS3DH_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define LIS3DH_ID          0x33U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS3DH_STATUS_REG_AUX        0x07U
+typedef struct {
+  uint8_t _1da              : 1;
+  uint8_t _2da              : 1;
+  uint8_t _3da              : 1;
+  uint8_t _321da            : 1;
+  uint8_t _1or              : 1;
+  uint8_t _2or              : 1;
+  uint8_t _3or              : 1;
+  uint8_t _321or            : 1;
+} lis3dh_status_reg_aux_t;
+
+#define LIS3DH_OUT_ADC1_L            0x08U
+#define LIS3DH_OUT_ADC1_H            0x09U
+#define LIS3DH_OUT_ADC2_L            0x0AU
+#define LIS3DH_OUT_ADC2_H            0x0BU
+#define LIS3DH_OUT_ADC3_L            0x0CU
+#define LIS3DH_OUT_ADC3_H            0x0DU
+#define LIS3DH_WHO_AM_I              0x0FU
+
+#define LIS3DH_CTRL_REG0             0x1EU
+typedef struct {
+  uint8_t not_used_01       : 7;
+  uint8_t sdo_pu_disc       : 1;
+} lis3dh_ctrl_reg0_t;
+
+#define LIS3DH_TEMP_CFG_REG          0x1FU
+typedef struct {
+  uint8_t not_used_01       : 6;
+  uint8_t adc_pd            : 1;
+  uint8_t temp_en           : 1;
+} lis3dh_temp_cfg_reg_t;
+
+#define LIS3DH_CTRL_REG1             0x20U
+typedef struct {
+  uint8_t xen               : 1;
+  uint8_t yen               : 1;
+  uint8_t zen               : 1;
+  uint8_t lpen              : 1;
+  uint8_t odr               : 4;
+} lis3dh_ctrl_reg1_t;
+
+#define LIS3DH_CTRL_REG2             0x21U
+typedef struct {
+  uint8_t hp                : 3; /* HPCLICK + HP_IA2 + HP_IA1 -> HP */
+  uint8_t fds               : 1;
+  uint8_t hpcf              : 2;
+  uint8_t hpm               : 2;
+} lis3dh_ctrl_reg2_t;
+
+#define LIS3DH_CTRL_REG3             0x22U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t i1_overrun        : 1;
+  uint8_t i1_wtm            : 1;
+  uint8_t not_used_02       : 1;
+  uint8_t i1_zyxda          : 1;
+  uint8_t i1_ia2            : 1;
+  uint8_t i1_ia1            : 1;
+  uint8_t i1_click          : 1;
+} lis3dh_ctrl_reg3_t;
+
+#define LIS3DH_CTRL_REG4             0x23U
+typedef struct {
+  uint8_t sim               : 1;
+  uint8_t st                : 2;
+  uint8_t hr                : 1;
+  uint8_t fs                : 2;
+  uint8_t ble               : 1;
+  uint8_t bdu               : 1;
+} lis3dh_ctrl_reg4_t;
+
+#define LIS3DH_CTRL_REG5             0x24U
+typedef struct {
+  uint8_t d4d_int2          : 1;
+  uint8_t lir_int2          : 1;
+  uint8_t d4d_int1          : 1;
+  uint8_t lir_int1          : 1;
+  uint8_t not_used_01       : 2;
+  uint8_t fifo_en           : 1;
+  uint8_t boot              : 1;
+} lis3dh_ctrl_reg5_t;
+
+#define LIS3DH_CTRL_REG6            0x25U
+typedef struct {
+  uint8_t not_used_01       : 1;
+  uint8_t int_polarity      : 1;
+  uint8_t not_used_02       : 1;
+  uint8_t i2_act            : 1;
+  uint8_t i2_boot           : 1;
+  uint8_t i2_ia2            : 1;
+  uint8_t i2_ia1            : 1;
+  uint8_t i2_click          : 1;
+} lis3dh_ctrl_reg6_t;
+
+#define LIS3DH_REFERENCE            0x26U
+#define LIS3DH_STATUS_REG           0x27U
+typedef struct {
+  uint8_t xda               : 1;
+  uint8_t yda               : 1;
+  uint8_t zda               : 1;
+  uint8_t zyxda             : 1;
+  uint8_t _xor              : 1;
+  uint8_t yor               : 1;
+  uint8_t zor               : 1;
+  uint8_t zyxor             : 1;
+} lis3dh_status_reg_t;
+
+#define LIS3DH_OUT_X_L              0x28U
+#define LIS3DH_OUT_X_H              0x29U
+#define LIS3DH_OUT_Y_L              0x2AU
+#define LIS3DH_OUT_Y_H              0x2BU
+#define LIS3DH_OUT_Z_L              0x2CU
+#define LIS3DH_OUT_Z_H              0x2DU
+#define LIS3DH_FIFO_CTRL_REG        0x2EU
+typedef struct {
+  uint8_t fth               : 5;
+  uint8_t tr                : 1;
+  uint8_t fm                : 2;
+} lis3dh_fifo_ctrl_reg_t;
+
+#define LIS3DH_FIFO_SRC_REG         0x2FU
+typedef struct {
+  uint8_t fss               : 5;
+  uint8_t empty             : 1;
+  uint8_t ovrn_fifo         : 1;
+  uint8_t wtm               : 1;
+} lis3dh_fifo_src_reg_t;
+
+#define LIS3DH_INT1_CFG             0x30U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} lis3dh_int1_cfg_t;
+
+#define LIS3DH_INT1_SRC             0x31U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis3dh_int1_src_t;
+
+#define LIS3DH_INT1_THS             0x32U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} lis3dh_int1_ths_t;
+
+#define LIS3DH_INT1_DURATION        0x33U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} lis3dh_int1_duration_t;
+
+#define LIS3DH_INT2_CFG             0x34U
+typedef struct {
+  uint8_t xlie              : 1;
+  uint8_t xhie              : 1;
+  uint8_t ylie              : 1;
+  uint8_t yhie              : 1;
+  uint8_t zlie              : 1;
+  uint8_t zhie              : 1;
+  uint8_t _6d               : 1;
+  uint8_t aoi               : 1;
+} lis3dh_int2_cfg_t;
+
+#define LIS3DH_INT2_SRC             0x35U
+typedef struct {
+  uint8_t xl                : 1;
+  uint8_t xh                : 1;
+  uint8_t yl                : 1;
+  uint8_t yh                : 1;
+  uint8_t zl                : 1;
+  uint8_t zh                : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis3dh_int2_src_t;
+
+#define LIS3DH_INT2_THS             0x36U
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t not_used_01       : 1;
+} lis3dh_int2_ths_t;
+
+#define LIS3DH_INT2_DURATION        0x37U
+typedef struct {
+  uint8_t d                 : 7;
+  uint8_t not_used_01       : 1;
+} lis3dh_int2_duration_t;
+
+#define LIS3DH_CLICK_CFG            0x38U
+typedef struct {
+  uint8_t xs                : 1;
+  uint8_t xd                : 1;
+  uint8_t ys                : 1;
+  uint8_t yd                : 1;
+  uint8_t zs                : 1;
+  uint8_t zd                : 1;
+  uint8_t not_used_01       : 2;
+} lis3dh_click_cfg_t;
+
+#define LIS3DH_CLICK_SRC            0x39U
+typedef struct {
+  uint8_t x                 : 1;
+  uint8_t y                 : 1;
+  uint8_t z                 : 1;
+  uint8_t sign              : 1;
+  uint8_t sclick            : 1;
+  uint8_t dclick            : 1;
+  uint8_t ia                : 1;
+  uint8_t not_used_01       : 1;
+} lis3dh_click_src_t;
+
+#define LIS3DH_CLICK_THS            0x3AU
+typedef struct {
+  uint8_t ths               : 7;
+  uint8_t lir_click         : 1;
+} lis3dh_click_ths_t;
+
+#define LIS3DH_TIME_LIMIT           0x3BU
+typedef struct {
+  uint8_t tli               : 7;
+  uint8_t not_used_01       : 1;
+} lis3dh_time_limit_t;
+
+#define LIS3DH_TIME_LATENCY         0x3CU
+typedef struct {
+  uint8_t tla               : 8;
+} lis3dh_time_latency_t;
+
+#define LIS3DH_TIME_WINDOW          0x3DU
+typedef struct {
+  uint8_t tw                : 8;
+} lis3dh_time_window_t;
+
+#define LIS3DH_ACT_THS              0x3EU
+typedef struct {
+  uint8_t acth              : 7;
+  uint8_t not_used_01       : 1;
+} lis3dh_act_ths_t;
+
+#define LIS3DH_ACT_DUR              0x3FU
+typedef struct {
+  uint8_t actd              : 8;
+} lis3dh_act_dur_t;
+
+/**
+  * @defgroup LIS3DH_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is usefull but not need by the driver.
+  *
+  *           REMOVING this union you are complient with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis3dh_status_reg_aux_t status_reg_aux;
+  lis3dh_ctrl_reg0_t      ctrl_reg0;
+  lis3dh_temp_cfg_reg_t   temp_cfg_reg;
+  lis3dh_ctrl_reg1_t      ctrl_reg1;
+  lis3dh_ctrl_reg2_t      ctrl_reg2;
+  lis3dh_ctrl_reg3_t      ctrl_reg3;
+  lis3dh_ctrl_reg4_t      ctrl_reg4;
+  lis3dh_ctrl_reg5_t      ctrl_reg5;
+  lis3dh_ctrl_reg6_t      ctrl_reg6;
+  lis3dh_status_reg_t     status_reg;
+  lis3dh_fifo_ctrl_reg_t  fifo_ctrl_reg;
+  lis3dh_fifo_src_reg_t   fifo_src_reg;
+  lis3dh_int1_cfg_t       int1_cfg;
+  lis3dh_int1_src_t       int1_src;
+  lis3dh_int1_ths_t       int1_ths;
+  lis3dh_int1_duration_t  int1_duration;
+  lis3dh_int2_cfg_t       int2_cfg;
+  lis3dh_int2_src_t       int2_src;
+  lis3dh_int2_ths_t       int2_ths;
+  lis3dh_int2_duration_t  int2_duration;
+  lis3dh_click_cfg_t      click_cfg;
+  lis3dh_click_src_t      click_src;
+  lis3dh_click_ths_t      click_ths;
+  lis3dh_time_limit_t     time_limit;
+  lis3dh_time_latency_t   time_latency;
+  lis3dh_time_window_t    time_window;
+  lis3dh_act_ths_t        act_ths;
+  lis3dh_act_dur_t        act_dur;
+  bitwise_t                 bitwise;
+  uint8_t                   byte;
+} lis3dh_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis3dh_read_reg(lis3dh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lis3dh_write_reg(lis3dh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float lis3dh_from_fs2_hr_to_mg(int16_t lsb);
+extern float lis3dh_from_fs4_hr_to_mg(int16_t lsb);
+extern float lis3dh_from_fs8_hr_to_mg(int16_t lsb);
+extern float lis3dh_from_fs16_hr_to_mg(int16_t lsb);
+extern float lis3dh_from_lsb_hr_to_celsius(int16_t lsb);
+
+extern float lis3dh_from_fs2_nm_to_mg(int16_t lsb);
+extern float lis3dh_from_fs4_nm_to_mg(int16_t lsb);
+extern float lis3dh_from_fs8_nm_to_mg(int16_t lsb);
+extern float lis3dh_from_fs16_nm_to_mg(int16_t lsb);
+extern float lis3dh_from_lsb_nm_to_celsius(int16_t lsb);
+
+extern float lis3dh_from_fs2_lp_to_mg(int16_t lsb);
+extern float lis3dh_from_fs4_lp_to_mg(int16_t lsb);
+extern float lis3dh_from_fs8_lp_to_mg(int16_t lsb);
+extern float lis3dh_from_fs16_lp_to_mg(int16_t lsb);
+extern float lis3dh_from_lsb_lp_to_celsius(int16_t lsb);
+
+int32_t lis3dh_temp_status_reg_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_temp_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_temp_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_temperature_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3dh_adc_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS3DH_AUX_DISABLE          = 0,
+  LIS3DH_AUX_ON_TEMPERATURE   = 3,
+  LIS3DH_AUX_ON_PADS          = 1,
+} lis3dh_temp_en_t;
+int32_t lis3dh_aux_adc_set(lis3dh_ctx_t *ctx, lis3dh_temp_en_t val);
+int32_t lis3dh_aux_adc_get(lis3dh_ctx_t *ctx, lis3dh_temp_en_t *val);
+
+typedef enum {
+  LIS3DH_HR_12bit   = 0,
+  LIS3DH_NM_10bit   = 1,
+  LIS3DH_LP_8bit    = 2,
+} lis3dh_op_md_t;
+int32_t lis3dh_operating_mode_set(lis3dh_ctx_t *ctx,
+                                    lis3dh_op_md_t val);
+int32_t lis3dh_operating_mode_get(lis3dh_ctx_t *ctx,
+                                    lis3dh_op_md_t *val);
+
+typedef enum {
+  LIS3DH_POWER_DOWN                      = 0x00,
+  LIS3DH_ODR_1Hz                         = 0x01,
+  LIS3DH_ODR_10Hz                        = 0x02,
+  LIS3DH_ODR_25Hz                        = 0x03,
+  LIS3DH_ODR_50Hz                        = 0x04,
+  LIS3DH_ODR_100Hz                       = 0x05,
+  LIS3DH_ODR_200Hz                       = 0x06,
+  LIS3DH_ODR_400Hz                       = 0x07,
+  LIS3DH_ODR_1kHz620_LP                  = 0x08,
+  LIS3DH_ODR_5kHz376_LP_1kHz344_NM_HP    = 0x09,
+} lis3dh_odr_t;
+int32_t lis3dh_data_rate_set(lis3dh_ctx_t *ctx, lis3dh_odr_t val);
+int32_t lis3dh_data_rate_get(lis3dh_ctx_t *ctx, lis3dh_odr_t *val);
+
+int32_t lis3dh_high_pass_on_outputs_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_high_pass_on_outputs_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_AGGRESSIVE  = 0,
+  LIS3DH_STRONG      = 1,
+  LIS3DH_MEDIUM      = 2,
+  LIS3DH_LIGHT       = 3,
+} lis3dh_hpcf_t;
+int32_t lis3dh_high_pass_bandwidth_set(lis3dh_ctx_t *ctx,
+                                         lis3dh_hpcf_t val);
+int32_t lis3dh_high_pass_bandwidth_get(lis3dh_ctx_t *ctx,
+                                         lis3dh_hpcf_t *val);
+
+typedef enum {
+  LIS3DH_NORMAL_WITH_RST  = 0,
+  LIS3DH_REFERENCE_MODE   = 1,
+  LIS3DH_NORMAL           = 2,
+  LIS3DH_AUTORST_ON_INT   = 3,
+} lis3dh_hpm_t;
+int32_t lis3dh_high_pass_mode_set(lis3dh_ctx_t *ctx, lis3dh_hpm_t val);
+int32_t lis3dh_high_pass_mode_get(lis3dh_ctx_t *ctx, lis3dh_hpm_t *val);
+
+typedef enum {
+  LIS3DH_2g   = 0,
+  LIS3DH_4g   = 1,
+  LIS3DH_8g   = 2,
+  LIS3DH_16g  = 3,
+} lis3dh_fs_t;
+int32_t lis3dh_full_scale_set(lis3dh_ctx_t *ctx, lis3dh_fs_t val);
+int32_t lis3dh_full_scale_get(lis3dh_ctx_t *ctx, lis3dh_fs_t *val);
+
+int32_t lis3dh_block_data_update_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_block_data_update_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_filter_reference_set(lis3dh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_filter_reference_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3dh_xl_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_xl_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_acceleration_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3dh_device_id_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS3DH_ST_DISABLE   = 0,
+  LIS3DH_ST_POSITIVE  = 1,
+  LIS3DH_ST_NEGATIVE  = 2,
+} lis3dh_st_t;
+int32_t lis3dh_self_test_set(lis3dh_ctx_t *ctx, lis3dh_st_t val);
+int32_t lis3dh_self_test_get(lis3dh_ctx_t *ctx, lis3dh_st_t *val);
+
+typedef enum {
+  LIS3DH_LSB_AT_LOW_ADD = 0,
+  LIS3DH_MSB_AT_LOW_ADD = 1,
+} lis3dh_ble_t;
+int32_t lis3dh_data_format_set(lis3dh_ctx_t *ctx, lis3dh_ble_t val);
+int32_t lis3dh_data_format_get(lis3dh_ctx_t *ctx, lis3dh_ble_t *val);
+
+int32_t lis3dh_boot_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_boot_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_status_get(lis3dh_ctx_t *ctx, lis3dh_status_reg_t *val);
+
+int32_t lis3dh_int1_gen_conf_set(lis3dh_ctx_t *ctx,
+                                   lis3dh_int1_cfg_t *val);
+int32_t lis3dh_int1_gen_conf_get(lis3dh_ctx_t *ctx,
+                                   lis3dh_int1_cfg_t *val);
+
+int32_t lis3dh_int1_gen_source_get(lis3dh_ctx_t *ctx,
+                                     lis3dh_int1_src_t *val);
+
+int32_t lis3dh_int1_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_int1_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_int2_gen_conf_set(lis3dh_ctx_t *ctx,
+                                   lis3dh_int2_cfg_t *val);
+int32_t lis3dh_int2_gen_conf_get(lis3dh_ctx_t *ctx,
+                                   lis3dh_int2_cfg_t *val);
+
+int32_t lis3dh_int2_gen_source_get(lis3dh_ctx_t *ctx,
+                                     lis3dh_int2_src_t *val);
+
+int32_t lis3dh_int2_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_int2_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_DISC_FROM_INT_GENERATOR  = 0,
+  LIS3DH_ON_INT1_GEN              = 1,
+  LIS3DH_ON_INT2_GEN              = 2,
+  LIS3DH_ON_TAP_GEN               = 4,
+  LIS3DH_ON_INT1_INT2_GEN         = 3,
+  LIS3DH_ON_INT1_TAP_GEN          = 5,
+  LIS3DH_ON_INT2_TAP_GEN          = 6,
+  LIS3DH_ON_INT1_INT2_TAP_GEN     = 7,
+} lis3dh_hp_t;
+int32_t lis3dh_high_pass_int_conf_set(lis3dh_ctx_t *ctx,
+                                        lis3dh_hp_t val);
+int32_t lis3dh_high_pass_int_conf_get(lis3dh_ctx_t *ctx,
+                                        lis3dh_hp_t *val);
+
+int32_t lis3dh_pin_int1_config_set(lis3dh_ctx_t *ctx,
+                                     lis3dh_ctrl_reg3_t *val);
+int32_t lis3dh_pin_int1_config_get(lis3dh_ctx_t *ctx,
+                                     lis3dh_ctrl_reg3_t *val);
+
+int32_t lis3dh_int2_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_INT2_PULSED   = 0,
+  LIS3DH_INT2_LATCHED  = 1,
+} lis3dh_lir_int2_t;
+int32_t lis3dh_int2_pin_notification_mode_set(lis3dh_ctx_t *ctx,
+                                                lis3dh_lir_int2_t val);
+int32_t lis3dh_int2_pin_notification_mode_get(lis3dh_ctx_t *ctx,
+                                                lis3dh_lir_int2_t *val);
+
+int32_t lis3dh_int1_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_INT1_PULSED   = 0,
+  LIS3DH_INT1_LATCHED  = 1,
+} lis3dh_lir_int1_t;
+int32_t lis3dh_int1_pin_notification_mode_set(lis3dh_ctx_t *ctx,
+                                                lis3dh_lir_int1_t val);
+int32_t lis3dh_int1_pin_notification_mode_get(lis3dh_ctx_t *ctx,
+                                                lis3dh_lir_int1_t *val);
+
+int32_t lis3dh_pin_int2_config_set(lis3dh_ctx_t *ctx,
+                                     lis3dh_ctrl_reg6_t *val);
+int32_t lis3dh_pin_int2_config_get(lis3dh_ctx_t *ctx,
+                                     lis3dh_ctrl_reg6_t *val);
+
+int32_t lis3dh_fifo_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_fifo_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_fifo_watermark_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_fifo_watermark_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_INT1_GEN = 0,
+  LIS3DH_INT2_GEN = 1,
+} lis3dh_tr_t;
+int32_t lis3dh_fifo_trigger_event_set(lis3dh_ctx_t *ctx,
+                                        lis3dh_tr_t val);
+int32_t lis3dh_fifo_trigger_event_get(lis3dh_ctx_t *ctx,
+                                        lis3dh_tr_t *val);
+
+typedef enum {
+  LIS3DH_BYPASS_MODE           = 0,
+  LIS3DH_FIFO_MODE             = 1,
+  LIS3DH_DYNAMIC_STREAM_MODE   = 2,
+  LIS3DH_STREAM_TO_FIFO_MODE   = 3,
+} lis3dh_fm_t;
+int32_t lis3dh_fifo_mode_set(lis3dh_ctx_t *ctx, lis3dh_fm_t val);
+int32_t lis3dh_fifo_mode_get(lis3dh_ctx_t *ctx, lis3dh_fm_t *val);
+
+int32_t lis3dh_fifo_status_get(lis3dh_ctx_t *ctx,
+                                 lis3dh_fifo_src_reg_t *val);
+
+int32_t lis3dh_fifo_data_level_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_fifo_empty_flag_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_fifo_ovr_flag_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_fifo_fth_flag_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_tap_conf_set(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val);
+int32_t lis3dh_tap_conf_get(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val);
+
+int32_t lis3dh_tap_source_get(lis3dh_ctx_t *ctx,
+                                lis3dh_click_src_t *val);
+
+int32_t lis3dh_tap_threshold_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_tap_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_TAP_PULSED   = 0,
+  LIS3DH_TAP_LATCHED  = 1,
+} lis3dh_lir_click_t;
+int32_t lis3dh_tap_notification_mode_set(lis3dh_ctx_t *ctx,
+                                           lis3dh_lir_click_t val);
+int32_t lis3dh_tap_notification_mode_get(lis3dh_ctx_t *ctx,
+                                           lis3dh_lir_click_t *val);
+
+int32_t lis3dh_shock_dur_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_shock_dur_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_quiet_dur_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_quiet_dur_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_double_tap_timeout_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_double_tap_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_act_threshold_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_act_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dh_act_timeout_set(lis3dh_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_act_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DH_PULL_UP_DISCONNECT  = 0,
+  LIS3DH_PULL_UP_CONNECT     = 1,
+} lis3dh_sdo_pu_disc_t;
+int32_t lis3dh_pin_sdo_sa0_mode_set(lis3dh_ctx_t *ctx,
+                                      lis3dh_sdo_pu_disc_t val);
+int32_t lis3dh_pin_sdo_sa0_mode_get(lis3dh_ctx_t *ctx,
+                                      lis3dh_sdo_pu_disc_t *val);
+
+typedef enum {
+  LIS3DH_SPI_4_WIRE = 0,
+  LIS3DH_SPI_3_WIRE = 1,
+} lis3dh_sim_t;
+int32_t lis3dh_spi_mode_set(lis3dh_ctx_t *ctx, lis3dh_sim_t val);
+int32_t lis3dh_spi_mode_get(lis3dh_ctx_t *ctx, lis3dh_sim_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS3DH_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.c
+++ b/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.c
@@ -1,0 +1,1526 @@
+/*
+ ******************************************************************************
+ * @file    lis3dhh_reg.c
+ * @author  Sensor Solutions Software Team
+ * @brief   LIS3DHH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis3dhh_reg.h"
+
+/**
+  * @defgroup  LIS3DHH
+  * @brief     This file provides a set of functions needed to drive the
+  *            lis3dhh enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LIS3DHH_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dhh_read_reg(lis3dhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3dhh_write_reg(lis3dhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @defgroup    LIS3DHH_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lis3dhh_from_lsb_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.076f);
+}
+
+float_t lis3dhh_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 16.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS3DHH_Data_generation
+  * @brief      This section groups all the functions concerning data
+  *             generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Blockdataupdate.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_block_data_update_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.bdu = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_block_data_update_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of norm_mod_en in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_data_rate_set(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.norm_mod_en = (uint8_t)val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of norm_mod_en in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_data_rate_get(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t *val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+
+  switch (ctrl_reg1.norm_mod_en){
+    case LIS3DHH_POWER_DOWN:
+      *val = LIS3DHH_POWER_DOWN;
+      break;
+    case LIS3DHH_1kHz1:
+      *val = LIS3DHH_1kHz1;
+      break;
+    default:
+      *val = LIS3DHH_POWER_DOWN;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Offset temperature compensation enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of off_tcomp_en in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_offset_temp_comp_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.off_tcomp_en = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Offset temperature compensation enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of off_tcomp_en in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_offset_temp_comp_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.off_tcomp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_temperature_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  acceleration output value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_acceleration_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_OUT_X_L_XL, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Acceleration set of data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxda in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_xl_data_ready_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_status_t status;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_STATUS, (uint8_t*)&status, 1);
+  *val = status.zyxda;
+
+  return ret;
+}
+
+/**
+  * @brief  Acceleration set of data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxor in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_xl_data_ovr_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_status_t status;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_STATUS, (uint8_t*)&status, 1);
+  *val = status.zyxor;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DHH_common
+  * @brief     This section group common useful functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_device_id_get(lis3dhh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Asic identification.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of asic_id in reg ID_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_asic_id_get(lis3dhh_ctx_t *ctx, lis3dhh_asic_id_t *val)
+{
+  lis3dhh_id_reg_t id_reg;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_ID_REG, (uint8_t*)&id_reg, 1);
+
+  switch (id_reg.asic_id){
+    case LIS3DHH_VER_A:
+      *val = LIS3DHH_VER_A;
+      break;
+    case LIS3DHH_VER_B:
+      *val = LIS3DHH_VER_B;
+      break;
+    default:
+      *val = LIS3DHH_VER_A;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_reset_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.sw_reset = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sw_reset in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_reset_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_boot_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.boot = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_boot_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_self_test_set(lis3dhh_ctx_t *ctx, lis3dhh_st_t val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.st = (uint8_t)val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_self_test_get(lis3dhh_ctx_t *ctx, lis3dhh_st_t *val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.st){
+    case LIS3DHH_ST_DISABLE:
+      *val = LIS3DHH_ST_DISABLE;
+      break;
+    case LIS3DHH_ST_POSITIVE:
+      *val = LIS3DHH_ST_POSITIVE;
+      break;
+    case LIS3DHH_ST_NEGATIVE:
+      *val = LIS3DHH_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS3DHH_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Digital filtering Phase/bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dsp in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_filter_config_set(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.dsp = (uint8_t)val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Digital filtering Phase/bandwidth selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dsp in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_filter_config_get(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t *val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.dsp){
+    case LIS3DHH_LINEAR_PHASE_440Hz:
+      *val = LIS3DHH_LINEAR_PHASE_440Hz;
+      break;
+    case LIS3DHH_LINEAR_PHASE_235Hz:
+      *val = LIS3DHH_LINEAR_PHASE_235Hz;
+      break;
+    case LIS3DHH_NO_LINEAR_PHASE_440Hz:
+      *val = LIS3DHH_NO_LINEAR_PHASE_440Hz;
+      break;
+    case LIS3DHH_NO_LINEAR_PHASE_235Hz:
+      *val = LIS3DHH_NO_LINEAR_PHASE_235Hz;
+      break;
+    default:
+      *val = LIS3DHH_LINEAR_PHASE_440Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Statusregister.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_status_get(lis3dhh_ctx_t *ctx, lis3dhh_status_t *val)
+{
+  int32_t ret;
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_STATUS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DHH_interrupts
+  * @brief     This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  DRDY latched / pulsed, pulse duration is 1/4 ODR.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_pulse in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_drdy_notification_mode_set(lis3dhh_ctx_t *ctx,
+                                            lis3dhh_drdy_pulse_t val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.drdy_pulse = (uint8_t)val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   DRDY latched / pulsed, pulse duration is 1/4 ODR.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_pulse in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_drdy_notification_mode_get(lis3dhh_ctx_t *ctx,
+                                            lis3dhh_drdy_pulse_t *val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+
+  switch (ctrl_reg1.drdy_pulse){
+    case LIS3DHH_LATCHED:
+      *val = LIS3DHH_LATCHED;
+      break;
+    case LIS3DHH_PULSED:
+      *val = LIS3DHH_PULSED;
+      break;
+    default:
+      *val = LIS3DHH_LATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It configures the INT1 pad as output for FIFO flags or as
+  *                external asynchronous input trigger to FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_ext in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_int1_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_ext = (uint8_t)val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  It configures the INT1 pad as output for FIFO flags or as
+  *                external asynchronous input trigger to FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_ext in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_int1_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t *val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+
+  switch (int1_ctrl.int1_ext){
+    case LIS3DHH_PIN_AS_INTERRUPT:
+      *val = LIS3DHH_PIN_AS_INTERRUPT;
+      break;
+    case LIS3DHH_PIN_AS_TRIGGER:
+      *val = LIS3DHH_PIN_AS_TRIGGER;
+      break;
+    default:
+      *val = LIS3DHH_PIN_AS_INTERRUPT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_fth in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_threshold_on_int1_set(lis3dhh_ctx_t *ctx,
+                                           uint8_t val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_fth = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_fth in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_threshold_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_fss5 in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_full_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_fss5 = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_fss5 in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_full_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_fss5;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_ovr in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_ovr_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_ovr = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_ovr in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_ovr_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  BOOT status on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_boot in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_boot_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_boot = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  BOOT status on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_boot in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_boot_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_drdy in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_drdy_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_drdy = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_drdy in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_drdy_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT2 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_fth in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_threshold_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_fth = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT2 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_fth in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_threshold_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT2 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_fss5 in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_full_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_fss5 = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT2 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_fss5 in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_full_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_fss5;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT2 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_ovr in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_ovr_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_ovr = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT2 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_ovr in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_ovr_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  BOOT status on INT2 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_boot in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_boot_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_boot = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  BOOT status on INT2 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_boot in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_boot_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT2 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_drdy in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_drdy_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_drdy = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT2 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_drdy in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_drdy_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_pin_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.pp_od = (uint8_t)val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_pin_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t *val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.pp_od){
+    case LIS3DHH_ALL_PUSH_PULL:
+      *val = LIS3DHH_ALL_PUSH_PULL;
+      break;
+    case LIS3DHH_INT1_OD_INT2_PP:
+      *val = LIS3DHH_INT1_OD_INT2_PP;
+      break;
+    case LIS3DHH_INT1_PP_INT2_OD:
+      *val = LIS3DHH_INT1_PP_INT2_OD;
+      break;
+    case LIS3DHH_ALL_OPEN_DRAIN:
+      *val = LIS3DHH_ALL_OPEN_DRAIN;
+      break;
+    default:
+      *val = LIS3DHH_ALL_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DHH_fifo
+  * @brief     This section group all the functions concerning the
+  *            fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFOenable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_en in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.fifo_en = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFOenable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the SPI high speed configuration for the FIFO block that
+            is used to guarantee a minimum duration of the window in which
+            writing operation of RAM output is blocked. This bit is recommended
+            for SPI clock frequencies higher than 6 MHz.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_spi_hs_on in reg CTRL_REG5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_block_spi_hs_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.fifo_spi_hs_on = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the SPI high speed configuration for the FIFO block that
+            is used to guarantee a minimum duration of the window in which
+            writing operation of RAM output is blocked. This bit is recommended
+            for SPI clock frequencies higher than 6 MHz.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_spi_hs_on in reg CTRL_REG5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_block_spi_hs_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.fifo_spi_hs_on;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fth in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_watermark_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.fth = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_watermark_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = fifo_ctrl.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fmode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t val)
+{
+  lis3dhh_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.fmode = (uint8_t)val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fmode in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t *val)
+{
+  lis3dhh_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+
+  switch (fifo_ctrl.fmode){
+    case LIS3DHH_BYPASS_MODE:
+      *val = LIS3DHH_BYPASS_MODE;
+      break;
+    case LIS3DHH_FIFO_MODE:
+      *val = LIS3DHH_FIFO_MODE;
+      break;
+    case LIS3DHH_STREAM_TO_FIFO_MODE:
+      *val = LIS3DHH_STREAM_TO_FIFO_MODE;
+      break;
+    case LIS3DHH_BYPASS_TO_STREAM_MODE:
+      *val = LIS3DHH_BYPASS_TO_STREAM_MODE;
+      break;
+    case LIS3DHH_DYNAMIC_STREAM_MODE:
+      *val = LIS3DHH_DYNAMIC_STREAM_MODE;
+      break;
+    default:
+      *val = LIS3DHH_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO status register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_status_get(lis3dhh_ctx_t *ctx, lis3dhh_fifo_src_t *val)
+{
+  int32_t ret;
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fss in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_full_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ovrn in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_ovr_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.ovrn;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_fifo_fth_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fth;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS3DHH_serial_interface
+  * @brief     This section group all the functions concerning serial
+  *            interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface (I2C or SPI).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_add_inc in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_auto_add_inc_set(lis3dhh_ctx_t *ctx, uint8_t val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.if_add_inc = val;
+    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface (I2C or SPI).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_add_inc in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis3dhh_auto_add_inc_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+{
+  lis3dhh_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.h
+++ b/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.h
@@ -1,0 +1,435 @@
+/*
+ ******************************************************************************
+ * @file    li3dhh_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          li3dhh_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS3DHH_REGS_H
+#define LIS3DHH_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS3DHH
+  * @{
+  *
+  */
+
+/** @defgroup LIS3DHH_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LIS3DHH_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis3dhh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis3dhh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis3dhh_write_ptr  write_reg;
+  lis3dhh_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis3dhh_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS3DHH_Infos
+  * @{
+  *
+  */
+
+/** Device Identification (Who am I) **/
+#define LIS3DHH_ID            0x11U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS3DHH_WHO_AM_I      0x0FU
+#define LIS3DHH_ID_REG        0x1BU
+typedef struct {
+  uint8_t not_used_01      : 7;
+  uint8_t asic_id          : 1;
+} lis3dhh_id_reg_t;
+
+#define LIS3DHH_CTRL_REG1     0x20U
+typedef struct {
+  uint8_t bdu              : 1;
+  uint8_t drdy_pulse       : 1;
+  uint8_t sw_reset         : 1;
+  uint8_t boot             : 1;
+  uint8_t not_used_01      : 2;
+  uint8_t if_add_inc       : 1;
+  uint8_t norm_mod_en      : 1;
+} lis3dhh_ctrl_reg1_t;
+
+#define LIS3DHH_INT1_CTRL     0x21U
+typedef struct {
+  uint8_t not_used_01      : 2;
+  uint8_t int1_ext         : 1;
+  uint8_t int1_fth         : 1;
+  uint8_t int1_fss5        : 1;
+  uint8_t int1_ovr         : 1;
+  uint8_t int1_boot        : 1;
+  uint8_t int1_drdy        : 1;
+} lis3dhh_int1_ctrl_t;
+
+#define LIS3DHH_INT2_CTRL     0x22U
+typedef struct {
+  uint8_t not_used_01      : 3;
+  uint8_t int2_fth         : 1;
+  uint8_t int2_fss5        : 1;
+  uint8_t int2_ovr         : 1;
+  uint8_t int2_boot        : 1;
+  uint8_t int2_drdy        : 1;
+} lis3dhh_int2_ctrl_t;
+
+#define LIS3DHH_CTRL_REG4     0x23U
+typedef struct {
+  uint8_t off_tcomp_en     : 1;
+  uint8_t fifo_en          : 1;
+  uint8_t pp_od            : 2;
+  uint8_t st               : 2;
+  uint8_t dsp              : 2;
+} lis3dhh_ctrl_reg4_t;
+
+#define LIS3DHH_CTRL_REG5     0x24U
+typedef struct {
+  uint8_t fifo_spi_hs_on   : 1;
+  uint8_t not_used_01      : 7;
+} lis3dhh_ctrl_reg5_t;
+
+#define LIS3DHH_OUT_TEMP_L    0x25U
+#define LIS3DHH_OUT_TEMP_H    0x26U
+#define LIS3DHH_STATUS        0x27U
+typedef struct {
+  uint8_t xda              : 1;
+  uint8_t yda              : 1;
+  uint8_t zda              : 1;
+  uint8_t zyxda            : 1;
+  uint8_t _xor             : 1;
+  uint8_t yor              : 1;
+  uint8_t zor              : 1;
+  uint8_t zyxor            : 1;
+} lis3dhh_status_t;
+
+#define LIS3DHH_OUT_X_L_XL    0x28U
+#define LIS3DHH_OUT_X_H_XL    0x29U
+#define LIS3DHH_OUT_Y_L_XL    0x2AU
+#define LIS3DHH_OUT_Y_H_XL    0x2BU
+#define LIS3DHH_OUT_Z_L_XL    0x2CU
+#define LIS3DHH_OUT_Z_H_XL    0x2DU
+#define LIS3DHH_FIFO_CTRL     0x2EU
+typedef struct {
+  uint8_t fth              : 5;
+  uint8_t fmode            : 3;
+} lis3dhh_fifo_ctrl_t;
+
+#define LIS3DHH_FIFO_SRC      0x2FU
+typedef struct {
+  uint8_t fss      : 6;
+  uint8_t ovrn      : 1;
+  uint8_t fth      : 1;
+} lis3dhh_fifo_src_t;
+
+/**
+  * @defgroup LIS3DHH_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis3dhh_id_reg_t       id_reg;
+  lis3dhh_ctrl_reg1_t    ctrl_reg1;
+  lis3dhh_int1_ctrl_t    int1_ctrl;
+  lis3dhh_int2_ctrl_t    int2_ctrl;
+  lis3dhh_ctrl_reg4_t    ctrl_reg4;
+  lis3dhh_ctrl_reg5_t    ctrl_reg5;
+  lis3dhh_status_t       status;
+  lis3dhh_fifo_ctrl_t    fifo_ctrl;
+  lis3dhh_fifo_src_t     fifo_src;
+  bitwise_t              bitwise;
+  uint8_t                byte;
+} lis3dhh_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis3dhh_read_reg(lis3dhh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lis3dhh_write_reg(lis3dhh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lis3dhh_from_lsb_to_mg(int16_t lsb);
+extern float_t lis3dhh_from_lsb_to_celsius(int16_t lsb);
+
+int32_t lis3dhh_block_data_update_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_block_data_update_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DHH_POWER_DOWN  = 0,
+  LIS3DHH_1kHz1       = 1,
+} lis3dhh_norm_mod_en_t;
+int32_t lis3dhh_data_rate_set(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t val);
+int32_t lis3dhh_data_rate_get(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t *val);
+
+int32_t lis3dhh_offset_temp_comp_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_offset_temp_comp_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_temperature_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dhh_acceleration_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3dhh_xl_data_ready_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_xl_data_ovr_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_device_id_get(lis3dhh_ctx_t *ctx, uint8_t *buff);
+typedef enum {
+  LIS3DHH_VER_A   = 0,
+  LIS3DHH_VER_B   = 1,
+} lis3dhh_asic_id_t;
+int32_t lis3dhh_asic_id_get(lis3dhh_ctx_t *ctx, lis3dhh_asic_id_t *val);
+
+
+int32_t lis3dhh_reset_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_reset_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_boot_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_boot_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DHH_ST_DISABLE   = 0,
+  LIS3DHH_ST_POSITIVE  = 1,
+  LIS3DHH_ST_NEGATIVE  = 2,
+} lis3dhh_st_t;
+int32_t lis3dhh_self_test_set(lis3dhh_ctx_t *ctx, lis3dhh_st_t val);
+int32_t lis3dhh_self_test_get(lis3dhh_ctx_t *ctx, lis3dhh_st_t *val);
+
+typedef enum {
+  LIS3DHH_LINEAR_PHASE_440Hz      = 0,
+  LIS3DHH_LINEAR_PHASE_235Hz      = 1,
+  LIS3DHH_NO_LINEAR_PHASE_440Hz   = 2,
+  LIS3DHH_NO_LINEAR_PHASE_235Hz   = 3,
+} lis3dhh_dsp_t;
+int32_t lis3dhh_filter_config_set(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t val);
+int32_t lis3dhh_filter_config_get(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t *val);
+
+int32_t lis3dhh_status_get(lis3dhh_ctx_t *ctx, lis3dhh_status_t *val);
+
+typedef enum {
+  LIS3DHH_LATCHED  = 0,
+  LIS3DHH_PULSED   = 1,
+} lis3dhh_drdy_pulse_t;
+int32_t lis3dhh_drdy_notification_mode_set(lis3dhh_ctx_t *ctx,
+                                           lis3dhh_drdy_pulse_t val);
+int32_t lis3dhh_drdy_notification_mode_get(lis3dhh_ctx_t *ctx,
+                                           lis3dhh_drdy_pulse_t *val);
+
+
+typedef enum {
+  LIS3DHH_PIN_AS_INTERRUPT   = 0,
+  LIS3DHH_PIN_AS_TRIGGER     = 1,
+} lis3dhh_int1_ext_t;
+int32_t lis3dhh_int1_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t val);
+int32_t lis3dhh_int1_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t *val);
+
+
+int32_t lis3dhh_fifo_threshold_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_threshold_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_full_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_full_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_ovr_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_ovr_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_boot_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_boot_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_drdy_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_drdy_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_threshold_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_threshold_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_full_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_full_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_ovr_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_ovr_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_boot_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_boot_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_drdy_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_drdy_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DHH_ALL_PUSH_PULL    = 0,
+  LIS3DHH_INT1_OD_INT2_PP  = 1,
+  LIS3DHH_INT1_PP_INT2_OD  = 2,
+  LIS3DHH_ALL_OPEN_DRAIN   = 3,
+} lis3dhh_pp_od_t;
+int32_t lis3dhh_pin_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t val);
+int32_t lis3dhh_pin_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t *val);
+
+int32_t lis3dhh_fifo_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_block_spi_hs_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_block_spi_hs_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_watermark_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_watermark_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS3DHH_BYPASS_MODE             = 0,
+  LIS3DHH_FIFO_MODE               = 1,
+  LIS3DHH_STREAM_TO_FIFO_MODE     = 3,
+  LIS3DHH_BYPASS_TO_STREAM_MODE   = 4,
+  LIS3DHH_DYNAMIC_STREAM_MODE     = 6,
+} lis3dhh_fmode_t;
+int32_t lis3dhh_fifo_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t val);
+int32_t lis3dhh_fifo_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t *val);
+
+int32_t lis3dhh_fifo_status_get(lis3dhh_ctx_t *ctx, lis3dhh_fifo_src_t *val);
+
+int32_t lis3dhh_fifo_full_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_ovr_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_fifo_fth_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3dhh_auto_add_inc_set(lis3dhh_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_auto_add_inc_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS3DHH_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis3mdl_STdC/driver/lis3mdl_reg.c
+++ b/sensor/stmemsc/lis3mdl_STdC/driver/lis3mdl_reg.c
@@ -1,0 +1,1426 @@
+/*
+ ******************************************************************************
+ * @file    lis3mdl_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS3MDL driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions 
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright 
+ *      notice, this list of conditions and the following disclaimer in the 
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its 
+ *      contributors may be used to endorse or promote products derived from 
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lis3mdl_reg.h"
+
+/**
+  * @defgroup    LIS3MDL
+  * @brief       This file provides a set of functions needed to drive the
+  *              lis3mdl enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LIS3MDL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_read_reg(lis3mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_write_reg(lis3mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS3MDL_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float lis3mdl_from_fs4_to_gauss(int16_t lsb)
+{
+  return ((float)lsb / 6842.0f);
+}
+
+float lis3mdl_from_fs8_to_gauss(int16_t lsb)
+{
+  return ((float)lsb / 3421.0f);
+}
+
+float lis3mdl_from_fs12_to_gauss(int16_t lsb)
+{
+  return ((float)lsb / 2281.0f);
+}
+
+float lis3mdl_from_fs16_to_gauss(int16_t lsb)
+{
+  return ((float)lsb / 1711.0f);
+}
+
+float lis3mdl_from_lsb_to_celsius(int16_t lsb)
+{
+  return ((float)lsb / 8.0f ) + ( 25.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS3MDL_Data_Generation
+  * @brief       This section group all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         change the values of om in reg CTRL_REG1
+  * @retval             interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_data_rate_set(lis3mdl_ctx_t *ctx, lis3mdl_om_t val)
+{
+  lis3mdl_ctrl_reg1_t ctrl_reg1;
+  lis3mdl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0)
+  {
+    ctrl_reg1.om = (uint8_t)val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  
+  if (ret == 0)
+  {
+    /* set mode also for z axis, ctrl_reg4 -> omz */
+    ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  
+  if (ret == 0)
+  {
+    ctrl_reg4.omz = (uint8_t)(((uint8_t) val >> 4) & 0x03U);
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      Get the values of om in reg CTRL_REG1(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_data_rate_get(lis3mdl_ctx_t *ctx, lis3mdl_om_t *val)
+{
+  lis3mdl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  /* z axis, ctrl_reg4 -> omz is aligned with x/y axis ctrl_reg1 -> om*/
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.om)
+  {
+    case LIS3MDL_LP_Hz625:
+      *val = LIS3MDL_LP_Hz625;
+      break;
+    case LIS3MDL_LP_1kHz:
+      *val = LIS3MDL_LP_1kHz;
+      break;
+    case LIS3MDL_MP_560Hz:
+      *val = LIS3MDL_MP_560Hz;
+      break;
+    case LIS3MDL_HP_300Hz:
+      *val = LIS3MDL_HP_300Hz;
+      break;
+    case LIS3MDL_UHP_155Hz:
+      *val = LIS3MDL_UHP_155Hz;
+      break;
+    case LIS3MDL_LP_1Hz25:
+      *val = LIS3MDL_LP_1Hz25;
+      break;
+    case LIS3MDL_LP_2Hz5:
+      *val = LIS3MDL_LP_2Hz5;
+      break;
+    case LIS3MDL_LP_5Hz:
+      *val = LIS3MDL_LP_5Hz;
+      break;
+    case LIS3MDL_LP_10Hz:
+      *val = LIS3MDL_LP_10Hz;
+      break;
+    case LIS3MDL_LP_20Hz:
+      *val = LIS3MDL_LP_20Hz;
+      break;
+    case LIS3MDL_LP_40Hz:
+      *val = LIS3MDL_LP_40Hz;
+      break;
+    case LIS3MDL_LP_80Hz:
+      *val = LIS3MDL_LP_80Hz;
+      break;
+    case LIS3MDL_MP_1Hz25:
+      *val = LIS3MDL_MP_1Hz25;
+      break;
+    case LIS3MDL_MP_2Hz5:
+      *val = LIS3MDL_MP_2Hz5;
+      break;
+    case LIS3MDL_MP_5Hz:
+      *val = LIS3MDL_MP_5Hz;
+      break;
+    case LIS3MDL_MP_10Hz:
+      *val = LIS3MDL_MP_10Hz;
+      break;
+    case LIS3MDL_MP_20Hz:
+      *val = LIS3MDL_MP_20Hz;
+      break;
+    case LIS3MDL_MP_40Hz:
+      *val = LIS3MDL_MP_40Hz;
+      break;
+    case LIS3MDL_MP_80Hz:
+      *val = LIS3MDL_MP_80Hz;
+      break;
+    case LIS3MDL_HP_1Hz25:
+      *val = LIS3MDL_HP_1Hz25;
+      break;
+    case LIS3MDL_HP_2Hz5:
+      *val = LIS3MDL_HP_2Hz5;
+      break;
+    case LIS3MDL_HP_5Hz:
+      *val = LIS3MDL_HP_5Hz;
+      break;
+    case LIS3MDL_HP_10Hz:
+      *val = LIS3MDL_HP_10Hz;
+      break;
+    case LIS3MDL_HP_20Hz:
+      *val = LIS3MDL_HP_20Hz;
+      break;
+    case LIS3MDL_HP_40Hz:
+      *val = LIS3MDL_HP_40Hz;
+      break;
+    case LIS3MDL_HP_80Hz:
+      *val = LIS3MDL_HP_80Hz;
+      break;
+    case LIS3MDL_UHP_1Hz25:
+      *val = LIS3MDL_UHP_1Hz25;
+      break;
+    case LIS3MDL_UHP_2Hz5:
+      *val = LIS3MDL_UHP_2Hz5;
+      break;
+    case LIS3MDL_UHP_5Hz:
+      *val = LIS3MDL_UHP_5Hz;
+      break;
+    case LIS3MDL_UHP_10Hz:
+      *val = LIS3MDL_UHP_10Hz;
+      break;
+    case LIS3MDL_UHP_20Hz:
+      *val = LIS3MDL_UHP_20Hz;
+      break;
+    case LIS3MDL_UHP_40Hz:
+      *val = LIS3MDL_UHP_40Hz;
+      break;
+    case LIS3MDL_UHP_80Hz:
+      *val = LIS3MDL_UHP_80Hz;
+      break;
+    default:
+      *val = LIS3MDL_UHP_80Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor enable[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of temp_en in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_temperature_meas_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0)
+  {
+    ctrl_reg1.temp_en = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor enable[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of temp_en in reg CTRL_REG1(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_temperature_meas_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = (uint8_t)ctrl_reg1.temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of fs in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_full_scale_set(lis3mdl_ctx_t *ctx, lis3mdl_fs_t val)
+{
+  lis3mdl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0)
+  {
+    ctrl_reg2.fs = (uint8_t)val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of fs in reg CTRL_REG2(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_full_scale_get(lis3mdl_ctx_t *ctx, lis3mdl_fs_t *val)
+{
+  lis3mdl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.fs)
+  {
+    case LIS3MDL_4_GAUSS:
+      *val = LIS3MDL_4_GAUSS;
+      break;
+    case LIS3MDL_8_GAUSS:
+      *val = LIS3MDL_8_GAUSS;
+      break;
+    case LIS3MDL_12_GAUSS:
+      *val = LIS3MDL_12_GAUSS;
+      break;
+    case LIS3MDL_16_GAUSS:
+      *val = LIS3MDL_16_GAUSS;
+      break;
+    default:
+      *val = LIS3MDL_4_GAUSS;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of md in reg CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_operating_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_md_t val)
+{
+  lis3mdl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0)
+  {
+    ctrl_reg3.md = (uint8_t)val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      Get the values of md in reg CTRL_REG3(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_operating_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_md_t *val)
+{
+  lis3mdl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.md)
+  {
+    case LIS3MDL_CONTINUOUS_MODE:
+      *val = LIS3MDL_CONTINUOUS_MODE;
+      break;
+    case LIS3MDL_SINGLE_TRIGGER:
+      *val = LIS3MDL_SINGLE_TRIGGER;
+      break;
+    case LIS3MDL_POWER_DOWN:
+      *val = LIS3MDL_POWER_DOWN;
+      break;
+    default:
+      *val = LIS3MDL_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  If this bit is high, device is set in low power to 0.625 Hz[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of lp in reg CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_fast_low_power_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0)
+  {
+    ctrl_reg3.lp = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  If this bit is high, device is set in low power to 0.625 Hz[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of lp in reg CTRL_REG3(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_fast_low_power_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = (uint8_t)ctrl_reg3.lp;
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of bdu in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_block_data_update_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0)
+  {
+    ctrl_reg5.bdu = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of bdu in reg CTRL_REG5(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_block_data_update_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  fast_read allows reading the high part of DATA OUT only in order
+  *         to increase reading efficiency[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of fast_read in reg CTRL_REG5
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_high_part_cycle_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0)
+  {
+    ctrl_reg5.fast_read = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  fast_read allows reading the high part of DATA OUT only in order
+  *         to increase reading efficiency[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of fast_read in reg CTRL_REG5(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_high_part_cycle_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = (uint8_t)ctrl_reg5.fast_read;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic set of data available[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of zyxda in reg STATUS_REG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_mag_data_ready_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = (uint8_t)status_reg.zyxda;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic set of data overrun[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of zyxor in reg STATUS_REG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_mag_data_ovr_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = (uint8_t)status_reg.zyxor;
+
+  return ret;
+}
+/**
+  * @brief  Magnetic output value[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      buffer that stores data read(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_magnetic_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_OUT_X_L, (uint8_t*) buff, 6);
+  return ret;
+}
+/**
+  * @brief  Temperature output value[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      buffer that stores data read(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_temperature_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;  
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_TEMP_OUT_L, (uint8_t*) buff, 2);
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS3MDL_Common
+  * @brief       This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      buffer that stores data read(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_device_id_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;  
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_WHO_AM_I, (uint8_t*) buff, 1);
+  return ret;
+}
+/**
+  * @brief  Self test[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of st in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_self_test_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0)
+  {
+    ctrl_reg1.st = (uint8_t)val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Self_test[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of st in reg CTRL_REG1(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_self_test_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = (uint8_t)ctrl_reg1.st;
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of soft_rst in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_reset_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0)
+  {
+    ctrl_reg2.soft_rst = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of soft_rst in reg CTRL_REG2(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_reset_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = (uint8_t)ctrl_reg2.soft_rst;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of reboot in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_boot_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0)
+  {
+    ctrl_reg2.reboot = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of reboot in reg CTRL_REG2(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_boot_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = (uint8_t)ctrl_reg2.reboot;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of ble in reg CTRL_REG4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_data_format_set(lis3mdl_ctx_t *ctx, lis3mdl_ble_t val)
+{
+  lis3mdl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0)
+  {
+    ctrl_reg4.ble = (uint8_t)val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      Get the values of ble in reg CTRL_REG4(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_data_format_get(lis3mdl_ctx_t *ctx, lis3mdl_ble_t *val)
+{
+  lis3mdl_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  switch (ctrl_reg4.ble)
+  {
+    case LIS3MDL_LSB_AT_LOW_ADD:
+      *val = LIS3MDL_LSB_AT_LOW_ADD;
+      break;
+    case LIS3MDL_MSB_AT_LOW_ADD:
+      *val = LIS3MDL_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LIS3MDL_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Status register[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      Registers STATUS_REG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_status_get(lis3mdl_ctx_t *ctx, lis3mdl_status_reg_t *val)
+{
+  return lis3mdl_read_reg(ctx, LIS3MDL_STATUS_REG, (uint8_t*) val, 1);
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS3MDL_interrupts
+  * @brief       This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt configuration register[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      Registers INT_CFG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_config_set(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val)
+{
+  return lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  Interrupt configuration register[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      Registers INT_CFG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_config_get(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val)
+{
+  return lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*) val, 1);
+}
+/**
+  * @brief  Interrupt enable on INT pin[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of ien in reg INT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_generation_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  if(ret == 0)
+  {
+    int_cfg.ien = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt enable on INT pin[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of ien in reg INT_CFG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_generation_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  *val = (uint8_t)int_cfg.ien;
+
+  return ret;
+}
+
+/**
+  * @brief   Interrupt request to the INT_SOURCE (25h) register
+  *      mode (pulsed / latched)[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of lir in reg INT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_notification_mode_set(lis3mdl_ctx_t *ctx,
+    lis3mdl_lir_t val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  if(ret == 0)
+  {
+    int_cfg.lir = (uint8_t)val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt request to the INT_SOURCE (25h) register
+  *          mode (pulsed / latched)[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of lir in reg INT_CFG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_notification_mode_get(lis3mdl_ctx_t *ctx,
+    lis3mdl_lir_t *val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  switch (int_cfg.lir)
+  {
+    case LIS3MDL_INT_PULSED:
+      *val = LIS3MDL_INT_PULSED;
+      break;
+    case LIS3MDL_INT_LATCHED:
+      *val = LIS3MDL_INT_LATCHED;
+      break;
+    default:
+      *val = LIS3MDL_INT_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of iea in reg INT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_polarity_set(lis3mdl_ctx_t *ctx, lis3mdl_iea_t val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  if(ret == 0)
+  {
+    int_cfg.iea = (uint8_t)val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of iea in reg INT_CFG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_polarity_get(lis3mdl_ctx_t *ctx, lis3mdl_iea_t *val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  switch (int_cfg.iea)
+  {
+    case LIS3MDL_ACTIVE_HIGH:
+      *val = LIS3MDL_ACTIVE_HIGH;
+      break;
+    case LIS3MDL_ACTIVE_LOW:
+      *val = LIS3MDL_ACTIVE_LOW;
+      break;
+    default:
+      *val = LIS3MDL_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on Z-axis[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of zien in reg INT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_on_z_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  if(ret == 0)
+  {
+    int_cfg.zien = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on Z-axis[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of zien in reg INT_CFG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_on_z_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  *val = (uint8_t)int_cfg.zien;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on Y-axis[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of yien in reg INT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_on_y_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  if(ret == 0)
+  {
+    int_cfg.yien = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on Y-axis[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of yien in reg INT_CFG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_on_y_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  *val = (uint8_t)int_cfg.yien;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on X-axis[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of xien in reg INT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_on_x_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  if(ret == 0)
+  {
+    int_cfg.xien = val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on X-axis[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of xien in reg INT_CFG(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_on_x_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_cfg_t int_cfg;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*)&int_cfg, 1);
+  *val = (uint8_t)int_cfg.xien;
+
+  return ret;
+}
+
+/**
+  * @brief Interrupt source register[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      register INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_source_get(lis3mdl_ctx_t *ctx, lis3mdl_int_src_t *val)
+{
+  return lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  Interrupt active flag[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of int in reg INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_interrupt_event_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_src_t int_src;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*)&int_src, 1);
+  *val = (uint8_t)int_src.int_;
+
+  return ret;
+}
+
+/**
+  * @brief  Internal measurement range overflow on magnetic value[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of mroi in reg INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_mag_over_range_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_src_t int_src;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*)&int_src, 1);
+  *val = (uint8_t)int_src.mroi;
+
+  return ret;
+}
+
+/**
+  * @brief  Value on Z-axis exceeds the threshold on the negative side.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of nth_z in reg INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_neg_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_src_t int_src;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*)&int_src, 1);
+  *val = (uint8_t)int_src.nth_z;
+
+  return ret;
+}
+
+/**
+  * @brief  Value on Y-axis exceeds the threshold on the negative side[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of nth_y in reg INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_neg_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_src_t int_src;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*)&int_src, 1);
+  *val = (uint8_t)int_src.nth_y;
+
+  return ret;
+}
+/**
+  * @brief  Value on X-axis exceeds the threshold on the negative side[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of nth_x in reg INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_neg_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_src_t int_src;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*)&int_src, 1);
+  *val = (uint8_t)int_src.nth_x;
+
+  return ret;
+}
+/**
+  * @brief  Value on Z-axis exceeds the threshold on the positive side[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pth_z in reg INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_pos_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_src_t int_src;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*)&int_src, 1);
+  *val = (uint8_t)int_src.pth_z;
+
+  return ret;
+}
+/**
+  * @brief  Value on Y-axis exceeds the threshold on the positive side[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pth_y in reg INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_pos_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_src_t int_src;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*)&int_src, 1);
+  *val = (uint8_t)int_src.pth_y;
+
+  return ret;
+}
+/**
+  * @brief  Value on X-axis exceeds the threshold on the positive side[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pth_x in reg INT_SRC(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_pos_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+{
+  lis3mdl_int_src_t int_src;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*)&int_src, 1);
+  *val = (uint8_t)int_src.pth_x;
+
+  return ret;
+}
+/**
+  * @brief  User-defined threshold value for pressure interrupt event[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param buff      buffer that contains data to write(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_threshold_set(lis3mdl_ctx_t *ctx, uint8_t *buff)
+{
+  return lis3mdl_read_reg(ctx, LIS3MDL_INT_THS_L, buff, 2);
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param buff      buffer that stores data read(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_int_threshold_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
+{
+  return lis3mdl_read_reg(ctx, LIS3MDL_INT_THS_L, buff, 2);
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LIS3MDL_Serial_Interface
+  * @brief       This section group all the functions concerning
+  *              serial interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sim in reg CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_spi_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_sim_t val)
+{
+  lis3mdl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0)
+  {
+    ctrl_reg3.sim = (uint8_t)val;
+    ret = lis3mdl_write_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sim in reg CTRL_REG3(ptr)
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis3mdl_spi_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_sim_t *val)
+{
+  lis3mdl_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lis3mdl_read_reg(ctx, LIS3MDL_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.sim)
+  {
+    case LIS3MDL_SPI_4_WIRE:
+      *val = LIS3MDL_SPI_4_WIRE;
+      break;
+    case LIS3MDL_SPI_3_WIRE:
+      *val = LIS3MDL_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS3MDL_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis3mdl_STdC/driver/lis3mdl_reg.h
+++ b/sensor/stmemsc/lis3mdl_STdC/driver/lis3mdl_reg.h
@@ -1,0 +1,493 @@
+/*
+ ******************************************************************************
+ * @file    lis3mdl_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis3mdl_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions 
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright 
+ *      notice, this list of conditions and the following disclaimer in the 
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its 
+ *      contributors may be used to endorse or promote products derived from 
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS3MDL_REGS_H
+#define LIS3MDL_REGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS3MDL
+  * @{
+  *
+  */
+
+/** @defgroup LIS3MDL_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LIS3MDL_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lis3mdl_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lis3mdl_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lis3mdl_write_ptr  write_reg;
+  lis3mdl_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lis3mdl_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS3MDL_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0x39 if SA0=1 -> 0x3D **/
+#define LIS3MDL_I2C_ADD_L   0x39U
+#define LIS3MDL_I2C_ADD_H   0x3DU
+
+/** Device Identification (Who am I) **/
+#define LIS3MDL_ID          0x3DU
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  LIS3MDL_Sensitivity
+  * @brief       These macro are maintained for back compatibility.
+  *              in order to convert data into engineering units please
+  *              use functions:
+  *                -> _from_fs4_to_gauss(int16_t lsb);
+  *                -> _from_fs8_to_gauss(int16_t lsb);
+  *                -> _from_fs12_to_gauss(int16_t lsb);
+  *                -> _from_fs16_to_gauss(int16_t lsb);
+  *                -> _from_lsb_to_celsius(int16_t lsb);
+  *
+  *              REMOVING the MACRO you are compliant with:
+  *              MISRA-C 2012 [Dir 4.9] -> " avoid function-like macros "
+  * @{
+  *
+  */
+
+#define LIS3MDL_FROM_FS_4G_TO_G(lsb)     (float)( lsb / 6842.0f )
+#define LIS3MDL_FROM_FS_8G_TO_G(lsb)     (float)( lsb / 3421.0f )
+#define LIS3MDL_FROM_FS_12G_TO_G(lsb)    (float)( lsb / 2281.0f )
+#define LIS3MDL_FROM_FS_16G_TO_G(lsb)    (float)( lsb / 1711.0f )
+
+#define LIS3MDL_FROM_LSB_TO_degC(lsb)    (float)(lsb / 8.0f ) + ( 25.0f )
+
+/**
+  * @}
+  *
+  */
+
+#define LIS3MDL_WHO_AM_I       0x0FU
+#define LIS3MDL_CTRL_REG1      0x20U
+typedef struct{
+  uint8_t st              : 1;
+  uint8_t om              : 6; /* om + do + fast_odr -> om */
+  uint8_t temp_en         : 1;
+} lis3mdl_ctrl_reg1_t;
+
+#define LIS3MDL_CTRL_REG2      0x21U
+typedef struct
+{
+  uint8_t not_used_01     : 2;
+  uint8_t soft_rst        : 1;
+  uint8_t reboot          : 1;
+  uint8_t not_used_02     : 1;
+  uint8_t fs              : 2;
+  uint8_t not_used_03     : 1;
+} lis3mdl_ctrl_reg2_t;
+
+#define LIS3MDL_CTRL_REG3      0x22U
+typedef struct{
+  uint8_t md              : 2;
+  uint8_t sim             : 1;
+  uint8_t not_used_01     : 2;
+  uint8_t lp              : 1;
+  uint8_t not_used_02     : 2;
+} lis3mdl_ctrl_reg3_t;
+
+#define LIS3MDL_CTRL_REG4      0x23U
+typedef struct{
+  uint8_t not_used_01     : 1;
+  uint8_t ble             : 1;
+  uint8_t omz             : 2;
+  uint8_t not_used_02     : 4;
+} lis3mdl_ctrl_reg4_t;
+
+#define LIS3MDL_CTRL_REG5      0x24U
+typedef struct{
+  uint8_t not_used_01     : 6;
+  uint8_t bdu             : 1;
+  uint8_t fast_read       : 1;
+} lis3mdl_ctrl_reg5_t;
+
+#define LIS3MDL_STATUS_REG     0x27U
+typedef struct{
+  uint8_t xda             : 1;
+  uint8_t yda             : 1;
+  uint8_t zda             : 1;
+  uint8_t zyxda           : 1;
+  uint8_t _xor            : 1;
+  uint8_t yor             : 1;
+  uint8_t zor             : 1;
+  uint8_t zyxor           : 1;
+} lis3mdl_status_reg_t;
+
+#define LIS3MDL_OUT_X_L        0x28U
+#define LIS3MDL_OUT_X_H        0x29U
+#define LIS3MDL_OUT_Y_L        0x2AU
+#define LIS3MDL_OUT_Y_H        0x2BU
+#define LIS3MDL_OUT_Z_L        0x2CU
+#define LIS3MDL_OUT_Z_H        0x2DU
+#define LIS3MDL_TEMP_OUT_L     0x2EU
+#define LIS3MDL_TEMP_OUT_H     0x2FU
+#define LIS3MDL_INT_CFG        0x30U
+typedef struct{
+  uint8_t ien             : 1;
+  uint8_t lir             : 1;
+  uint8_t iea             : 1;
+  uint8_t not_used_01     : 2;
+  uint8_t zien            : 1;
+  uint8_t yien            : 1;
+  uint8_t xien            : 1;
+} lis3mdl_int_cfg_t;
+
+#define LIS3MDL_INT_SRC        0x31U
+typedef struct{
+  uint8_t int_            : 1;
+  uint8_t mroi            : 1;
+  uint8_t nth_z           : 1;
+  uint8_t nth_y           : 1;
+  uint8_t nth_x           : 1;
+  uint8_t pth_z           : 1;
+  uint8_t pth_y           : 1;
+  uint8_t pth_x           : 1;
+} lis3mdl_int_src_t;
+
+#define LIS3MDL_INT_THS_L      0x32U
+#define LIS3MDL_INT_THS_H      0x33U
+
+/**
+  * @defgroup LIS3MDL_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis3mdl_ctrl_reg1_t      ctrl_reg1;
+  lis3mdl_ctrl_reg2_t      ctrl_reg2;
+  lis3mdl_ctrl_reg3_t      ctrl_reg3;
+  lis3mdl_ctrl_reg4_t      ctrl_reg4;
+  lis3mdl_ctrl_reg5_t      ctrl_reg5;
+  lis3mdl_status_reg_t     status_reg;
+  lis3mdl_int_cfg_t        int_cfg;
+  lis3mdl_int_src_t        int_src;
+  bitwise_t                bitwise;
+  uint8_t                  byte;
+} lis3mdl_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis3mdl_read_reg(lis3mdl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lis3mdl_write_reg(lis3mdl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float lis3mdl_from_fs4_to_gauss(int16_t lsb);
+extern float lis3mdl_from_fs8_to_gauss(int16_t lsb);
+extern float lis3mdl_from_fs12_to_gauss(int16_t lsb);
+extern float lis3mdl_from_fs16_to_gauss(int16_t lsb);
+extern float lis3mdl_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum{
+  LIS3MDL_LP_Hz625      = 0x00,
+  LIS3MDL_LP_1kHz       = 0x01,
+  LIS3MDL_MP_560Hz      = 0x11,
+  LIS3MDL_HP_300Hz      = 0x21,
+  LIS3MDL_UHP_155Hz     = 0x31,
+
+  LIS3MDL_LP_1Hz25      = 0x02,
+  LIS3MDL_LP_2Hz5       = 0x04,
+  LIS3MDL_LP_5Hz        = 0x06,
+  LIS3MDL_LP_10Hz       = 0x08,
+  LIS3MDL_LP_20Hz       = 0x0A,
+  LIS3MDL_LP_40Hz       = 0x0C,
+  LIS3MDL_LP_80Hz       = 0x0E,
+
+  LIS3MDL_MP_1Hz25      = 0x12,
+  LIS3MDL_MP_2Hz5       = 0x14,
+  LIS3MDL_MP_5Hz        = 0x16,
+  LIS3MDL_MP_10Hz       = 0x18,
+  LIS3MDL_MP_20Hz       = 0x1A,
+  LIS3MDL_MP_40Hz       = 0x1C,
+  LIS3MDL_MP_80Hz       = 0x1E,
+
+  LIS3MDL_HP_1Hz25      = 0x22,
+  LIS3MDL_HP_2Hz5       = 0x24,
+  LIS3MDL_HP_5Hz        = 0x26,
+  LIS3MDL_HP_10Hz       = 0x28,
+  LIS3MDL_HP_20Hz       = 0x2A,
+  LIS3MDL_HP_40Hz       = 0x2C,
+  LIS3MDL_HP_80Hz       = 0x2E,
+
+  LIS3MDL_UHP_1Hz25     = 0x32,
+  LIS3MDL_UHP_2Hz5      = 0x34,
+  LIS3MDL_UHP_5Hz       = 0x36,
+  LIS3MDL_UHP_10Hz      = 0x38,
+  LIS3MDL_UHP_20Hz      = 0x3A,
+  LIS3MDL_UHP_40Hz      = 0x3C,
+  LIS3MDL_UHP_80Hz      = 0x3E,
+
+} lis3mdl_om_t;
+int32_t lis3mdl_data_rate_set(lis3mdl_ctx_t *ctx, lis3mdl_om_t val);
+int32_t lis3mdl_data_rate_get(lis3mdl_ctx_t *ctx, lis3mdl_om_t *val);
+
+int32_t lis3mdl_temperature_meas_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_temperature_meas_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+typedef enum{
+  LIS3MDL_4_GAUSS   = 0,
+  LIS3MDL_8_GAUSS   = 1,
+  LIS3MDL_12_GAUSS  = 2,
+  LIS3MDL_16_GAUSS  = 3,
+} lis3mdl_fs_t;
+int32_t lis3mdl_full_scale_set(lis3mdl_ctx_t *ctx, lis3mdl_fs_t val);
+int32_t lis3mdl_full_scale_get(lis3mdl_ctx_t *ctx, lis3mdl_fs_t *val);
+
+typedef enum{
+  LIS3MDL_CONTINUOUS_MODE  = 0,
+  LIS3MDL_SINGLE_TRIGGER   = 1,
+  LIS3MDL_POWER_DOWN       = 2,
+} lis3mdl_md_t;
+int32_t lis3mdl_operating_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_md_t val);
+int32_t lis3mdl_operating_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_md_t *val);
+
+int32_t lis3mdl_fast_low_power_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_fast_low_power_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_block_data_update_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_block_data_update_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_high_part_cycle_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_high_part_cycle_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_mag_data_ready_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_mag_data_ovr_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_magnetic_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3mdl_temperature_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3mdl_device_id_get(lis3mdl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis3mdl_self_test_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_self_test_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_reset_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_reset_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_boot_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_boot_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+typedef enum{
+  LIS3MDL_LSB_AT_LOW_ADD  = 0,
+  LIS3MDL_MSB_AT_LOW_ADD  = 1,
+} lis3mdl_ble_t;
+int32_t lis3mdl_data_format_set(lis3mdl_ctx_t *ctx, lis3mdl_ble_t val);
+int32_t lis3mdl_data_format_get(lis3mdl_ctx_t *ctx, lis3mdl_ble_t *val);
+
+int32_t lis3mdl_status_get(lis3mdl_ctx_t *ctx, lis3mdl_status_reg_t *val);
+
+int32_t lis3mdl_int_config_set(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val);
+int32_t lis3mdl_int_config_get(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val);
+
+int32_t lis3mdl_int_generation_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_int_generation_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+typedef enum{
+  LIS3MDL_INT_PULSED   = 0,
+  LIS3MDL_INT_LATCHED  = 1,
+} lis3mdl_lir_t;
+int32_t lis3mdl_int_notification_mode_set(lis3mdl_ctx_t *ctx,
+                                          lis3mdl_lir_t val);
+int32_t lis3mdl_int_notification_mode_get(lis3mdl_ctx_t *ctx,
+                                          lis3mdl_lir_t *val);
+
+typedef enum{
+  LIS3MDL_ACTIVE_HIGH  = 0,
+  LIS3MDL_ACTIVE_LOW   = 1,
+} lis3mdl_iea_t;
+int32_t lis3mdl_int_polarity_set(lis3mdl_ctx_t *ctx, lis3mdl_iea_t val);
+int32_t lis3mdl_int_polarity_get(lis3mdl_ctx_t *ctx, lis3mdl_iea_t *val);
+
+int32_t lis3mdl_int_on_z_ax_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_int_on_z_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_on_y_ax_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_int_on_y_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_on_x_ax_set(lis3mdl_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_int_on_x_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_source_get(lis3mdl_ctx_t *ctx, lis3mdl_int_src_t *val);
+
+int32_t lis3mdl_interrupt_event_flag_get(lis3mdl_ctx_t *ctx,
+    uint8_t *val);
+
+int32_t lis3mdl_int_mag_over_range_flag_get(lis3mdl_ctx_t *ctx,
+    uint8_t *val);
+
+int32_t lis3mdl_int_neg_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_neg_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_neg_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_pos_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_pos_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_pos_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+
+int32_t lis3mdl_int_threshold_set(lis3mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis3mdl_int_threshold_get(lis3mdl_ctx_t *ctx, uint8_t *buff);
+
+typedef enum{
+  LIS3MDL_SPI_4_WIRE   = 0,
+  LIS3MDL_SPI_3_WIRE   = 1,
+} lis3mdl_sim_t;
+int32_t lis3mdl_spi_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_sim_t val);
+int32_t lis3mdl_spi_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_sim_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIS3MDL_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.c
+++ b/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.c
@@ -1,0 +1,1865 @@
+/*
+ ******************************************************************************
+ * @file    lps22hb_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LPS22HB driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lps22hb_reg.h"
+
+/**
+  * @defgroup    LPS22HB
+  * @brief       This file provides a set of functions needed to drive the
+  *              ultra-compact piezoresistive absolute pressure sensor.
+  * @{
+  *
+  */
+
+/** 
+  * @defgroup    LPS22HB_Interfaces_functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hb_read_reg(lps22hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hb_write_reg(lps22hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS22HB_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lps22hb_from_lsb_to_hpa(uint32_t lsb)
+{
+  return ( (float_t)lsb / 4096.0f );
+}
+
+float_t lps22hb_from_lsb_to_degc(int16_t lsb)
+{
+  return ( (float_t)lsb / 100.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS22HB_data_generation_c
+  * @brief       This section group all the functions concerning data
+  *              generation
+  * @{
+  *
+  */
+
+
+/**
+  * @brief  Reset Autozero function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_az in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+
+int32_t lps22hb_autozero_rst_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.reset_az = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Autozero function.[get] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_az in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_autozero_rst_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.reset_az;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autozero in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_autozero_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG, 
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.autozero = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autozero in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_autozero_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.autozero;
+
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[set] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_snap_rst_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.reset_arp = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_snap_rst_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.reset_arp;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRifP function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autorifp in reg INTERRUPT_CFG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_snap_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.autorifp = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRifP function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autorifp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_snap_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.autorifp;
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_block_data_update_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.bdu = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_block_data_update_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lpfp in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_low_pass_filter_mode_set(lps22hb_ctx_t *ctx,
+                                          lps22hb_lpfp_t val)
+{
+  lps22hb_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.lpfp = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Low-pass bandwidth selection.[get] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpfp in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_low_pass_filter_mode_get(lps22hb_ctx_t *ctx,
+                                         lps22hb_lpfp_t *val)
+{
+  lps22hb_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.lpfp){
+    case LPS22HB_LPF_ODR_DIV_2:
+      *val = LPS22HB_LPF_ODR_DIV_2;
+      break;
+    case LPS22HB_LPF_ODR_DIV_9:
+      *val = LPS22HB_LPF_ODR_DIV_9;
+      break;
+    case LPS22HB_LPF_ODR_DIV_20:
+      *val = LPS22HB_LPF_ODR_DIV_20;
+      break;
+    default:
+      *val = LPS22HB_LPF_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_data_rate_set(lps22hb_ctx_t *ctx, lps22hb_odr_t val)
+{
+  lps22hb_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.odr = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_data_rate_get(lps22hb_ctx_t *ctx, lps22hb_odr_t *val)
+{
+  lps22hb_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.odr){
+    case LPS22HB_POWER_DOWN:
+      *val = LPS22HB_POWER_DOWN;
+      break;
+    case LPS22HB_ODR_1_Hz:
+      *val = LPS22HB_ODR_1_Hz;
+      break;
+    case LPS22HB_ODR_10_Hz:
+      *val = LPS22HB_ODR_10_Hz;
+      break;
+    case LPS22HB_ODR_25_Hz:
+      *val = LPS22HB_ODR_25_Hz;
+      break;
+    case LPS22HB_ODR_50_Hz:
+      *val = LPS22HB_ODR_50_Hz;
+      break;
+    case LPS22HB_ODR_75_Hz:
+      *val = LPS22HB_ODR_75_Hz;
+      break;
+    default:
+      *val = LPS22HB_ODR_1_Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[set] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of one_shot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_one_shoot_trigger_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.one_shot = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of one_shot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_one_shoot_trigger_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.one_shot;
+
+  return ret;
+}
+
+/**
+  * @brief  pressure_ref:   The Reference pressure value is a 24-bit data
+  *         expressed as 2’s complement. The value is used when AUTOZERO
+  *         or AUTORIFP function is enabled.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_ref_set(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_write_reg(ctx, LPS22HB_REF_P_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  pressure_ref:   The Reference pressure value is a 24-bit data
+  *         expressed as 2’s complement. The value is used when AUTOZERO
+  *         or AUTORIFP function is enabled.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_ref_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_REF_P_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data that can be used to
+  *         implement one-point calibration (OPC) after soldering.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_offset_set(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_write_reg(ctx, LPS22HB_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data that can be used to
+  *         implement one-point calibration (OPC) after soldering.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_offset_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Pressure data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of p_da in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_press_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_status_t status;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_STATUS, (uint8_t*)&status, 1);
+  *val = status.p_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of t_da in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_temp_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_status_t status;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_STATUS, (uint8_t*)&status, 1);
+  *val = status.t_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of p_or in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_press_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_status_t status;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_STATUS, (uint8_t*)&status, 1);
+  *val = status.p_or;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of t_or in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_temp_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_status_t status;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_STATUS, (uint8_t*)&status, 1);
+  *val = status.t_or;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure output value[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pressure_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_PRESS_OUT_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  temperature_raw:   Temperature output value[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_temperature_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_TEMP_OUT_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Low-pass filter reset register. If the LPFP is active, in
+  *         order to avoid the transitory phase, the filter can be
+  *         reset by reading this register before generating pressure
+  *         measurements.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_low_pass_rst_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_LPFP_RES, (uint8_t*) buff, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS22HB_common
+  * @brief       This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_device_id_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_WHO_AM_I, (uint8_t*) buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of swreset in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_reset_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.swreset = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of swreset in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_reset_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.swreset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_boot_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.boot = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_boot_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Low current mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lc_en in reg RES_CONF
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_low_power_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_res_conf_t res_conf;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_RES_CONF, (uint8_t*)&res_conf, 1);
+  if(ret == 0){
+    res_conf.lc_en = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_RES_CONF, (uint8_t*)&res_conf, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low current mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lc_en in reg RES_CONF
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_low_power_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_res_conf_t res_conf;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_RES_CONF, (uint8_t*)&res_conf, 1);
+  *val = res_conf.lc_en;
+
+  return ret;
+}
+
+/**
+  * @brief  If ‘1’ indicates that the Boot (Reboot) phase is running.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot_status in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_boot_status_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.boot_status;
+
+  return ret;
+}
+
+/**
+  * @brief  All the status bit, FIFO and data generation[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from FIFO_STATUS to STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_dev_status_get(lps22hb_ctx_t *ctx, lps22hb_dev_stat_t *val)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_FIFO_STATUS, (uint8_t*) val, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS22HB_interrupts
+  * @brief       This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pe in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_sign_of_int_threshold_set(lps22hb_ctx_t *ctx,
+                                           lps22hb_pe_t val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.pe = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pe in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_sign_of_int_threshold_get(lps22hb_ctx_t *ctx,
+                                           lps22hb_pe_t *val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  switch (interrupt_cfg.pe){
+    case LPS22HB_NO_THRESHOLD:
+      *val = LPS22HB_NO_THRESHOLD;
+      break;
+    case LPS22HB_POSITIVE:
+      *val = LPS22HB_POSITIVE;
+      break;
+    case LPS22HB_NEGATIVE:
+      *val = LPS22HB_NEGATIVE;
+      break;
+    case LPS22HB_BOTH:
+      *val = LPS22HB_BOTH;
+      break;
+    default:
+      *val = LPS22HB_NO_THRESHOLD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt request to the INT_SOURCE (25h) register
+  *         mode (pulsed / latched) [set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lir in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_notification_mode_set(lps22hb_ctx_t *ctx,
+                                           lps22hb_lir_t val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.lir = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt request to the INT_SOURCE (25h) register
+  *          mode (pulsed / latched) [get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lir in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_notification_mode_get(lps22hb_ctx_t *ctx,
+                                          lps22hb_lir_t *val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  switch (interrupt_cfg.lir){
+    case LPS22HB_INT_PULSED:
+      *val = LPS22HB_INT_PULSED;
+      break;
+    case LPS22HB_INT_LATCHED:
+      *val = LPS22HB_INT_LATCHED;
+      break;
+    default:
+      *val = LPS22HB_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of diff_en in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_generation_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.diff_en = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of diff_en in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_generation_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.diff_en;
+
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_threshold_set(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_write_reg(ctx, LPS22HB_THS_P_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_threshold_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_THS_P_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT_DRDY pin control bits.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int_s in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_int_s_t val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.int_s = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT_DRDY pin control bits.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of int_s in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_int_s_t *val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.int_s){
+    case LPS22HB_DRDY_OR_FIFO_FLAGS:
+      *val = LPS22HB_DRDY_OR_FIFO_FLAGS;
+      break;
+    case LPS22HB_HIGH_PRES_INT:
+      *val = LPS22HB_HIGH_PRES_INT;
+      break;
+    case LPS22HB_LOW_PRES_INT:
+      *val = LPS22HB_LOW_PRES_INT;
+      break;
+    case LPS22HB_EVERY_PRES_INT:
+      *val = LPS22HB_EVERY_PRES_INT;
+      break;
+    default:
+      *val = LPS22HB_DRDY_OR_FIFO_FLAGS;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_drdy_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.drdy = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_drdy_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_ovr in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_ovr_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_ovr = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_ovr in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_ovr_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fth in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_threshold_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_fth = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   FIFO watermark status on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fth in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_threshold_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fss5 in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_full_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_fss5 = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fss5 in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_full_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_fss5;
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_pp_od_t val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_pp_od_t *val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.pp_od){
+    case LPS22HB_PUSH_PULL:
+      *val = LPS22HB_PUSH_PULL;
+      break;
+    case LPS22HB_OPEN_DRAIN:
+      *val = LPS22HB_OPEN_DRAIN;
+      break;
+    default:
+      *val = LPS22HB_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int_h_l in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_polarity_set(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.int_h_l = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of int_h_l in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_polarity_get(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t *val)
+{
+  lps22hb_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.int_h_l){
+    case LPS22HB_ACTIVE_HIGH:
+      *val = LPS22HB_ACTIVE_HIGH;
+      break;
+    case LPS22HB_ACTIVE_LOW:
+      *val = LPS22HB_ACTIVE_LOW;
+      break;
+    default:
+      *val = LPS22HB_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt source register[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Register INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_source_get(lps22hb_ctx_t *ctx, lps22hb_int_source_t *val)
+{
+  int32_t ret;
+  ret =  lps22hb_read_reg(ctx, LPS22HB_INT_SOURCE, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Differential pressure high interrupt flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ph in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_on_press_high_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.ph;
+
+  return ret;
+}
+
+/**
+  * @brief  Differential pressure low interrupt flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pl in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_int_on_press_low_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.pl;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ia in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_interrupt_event_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.ia;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS22HB_fifo
+  * @brief       This section group all the functions concerning the
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief   Stop on FIFO watermark. Enable FIFO watermark level use.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_stop_on_fifo_threshold_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.stop_on_fth = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Stop on FIFO watermark. Enable FIFO watermark level use.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_stop_on_fifo_threshold_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_en in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.fifo_en = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_en in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wtm in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_watermark_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.wtm = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wtm in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_watermark_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = fifo_ctrl.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_mode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_mode_set(lps22hb_ctx_t *ctx, lps22hb_f_mode_t val)
+{
+  lps22hb_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.f_mode = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of f_mode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_mode_get(lps22hb_ctx_t *ctx, lps22hb_f_mode_t *val)
+{
+  lps22hb_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  switch (fifo_ctrl.f_mode){
+    case LPS22HB_BYPASS_MODE:
+      *val = LPS22HB_BYPASS_MODE;
+      break;
+    case LPS22HB_FIFO_MODE:
+      *val = LPS22HB_FIFO_MODE;
+      break;
+    case LPS22HB_STREAM_MODE:
+      *val = LPS22HB_STREAM_MODE;
+      break;
+    case LPS22HB_STREAM_TO_FIFO_MODE:
+      *val = LPS22HB_STREAM_TO_FIFO_MODE;
+      break;
+    case LPS22HB_BYPASS_TO_STREAM_MODE:
+      *val = LPS22HB_BYPASS_TO_STREAM_MODE;
+      break;
+    case LPS22HB_DYNAMIC_STREAM_MODE:
+      *val = LPS22HB_DYNAMIC_STREAM_MODE;
+      break;
+    case LPS22HB_BYPASS_TO_FIFO_MODE:
+      *val = LPS22HB_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LPS22HB_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fss in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_data_level_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ovr in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_ovr_flag_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth_fifo in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_fifo_fth_flag_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.fth_fifo;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS22HB_serial_interface
+  * @brief       This section group all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sim in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_spi_mode_set(lps22hb_ctx_t *ctx, lps22hb_sim_t val)
+{
+  lps22hb_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.sim = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_spi_mode_get(lps22hb_ctx_t *ctx, lps22hb_sim_t *val)
+{
+  lps22hb_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.sim){
+    case LPS22HB_SPI_4_WIRE:
+      *val = LPS22HB_SPI_4_WIRE;
+      break;
+    case LPS22HB_SPI_3_WIRE:
+      *val = LPS22HB_SPI_3_WIRE;
+      break;
+    default:
+      *val = LPS22HB_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of i2c_dis in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_i2c_interface_set(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.i2c_dis = (uint8_t)val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of i2c_dis in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_i2c_interface_get(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t *val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.i2c_dis){
+    case LPS22HB_I2C_ENABLE:
+      *val = LPS22HB_I2C_ENABLE;
+      break;
+    case LPS22HB_I2C_DISABLE:
+      *val = LPS22HB_I2C_DISABLE;
+      break;
+    default:
+      *val = LPS22HB_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a
+  *         multiple byte access with a serial interface (I2C or SPI).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_add_inc in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_auto_add_inc_set(lps22hb_ctx_t *ctx, uint8_t val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.if_add_inc = val;
+    ret = lps22hb_write_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a
+  *         multiple byte access with a serial interface (I2C or SPI).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_add_inc in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps22hb_auto_add_inc_get(lps22hb_ctx_t *ctx, uint8_t *val)
+{
+  lps22hb_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hb_read_reg(ctx, LPS22HB_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.h
+++ b/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.h
@@ -1,0 +1,502 @@
+/*
+ ******************************************************************************
+ * @file    lps22hb_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lps22hb_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LPS22HB_REGS_H
+#define LPS22HB_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LPS22HB
+  * @{
+  *
+  */
+
+/** @defgroup LPS22HB_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LPS22HB_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lps22hb_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lps22hb_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lps22hb_write_ptr  write_reg;
+  lps22hb_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lps22hb_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+
+/** @defgroup LSM9DS1_Infos
+  * @{
+  *
+  */
+
+  /** I2C Device Address 8 bit format: if SA0=0 -> 0xB9 if SA0=1 -> 0xBB **/
+#define LPS22HB_I2C_ADD_H   0xBBU
+#define LPS22HB_I2C_ADD_L   0xB9U
+
+/** Device Identification (Who am I) **/
+#define LPS22HB_ID            0xB1U
+
+/**
+  * @}
+  *
+  */
+
+#define LPS22HB_INTERRUPT_CFG  0x0BU
+typedef struct {
+  uint8_t pe               : 2; /* ple + phe -> pe */
+  uint8_t lir              : 1;
+  uint8_t diff_en          : 1;
+  uint8_t reset_az         : 1;
+  uint8_t autozero         : 1;
+  uint8_t reset_arp        : 1;
+  uint8_t autorifp         : 1;
+} lps22hb_interrupt_cfg_t;
+
+#define LPS22HB_THS_P_L        0x0CU
+#define LPS22HB_THS_P_H        0x0DU
+#define LPS22HB_WHO_AM_I       0x0FU
+#define LPS22HB_CTRL_REG1      0x10U
+typedef struct {
+  uint8_t sim              : 1;
+  uint8_t bdu              : 1;
+  uint8_t lpfp             : 2; /* en_lpfp + lpfp_cfg -> lpfp */
+  uint8_t odr              : 3;
+  uint8_t not_used_01      : 1;
+} lps22hb_ctrl_reg1_t;
+
+#define LPS22HB_CTRL_REG2      0x11U
+typedef struct {
+  uint8_t one_shot         : 1;
+  uint8_t not_used_01      : 1;
+  uint8_t swreset          : 1;
+  uint8_t i2c_dis          : 1;
+  uint8_t if_add_inc       : 1;
+  uint8_t stop_on_fth      : 1;
+  uint8_t fifo_en          : 1;
+  uint8_t boot             : 1;
+} lps22hb_ctrl_reg2_t;
+
+#define LPS22HB_CTRL_REG3      0x12U
+typedef struct {
+  uint8_t int_s            : 2;
+  uint8_t drdy             : 1;
+  uint8_t f_ovr            : 1;
+  uint8_t f_fth            : 1;
+  uint8_t f_fss5           : 1;
+  uint8_t pp_od            : 1;
+  uint8_t int_h_l          : 1;
+} lps22hb_ctrl_reg3_t;
+
+
+#define LPS22HB_FIFO_CTRL      0x14U
+typedef struct {
+  uint8_t wtm              : 5;
+  uint8_t f_mode           : 3;
+} lps22hb_fifo_ctrl_t;
+
+#define LPS22HB_REF_P_XL       0x15U
+#define LPS22HB_REF_P_L        0x16U
+#define LPS22HB_REF_P_H        0x17U
+#define LPS22HB_RPDS_L         0x18U
+#define LPS22HB_RPDS_H         0x19U
+
+#define LPS22HB_RES_CONF       0x1AU
+typedef struct {
+  uint8_t lc_en            : 1;
+  uint8_t not_used_01      : 7;
+} lps22hb_res_conf_t;
+
+#define LPS22HB_INT_SOURCE     0x25U
+typedef struct {
+  uint8_t ph               : 1;
+  uint8_t pl               : 1;
+  uint8_t ia               : 1;
+  uint8_t not_used_01      : 4;
+  uint8_t boot_status      : 1;
+} lps22hb_int_source_t;
+
+#define LPS22HB_FIFO_STATUS    0x26U
+typedef struct {
+  uint8_t fss              : 6;
+  uint8_t ovr              : 1;
+  uint8_t fth_fifo         : 1;
+} lps22hb_fifo_status_t;
+
+#define LPS22HB_STATUS         0x27U
+typedef struct {
+  uint8_t p_da             : 1;
+  uint8_t t_da             : 1;
+  uint8_t not_used_02      : 2;
+  uint8_t p_or             : 1;
+  uint8_t t_or             : 1;
+  uint8_t not_used_01      : 2;
+} lps22hb_status_t;
+
+#define LPS22HB_PRESS_OUT_XL   0x28U
+#define LPS22HB_PRESS_OUT_L    0x29U
+#define LPS22HB_PRESS_OUT_H    0x2AU
+#define LPS22HB_TEMP_OUT_L     0x2BU
+#define LPS22HB_TEMP_OUT_H     0x2CU
+#define LPS22HB_LPFP_RES       0x33U
+
+/**
+  * @defgroup LPS22HB_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  lps22hb_interrupt_cfg_t      interrupt_cfg;
+  lps22hb_ctrl_reg1_t          ctrl_reg1;
+  lps22hb_ctrl_reg2_t          ctrl_reg2;
+  lps22hb_ctrl_reg3_t          ctrl_reg3;
+  lps22hb_fifo_ctrl_t          fifo_ctrl;
+  lps22hb_res_conf_t           res_conf;
+  lps22hb_int_source_t         int_source;
+  lps22hb_fifo_status_t        fifo_status;
+  lps22hb_status_t             status;
+  bitwise_t                    bitwise;
+  uint8_t                      byte;
+} lps22hb_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lps22hb_read_reg(lps22hb_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lps22hb_write_reg(lps22hb_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lps22hb_from_lsb_to_hpa(uint32_t lsb);
+extern float_t lps22hb_from_lsb_to_degc(int16_t lsb);
+
+int32_t lps22hb_autozero_rst_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_autozero_rst_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_autozero_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_autozero_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_pressure_snap_rst_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_pressure_snap_rst_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_pressure_snap_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_pressure_snap_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_block_data_update_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_block_data_update_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS22HB_LPF_ODR_DIV_2  = 0,
+  LPS22HB_LPF_ODR_DIV_9  = 2,
+  LPS22HB_LPF_ODR_DIV_20 = 3,
+} lps22hb_lpfp_t;
+int32_t lps22hb_low_pass_filter_mode_set(lps22hb_ctx_t *ctx,
+                                         lps22hb_lpfp_t val);
+int32_t lps22hb_low_pass_filter_mode_get(lps22hb_ctx_t *ctx,
+                                         lps22hb_lpfp_t *val);
+
+typedef enum {
+  LPS22HB_POWER_DOWN  = 0,
+  LPS22HB_ODR_1_Hz    = 1,
+  LPS22HB_ODR_10_Hz   = 2,
+  LPS22HB_ODR_25_Hz   = 3,
+  LPS22HB_ODR_50_Hz   = 4,
+  LPS22HB_ODR_75_Hz   = 5,
+} lps22hb_odr_t;
+int32_t lps22hb_data_rate_set(lps22hb_ctx_t *ctx, lps22hb_odr_t val);
+int32_t lps22hb_data_rate_get(lps22hb_ctx_t *ctx, lps22hb_odr_t *val);
+
+int32_t lps22hb_one_shoot_trigger_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_one_shoot_trigger_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_pressure_ref_set(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_pressure_ref_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hb_pressure_offset_set(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_pressure_offset_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hb_press_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_temp_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_press_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_temp_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_pressure_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hb_temperature_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hb_low_pass_rst_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hb_device_id_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hb_reset_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_reset_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_boot_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_boot_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_low_power_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_low_power_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_boot_status_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+typedef struct{
+  lps22hb_fifo_status_t  fifo_status;
+  lps22hb_status_t       status;
+} lps22hb_dev_stat_t;
+int32_t lps22hb_dev_status_get(lps22hb_ctx_t *ctx, lps22hb_dev_stat_t *val);
+
+typedef enum {
+  LPS22HB_NO_THRESHOLD = 0,
+  LPS22HB_POSITIVE     = 1,
+  LPS22HB_NEGATIVE     = 2,
+  LPS22HB_BOTH         = 3,
+} lps22hb_pe_t;
+int32_t lps22hb_sign_of_int_threshold_set(lps22hb_ctx_t *ctx,
+                                          lps22hb_pe_t val);
+int32_t lps22hb_sign_of_int_threshold_get(lps22hb_ctx_t *ctx,
+                                          lps22hb_pe_t *val);
+
+typedef enum {
+  LPS22HB_INT_PULSED  = 0,
+  LPS22HB_INT_LATCHED = 1,
+} lps22hb_lir_t;
+int32_t lps22hb_int_notification_mode_set(lps22hb_ctx_t *ctx,
+                                          lps22hb_lir_t val);
+int32_t lps22hb_int_notification_mode_get(lps22hb_ctx_t *ctx,
+                                          lps22hb_lir_t *val);
+
+int32_t lps22hb_int_generation_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_int_generation_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_int_threshold_set(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_int_threshold_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LPS22HB_DRDY_OR_FIFO_FLAGS = 0,
+  LPS22HB_HIGH_PRES_INT      = 1,
+  LPS22HB_LOW_PRES_INT       = 2,
+  LPS22HB_EVERY_PRES_INT     = 3,
+} lps22hb_int_s_t;
+int32_t lps22hb_int_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_int_s_t val);
+int32_t lps22hb_int_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_int_s_t *val);
+
+int32_t lps22hb_drdy_on_int_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_drdy_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_fifo_ovr_on_int_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_ovr_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_fifo_threshold_on_int_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_threshold_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_fifo_full_on_int_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_full_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS22HB_PUSH_PULL  = 0,
+  LPS22HB_OPEN_DRAIN = 1,
+} lps22hb_pp_od_t;
+int32_t lps22hb_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_pp_od_t val);
+int32_t lps22hb_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_pp_od_t *val);
+
+typedef enum {
+  LPS22HB_ACTIVE_HIGH = 0,
+  LPS22HB_ACTIVE_LOW = 1,
+} lps22hb_int_h_l_t;
+int32_t lps22hb_int_polarity_set(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t val);
+int32_t lps22hb_int_polarity_get(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t *val);
+
+int32_t lps22hb_int_source_get(lps22hb_ctx_t *ctx, lps22hb_int_source_t *val);
+
+int32_t lps22hb_int_on_press_high_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_int_on_press_low_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_interrupt_event_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_stop_on_fifo_threshold_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_stop_on_fifo_threshold_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_fifo_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_fifo_watermark_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_watermark_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS22HB_BYPASS_MODE           = 0,
+  LPS22HB_FIFO_MODE             = 1,
+  LPS22HB_STREAM_MODE           = 2,
+  LPS22HB_STREAM_TO_FIFO_MODE   = 3,
+  LPS22HB_BYPASS_TO_STREAM_MODE = 4,
+  LPS22HB_DYNAMIC_STREAM_MODE   = 6,
+  LPS22HB_BYPASS_TO_FIFO_MODE   = 7,
+} lps22hb_f_mode_t;
+int32_t lps22hb_fifo_mode_set(lps22hb_ctx_t *ctx, lps22hb_f_mode_t val);
+int32_t lps22hb_fifo_mode_get(lps22hb_ctx_t *ctx, lps22hb_f_mode_t *val);
+
+int32_t lps22hb_fifo_data_level_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_fifo_ovr_flag_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hb_fifo_fth_flag_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS22HB_SPI_4_WIRE = 0,
+  LPS22HB_SPI_3_WIRE = 1,
+} lps22hb_sim_t;
+int32_t lps22hb_spi_mode_set(lps22hb_ctx_t *ctx, lps22hb_sim_t val);
+int32_t lps22hb_spi_mode_get(lps22hb_ctx_t *ctx, lps22hb_sim_t *val);
+
+typedef enum {
+  LPS22HB_I2C_ENABLE = 0,
+  LPS22HB_I2C_DISABLE = 1,
+} lps22hb_i2c_dis_t;
+int32_t lps22hb_i2c_interface_set(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t val);
+int32_t lps22hb_i2c_interface_get(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t *val);
+
+int32_t lps22hb_auto_add_inc_set(lps22hb_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_auto_add_inc_get(lps22hb_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPS22HB_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.c
+++ b/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.c
@@ -1,0 +1,1832 @@
+/*
+ ******************************************************************************
+ * @file    lps22hh_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LPS22HH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+#include "lps22hh_reg.h"
+
+/**
+  * @defgroup  LPS22HH
+  * @brief     This file provides a set of functions needed to drive the
+  *            lps22hh enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LPS22HH_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_read_reg(lps22hh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_write_reg(lps22hh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS22HH_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+float_t lps22hh_from_lsb_to_hpa(int16_t lsb)
+{
+  return ( (float_t) lsb / 4096.0f );
+}
+
+float_t lps22hh_from_lsb_to_celsius(int16_t lsb)
+{
+  return ( (float_t) lsb / 100.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS22HH_Data_Generation
+  * @brief     This section groups all the functions concerning
+  *            data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Reset Autozero function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reset_az in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_autozero_rst_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.reset_az = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Autozero function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reset_az in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_autozero_rst_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  *val = reg.reset_az;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of autozero in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_autozero_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.autozero = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of autozero in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_autozero_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  *val = reg.autozero;
+
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_snap_rst_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.reset_arp = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_snap_rst_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  *val = reg.reset_arp;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRefP function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of autorefp in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_snap_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.autorefp = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRefP function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of autorefp in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_snap_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  *val = reg.autorefp;
+
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_block_data_update_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_block_data_update_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_data_rate_set(lps22hh_ctx_t *ctx, lps22hh_odr_t val)
+{
+  lps22hh_ctrl_reg1_t ctrl_reg1;
+  lps22hh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  if (ret == 0) {
+    ctrl_reg1.odr = (uint8_t)val & 0x07U;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  if (ret == 0) {
+    ctrl_reg2.low_noise_en = ((uint8_t)val & 0x10U) >> 4;
+    ctrl_reg2.one_shot = ((uint8_t)val & 0x08U) >> 3;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_data_rate_get(lps22hh_ctx_t *ctx, lps22hh_odr_t *val)
+{
+  lps22hh_ctrl_reg1_t ctrl_reg1;
+  lps22hh_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  if (ret == 0) {
+    ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+    switch (((ctrl_reg2.low_noise_en << 4) + (ctrl_reg2.one_shot << 3) +
+            ctrl_reg1.odr )) {
+      case LPS22HH_POWER_DOWN:
+        *val = LPS22HH_POWER_DOWN;
+        break;
+      case LPS22HH_ONE_SHOOT:
+        *val = LPS22HH_ONE_SHOOT;
+        break;
+      case LPS22HH_1_Hz:
+        *val = LPS22HH_1_Hz;
+        break;
+      case LPS22HH_10_Hz:
+        *val = LPS22HH_10_Hz;
+        break;
+      case LPS22HH_25_Hz:
+        *val = LPS22HH_25_Hz;
+        break;
+      case LPS22HH_50_Hz:
+        *val = LPS22HH_50_Hz;
+        break;
+      case LPS22HH_75_Hz:
+        *val = LPS22HH_75_Hz;
+        break;
+      case LPS22HH_1_Hz_LOW_NOISE:
+        *val = LPS22HH_1_Hz_LOW_NOISE;
+        break;
+      case LPS22HH_10_Hz_LOW_NOISE:
+        *val = LPS22HH_10_Hz_LOW_NOISE;
+        break;
+      case LPS22HH_25_Hz_LOW_NOISE:
+        *val = LPS22HH_25_Hz_LOW_NOISE;
+        break;
+      case LPS22HH_50_Hz_LOW_NOISE:
+        *val = LPS22HH_50_Hz_LOW_NOISE;
+        break;
+      case LPS22HH_75_Hz_LOW_NOISE:
+        *val = LPS22HH_75_Hz_LOW_NOISE;
+        break;
+      case LPS22HH_100_Hz:
+        *val = LPS22HH_100_Hz;
+        break;
+      case LPS22HH_200_Hz:
+        *val = LPS22HH_200_Hz;
+        break;
+      default:
+        *val = LPS22HH_POWER_DOWN;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  The Reference pressure value is a 16-bit data
+  *         expressed as 2’s complement. The value is used
+  *         when AUTOZERO or AUTORIFP function is enabled.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_ref_set(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lps22hh_write_reg(ctx, LPS22HH_REF_P_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The Reference pressure value is a 16-bit
+  *         data expressed as 2’s complement.
+  *         The value is used when AUTOZERO or AUTORIFP
+  *         function is enabled.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_ref_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_REF_P_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data
+  *         that can be used to implement one-point
+  *         calibration (OPC) after soldering.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_offset_set(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_write_reg(ctx, LPS22HH_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit
+  *         data that can be used to implement
+  *         one-point calibration (OPC) after
+  *         soldering.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_offset_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers STATUS,FIFO_STATUS2,INT_SOURCE
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_all_sources_get(lps22hh_ctx_t *ctx, lps22hh_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INT_SOURCE,
+                         (uint8_t*) &(val->int_source), 1);
+  if (ret == 0) {
+    ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_STATUS2,
+                           (uint8_t*) &(val->fifo_status2), 1);
+  }
+  if (ret == 0) {
+    ret = lps22hh_read_reg(ctx, LPS22HH_STATUS,
+                           (uint8_t*) &(val->status), 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      structure of registers from STATUS to STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_status_reg_get(lps22hh_ctx_t *ctx, lps22hh_status_t *val)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_STATUS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Pressure new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of p_da in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_press_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_status_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_STATUS, (uint8_t*) &reg, 1);
+  *val = reg.p_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of t_da in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_temp_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_status_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_STATUS, (uint8_t*) &reg, 1);
+  *val = reg.t_da;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS22HH_Data_Output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Pressure output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_PRESS_OUT_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_TEMP_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Pressure output from FIFO value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_FIFO_DATA_OUT_PRESS_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Temperature output from FIFO value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_FIFO_DATA_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS22HH_Common
+  * @brief     This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_device_id_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values
+  *         in user registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of swreset in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_reset_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.swreset = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Software reset. Restore the default values
+  *          in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of swreset in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_reset_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.swreset;
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically
+  *         incremented during a multiple byte access
+  *         with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_auto_increment_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.if_add_inc = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically
+  *         incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_auto_increment_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration
+  *         parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_boot_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.boot = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration
+  *         parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_boot_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS22HH_Filters
+  * @brief     This section group all the functions concerning the
+  *            filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Low-pass bandwidth selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpfp_cfg in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_lp_bandwidth_set(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t val)
+{
+  lps22hh_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lpfp_cfg = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lpfp_cfg in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_lp_bandwidth_get(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t *val)
+{
+  lps22hh_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  switch (reg.lpfp_cfg) {
+      case LPS22HH_LPF_ODR_DIV_2:
+        *val = LPS22HH_LPF_ODR_DIV_2;
+        break;
+      case LPS22HH_LPF_ODR_DIV_9:
+        *val = LPS22HH_LPF_ODR_DIV_9;
+        break;
+      case LPS22HH_LPF_ODR_DIV_20:
+        *val = LPS22HH_LPF_ODR_DIV_20;
+        break;
+      default:
+        *val = LPS22HH_LPF_ODR_DIV_2;
+        break;
+    }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS22HH_Serial_Interface
+  * @brief     This section groups all the functions concerning serial
+  *            interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable/Disable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_disable in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_i2c_interface_set(lps22hh_ctx_t *ctx,
+                                  lps22hh_i2c_disable_t val)
+{
+  lps22hh_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i2c_disable = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable I2C interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_disable in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_i2c_interface_get(lps22hh_ctx_t *ctx,
+                                  lps22hh_i2c_disable_t *val)
+{
+  lps22hh_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  switch (reg.i2c_disable) {
+      case LPS22HH_I2C_ENABLE:
+        *val = LPS22HH_I2C_ENABLE;
+        break;
+      case LPS22HH_I2C_DISABLE:
+        *val = LPS22HH_I2C_DISABLE;
+        break;
+      default:
+        *val = LPS22HH_I2C_ENABLE;
+        break;
+    }
+
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_en_i3c in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_i3c_interface_set(lps22hh_ctx_t *ctx,
+                                  lps22hh_i3c_disable_t val)
+{
+  lps22hh_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i3c_disable = ((uint8_t)val & 0x01u);
+    reg.int_en_i3c = ((uint8_t)val & 0x10U) >> 4;
+    ret = lps22hh_write_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_en_i3c in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_i3c_interface_get(lps22hh_ctx_t *ctx,
+                                  lps22hh_i3c_disable_t *val)
+{
+  lps22hh_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+
+  switch ((reg.int_en_i3c << 4) + reg.int_en_i3c) {
+    case LPS22HH_I3C_ENABLE:
+      *val = LPS22HH_I3C_ENABLE;
+      break;
+    case LPS22HH_I3C_ENABLE_INT_PIN_ENABLE:
+      *val = LPS22HH_I3C_ENABLE_INT_PIN_ENABLE;
+      break;
+    case LPS22HH_I3C_DISABLE:
+      *val = LPS22HH_I3C_DISABLE;
+      break;
+    default:
+      *val = LPS22HH_I3C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable pull-up on SDO pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sdo_pu_en in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_sdo_sa0_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val)
+{
+  lps22hh_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sdo_pu_en = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable pull-up on SDO pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sdo_pu_en in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_sdo_sa0_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val)
+{
+  lps22hh_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  switch (reg.sdo_pu_en) {
+    case LPS22HH_PULL_UP_DISCONNECT:
+      *val = LPS22HH_PULL_UP_DISCONNECT;
+      break;
+    case LPS22HH_PULL_UP_CONNECT:
+      *val = LPS22HH_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LPS22HH_PULL_UP_DISCONNECT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sda_pu_en in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_sda_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val)
+{
+  lps22hh_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sda_pu_en = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sda_pu_en in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_sda_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val)
+{
+  lps22hh_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_IF_CTRL, (uint8_t*) &reg, 1);
+  switch (reg.sda_pu_en) {
+    case LPS22HH_PULL_UP_DISCONNECT:
+      *val = LPS22HH_PULL_UP_DISCONNECT;
+      break;
+    case LPS22HH_PULL_UP_CONNECT:
+      *val = LPS22HH_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LPS22HH_PULL_UP_DISCONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_spi_mode_set(lps22hh_ctx_t *ctx, lps22hh_sim_t val)
+{
+  lps22hh_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sim = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_spi_mode_get(lps22hh_ctx_t *ctx, lps22hh_sim_t *val)
+{
+  lps22hh_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG1, (uint8_t*) &reg, 1);
+  switch (reg.sim) {
+    case LPS22HH_SPI_4_WIRE:
+      *val = LPS22HH_SPI_4_WIRE;
+      break;
+    case LPS22HH_SPI_3_WIRE:
+      *val = LPS22HH_SPI_3_WIRE;
+      break;
+    default:
+      *val = LPS22HH_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS22HH_Interrupt_Pins
+  * @brief     This section groups all the functions that manage
+  *            interrupt pins.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Latch interrupt request to the INT_SOURCE (24h) register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_int_notification_set(lps22hh_ctx_t *ctx, lps22hh_lir_t val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lir = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request to the INT_SOURCE (24h) register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_int_notification_get(lps22hh_ctx_t *ctx, lps22hh_lir_t *val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+
+  switch (reg.lir) {
+    case LPS22HH_INT_PULSED:
+      *val = LPS22HH_INT_PULSED;
+      break;
+    case LPS22HH_INT_LATCHED:
+      *val = LPS22HH_INT_LATCHED;
+      break;
+    default:
+      *val = LPS22HH_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pp_od in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pin_mode_set(lps22hh_ctx_t *ctx, lps22hh_pp_od_t val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.pp_od = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pp_od in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pin_mode_get(lps22hh_ctx_t *ctx, lps22hh_pp_od_t *val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+
+
+  switch (reg.pp_od) {
+    case LPS22HH_PUSH_PULL:
+      *val = LPS22HH_PUSH_PULL;
+      break;
+    case LPS22HH_OPEN_DRAIN:
+      *val = LPS22HH_OPEN_DRAIN;
+      break;
+    default:
+      *val = LPS22HH_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_h_l in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pin_polarity_set(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.int_h_l = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of int_h_l in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pin_polarity_get(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t *val)
+{
+  lps22hh_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG2, (uint8_t*) &reg, 1);
+
+  switch (reg.int_h_l) {
+    case LPS22HH_ACTIVE_HIGH:
+      *val = LPS22HH_ACTIVE_HIGH;
+      break;
+    case LPS22HH_ACTIVE_LOW:
+      *val = LPS22HH_ACTIVE_LOW;
+      break;
+    default:
+      *val = LPS22HH_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pin_int_route_set(lps22hh_ctx_t *ctx,
+                                  lps22hh_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret =  lps22hh_write_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_pin_int_route_get(lps22hh_ctx_t *ctx,
+                                  lps22hh_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LPS22HH_Interrupt_on_Threshold
+  * @brief      This section groups all the functions that manage the
+  *             interrupt on threshold event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Enable interrupt generation on pressure low/high event.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pe in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_int_on_threshold_set(lps22hh_ctx_t *ctx, lps22hh_pe_t val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.pe = (uint8_t)val;
+
+    if (val == LPS22HH_NO_THRESHOLD){
+      reg.diff_en = PROPERTY_DISABLE;
+    }
+    else{
+      reg.diff_en = PROPERTY_ENABLE;
+    }
+    ret = lps22hh_write_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pe in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_int_on_threshold_get(lps22hh_ctx_t *ctx, lps22hh_pe_t *val)
+{
+  lps22hh_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+
+  switch (reg.pe) {
+    case LPS22HH_NO_THRESHOLD:
+      *val = LPS22HH_NO_THRESHOLD;
+      break;
+    case LPS22HH_POSITIVE:
+      *val = LPS22HH_POSITIVE;
+      break;
+    case LPS22HH_NEGATIVE:
+      *val = LPS22HH_NEGATIVE;
+      break;
+    case LPS22HH_BOTH:
+      *val = LPS22HH_BOTH;
+      break;
+    default:
+      *val = LPS22HH_NO_THRESHOLD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_int_treshold_set(lps22hh_ctx_t *ctx, uint16_t buff)
+{
+  int32_t ret;
+  lps22hh_ths_p_l_t ths_p_l;
+  lps22hh_ths_p_h_t ths_p_h;
+  
+  ths_p_l.ths = (uint8_t)(buff & 0x00FFU);
+  ths_p_h.ths = (uint8_t)((buff & 0x7F00U) >> 8);
+  
+  ret =  lps22hh_write_reg(ctx, LPS22HH_THS_P_L,
+                           (uint8_t*)&ths_p_l, 1);
+  if (ret == 0) {
+      ret =  lps22hh_write_reg(ctx, LPS22HH_THS_P_H, 
+                               (uint8_t*)&ths_p_h, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   User-defined threshold value for pressure interrupt event.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_int_treshold_get(lps22hh_ctx_t *ctx, uint16_t *buff)
+{
+  int32_t ret;
+  lps22hh_ths_p_l_t ths_p_l;
+  lps22hh_ths_p_h_t ths_p_h;
+  
+  ret =  lps22hh_read_reg(ctx, LPS22HH_THS_P_L,
+                           (uint8_t*)&ths_p_l, 1);
+  if (ret == 0) {
+      ret =  lps22hh_read_reg(ctx, LPS22HH_THS_P_H, 
+                               (uint8_t*)&ths_p_h, 1);
+      *buff = (uint16_t)ths_p_h.ths << 8;
+      *buff |= (uint16_t)ths_p_l.ths;
+  }  
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS22HH_Fifo
+  * @brief   This section group all the functions concerning the fifo usage.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Fifo Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of f_mode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_mode_set(lps22hh_ctx_t *ctx, lps22hh_f_mode_t val)
+{
+  lps22hh_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.f_mode = (uint8_t)val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_FIFO_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Fifo Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of f_mode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_mode_get(lps22hh_ctx_t *ctx, lps22hh_f_mode_t *val)
+{
+  lps22hh_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_CTRL, (uint8_t*) &reg, 1);
+
+  switch (reg.f_mode) {
+    case LPS22HH_BYPASS_MODE:
+      *val = LPS22HH_BYPASS_MODE;
+      break;
+    case LPS22HH_FIFO_MODE:
+      *val = LPS22HH_FIFO_MODE;
+      break;
+    case LPS22HH_STREAM_MODE:
+      *val = LPS22HH_STREAM_MODE;
+      break;
+    case LPS22HH_DYNAMIC_STREAM_MODE:
+      *val = LPS22HH_DYNAMIC_STREAM_MODE;
+      break;
+    case LPS22HH_BYPASS_TO_FIFO_MODE:
+      *val = LPS22HH_BYPASS_TO_FIFO_MODE;
+      break;
+    case LPS22HH_BYPASS_TO_STREAM_MODE:
+      *val = LPS22HH_BYPASS_TO_STREAM_MODE;
+      break;
+    case LPS22HH_STREAM_TO_FIFO_MODE:
+      *val = LPS22HH_STREAM_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LPS22HH_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at
+  *         threshold level.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of stop_on_wtm in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_stop_on_wtm_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.stop_on_wtm = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_FIFO_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensing chain FIFO stop values memorization at threshold
+  *          level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of stop_on_wtm in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_stop_on_wtm_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_CTRL, (uint8_t*) &reg, 1);
+  *val = reg.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_WTM
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_watermark_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_fifo_wtm_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_WTM, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wtm = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_FIFO_WTM, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_WTM
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_watermark_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_fifo_wtm_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_WTM, (uint8_t*) &reg, 1);
+  *val = reg.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_data_level_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_FIFO_STATUS1, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Read all the FIFO status flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_src_get(lps22hh_ctx_t *ctx, lps22hh_fifo_status2_t *val)
+{
+  int32_t ret;
+  ret =  lps22hh_read_reg(ctx, LPS22HH_FIFO_STATUS2, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO full status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_full_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_STATUS2, (uint8_t*) &reg, 1);
+  *val = reg.fifo_full_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_ovr_ia in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_ovr_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_STATUS2, (uint8_t*) &reg, 1);
+  *val = reg.fifo_ovr_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps22hh_fifo_wtm_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_FIFO_STATUS2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_wtm_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[set]
+  *
+  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_ovr in reg CTRL_REG3
+  *
+  */
+int32_t lps22hh_fifo_ovr_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int_f_ovr = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[get]
+  *
+  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_ovr in reg CTRL_REG3
+  *
+  */
+int32_t lps22hh_fifo_ovr_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  *val = reg.int_f_ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[set]
+  *
+  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_fth in reg CTRL_REG3
+  *
+  */
+int32_t lps22hh_fifo_threshold_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int_f_wtm = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[get]
+  *
+  * @param  lps22hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_fth in reg CTRL_REG3
+  *
+  */
+int32_t lps22hh_fifo_threshold_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  *val = reg.int_f_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[set]
+  *
+  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_fss5 in reg CTRL_REG3
+  *
+  */
+int32_t lps22hh_fifo_full_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
+{
+  lps22hh_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int_f_full = val;
+    ret = lps22hh_write_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[get]
+  *
+  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_fss5 in reg CTRL_REG3
+  *
+  */
+int32_t lps22hh_fifo_full_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val)
+{
+  lps22hh_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps22hh_read_reg(ctx, LPS22HH_CTRL_REG3, (uint8_t*)&reg, 1);
+  *val = reg.int_f_full;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.h
+++ b/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.h
@@ -1,0 +1,525 @@
+/*
+ ******************************************************************************
+ * @file    lps22hh_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lps22hh_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LPS22HH_DRIVER_H
+#define LPS22HH_DRIVER_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LPS22HH
+  * @{
+  *
+  */
+
+/** @defgroup LPS22HH_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LPS22HH_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lps22hh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lps22hh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lps22hh_write_ptr  write_reg;
+  lps22hh_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lps22hh_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LPS22HH_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> B9 if SA0=1 -> BB **/
+#define LPS22HH_I2C_ADD_H                       0xBBU
+#define LPS22HH_I2C_ADD_L                       0xB9U
+
+/** Device Identification (Who am I) **/
+#define LPS22HH_ID                              0xB3U
+
+/**
+  * @}
+  *
+  */
+
+#define LPS22HH_INTERRUPT_CFG                   0x0BU
+typedef struct {
+  uint8_t pe                              : 2;  /* ple + phe */
+  uint8_t lir                             : 1;
+  uint8_t diff_en                         : 1;
+  uint8_t reset_az                        : 1;
+  uint8_t autozero                        : 1;
+  uint8_t reset_arp                       : 1;
+  uint8_t autorefp                        : 1;
+} lps22hh_interrupt_cfg_t;
+
+#define LPS22HH_THS_P_L                         0x0CU
+typedef struct {
+  uint8_t ths                             : 8;
+} lps22hh_ths_p_l_t;
+
+#define LPS22HH_THS_P_H                         0x0DU
+typedef struct {
+  uint8_t ths                             : 7;
+  uint8_t not_used_01                     : 1;
+} lps22hh_ths_p_h_t;
+
+#define LPS22HH_IF_CTRL                         0x0EU
+typedef struct {
+  uint8_t i2c_disable                     : 1;
+  uint8_t i3c_disable                     : 1;
+  uint8_t pd_dis_int1                     : 1;
+  uint8_t sdo_pu_en                       : 1;
+  uint8_t sda_pu_en                       : 1;
+  uint8_t not_used_01                     : 2;
+  uint8_t int_en_i3c                      : 1;
+} lps22hh_if_ctrl_t;
+
+#define LPS22HH_WHO_AM_I                        0x0FU
+#define LPS22HH_CTRL_REG1                       0x10U
+typedef struct {
+  uint8_t sim                             : 1;
+  uint8_t bdu                             : 1;
+  uint8_t lpfp_cfg                        : 2;  /* en_lpfp + lpfp_cfg */
+  uint8_t odr                             : 3;
+  uint8_t not_used_01                     : 1;
+} lps22hh_ctrl_reg1_t;
+
+#define LPS22HH_CTRL_REG2                       0x11U
+typedef struct {
+  uint8_t one_shot                        : 1;
+  uint8_t low_noise_en                    : 1;
+  uint8_t swreset                         : 1;
+  uint8_t not_used_01                     : 1;
+  uint8_t if_add_inc                      : 1;
+  uint8_t pp_od                           : 1;
+  uint8_t int_h_l                         : 1;
+  uint8_t boot                            : 1;
+} lps22hh_ctrl_reg2_t;
+
+#define LPS22HH_CTRL_REG3                       0x12U
+typedef struct {
+  uint8_t int_s                           : 2;
+  uint8_t drdy                            : 1;
+  uint8_t int_f_ovr                       : 1;
+  uint8_t int_f_wtm                       : 1;
+  uint8_t int_f_full                      : 1;
+  uint8_t not_used_01                     : 2;
+} lps22hh_ctrl_reg3_t;
+
+#define LPS22HH_FIFO_CTRL                       0x13U
+typedef struct {
+  uint8_t f_mode                          : 3;  /* f_mode + trig_modes */
+  uint8_t stop_on_wtm                     : 1;
+  uint8_t not_used_01                     : 4;
+} lps22hh_fifo_ctrl_t;
+
+#define LPS22HH_FIFO_WTM                        0x14U
+typedef struct {
+  uint8_t wtm                             : 7;
+  uint8_t not_used_01                     : 1;
+} lps22hh_fifo_wtm_t;
+
+#define LPS22HH_REF_P_L                         0x15U
+#define LPS22HH_REF_P_H                         0x16U
+#define LPS22HH_RPDS_L                          0x18U
+#define LPS22HH_RPDS_H                          0x19U
+#define LPS22HH_INT_SOURCE                      0x24U
+typedef struct {
+  uint8_t ph                              : 1;
+  uint8_t pl                              : 1;
+  uint8_t ia                              : 1;
+  uint8_t not_used_01                     : 4;
+  uint8_t boot_on                         : 1;
+} lps22hh_int_source_t;
+
+#define LPS22HH_FIFO_STATUS1                    0x25U
+#define LPS22HH_FIFO_STATUS2                    0x26U
+typedef struct {
+  uint8_t not_used_01                     : 5;
+  uint8_t fifo_full_ia                    : 1;
+  uint8_t fifo_ovr_ia                     : 1;
+  uint8_t fifo_wtm_ia                     : 1;
+} lps22hh_fifo_status2_t;
+
+#define LPS22HH_STATUS                          0x27U
+typedef struct {
+  uint8_t p_da                            : 1;
+  uint8_t t_da                            : 1;
+  uint8_t not_used_01                     : 2;
+  uint8_t p_or                            : 1;
+  uint8_t t_or                            : 1;
+  uint8_t not_used_02                     : 2;
+} lps22hh_status_t;
+
+#define LPS22HH_PRESS_OUT_XL                    0x28U
+#define LPS22HH_PRESS_OUT_L                     0x29U
+#define LPS22HH_PRESS_OUT_H                     0x2AU
+#define LPS22HH_TEMP_OUT_L                      0x2BU
+#define LPS22HH_TEMP_OUT_H                      0x2CU
+#define LPS22HH_FIFO_DATA_OUT_PRESS_XL          0x78U
+#define LPS22HH_FIFO_DATA_OUT_PRESS_L           0x79U
+#define LPS22HH_FIFO_DATA_OUT_PRESS_H           0x7AU
+#define LPS22HH_FIFO_DATA_OUT_TEMP_L            0x7BU
+#define LPS22HH_FIFO_DATA_OUT_TEMP_H            0x7CU
+
+/**
+  * @defgroup LPS22HH_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lps22hh_interrupt_cfg_t        interrupt_cfg;
+  lps22hh_if_ctrl_t              if_ctrl;
+  lps22hh_ctrl_reg1_t            ctrl_reg1;
+  lps22hh_ctrl_reg2_t            ctrl_reg2;
+  lps22hh_ctrl_reg3_t            ctrl_reg3;
+  lps22hh_fifo_ctrl_t            fifo_ctrl;
+  lps22hh_fifo_wtm_t             fifo_wtm;
+  lps22hh_int_source_t           int_source;
+  lps22hh_fifo_status2_t         fifo_status2;
+  lps22hh_status_t               status;
+  bitwise_t                      bitwise;
+  uint8_t                        byte;
+} lps22hh_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lps22hh_read_reg(lps22hh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lps22hh_write_reg(lps22hh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float lps22hh_from_lsb_to_hpa(int16_t lsb);
+extern float lps22hh_from_lsb_to_celsius(int16_t lsb);
+
+int32_t lps22hh_autozero_rst_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_autozero_rst_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_autozero_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_autozero_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_pressure_snap_rst_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_pressure_snap_rst_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_pressure_snap_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_pressure_snap_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_block_data_update_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_block_data_update_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS22HH_POWER_DOWN          = 0x00,
+  LPS22HH_ONE_SHOOT           = 0x08,
+  LPS22HH_1_Hz                = 0x01,
+  LPS22HH_10_Hz               = 0x02,
+  LPS22HH_25_Hz               = 0x03,
+  LPS22HH_50_Hz               = 0x04,
+  LPS22HH_75_Hz               = 0x05,
+  LPS22HH_1_Hz_LOW_NOISE      = 0x11,
+  LPS22HH_10_Hz_LOW_NOISE     = 0x12,
+  LPS22HH_25_Hz_LOW_NOISE     = 0x13,
+  LPS22HH_50_Hz_LOW_NOISE     = 0x14,
+  LPS22HH_75_Hz_LOW_NOISE     = 0x15,
+  LPS22HH_100_Hz              = 0x06,
+  LPS22HH_200_Hz              = 0x07,
+} lps22hh_odr_t;
+int32_t lps22hh_data_rate_set(lps22hh_ctx_t *ctx, lps22hh_odr_t val);
+int32_t lps22hh_data_rate_get(lps22hh_ctx_t *ctx, lps22hh_odr_t *val);
+
+int32_t lps22hh_pressure_ref_set(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_pressure_ref_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hh_pressure_offset_set(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_pressure_offset_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+
+typedef struct{
+  lps22hh_int_source_t    int_source;
+  lps22hh_fifo_status2_t  fifo_status2;
+  lps22hh_status_t        status;
+} lps22hh_all_sources_t;
+int32_t lps22hh_all_sources_get(lps22hh_ctx_t *ctx,
+                                lps22hh_all_sources_t *val);
+
+int32_t lps22hh_status_reg_get(lps22hh_ctx_t *ctx, lps22hh_status_t *val);
+
+int32_t lps22hh_press_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_temp_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hh_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hh_fifo_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hh_fifo_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hh_device_id_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hh_reset_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_reset_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_auto_increment_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_auto_increment_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_boot_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_boot_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS22HH_LPF_ODR_DIV_2    = 0,
+  LPS22HH_LPF_ODR_DIV_9    = 2,
+  LPS22HH_LPF_ODR_DIV_20   = 3,
+} lps22hh_lpfp_cfg_t;
+int32_t lps22hh_lp_bandwidth_set(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t val);
+int32_t lps22hh_lp_bandwidth_get(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t *val);
+
+typedef enum {
+  LPS22HH_I2C_ENABLE    = 0,
+  LPS22HH_I2C_DISABLE   = 1,
+} lps22hh_i2c_disable_t;
+int32_t lps22hh_i2c_interface_set(lps22hh_ctx_t *ctx,
+                                  lps22hh_i2c_disable_t val);
+int32_t lps22hh_i2c_interface_get(lps22hh_ctx_t *ctx,
+                                  lps22hh_i2c_disable_t *val);
+
+typedef enum {
+  LPS22HH_I3C_ENABLE                 = 0x00,
+  LPS22HH_I3C_ENABLE_INT_PIN_ENABLE  = 0x10,
+  LPS22HH_I3C_DISABLE                = 0x11,
+} lps22hh_i3c_disable_t;
+int32_t lps22hh_i3c_interface_set(lps22hh_ctx_t *ctx,
+                                  lps22hh_i3c_disable_t val);
+int32_t lps22hh_i3c_interface_get(lps22hh_ctx_t *ctx,
+                                  lps22hh_i3c_disable_t *val);
+
+typedef enum {
+  LPS22HH_PULL_UP_DISCONNECT    = 0,
+  LPS22HH_PULL_UP_CONNECT       = 1,
+} lps22hh_pu_en_t;
+int32_t lps22hh_sdo_sa0_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val);
+int32_t lps22hh_sdo_sa0_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val);
+int32_t lps22hh_sda_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val);
+int32_t lps22hh_sda_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val);
+
+typedef enum {
+  LPS22HH_SPI_4_WIRE  = 0,
+  LPS22HH_SPI_3_WIRE  = 1,
+} lps22hh_sim_t;
+int32_t lps22hh_spi_mode_set(lps22hh_ctx_t *ctx, lps22hh_sim_t val);
+int32_t lps22hh_spi_mode_get(lps22hh_ctx_t *ctx, lps22hh_sim_t *val);
+
+typedef enum {
+  LPS22HH_INT_PULSED   = 0,
+  LPS22HH_INT_LATCHED  = 1,
+} lps22hh_lir_t;
+int32_t lps22hh_int_notification_set(lps22hh_ctx_t *ctx, lps22hh_lir_t val);
+int32_t lps22hh_int_notification_get(lps22hh_ctx_t *ctx, lps22hh_lir_t *val);
+
+typedef enum {
+  LPS22HH_PUSH_PULL   = 0,
+  LPS22HH_OPEN_DRAIN  = 1,
+} lps22hh_pp_od_t;
+int32_t lps22hh_pin_mode_set(lps22hh_ctx_t *ctx, lps22hh_pp_od_t val);
+int32_t lps22hh_pin_mode_get(lps22hh_ctx_t *ctx, lps22hh_pp_od_t *val);
+
+typedef enum {
+  LPS22HH_ACTIVE_HIGH = 0,
+  LPS22HH_ACTIVE_LOW  = 1,
+} lps22hh_int_h_l_t;
+int32_t lps22hh_pin_polarity_set(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t val);
+int32_t lps22hh_pin_polarity_get(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t *val);
+
+int32_t lps22hh_pin_int_route_set(lps22hh_ctx_t *ctx,
+                                  lps22hh_ctrl_reg3_t *val);
+int32_t lps22hh_pin_int_route_get(lps22hh_ctx_t *ctx,
+                                  lps22hh_ctrl_reg3_t *val);
+
+typedef enum {
+  LPS22HH_NO_THRESHOLD  = 0,
+  LPS22HH_POSITIVE      = 1,
+  LPS22HH_NEGATIVE      = 2,
+  LPS22HH_BOTH          = 3,
+} lps22hh_pe_t;
+int32_t lps22hh_int_on_threshold_set(lps22hh_ctx_t *ctx, lps22hh_pe_t val);
+int32_t lps22hh_int_on_threshold_get(lps22hh_ctx_t *ctx, lps22hh_pe_t *val);
+
+int32_t lps22hh_int_treshold_set(lps22hh_ctx_t *ctx, uint16_t buff);
+int32_t lps22hh_int_treshold_get(lps22hh_ctx_t *ctx, uint16_t *buff);
+
+typedef enum {
+  LPS22HH_BYPASS_MODE            = 0,
+  LPS22HH_FIFO_MODE              = 1,
+  LPS22HH_STREAM_MODE            = 2,
+  LPS22HH_DYNAMIC_STREAM_MODE    = 3,
+  LPS22HH_BYPASS_TO_FIFO_MODE    = 5,
+  LPS22HH_BYPASS_TO_STREAM_MODE  = 6,
+  LPS22HH_STREAM_TO_FIFO_MODE    = 7,
+} lps22hh_f_mode_t;
+int32_t lps22hh_fifo_mode_set(lps22hh_ctx_t *ctx, lps22hh_f_mode_t val);
+int32_t lps22hh_fifo_mode_get(lps22hh_ctx_t *ctx, lps22hh_f_mode_t *val);
+
+int32_t lps22hh_fifo_stop_on_wtm_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_stop_on_wtm_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_fifo_watermark_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_watermark_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_fifo_data_level_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps22hh_fifo_src_get(lps22hh_ctx_t *ctx, lps22hh_fifo_status2_t *val);
+
+int32_t lps22hh_fifo_full_flag_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_fifo_ovr_flag_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_fifo_wtm_flag_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_fifo_ovr_on_int_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_ovr_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_fifo_threshold_on_int_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_threshold_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+int32_t lps22hh_fifo_full_on_int_set(lps22hh_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_full_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*LPS22HH_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps25hb_STdC/driver/lps25hb_reg.c
+++ b/sensor/stmemsc/lps25hb_STdC/driver/lps25hb_reg.c
@@ -1,0 +1,1480 @@
+/*
+ ******************************************************************************
+ * @file    lps25hb_reg.c
+ * @author  MEMS Software Solution Team
+ * @date    20-September-2017
+ * @brief   LPS25HB driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lps25hb_reg.h"
+
+/**
+  * @addtogroup  lps25hb
+  * @brief  This file provides a set of functions needed to drive the
+  *         lps25hb enanced inertial module.
+  * @{
+  */
+
+/**
+  * @addtogroup  interfaces_functions
+  * @brief  This section provide a set of functions used to read and write
+  *         a generic register of the device.
+  * @{
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  lps25hb_ctx_t* ctx: read / write interface definitions
+  * @param  uint8_t reg: register to read
+  * @param  uint8_t* data: pointer to buffer that store the data read
+  * @param  uint16_t len: number of consecutive register to read
+  *
+  */
+int32_t lps25hb_read_reg(lps25hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  return ctx->read_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t reg: register to write
+  * @param  uint8_t* data: pointer to data to write in register reg
+  * @param  uint16_t len: number of consecutive register to write
+  *
+*/
+int32_t lps25hb_write_reg(lps25hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  return ctx->write_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  data_generation_c
+  * @brief   This section group all the functions concerning data generation
+  * @{
+  */
+
+/**
+  * @brief  pressure_ref: [set]  The Reference pressure value is a 24-bit
+  *                              data expressed as 2’s complement. The value
+  *                              is used when AUTOZERO or AUTORIFP function
+  *                              is enabled.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t lps25hb_pressure_ref_set(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_REF_P_XL,  buff, 3);
+}
+
+/**
+  * @brief  pressure_ref: [get]  The Reference pressure value is a 24-bit
+  *                              data expressed as 2’s complement. The value
+  *                              is used when AUTOZERO or AUTORIFP function
+  *                              is enabled.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lps25hb_pressure_ref_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_REF_P_XL,  buff, 3);
+}
+
+/**
+  * @brief  pressure_avg: [set]  Pressure internal average configuration.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_avgp_t: change the values of avgp in reg RES_CONF
+  *
+  */
+int32_t lps25hb_pressure_avg_set(lps25hb_ctx_t *ctx, lps25hb_avgp_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
+  reg.res_conf.avgp = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pressure_avg: [get]  Pressure internal average configuration.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_avgp_t: Get the values of avgp in reg RES_CONF
+  *
+  */
+int32_t lps25hb_pressure_avg_get(lps25hb_ctx_t *ctx, lps25hb_avgp_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
+  *val = (lps25hb_avgp_t) reg.res_conf.avgp;
+
+  return mm_error;
+}
+
+/**
+  * @brief  temperature_avg: [set]  Temperature internal average configuration.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_avgt_t: change the values of avgt in reg RES_CONF
+  *
+  */
+int32_t lps25hb_temperature_avg_set(lps25hb_ctx_t *ctx, lps25hb_avgt_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
+  reg.res_conf.avgt = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  temperature_avg: [get]  Temperature internal average configuration.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_avgt_t: Get the values of avgt in reg RES_CONF
+  *
+  */
+int32_t lps25hb_temperature_avg_get(lps25hb_ctx_t *ctx, lps25hb_avgt_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
+  *val = (lps25hb_avgt_t) reg.res_conf.avgt;
+
+  return mm_error;
+}
+
+/**
+  * @brief  autozero_rst: [set]  Reset Autozero function.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of reset_az in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_autozero_rst_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.reset_az = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  autozero_rst: [get]  Reset Autozero function.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of reset_az in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_autozero_rst_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  *val = reg.ctrl_reg1.reset_az;
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [set] Blockdataupdate.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of bdu in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_block_data_update_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.bdu = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [get] Blockdataupdate.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of bdu in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_block_data_update_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  *val = reg.ctrl_reg1.bdu;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_rate: [set]  Output data rate selection.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_odr_t: change the values of odr in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_data_rate_set(lps25hb_ctx_t *ctx, lps25hb_odr_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.odr = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_rate: [get]  Output data rate selection.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_odr_t: Get the values of odr in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_data_rate_get(lps25hb_ctx_t *ctx, lps25hb_odr_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  *val = (lps25hb_odr_t) reg.ctrl_reg1.odr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  one_shoot_trigger: [set]  One-shot mode. Device perform a
+  *                                   single measure.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of one_shot in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_one_shoot_trigger_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  reg.ctrl_reg2.one_shot = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  one_shoot_trigger: [get]  One-shot mode. Device perform a
+  *                                   single measure.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of one_shot in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_one_shoot_trigger_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  *val = reg.ctrl_reg2.one_shot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  autozero: [set]  Enable Autozero function.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of autozero in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_autozero_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  reg.ctrl_reg2.autozero = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  autozero: [get]  Enable Autozero function.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of autozero in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_autozero_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  *val = reg.ctrl_reg2.autozero;
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_mean_decimator: [set]  Enable to decimate the output
+  *                                      pressure to 1Hz with FIFO Mean mode.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of fifo_mean_dec in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_fifo_mean_decimator_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  reg.ctrl_reg2.fifo_mean_dec = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_mean_decimator: [get]  Enable to decimate the output
+  *                                      pressure to 1Hz with FIFO Mean mode.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_mean_dec in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_fifo_mean_decimator_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  *val = reg.ctrl_reg2.fifo_mean_dec;
+
+  return mm_error;
+}
+
+/**
+  * @brief  press_data_ready: [get]  Pressure data available.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of p_da in reg STATUS_REG
+  *
+  */
+int32_t lps25hb_press_data_ready_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, &reg.byte, 1);
+  *val = reg.status_reg.p_da;
+
+  return mm_error;
+}
+
+/**
+  * @brief  temp_data_ready: [get]  Temperature data available.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of t_da in reg STATUS_REG
+  *
+  */
+int32_t lps25hb_temp_data_ready_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, &reg.byte, 1);
+  *val = reg.status_reg.t_da;
+
+  return mm_error;
+}
+
+/**
+  * @brief  temp_data_ovr: [get]   Temperature data overrun.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of t_or in reg STATUS_REG
+  *
+  */
+int32_t lps25hb_temp_data_ovr_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, &reg.byte, 1);
+  *val = reg.status_reg.t_or;
+
+  return mm_error;
+}
+
+/**
+  * @brief  press_data_ovr: [get]   Pressure data overrun.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of p_or in reg STATUS_REG
+  *
+  */
+int32_t lps25hb_press_data_ovr_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, &reg.byte, 1);
+  *val = reg.status_reg.p_or;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pressure_raw: [get]  Pressure output value.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lps25hb_pressure_raw_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_PRESS_OUT_XL,  buff, 3);
+}
+
+/**
+  * @brief  temperature_raw: [get]  Temperature output value.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lps25hb_temperature_raw_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_TEMP_OUT_L,  buff, 2);
+}
+
+/**
+  * @brief  pressure_offset: [set]  The pressure offset value is 16-bit
+  *                                 data that can be used to implement
+  *                                 one-point calibration (OPC)
+  *                                 after soldering.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t lps25hb_pressure_offset_set(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_RPDS_L,  buff, 2);
+}
+
+/**
+  * @brief  pressure_offset: [get]  The pressure offset value is 16-bit
+  *                                 data that can be used to implement
+  *                                 one-point calibration (OPC) after
+  *                                 soldering.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lps25hb_pressure_offset_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_RPDS_L,  buff, 2);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  common
+  * @brief   This section group common usefull functions
+  * @{
+  */
+
+/**
+  * @brief  device_id: [get] DeviceWhoamI.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lps25hb_device_id_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_WHO_AM_I,  buff, 1);
+}
+
+/**
+  * @brief  reset: [set]  Software reset. Restore the default values
+  *                       in user registers
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of swreset in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_reset_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  reg.ctrl_reg2.swreset = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [get]  Software reset. Restore the default values
+  *                       in user registers
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of swreset in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_reset_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  *val = reg.ctrl_reg2.swreset;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [set]  Reboot memory content. Reload the calibration
+  *                      parameters
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_boot_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  reg.ctrl_reg2.boot = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [get]  Reboot memory content. Reload the calibration
+  *                      parameters
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of boot in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_boot_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  *val = reg.ctrl_reg2.boot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  status: [get]
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_: registers STATUS_REG.
+  *
+  */
+int32_t lps25hb_status_get(lps25hb_ctx_t *ctx, lps25hb_status_reg_t *val)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  interrupts
+  * @brief   This section group all the functions that manage interrupts
+  * @{
+  */
+
+/**
+  * @brief  int_generation: [set]  Enable interrupt generation.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of diff_en in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_int_generation_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.diff_en = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_generation: [get]  Enable interrupt generation.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of diff_en in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_int_generation_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  *val = reg.ctrl_reg1.diff_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_pin_mode: [set]  Data signal on INT_DRDY pin control bits.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_int_s_t: change the values of int_s in reg CTRL_REG3
+  *
+  */
+int32_t lps25hb_int_pin_mode_set(lps25hb_ctx_t *ctx, lps25hb_int_s_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+  reg.ctrl_reg3.int_s = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_pin_mode: [get]  Data signal on INT_DRDY pin control bits.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_int_s_t: Get the values of int_s in reg CTRL_REG3
+  *
+  */
+int32_t lps25hb_int_pin_mode_get(lps25hb_ctx_t *ctx, lps25hb_int_s_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+  *val = (lps25hb_int_s_t) reg.ctrl_reg3.int_s;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_mode: [set]  Push-pull/open drain selection on interrupt pads.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_pp_od_t: change the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t lps25hb_pin_mode_set(lps25hb_ctx_t *ctx, lps25hb_pp_od_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+  reg.ctrl_reg3.pp_od = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_mode: [get]  Push-pull/open drain selection on interrupt pads.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_pp_od_t: Get the values of pp_od in reg CTRL_REG3
+  *
+  */
+int32_t lps25hb_pin_mode_get(lps25hb_ctx_t *ctx, lps25hb_pp_od_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+  *val = (lps25hb_pp_od_t) reg.ctrl_reg3.pp_od;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_polarity: [set]  Interrupt active-high/low.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_int_h_l_t: change the values of int_h_l in reg CTRL_REG3
+  *
+  */
+int32_t lps25hb_int_polarity_set(lps25hb_ctx_t *ctx, lps25hb_int_h_l_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+  reg.ctrl_reg3.int_h_l = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_polarity: [get]  Interrupt active-high/low.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_int_h_l_t: Get the values of int_h_l in reg CTRL_REG3
+  *
+  */
+int32_t lps25hb_int_polarity_get(lps25hb_ctx_t *ctx, lps25hb_int_h_l_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+  *val = (lps25hb_int_h_l_t) reg.ctrl_reg3.int_h_l;
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_int: [set]  Data-ready signal on INT_DRDY pin.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of drdy in reg CTRL_REG4
+  *
+  */
+int32_t lps25hb_drdy_on_int_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.drdy = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_int: [get]  Data-ready signal on INT_DRDY pin.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of drdy in reg CTRL_REG4
+  *
+  */
+int32_t lps25hb_drdy_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+  *val = reg.ctrl_reg4.drdy;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_on_int: [set]  FIFO overrun interrupt on INT_DRDY pin.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_ovr in reg CTRL_REG4
+  *
+  */
+int32_t lps25hb_fifo_ovr_on_int_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.f_ovr = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_on_int: [get]  FIFO overrun interrupt on INT_DRDY pin.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_ovr in reg CTRL_REG4
+  *
+  */
+int32_t lps25hb_fifo_ovr_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+  *val = reg.ctrl_reg4.f_ovr;
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_threshold_on_int: [set]  FIFO watermark status
+  *                                        on INT_DRDY pin.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_fth in reg CTRL_REG4
+  *
+  */
+int32_t lps25hb_fifo_threshold_on_int_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.f_fth = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_threshold_on_int: [get]  FIFO watermark status
+  *                                        on INT_DRDY pin.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_fth in reg CTRL_REG4
+  *
+  */
+int32_t lps25hb_fifo_threshold_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+  *val = reg.ctrl_reg4.f_fth;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_empty_on_int: [set]  FIFO empty flag on INT_DRDY pin.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_empty in reg CTRL_REG4
+  *
+  */
+int32_t lps25hb_fifo_empty_on_int_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+  reg.ctrl_reg4.f_empty = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_empty_on_int: [get]  FIFO empty flag on INT_DRDY pin.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_empty in reg CTRL_REG4
+  *
+  */
+int32_t lps25hb_fifo_empty_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
+  *val = reg.ctrl_reg4.f_empty;
+
+  return mm_error;
+}
+
+/**
+  * @brief   sign_of_int_threshold: [set]  Enable interrupt generation on
+  *                                        pressure low/high event.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_pe_t: change the values of pe in reg INTERRUPT_CFG
+  *
+  */
+int32_t lps25hb_sign_of_int_threshold_set(lps25hb_ctx_t *ctx,
+                                          lps25hb_pe_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
+  reg.interrupt_cfg.pe = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   sign_of_int_threshold: [get]  Enable interrupt generation on
+  *                                        pressure low/high event.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_pe_t: Get the values of pe in reg INTERRUPT_CFG
+  *
+  */
+int32_t lps25hb_sign_of_int_threshold_get(lps25hb_ctx_t *ctx,
+                                          lps25hb_pe_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
+  *val = (lps25hb_pe_t) reg.interrupt_cfg.pe;
+
+  return mm_error;
+}
+
+/**
+  * @brief   int_notification_mode: [set]  Interrupt request to the
+  *                                        INT_SOURCE (25h) register
+  *                                        mode (pulsed / latched)
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_lir_t: change the values of lir in reg INTERRUPT_CFG
+  *
+  */
+int32_t lps25hb_int_notification_mode_set(lps25hb_ctx_t *ctx,
+                                          lps25hb_lir_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
+  reg.interrupt_cfg.lir = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   int_notification_mode: [get]  Interrupt request to the
+  *                                        INT_SOURCE (25h) register mode
+  *                                        (pulsed / latched)
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_lir_t: Get the values of lir in reg INTERRUPT_CFG
+  *
+  */
+int32_t lps25hb_int_notification_mode_get(lps25hb_ctx_t *ctx,
+                                          lps25hb_lir_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
+  *val = (lps25hb_lir_t) reg.interrupt_cfg.lir;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_source: [get]  Interrupt source register
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_int_source_t: registers INT_SOURCE
+  *
+  */
+int32_t lps25hb_int_source_get(lps25hb_ctx_t *ctx, lps25hb_int_source_t *val)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  int_on_press_high: [get]  Differential pressure high
+  *                                   interrupt flag.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ph in reg INT_SOURCE
+  *
+  */
+int32_t lps25hb_int_on_press_high_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, &reg.byte, 1);
+  *val = reg.int_source.ph;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_on_press_low: [get]  Differential pressure low
+  *                                  interrupt flag.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of pl in reg INT_SOURCE
+  *
+  */
+int32_t lps25hb_int_on_press_low_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, &reg.byte, 1);
+  *val = reg.int_source.pl;
+
+  return mm_error;
+}
+
+/**
+  * @brief  interrupt_event: [get]  Interrupt active flag.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ia in reg INT_SOURCE
+  *
+  */
+int32_t lps25hb_interrupt_event_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, &reg.byte, 1);
+  *val = reg.int_source.ia;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_threshold: [set]  User-defined threshold value for
+  *                              pressure interrupt event
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t lps25hb_int_threshold_set(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_THS_P_L,  buff, 2);
+}
+
+/**
+  * @brief  int_threshold: [get]  User-defined threshold value for
+  *                              pressure interrupt event
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lps25hb_int_threshold_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_THS_P_L,  buff, 2);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  fifo
+  * @brief   This section group all the functions concerning the fifo usage
+  * @{
+  */
+
+/**
+  * @brief   stop_on_fifo_threshold: [set]  Stop on FIFO watermark.
+  *                                         Enable FIFO watermark level use.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of stop_on_fth in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_stop_on_fifo_threshold_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  reg.ctrl_reg2.stop_on_fth = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   stop_on_fifo_threshold: [get]  Stop on FIFO watermark.
+  *                                         Enable FIFO watermark
+  *                                         level use.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of stop_on_fth in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_stop_on_fifo_threshold_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  *val = reg.ctrl_reg2.stop_on_fth;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo: [set] FIFOenable.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of fifo_en in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_fifo_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  reg.ctrl_reg2.fifo_en = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo: [get] FIFOenable.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_en in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_fifo_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  *val = reg.ctrl_reg2.fifo_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of wtm_point in reg FIFO_CTRL
+  *
+  */
+int32_t lps25hb_fifo_watermark_set(lps25hb_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
+  reg.fifo_ctrl.wtm_point = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of wtm_point in reg FIFO_CTRL
+  *
+  */
+int32_t lps25hb_fifo_watermark_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
+  *val = reg.fifo_ctrl.wtm_point;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [set]  FIFO mode selection.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_f_mode_t: change the values of f_mode in reg FIFO_CTRL
+  *
+  */
+int32_t lps25hb_fifo_mode_set(lps25hb_ctx_t *ctx, lps25hb_f_mode_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
+  reg.fifo_ctrl.f_mode = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [get]  FIFO mode selection.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_f_mode_t: Get the values of f_mode in reg FIFO_CTRL
+  *
+  */
+int32_t lps25hb_fifo_mode_get(lps25hb_ctx_t *ctx, lps25hb_f_mode_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
+  *val = (lps25hb_f_mode_t) reg.fifo_ctrl.f_mode;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_status: [get]  FIFO status register.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_: registers FIFO_STATUS
+  *
+  */
+int32_t lps25hb_fifo_status_get(lps25hb_ctx_t *ctx, lps25hb_fifo_status_t *val)
+{
+  return lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  fifo_data_level: [get]  FIFO stored data level.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fss in reg FIFO_STATUS
+  *
+  */
+int32_t lps25hb_fifo_data_level_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, &reg.byte, 1);
+  *val = reg.fifo_status.fss;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_empty_flag: [get]  Empty FIFO status flag.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of empty_fifo in reg FIFO_STATUS
+  *
+  */
+int32_t lps25hb_fifo_empty_flag_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, &reg.byte, 1);
+  *val = reg.fifo_status.empty_fifo;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_flag: [get]  FIFO overrun status flag.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ovr in reg FIFO_STATUS
+  *
+  */
+int32_t lps25hb_fifo_ovr_flag_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, &reg.byte, 1);
+  *val = reg.fifo_status.ovr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_fth_flag: [get]  FIFO watermark status.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fth_fifo in reg FIFO_STATUS
+  *
+  */
+int32_t lps25hb_fifo_fth_flag_get(lps25hb_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, &reg.byte, 1);
+  *val = reg.fifo_status.fth_fifo;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  serial_interface
+  * @brief   This section group all the functions concerning serial
+  *          interface management
+  * @{
+  */
+
+/**
+  * @brief  spi_mode: [set]  SPI Serial Interface Mode selection.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_sim_t: change the values of sim in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_spi_mode_set(lps25hb_ctx_t *ctx, lps25hb_sim_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  reg.ctrl_reg1.sim = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  spi_mode: [get]  SPI Serial Interface Mode selection.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_sim_t: Get the values of sim in reg CTRL_REG1
+  *
+  */
+int32_t lps25hb_spi_mode_get(lps25hb_ctx_t *ctx, lps25hb_sim_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
+  *val = (lps25hb_sim_t) reg.ctrl_reg1.sim;
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [set]  Disable I2C interface.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_i2c_dis_t: change the values of i2c_dis in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_i2c_interface_set(lps25hb_ctx_t *ctx, lps25hb_i2c_dis_t val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  reg.ctrl_reg2.i2c_dis = val;
+  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [get]  Disable I2C interface.
+  *
+  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
+  * @param  lps25hb_i2c_dis_t: Get the values of i2c_dis in reg CTRL_REG2
+  *
+  */
+int32_t lps25hb_i2c_interface_get(lps25hb_ctx_t *ctx, lps25hb_i2c_dis_t *val)
+{
+  lps25hb_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
+  *val = (lps25hb_i2c_dis_t) reg.ctrl_reg2.i2c_dis;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps25hb_STdC/driver/lps25hb_reg.h
+++ b/sensor/stmemsc/lps25hb_STdC/driver/lps25hb_reg.h
@@ -1,0 +1,457 @@
+/*
+ ******************************************************************************
+ * @file    lps25hb_reg.h
+ * @author  MEMS Software Solution Team
+ * @date    20-September-2017
+ * @brief   This file contains all the functions prototypes for the
+ *          lps25hb_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __LPS25HB_DRIVER__H
+#define __LPS25HB_DRIVER__H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LPS25HB
+  * @{
+  *
+  */
+
+/** @defgroup LPS25HB_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup lps25hb_interface
+  * @{
+  */
+
+typedef int32_t (*lps25hb_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lps25hb_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lps25hb_write_ptr  write_reg;
+  lps25hb_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lps25hb_ctx_t;
+
+/**
+  * @}
+  */
+
+
+/** @defgroup lps25hb_Infos
+  * @{
+  */
+  /** I2C Device Address 8 bit format if SA0=0 -> B9 if SA0=1 -> BB **/
+#define LPS25HB_I2C_ADD_L    0xB9
+#define LPS25HB_I2C_ADD_H    0xBB
+
+/** Device Identification (Who am I) **/
+#define LPS25HB_ID             0xBD
+
+/**
+  * @}
+  */
+
+/**
+  * @defgroup lps25hb_Sensitivity
+  * @{
+  */
+
+#define LPS25HB_FROM_LSB_TO_hPa(lsb)      (float)( lsb / 4096.0f )
+#define LPS25HB_FROM_LSB_TO_degC(lsb)    ((float)( lsb / 480.0f ) + 42.5f )
+
+/**
+  * @}
+  */
+
+#define LPS25HB_REF_P_XL        0x08
+#define LPS25HB_REF_P_L         0x09
+#define LPS25HB_REF_P_H         0x0A
+#define LPS25HB_WHO_AM_I        0x0F
+#define LPS25HB_RES_CONF        0x10
+typedef struct {
+  uint8_t avgp             : 2;
+  uint8_t avgt             : 2;
+  uint8_t not_used_01      : 4;
+} lps25hb_res_conf_t;
+
+#define LPS25HB_CTRL_REG1       0x20
+typedef struct {
+  uint8_t sim              : 1;
+  uint8_t reset_az         : 1;
+  uint8_t bdu              : 1;
+  uint8_t diff_en          : 1;
+  uint8_t odr              : 4; /* pd + odr -> odr */
+} lps25hb_ctrl_reg1_t;
+
+#define LPS25HB_CTRL_REG2       0x21
+typedef struct {
+  uint8_t one_shot         : 1;
+  uint8_t autozero         : 1;
+  uint8_t swreset          : 1;
+  uint8_t i2c_dis          : 1;
+  uint8_t fifo_mean_dec    : 1;
+  uint8_t stop_on_fth      : 1;
+  uint8_t fifo_en          : 1;
+  uint8_t boot             : 1;
+} lps25hb_ctrl_reg2_t;
+
+#define LPS25HB_CTRL_REG3       0x22
+typedef struct {
+  uint8_t int_s           : 2;
+  uint8_t not_used_01     : 4;
+  uint8_t pp_od           : 1;
+  uint8_t int_h_l         : 1;
+} lps25hb_ctrl_reg3_t;
+
+#define LPS25HB_CTRL_REG4       0x23
+typedef struct {
+  uint8_t drdy            : 1;
+  uint8_t f_ovr           : 1;
+  uint8_t f_fth           : 1;
+  uint8_t f_empty         : 1;
+  uint8_t not_used_01     : 4;
+} lps25hb_ctrl_reg4_t;
+
+#define LPS25HB_INTERRUPT_CFG   0x24
+typedef struct {
+  uint8_t pe              : 2;  /* pl_e + ph_e -> pe */
+  uint8_t lir             : 1;
+  uint8_t not_used_01     : 5;
+} lps25hb_interrupt_cfg_t;
+
+#define LPS25HB_INT_SOURCE      0x25
+typedef struct {
+  uint8_t ph              : 1;
+  uint8_t pl              : 1;
+  uint8_t ia              : 1;
+  uint8_t not_used_01     : 5;
+} lps25hb_int_source_t;
+
+#define LPS25HB_STATUS_REG      0x27
+typedef struct {
+  uint8_t t_da            : 1;
+  uint8_t p_da            : 1;
+  uint8_t not_used_01     : 2;
+  uint8_t t_or            : 1;
+  uint8_t p_or            : 1;
+  uint8_t not_used_02     : 2;
+} lps25hb_status_reg_t;
+
+#define LPS25HB_PRESS_OUT_XL    0x28
+#define LPS25HB_PRESS_OUT_L     0x29
+#define LPS25HB_PRESS_OUT_H     0x2A
+#define LPS25HB_TEMP_OUT_L      0x2B
+#define LPS25HB_TEMP_OUT_H      0x2C
+#define LPS25HB_FIFO_CTRL       0x2E
+typedef struct {
+  uint8_t wtm_point       : 5;
+  uint8_t f_mode          : 3;
+} lps25hb_fifo_ctrl_t;
+
+#define LPS25HB_FIFO_STATUS     0x2F
+typedef struct {
+  uint8_t fss             : 5;
+  uint8_t empty_fifo      : 1;
+  uint8_t ovr             : 1;
+  uint8_t fth_fifo        : 1;
+} lps25hb_fifo_status_t;
+
+#define LPS25HB_THS_P_L         0x30
+#define LPS25HB_THS_P_H         0x31
+#define LPS25HB_RPDS_L          0x39
+#define LPS25HB_RPDS_H          0x3A
+
+typedef union{
+  lps25hb_res_conf_t            res_conf;
+  lps25hb_ctrl_reg1_t           ctrl_reg1;
+  lps25hb_ctrl_reg2_t           ctrl_reg2;
+  lps25hb_ctrl_reg3_t           ctrl_reg3;
+  lps25hb_ctrl_reg4_t           ctrl_reg4;
+  lps25hb_interrupt_cfg_t       interrupt_cfg;
+  lps25hb_int_source_t          int_source;
+  lps25hb_status_reg_t          status_reg;
+  lps25hb_fifo_ctrl_t           fifo_ctrl;
+  lps25hb_fifo_status_t         fifo_status;
+  bitwise_t                     bitwise;
+  uint8_t                       byte;
+} lps25hb_reg_t;
+
+int32_t lps25hb_read_reg(lps25hb_ctx_t *ctx, uint8_t reg, uint8_t* data, uint16_t len);
+int32_t lps25hb_write_reg(lps25hb_ctx_t *ctx, uint8_t reg, uint8_t* data, uint16_t len);
+
+int32_t lps25hb_pressure_ref_set(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_pressure_ref_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LPS25HB_P_AVG_8  = 0,
+  LPS25HB_P_AVG_16 = 1,
+  LPS25HB_P_AVG_32 = 2,
+  LPS25HB_P_AVG_64 = 3,
+} lps25hb_avgp_t;
+int32_t lps25hb_pressure_avg_set(lps25hb_ctx_t *ctx, lps25hb_avgp_t val);
+int32_t lps25hb_pressure_avg_get(lps25hb_ctx_t *ctx, lps25hb_avgp_t *val);
+
+typedef enum {
+  LPS25HB_T_AVG_8  = 0,
+  LPS25HB_T_AVG_16 = 1,
+  LPS25HB_T_AVG_32 = 2,
+  LPS25HB_T_AVG_64 = 3,
+} lps25hb_avgt_t;
+int32_t lps25hb_temperature_avg_set(lps25hb_ctx_t *ctx, lps25hb_avgt_t val);
+int32_t lps25hb_temperature_avg_get(lps25hb_ctx_t *ctx, lps25hb_avgt_t *val);
+
+int32_t lps25hb_autozero_rst_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_autozero_rst_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_block_data_update_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_block_data_update_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS25HB_POWER_DOWN = 0,
+  LPS25HB_ODR_1Hz    = 9,
+  LPS25HB_ODR_7Hz    = 11,
+  LPS25HB_ODR_12Hz5  = 12,
+  LPS25HB_ODR_25Hz   = 13,
+  LPS25HB_ONE_SHOT   = 8,
+} lps25hb_odr_t;
+int32_t lps25hb_data_rate_set(lps25hb_ctx_t *ctx, lps25hb_odr_t val);
+int32_t lps25hb_data_rate_get(lps25hb_ctx_t *ctx, lps25hb_odr_t *val);
+
+int32_t lps25hb_one_shoot_trigger_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_one_shoot_trigger_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_autozero_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_autozero_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_mean_decimator_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_mean_decimator_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_press_data_ready_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_temp_data_ready_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_temp_data_ovr_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_press_data_ovr_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_pressure_raw_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps25hb_temperature_raw_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps25hb_pressure_offset_set(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_pressure_offset_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps25hb_device_id_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps25hb_reset_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_reset_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_boot_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_boot_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_status_get(lps25hb_ctx_t *ctx, lps25hb_status_reg_t *val);
+
+int32_t lps25hb_int_generation_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_int_generation_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS25HB_DRDY_OR_FIFO_FLAGS  = 0,
+  LPS25HB_HIGH_PRES_INT       = 1,
+  LPS25HB_LOW_PRES_INT        = 2,
+  LPS25HB_EVERY_PRES_INT      = 3,
+} lps25hb_int_s_t;
+int32_t lps25hb_int_pin_mode_set(lps25hb_ctx_t *ctx, lps25hb_int_s_t val);
+int32_t lps25hb_int_pin_mode_get(lps25hb_ctx_t *ctx, lps25hb_int_s_t *val);
+
+typedef enum {
+  LPS25HB_PUSH_PULL   = 0,
+  LPS25HB_OPEN_DRAIN  = 1,
+} lps25hb_pp_od_t;
+int32_t lps25hb_pin_mode_set(lps25hb_ctx_t *ctx, lps25hb_pp_od_t val);
+int32_t lps25hb_pin_mode_get(lps25hb_ctx_t *ctx, lps25hb_pp_od_t *val);
+
+typedef enum {
+  LPS25HB_ACTIVE_HIGH = 0,
+  LPS25HB_ACTIVE_LOW  = 1,
+} lps25hb_int_h_l_t;
+int32_t lps25hb_int_polarity_set(lps25hb_ctx_t *ctx, lps25hb_int_h_l_t val);
+int32_t lps25hb_int_polarity_get(lps25hb_ctx_t *ctx, lps25hb_int_h_l_t *val);
+
+int32_t lps25hb_drdy_on_int_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_drdy_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_ovr_on_int_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_ovr_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_threshold_on_int_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_threshold_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_empty_on_int_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_empty_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS25HB_NO_THRESHOLD = 0,
+  LPS25HB_POSITIVE     = 1,
+  LPS25HB_NEGATIVE     = 2,
+  LPS25HB_BOTH         = 3,
+} lps25hb_pe_t;
+int32_t lps25hb_sign_of_int_threshold_set(lps25hb_ctx_t *ctx, lps25hb_pe_t val);
+int32_t lps25hb_sign_of_int_threshold_get(lps25hb_ctx_t *ctx, lps25hb_pe_t *val);
+
+typedef enum {
+  LPS25HB_INT_PULSED = 0,
+  LPS25HB_INT_LATCHED = 1,
+} lps25hb_lir_t;
+int32_t lps25hb_int_notification_mode_set(lps25hb_ctx_t *ctx, lps25hb_lir_t val);
+int32_t lps25hb_int_notification_mode_get(lps25hb_ctx_t *ctx, lps25hb_lir_t *val);
+
+int32_t lps25hb_int_source_get(lps25hb_ctx_t *ctx, lps25hb_int_source_t *val);
+
+int32_t lps25hb_int_on_press_high_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_int_on_press_low_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_interrupt_event_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_int_threshold_set(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_int_threshold_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps25hb_stop_on_fifo_threshold_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_stop_on_fifo_threshold_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_watermark_set(lps25hb_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_watermark_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS25HB_BYPASS_MODE               = 0,
+  LPS25HB_FIFO_MODE                 = 1,
+  LPS25HB_STREAM_MODE               = 2,
+  LPS25HB_Stream_to_FIFO_mode      = 3,
+  LPS25HB_BYPASS_TO_STREAM_MODE    = 4,
+  LPS25HB_MEAN_MODE                 = 6,
+  LPS25HB_BYPASS_TO_FIFO_MODE      = 7,
+} lps25hb_f_mode_t;
+int32_t lps25hb_fifo_mode_set(lps25hb_ctx_t *ctx, lps25hb_f_mode_t val);
+int32_t lps25hb_fifo_mode_get(lps25hb_ctx_t *ctx, lps25hb_f_mode_t *val);
+
+int32_t lps25hb_fifo_status_get(lps25hb_ctx_t *ctx, lps25hb_fifo_status_t *val);
+
+int32_t lps25hb_fifo_data_level_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_empty_flag_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_ovr_flag_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+int32_t lps25hb_fifo_fth_flag_get(lps25hb_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS25HB_SPI_4_WIRE = 0,
+  LPS25HB_SPI_3_WIRE = 1,
+} lps25hb_sim_t;
+int32_t lps25hb_spi_mode_set(lps25hb_ctx_t *ctx, lps25hb_sim_t val);
+int32_t lps25hb_spi_mode_get(lps25hb_ctx_t *ctx, lps25hb_sim_t *val);
+
+typedef enum {
+  LPS25HB_I2C_ENABLE  = 0,
+  LPS25HB_I2C_DISABLE = 1,
+} lps25hb_i2c_dis_t;
+int32_t lps25hb_i2c_interface_set(lps25hb_ctx_t *ctx, lps25hb_i2c_dis_t val);
+int32_t lps25hb_i2c_interface_get(lps25hb_ctx_t *ctx, lps25hb_i2c_dis_t *val);
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__LPS25HB_DRIVER__H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps33hw_STdC/driver/lps33hw_reg.c
+++ b/sensor/stmemsc/lps33hw_STdC/driver/lps33hw_reg.c
@@ -1,0 +1,1865 @@
+/*
+ ******************************************************************************
+ * @file    lps33hw_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LPS33HW driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lps33hw_reg.h"
+
+/**
+  * @defgroup    LPS33HW
+  * @brief       This file provides a set of functions needed to drive the
+  *              ultra-compact piezoresistive absolute pressure sensor.
+  * @{
+  *
+  */
+
+/** 
+  * @defgroup    LPS33HW_Interfaces_functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps33hw_read_reg(lps33hw_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps33hw_write_reg(lps33hw_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33HW_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lps33hw_from_lsb_to_hpa(int16_t lsb)
+{
+  return ( (float_t)lsb / 4096.0f );
+}
+
+float_t lps33hw_from_lsb_to_degc(int16_t lsb)
+{
+  return ( (float_t)lsb / 100.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33HW_data_generation_c
+  * @brief       This section group all the functions concerning data
+  *              generation
+  * @{
+  *
+  */
+
+
+/**
+  * @brief  Reset Autozero function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_az in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+
+int32_t lps33hw_autozero_rst_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.reset_az = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Autozero function.[get] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_az in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_autozero_rst_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.reset_az;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autozero in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_autozero_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG, 
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.autozero = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autozero in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_autozero_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.autozero;
+
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[set] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_snap_rst_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.reset_arp = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_snap_rst_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.reset_arp;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRifP function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autorifp in reg INTERRUPT_CFG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_snap_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.autorifp = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRifP function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autorifp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_snap_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.autorifp;
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_block_data_update_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.bdu = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_block_data_update_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lpfp in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_low_pass_filter_mode_set(lps33hw_ctx_t *ctx,
+                                          lps33hw_lpfp_t val)
+{
+  lps33hw_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.lpfp = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Low-pass bandwidth selection.[get] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpfp in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_low_pass_filter_mode_get(lps33hw_ctx_t *ctx,
+                                         lps33hw_lpfp_t *val)
+{
+  lps33hw_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.lpfp){
+    case LPS33HW_LPF_ODR_DIV_2:
+      *val = LPS33HW_LPF_ODR_DIV_2;
+      break;
+    case LPS33HW_LPF_ODR_DIV_9:
+      *val = LPS33HW_LPF_ODR_DIV_9;
+      break;
+    case LPS33HW_LPF_ODR_DIV_20:
+      *val = LPS33HW_LPF_ODR_DIV_20;
+      break;
+    default:
+      *val = LPS33HW_LPF_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_data_rate_set(lps33hw_ctx_t *ctx, lps33hw_odr_t val)
+{
+  lps33hw_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.odr = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_data_rate_get(lps33hw_ctx_t *ctx, lps33hw_odr_t *val)
+{
+  lps33hw_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.odr){
+    case LPS33HW_POWER_DOWN:
+      *val = LPS33HW_POWER_DOWN;
+      break;
+    case LPS33HW_ODR_1_Hz:
+      *val = LPS33HW_ODR_1_Hz;
+      break;
+    case LPS33HW_ODR_10_Hz:
+      *val = LPS33HW_ODR_10_Hz;
+      break;
+    case LPS33HW_ODR_25_Hz:
+      *val = LPS33HW_ODR_25_Hz;
+      break;
+    case LPS33HW_ODR_50_Hz:
+      *val = LPS33HW_ODR_50_Hz;
+      break;
+    case LPS33HW_ODR_75_Hz:
+      *val = LPS33HW_ODR_75_Hz;
+      break;
+    default:
+      *val = LPS33HW_ODR_1_Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[set] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of one_shot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_one_shoot_trigger_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.one_shot = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of one_shot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_one_shoot_trigger_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.one_shot;
+
+  return ret;
+}
+
+/**
+  * @brief  pressure_ref:   The Reference pressure value is a 24-bit data
+  *         expressed as 2’s complement. The value is used when AUTOZERO
+  *         or AUTORIFP function is enabled.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_ref_set(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_write_reg(ctx, LPS33HW_REF_P_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  pressure_ref:   The Reference pressure value is a 24-bit data
+  *         expressed as 2’s complement. The value is used when AUTOZERO
+  *         or AUTORIFP function is enabled.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_ref_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_REF_P_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data that can be used to
+  *         implement one-point calibration (OPC) after soldering.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_offset_set(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_write_reg(ctx, LPS33HW_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data that can be used to
+  *         implement one-point calibration (OPC) after soldering.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_offset_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Pressure data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of p_da in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_press_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_status_t status;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_STATUS, (uint8_t*)&status, 1);
+  *val = status.p_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of t_da in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_temp_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_status_t status;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_STATUS, (uint8_t*)&status, 1);
+  *val = status.t_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of p_or in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_press_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_status_t status;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_STATUS, (uint8_t*)&status, 1);
+  *val = status.p_or;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of t_or in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_temp_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_status_t status;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_STATUS, (uint8_t*)&status, 1);
+  *val = status.t_or;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure output value[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pressure_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_PRESS_OUT_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  temperature_raw:   Temperature output value[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_temperature_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_TEMP_OUT_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Low-pass filter reset register. If the LPFP is active, in
+  *         order to avoid the transitory phase, the filter can be
+  *         reset by reading this register before generating pressure
+  *         measurements.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_low_pass_rst_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_LPFP_RES, (uint8_t*) buff, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33HW_common
+  * @brief       This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_device_id_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_WHO_AM_I, (uint8_t*) buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of swreset in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_reset_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.swreset = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of swreset in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_reset_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.swreset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_boot_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.boot = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_boot_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Low current mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lc_en in reg RES_CONF
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_low_power_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_res_conf_t res_conf;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_RES_CONF, (uint8_t*)&res_conf, 1);
+  if(ret == 0){
+    res_conf.lc_en = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_RES_CONF, (uint8_t*)&res_conf, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low current mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lc_en in reg RES_CONF
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_low_power_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_res_conf_t res_conf;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_RES_CONF, (uint8_t*)&res_conf, 1);
+  *val = res_conf.lc_en;
+
+  return ret;
+}
+
+/**
+  * @brief  If ‘1’ indicates that the Boot (Reboot) phase is running.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot_status in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_boot_status_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.boot_status;
+
+  return ret;
+}
+
+/**
+  * @brief  All the status bit, FIFO and data generation[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from FIFO_STATUS to STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_dev_status_get(lps33hw_ctx_t *ctx, lps33hw_dev_stat_t *val)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_FIFO_STATUS, (uint8_t*) val, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33HW_interrupts
+  * @brief       This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pe in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_sign_of_int_threshold_set(lps33hw_ctx_t *ctx,
+                                           lps33hw_pe_t val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.pe = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pe in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_sign_of_int_threshold_get(lps33hw_ctx_t *ctx,
+                                           lps33hw_pe_t *val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  switch (interrupt_cfg.pe){
+    case LPS33HW_NO_THRESHOLD:
+      *val = LPS33HW_NO_THRESHOLD;
+      break;
+    case LPS33HW_POSITIVE:
+      *val = LPS33HW_POSITIVE;
+      break;
+    case LPS33HW_NEGATIVE:
+      *val = LPS33HW_NEGATIVE;
+      break;
+    case LPS33HW_BOTH:
+      *val = LPS33HW_BOTH;
+      break;
+    default:
+      *val = LPS33HW_NO_THRESHOLD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt request to the INT_SOURCE (25h) register
+  *         mode (pulsed / latched) [set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lir in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_notification_mode_set(lps33hw_ctx_t *ctx,
+                                           lps33hw_lir_t val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.lir = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt request to the INT_SOURCE (25h) register
+  *          mode (pulsed / latched) [get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lir in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_notification_mode_get(lps33hw_ctx_t *ctx,
+                                          lps33hw_lir_t *val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  switch (interrupt_cfg.lir){
+    case LPS33HW_INT_PULSED:
+      *val = LPS33HW_INT_PULSED;
+      break;
+    case LPS33HW_INT_LATCHED:
+      *val = LPS33HW_INT_LATCHED;
+      break;
+    default:
+      *val = LPS33HW_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of diff_en in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_generation_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.diff_en = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                            (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of diff_en in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_generation_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INTERRUPT_CFG,
+                         (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.diff_en;
+
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_threshold_set(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_write_reg(ctx, LPS33HW_THS_P_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_threshold_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_THS_P_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT_DRDY pin control bits.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int_s in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_int_s_t val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.int_s = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT_DRDY pin control bits.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of int_s in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_int_s_t *val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.int_s){
+    case LPS33HW_DRDY_OR_FIFO_FLAGS:
+      *val = LPS33HW_DRDY_OR_FIFO_FLAGS;
+      break;
+    case LPS33HW_HIGH_PRES_INT:
+      *val = LPS33HW_HIGH_PRES_INT;
+      break;
+    case LPS33HW_LOW_PRES_INT:
+      *val = LPS33HW_LOW_PRES_INT;
+      break;
+    case LPS33HW_EVERY_PRES_INT:
+      *val = LPS33HW_EVERY_PRES_INT;
+      break;
+    default:
+      *val = LPS33HW_DRDY_OR_FIFO_FLAGS;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_drdy_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.drdy = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_drdy_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_ovr in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_ovr_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_ovr = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_ovr in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_ovr_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fth in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_threshold_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_fth = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   FIFO watermark status on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fth in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_threshold_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fss5 in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_full_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_fss5 = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fss5 in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_full_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_fss5;
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_pp_od_t val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_pp_od_t *val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.pp_od){
+    case LPS33HW_PUSH_PULL:
+      *val = LPS33HW_PUSH_PULL;
+      break;
+    case LPS33HW_OPEN_DRAIN:
+      *val = LPS33HW_OPEN_DRAIN;
+      break;
+    default:
+      *val = LPS33HW_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int_h_l in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_polarity_set(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.int_h_l = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of int_h_l in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_polarity_get(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t *val)
+{
+  lps33hw_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.int_h_l){
+    case LPS33HW_ACTIVE_HIGH:
+      *val = LPS33HW_ACTIVE_HIGH;
+      break;
+    case LPS33HW_ACTIVE_LOW:
+      *val = LPS33HW_ACTIVE_LOW;
+      break;
+    default:
+      *val = LPS33HW_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt source register[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Register INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_source_get(lps33hw_ctx_t *ctx, lps33hw_int_source_t *val)
+{
+  int32_t ret;
+  ret =  lps33hw_read_reg(ctx, LPS33HW_INT_SOURCE, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Differential pressure high interrupt flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ph in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_on_press_high_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.ph;
+
+  return ret;
+}
+
+/**
+  * @brief  Differential pressure low interrupt flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pl in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_int_on_press_low_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.pl;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ia in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_interrupt_event_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.ia;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33HW_fifo
+  * @brief       This section group all the functions concerning the
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief   Stop on FIFO watermark. Enable FIFO watermark level use.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_stop_on_fifo_threshold_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.stop_on_fth = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Stop on FIFO watermark. Enable FIFO watermark level use.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_stop_on_fifo_threshold_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_en in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.fifo_en = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_en in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wtm in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_watermark_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.wtm = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wtm in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_watermark_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = fifo_ctrl.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_mode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_mode_set(lps33hw_ctx_t *ctx, lps33hw_f_mode_t val)
+{
+  lps33hw_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.f_mode = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of f_mode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_mode_get(lps33hw_ctx_t *ctx, lps33hw_f_mode_t *val)
+{
+  lps33hw_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  switch (fifo_ctrl.f_mode){
+    case LPS33HW_BYPASS_MODE:
+      *val = LPS33HW_BYPASS_MODE;
+      break;
+    case LPS33HW_FIFO_MODE:
+      *val = LPS33HW_FIFO_MODE;
+      break;
+    case LPS33HW_STREAM_MODE:
+      *val = LPS33HW_STREAM_MODE;
+      break;
+    case LPS33HW_STREAM_TO_FIFO_MODE:
+      *val = LPS33HW_STREAM_TO_FIFO_MODE;
+      break;
+    case LPS33HW_BYPASS_TO_STREAM_MODE:
+      *val = LPS33HW_BYPASS_TO_STREAM_MODE;
+      break;
+    case LPS33HW_DYNAMIC_STREAM_MODE:
+      *val = LPS33HW_DYNAMIC_STREAM_MODE;
+      break;
+    case LPS33HW_BYPASS_TO_FIFO_MODE:
+      *val = LPS33HW_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LPS33HW_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fss in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_data_level_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ovr in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_ovr_flag_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth_fifo in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_fifo_fth_flag_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.fth_fifo;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33HW_serial_interface
+  * @brief       This section group all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sim in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_spi_mode_set(lps33hw_ctx_t *ctx, lps33hw_sim_t val)
+{
+  lps33hw_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.sim = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_spi_mode_get(lps33hw_ctx_t *ctx, lps33hw_sim_t *val)
+{
+  lps33hw_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.sim){
+    case LPS33HW_SPI_4_WIRE:
+      *val = LPS33HW_SPI_4_WIRE;
+      break;
+    case LPS33HW_SPI_3_WIRE:
+      *val = LPS33HW_SPI_3_WIRE;
+      break;
+    default:
+      *val = LPS33HW_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of i2c_dis in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_i2c_interface_set(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.i2c_dis = (uint8_t)val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of i2c_dis in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_i2c_interface_get(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t *val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.i2c_dis){
+    case LPS33HW_I2C_ENABLE:
+      *val = LPS33HW_I2C_ENABLE;
+      break;
+    case LPS33HW_I2C_DISABLE:
+      *val = LPS33HW_I2C_DISABLE;
+      break;
+    default:
+      *val = LPS33HW_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a
+  *         multiple byte access with a serial interface (I2C or SPI).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_add_inc in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_auto_add_inc_set(lps33hw_ctx_t *ctx, uint8_t val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.if_add_inc = val;
+    ret = lps33hw_write_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a
+  *         multiple byte access with a serial interface (I2C or SPI).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_add_inc in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33hw_auto_add_inc_get(lps33hw_ctx_t *ctx, uint8_t *val)
+{
+  lps33hw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33hw_read_reg(ctx, LPS33HW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps33hw_STdC/driver/lps33hw_reg.h
+++ b/sensor/stmemsc/lps33hw_STdC/driver/lps33hw_reg.h
@@ -1,0 +1,502 @@
+/*
+ ******************************************************************************
+ * @file    lps33hw_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lps33hw_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LPS33HW_REGS_H
+#define LPS33HW_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LPS33HW
+  * @{
+  *
+  */
+
+/** @defgroup LPS33HW_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LPS33HW_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lps33hw_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lps33hw_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lps33hw_write_ptr  write_reg;
+  lps33hw_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lps33hw_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+
+/** @defgroup LSM9DS1_Infos
+  * @{
+  *
+  */
+
+  /** I2C Device Address 8 bit format: if SA0=0 -> 0xB9 if SA0=1 -> 0xBB **/
+#define LPS33HW_I2C_ADD_H   0xBBU
+#define LPS33HW_I2C_ADD_L   0xB9U
+
+/** Device Identification (Who am I) **/
+#define LPS33HW_ID            0xB1U
+
+/**
+  * @}
+  *
+  */
+
+#define LPS33HW_INTERRUPT_CFG  0x0BU
+typedef struct {
+  uint8_t pe               : 2; /* ple + phe -> pe */
+  uint8_t lir              : 1;
+  uint8_t diff_en          : 1;
+  uint8_t reset_az         : 1;
+  uint8_t autozero         : 1;
+  uint8_t reset_arp        : 1;
+  uint8_t autorifp         : 1;
+} lps33hw_interrupt_cfg_t;
+
+#define LPS33HW_THS_P_L        0x0CU
+#define LPS33HW_THS_P_H        0x0DU
+#define LPS33HW_WHO_AM_I       0x0FU
+#define LPS33HW_CTRL_REG1      0x10U
+typedef struct {
+  uint8_t sim              : 1;
+  uint8_t bdu              : 1;
+  uint8_t lpfp             : 2; /* en_lpfp + lpfp_cfg -> lpfp */
+  uint8_t odr              : 3;
+  uint8_t not_used_01      : 1;
+} lps33hw_ctrl_reg1_t;
+
+#define LPS33HW_CTRL_REG2      0x11U
+typedef struct {
+  uint8_t one_shot         : 1;
+  uint8_t not_used_01      : 1;
+  uint8_t swreset          : 1;
+  uint8_t i2c_dis          : 1;
+  uint8_t if_add_inc       : 1;
+  uint8_t stop_on_fth      : 1;
+  uint8_t fifo_en          : 1;
+  uint8_t boot             : 1;
+} lps33hw_ctrl_reg2_t;
+
+#define LPS33HW_CTRL_REG3      0x12U
+typedef struct {
+  uint8_t int_s            : 2;
+  uint8_t drdy             : 1;
+  uint8_t f_ovr            : 1;
+  uint8_t f_fth            : 1;
+  uint8_t f_fss5           : 1;
+  uint8_t pp_od            : 1;
+  uint8_t int_h_l          : 1;
+} lps33hw_ctrl_reg3_t;
+
+
+#define LPS33HW_FIFO_CTRL      0x14U
+typedef struct {
+  uint8_t wtm              : 5;
+  uint8_t f_mode           : 3;
+} lps33hw_fifo_ctrl_t;
+
+#define LPS33HW_REF_P_XL       0x15U
+#define LPS33HW_REF_P_L        0x16U
+#define LPS33HW_REF_P_H        0x17U
+#define LPS33HW_RPDS_L         0x18U
+#define LPS33HW_RPDS_H         0x19U
+
+#define LPS33HW_RES_CONF       0x1AU
+typedef struct {
+  uint8_t lc_en            : 1;
+  uint8_t not_used_01      : 7;
+} lps33hw_res_conf_t;
+
+#define LPS33HW_INT_SOURCE     0x25U
+typedef struct {
+  uint8_t ph               : 1;
+  uint8_t pl               : 1;
+  uint8_t ia               : 1;
+  uint8_t not_used_01      : 4;
+  uint8_t boot_status      : 1;
+} lps33hw_int_source_t;
+
+#define LPS33HW_FIFO_STATUS    0x26U
+typedef struct {
+  uint8_t fss              : 6;
+  uint8_t ovr              : 1;
+  uint8_t fth_fifo         : 1;
+} lps33hw_fifo_status_t;
+
+#define LPS33HW_STATUS         0x27U
+typedef struct {
+  uint8_t p_da             : 1;
+  uint8_t t_da             : 1;
+  uint8_t not_used_02      : 2;
+  uint8_t p_or             : 1;
+  uint8_t t_or             : 1;
+  uint8_t not_used_01      : 2;
+} lps33hw_status_t;
+
+#define LPS33HW_PRESS_OUT_XL   0x28U
+#define LPS33HW_PRESS_OUT_L    0x29U
+#define LPS33HW_PRESS_OUT_H    0x2AU
+#define LPS33HW_TEMP_OUT_L     0x2BU
+#define LPS33HW_TEMP_OUT_H     0x2CU
+#define LPS33HW_LPFP_RES       0x33U
+
+/**
+  * @defgroup LPS33HW_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  lps33hw_interrupt_cfg_t      interrupt_cfg;
+  lps33hw_ctrl_reg1_t          ctrl_reg1;
+  lps33hw_ctrl_reg2_t          ctrl_reg2;
+  lps33hw_ctrl_reg3_t          ctrl_reg3;
+  lps33hw_fifo_ctrl_t          fifo_ctrl;
+  lps33hw_res_conf_t           res_conf;
+  lps33hw_int_source_t         int_source;
+  lps33hw_fifo_status_t        fifo_status;
+  lps33hw_status_t             status;
+  bitwise_t                    bitwise;
+  uint8_t                      byte;
+} lps33hw_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lps33hw_read_reg(lps33hw_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lps33hw_write_reg(lps33hw_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lps33hw_from_lsb_to_hpa(int16_t lsb);
+extern float_t lps33hw_from_lsb_to_degc(int16_t lsb);
+
+int32_t lps33hw_autozero_rst_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_autozero_rst_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_autozero_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_autozero_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_pressure_snap_rst_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_pressure_snap_rst_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_pressure_snap_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_pressure_snap_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_block_data_update_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_block_data_update_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS33HW_LPF_ODR_DIV_2  = 0,
+  LPS33HW_LPF_ODR_DIV_9  = 2,
+  LPS33HW_LPF_ODR_DIV_20 = 3,
+} lps33hw_lpfp_t;
+int32_t lps33hw_low_pass_filter_mode_set(lps33hw_ctx_t *ctx,
+                                         lps33hw_lpfp_t val);
+int32_t lps33hw_low_pass_filter_mode_get(lps33hw_ctx_t *ctx,
+                                         lps33hw_lpfp_t *val);
+
+typedef enum {
+  LPS33HW_POWER_DOWN  = 0,
+  LPS33HW_ODR_1_Hz    = 1,
+  LPS33HW_ODR_10_Hz   = 2,
+  LPS33HW_ODR_25_Hz   = 3,
+  LPS33HW_ODR_50_Hz   = 4,
+  LPS33HW_ODR_75_Hz   = 5,
+} lps33hw_odr_t;
+int32_t lps33hw_data_rate_set(lps33hw_ctx_t *ctx, lps33hw_odr_t val);
+int32_t lps33hw_data_rate_get(lps33hw_ctx_t *ctx, lps33hw_odr_t *val);
+
+int32_t lps33hw_one_shoot_trigger_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_one_shoot_trigger_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_pressure_ref_set(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_pressure_ref_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33hw_pressure_offset_set(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_pressure_offset_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33hw_press_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_temp_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_press_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_temp_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_pressure_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33hw_temperature_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33hw_low_pass_rst_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33hw_device_id_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33hw_reset_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_reset_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_boot_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_boot_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_low_power_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_low_power_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_boot_status_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+typedef struct{
+  lps33hw_fifo_status_t  fifo_status;
+  lps33hw_status_t       status;
+} lps33hw_dev_stat_t;
+int32_t lps33hw_dev_status_get(lps33hw_ctx_t *ctx, lps33hw_dev_stat_t *val);
+
+typedef enum {
+  LPS33HW_NO_THRESHOLD = 0,
+  LPS33HW_POSITIVE     = 1,
+  LPS33HW_NEGATIVE     = 2,
+  LPS33HW_BOTH         = 3,
+} lps33hw_pe_t;
+int32_t lps33hw_sign_of_int_threshold_set(lps33hw_ctx_t *ctx,
+                                          lps33hw_pe_t val);
+int32_t lps33hw_sign_of_int_threshold_get(lps33hw_ctx_t *ctx,
+                                          lps33hw_pe_t *val);
+
+typedef enum {
+  LPS33HW_INT_PULSED  = 0,
+  LPS33HW_INT_LATCHED = 1,
+} lps33hw_lir_t;
+int32_t lps33hw_int_notification_mode_set(lps33hw_ctx_t *ctx,
+                                          lps33hw_lir_t val);
+int32_t lps33hw_int_notification_mode_get(lps33hw_ctx_t *ctx,
+                                          lps33hw_lir_t *val);
+
+int32_t lps33hw_int_generation_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_int_generation_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_int_threshold_set(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_int_threshold_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LPS33HW_DRDY_OR_FIFO_FLAGS = 0,
+  LPS33HW_HIGH_PRES_INT      = 1,
+  LPS33HW_LOW_PRES_INT       = 2,
+  LPS33HW_EVERY_PRES_INT     = 3,
+} lps33hw_int_s_t;
+int32_t lps33hw_int_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_int_s_t val);
+int32_t lps33hw_int_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_int_s_t *val);
+
+int32_t lps33hw_drdy_on_int_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_drdy_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_fifo_ovr_on_int_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_ovr_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_fifo_threshold_on_int_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_threshold_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_fifo_full_on_int_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_full_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS33HW_PUSH_PULL  = 0,
+  LPS33HW_OPEN_DRAIN = 1,
+} lps33hw_pp_od_t;
+int32_t lps33hw_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_pp_od_t val);
+int32_t lps33hw_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_pp_od_t *val);
+
+typedef enum {
+  LPS33HW_ACTIVE_HIGH = 0,
+  LPS33HW_ACTIVE_LOW = 1,
+} lps33hw_int_h_l_t;
+int32_t lps33hw_int_polarity_set(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t val);
+int32_t lps33hw_int_polarity_get(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t *val);
+
+int32_t lps33hw_int_source_get(lps33hw_ctx_t *ctx, lps33hw_int_source_t *val);
+
+int32_t lps33hw_int_on_press_high_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_int_on_press_low_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_interrupt_event_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_stop_on_fifo_threshold_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_stop_on_fifo_threshold_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_fifo_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_fifo_watermark_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_watermark_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS33HW_BYPASS_MODE           = 0,
+  LPS33HW_FIFO_MODE             = 1,
+  LPS33HW_STREAM_MODE           = 2,
+  LPS33HW_STREAM_TO_FIFO_MODE   = 3,
+  LPS33HW_BYPASS_TO_STREAM_MODE = 4,
+  LPS33HW_DYNAMIC_STREAM_MODE   = 6,
+  LPS33HW_BYPASS_TO_FIFO_MODE   = 7,
+} lps33hw_f_mode_t;
+int32_t lps33hw_fifo_mode_set(lps33hw_ctx_t *ctx, lps33hw_f_mode_t val);
+int32_t lps33hw_fifo_mode_get(lps33hw_ctx_t *ctx, lps33hw_f_mode_t *val);
+
+int32_t lps33hw_fifo_data_level_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_fifo_ovr_flag_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33hw_fifo_fth_flag_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS33HW_SPI_4_WIRE = 0,
+  LPS33HW_SPI_3_WIRE = 1,
+} lps33hw_sim_t;
+int32_t lps33hw_spi_mode_set(lps33hw_ctx_t *ctx, lps33hw_sim_t val);
+int32_t lps33hw_spi_mode_get(lps33hw_ctx_t *ctx, lps33hw_sim_t *val);
+
+typedef enum {
+  LPS33HW_I2C_ENABLE = 0,
+  LPS33HW_I2C_DISABLE = 1,
+} lps33hw_i2c_dis_t;
+int32_t lps33hw_i2c_interface_set(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t val);
+int32_t lps33hw_i2c_interface_get(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t *val);
+
+int32_t lps33hw_auto_add_inc_set(lps33hw_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_auto_add_inc_get(lps33hw_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPS33HW_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm303agr_STdC/driver/lsm303agr_reg.c
+++ b/sensor/stmemsc/lsm303agr_STdC/driver/lsm303agr_reg.c
@@ -1,0 +1,3561 @@
+/*
+  ******************************************************************************
+  * @file    lsm303agr_reg.c
+  * @author  Sensor Solutions Software Team
+  * @brief   LSM303AGR driver file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions
+  * are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright
+  *      notice, this list of conditions and the following disclaimer in the
+  *      documentation and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its
+  *      contributors may be used to endorse or promote products derived from
+  *      this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  * POSSIBILITY OF SUCH DAMAGE.
+  *
+  */
+
+#include "lsm303agr_reg.h"
+
+/**
+  * @defgroup  LSM303AGR
+  * @brief     This file provides a set of functions needed to drive the
+  *            lsm303agr enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LSM303AGR_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm303agr_read_reg(lsm303agr_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm303agr_write_reg(lsm303agr_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM303AGR_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lsm303agr_from_fs_2g_hr_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 16.0f ) * 0.98f;
+}
+
+float_t lsm303agr_from_fs_4g_hr_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 16.0f ) * 1.95f;
+}
+
+float_t lsm303agr_from_fs_8g_hr_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 16.0f ) * 3.9f;
+}
+
+float_t lsm303agr_from_fs_16g_hr_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 16.0f ) * 11.72f;
+}
+
+float_t lsm303agr_from_lsb_hr_to_celsius(int16_t lsb)
+{
+  return ( ( (float_t)lsb / 64.0f ) / 4.0f ) + 25.0f;
+}
+
+float_t lsm303agr_from_fs_2g_nm_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 64.0f ) * 3.9f;
+}
+
+float_t lsm303agr_from_fs_4g_nm_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 64.0f ) * 7.82f;
+}
+
+float_t lsm303agr_from_fs_8g_nm_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 64.0f ) * 15.63f;
+}
+
+float_t lsm303agr_from_fs_16g_nm_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 64.0f ) * 46.9f;
+}
+
+float_t lsm303agr_from_lsb_nm_to_celsius(int16_t lsb)
+{
+  return ( ( (float_t)lsb / 64.0f ) / 4.0f ) + 25.0f;
+}
+
+float_t lsm303agr_from_fs_2g_lp_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 256.0f ) * 15.63f;
+}
+
+float_t lsm303agr_from_fs_4g_lp_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 256.0f ) * 31.26f;
+}
+
+float_t lsm303agr_from_fs_8g_lp_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 256.0f ) * 62.52f;
+}
+
+float_t lsm303agr_from_fs_16g_lp_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb / 256.0f ) * 187.58f;
+}
+
+float_t lsm303agr_from_lsb_lp_to_celsius(int16_t lsb)
+{
+  return ( ( (float_t)lsb / 256.0f ) * 1.0f ) + 25.0f;
+}
+
+float_t lsm303agr_from_lsb_to_mgauss(int16_t lsb)
+{
+  return (float_t)lsb * 1.5f;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM303AGR_Data_generation
+  * @brief      This section group all the functions concerning data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature status register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_temp_status_reg_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_AUX_A, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tda in reg STATUS_REG_AUX_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_temp_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_status_reg_aux_a_t status_reg_aux_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_AUX_A,
+                           (uint8_t*)&status_reg_aux_a, 1);
+  *val = status_reg_aux_a.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tor in reg STATUS_REG_AUX_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_temp_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_status_reg_aux_a_t status_reg_aux_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_AUX_A,
+                           (uint8_t*)&status_reg_aux_a, 1);
+  *val = status_reg_aux_a.tor;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_temperature_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_OUT_TEMP_L_A, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of temp_en in reg TEMP_CFG_REG_A.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_temperature_meas_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_temp_en_a_t val)
+{
+  lsm303agr_temp_cfg_reg_a_t temp_cfg_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_TEMP_CFG_REG_A,
+                           (uint8_t*)&temp_cfg_reg_a, 1);
+  if(ret == 0){
+    temp_cfg_reg_a.temp_en = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_TEMP_CFG_REG_A,
+                              (uint8_t*)&temp_cfg_reg_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of temp_en in reg TEMP_CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_temperature_meas_get(lsm303agr_ctx_t *ctx,
+                                      lsm303agr_temp_en_a_t *val)
+{
+  lsm303agr_temp_cfg_reg_a_t temp_cfg_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_TEMP_CFG_REG_A,
+                           (uint8_t*)&temp_cfg_reg_a, 1);
+  switch (temp_cfg_reg_a.temp_en){
+    case LSM303AGR_TEMP_DISABLE:
+      *val = LSM303AGR_TEMP_DISABLE;
+      break;
+    case LSM303AGR_TEMP_ENABLE:
+      *val = LSM303AGR_TEMP_ENABLE;
+      break;
+    default:
+      *val = LSM303AGR_TEMP_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpen in reg
+  *                CTRL_REG1_A and HR in reg CTRL_REG4_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_operating_mode_set(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_op_md_a_t val)
+{
+  lsm303agr_ctrl_reg1_a_t ctrl_reg1_a;
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+  uint8_t lpen, hr;
+
+  if ( val == LSM303AGR_HR_12bit ){
+    lpen = 0;
+    hr   = 1;
+  } else if (val == LSM303AGR_NM_10bit) {
+    lpen = 0;
+    hr   = 0;
+  } else {
+    lpen = 1;
+    hr   = 0;
+  }
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG1_A,
+                           (uint8_t*)&ctrl_reg1_a, 1);
+  ctrl_reg1_a.lpen = (uint8_t)lpen;
+  if(ret == 0){
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG1_A,
+                              (uint8_t*)&ctrl_reg1_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                             (uint8_t*)&ctrl_reg4_a, 1);
+  }
+  if(ret == 0){
+    ctrl_reg4_a.hr = hr;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                              (uint8_t*)&ctrl_reg4_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lpen in reg CTRL_REG1_A and HR in
+  *                reg CTRL_REG4_AG1_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_operating_mode_get(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_op_md_a_t *val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  lsm303agr_ctrl_reg1_a_t ctrl_reg1_a;
+  int32_t ret;
+  
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG1_A,
+                           (uint8_t*)&ctrl_reg1_a, 1);
+  if(ret == 0){
+    ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                             (uint8_t*)&ctrl_reg4_a, 1);
+  }
+
+  if ( ctrl_reg1_a.lpen != PROPERTY_DISABLE ){
+    *val = LSM303AGR_LP_8bit;
+  } else if (ctrl_reg4_a.hr  != PROPERTY_DISABLE ) {
+    *val = LSM303AGR_HR_12bit;
+  } else{
+    *val = LSM303AGR_NM_10bit;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr in reg CTRL_REG1_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_data_rate_set(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_odr_a_t val)
+{
+  lsm303agr_ctrl_reg1_a_t ctrl_reg1_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG1_A,
+                           (uint8_t*)&ctrl_reg1_a, 1);
+  if(ret == 0){
+    ctrl_reg1_a.odr = (uint8_t)val;
+   ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG1_A,
+                             (uint8_t*)&ctrl_reg1_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CTRL_REG1_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_data_rate_get(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_odr_a_t *val)
+{
+  lsm303agr_ctrl_reg1_a_t ctrl_reg1_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG1_A,
+                           (uint8_t*)&ctrl_reg1_a, 1);
+
+  switch (ctrl_reg1_a.odr){
+    case LSM303AGR_XL_POWER_DOWN:
+      *val = LSM303AGR_XL_POWER_DOWN;
+      break;
+    case LSM303AGR_XL_ODR_1Hz:
+      *val = LSM303AGR_XL_ODR_1Hz;
+      break;
+    case LSM303AGR_XL_ODR_10Hz:
+      *val = LSM303AGR_XL_ODR_10Hz;
+      break;
+    case LSM303AGR_XL_ODR_25Hz:
+      *val = LSM303AGR_XL_ODR_25Hz;
+      break;
+    case LSM303AGR_XL_ODR_50Hz:
+      *val = LSM303AGR_XL_ODR_50Hz;
+      break;
+    case LSM303AGR_XL_ODR_100Hz:
+      *val = LSM303AGR_XL_ODR_100Hz;
+      break;
+    case LSM303AGR_XL_ODR_200Hz:
+      *val = LSM303AGR_XL_ODR_200Hz;
+      break;
+    case LSM303AGR_XL_ODR_400Hz:
+      *val = LSM303AGR_XL_ODR_400Hz;
+      break;
+    case LSM303AGR_XL_ODR_1kHz620_LP:
+      *val = LSM303AGR_XL_ODR_1kHz620_LP;
+      break;
+    case LSM303AGR_XL_ODR_1kHz344_NM_HP_5kHz376_LP:
+      *val = LSM303AGR_XL_ODR_1kHz344_NM_HP_5kHz376_LP;
+      break;
+    default:
+      *val = LSM303AGR_XL_POWER_DOWN;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   High pass data from internal filter sent to output register and FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fds in reg CTRL_REG2_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_high_pass_on_outputs_set(lsm303agr_ctx_t *ctx,
+                                              uint8_t val)
+{
+  lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                           (uint8_t*)&ctrl_reg2_a, 1);
+  if(ret == 0){
+    ctrl_reg2_a.fds = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                              (uint8_t*)&ctrl_reg2_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High pass data from internal filter sent to output
+  *         register and FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fds in reg CTRL_REG2_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_high_pass_on_outputs_get(lsm303agr_ctx_t *ctx,
+                                              uint8_t *val)
+{
+  lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                           (uint8_t*)&ctrl_reg2_a, 1);
+  *val = ctrl_reg2_a.fds;
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter cutoff frequency selection.[set]
+  *
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hpcf in reg CTRL_REG2_A
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_high_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
+                                             lsm303agr_hpcf_a_t val)
+{
+  lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                           (uint8_t*)&ctrl_reg2_a, 1);
+  if(ret == 0){
+    ctrl_reg2_a.hpcf = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                              (uint8_t*)&ctrl_reg2_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter cutoff frequency selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpcf in reg CTRL_REG2_A.(ptr)
+  *
+  * HPCF[2:1]\ft @1Hz    @10Hz  @25Hz  @50Hz @100Hz @200Hz @400Hz @1kHz6 ft@5kHz
+  * AGGRESSIVE   0.02Hz  0.2Hz  0.5Hz  1Hz   2Hz    4Hz    8Hz    32Hz   100Hz
+  * STRONG       0.008Hz 0.08Hz 0.2Hz  0.5Hz 1Hz    2Hz    4Hz    16Hz   50Hz
+  * MEDIUM       0.004Hz 0.04Hz 0.1Hz  0.2Hz 0.5Hz  1Hz    2Hz    8Hz    25Hz
+  * LIGHT        0.002Hz 0.02Hz 0.05Hz 0.1Hz 0.2Hz  0.5Hz  1Hz    4Hz    12Hz
+  *
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_high_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
+                                             lsm303agr_hpcf_a_t *val)
+{
+  lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                           (uint8_t*)&ctrl_reg2_a, 1);
+
+  switch (ctrl_reg2_a.hpcf){
+    case LSM303AGR_AGGRESSIVE:
+      *val = LSM303AGR_AGGRESSIVE;
+      break;
+    case LSM303AGR_STRONG:
+      *val = LSM303AGR_STRONG;
+      break;
+    case LSM303AGR_MEDIUM:
+      *val = LSM303AGR_MEDIUM;
+      break;
+    case LSM303AGR_LIGHT:
+      *val = LSM303AGR_LIGHT;
+      break;
+    default:
+      *val = LSM303AGR_AGGRESSIVE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hpm in reg CTRL_REG2_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_high_pass_mode_set(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_hpm_a_t val)
+{
+  lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                           (uint8_t*)&ctrl_reg2_a, 1);
+  if(ret == 0){
+    ctrl_reg2_a.hpm = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                              (uint8_t*)&ctrl_reg2_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpm in reg CTRL_REG2_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_high_pass_mode_get(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_hpm_a_t *val)
+{
+  lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                           (uint8_t*)&ctrl_reg2_a, 1);
+
+  switch (ctrl_reg2_a.hpm){
+    case LSM303AGR_NORMAL_WITH_RST:
+      *val = LSM303AGR_NORMAL_WITH_RST;
+      break;
+    case LSM303AGR_REFERENCE_MODE:
+      *val = LSM303AGR_REFERENCE_MODE;
+      break;
+    case LSM303AGR_NORMAL:
+      *val = LSM303AGR_NORMAL;
+      break;
+    case LSM303AGR_AUTORST_ON_INT:
+      *val = LSM303AGR_AUTORST_ON_INT;
+      break;
+    default:
+      *val = LSM303AGR_NORMAL_WITH_RST;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs in reg CTRL_REG4_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_full_scale_set(lsm303agr_ctx_t *ctx,
+                                    lsm303agr_fs_a_t val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+  if(ret == 0){
+    ctrl_reg4_a.fs = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                              (uint8_t*)&ctrl_reg4_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Full-scale configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs in reg CTRL_REG4_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_full_scale_get(lsm303agr_ctx_t *ctx,
+                                    lsm303agr_fs_a_t *val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+
+  switch (ctrl_reg4_a.fs){
+    case LSM303AGR_2g:
+      *val = LSM303AGR_2g;
+      break;
+    case LSM303AGR_4g:
+      *val = LSM303AGR_4g;
+      break;
+    case LSM303AGR_8g:
+      *val = LSM303AGR_8g;
+      break;
+    case LSM303AGR_16g:
+      *val = LSM303AGR_16g;
+      break;
+    default:
+      *val = LSM303AGR_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL_REG4_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_block_data_update_set(lsm303agr_ctx_t *ctx,
+                                           uint8_t val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+  if(ret == 0){
+    ctrl_reg4_a.bdu = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                              (uint8_t*)&ctrl_reg4_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CTRL_REG4_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_block_data_update_get(lsm303agr_ctx_t *ctx,
+                                           uint8_t *val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+  *val = ctrl_reg4_a.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[set]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_filter_reference_set(lsm303agr_ctx_t *ctx,
+                                          uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_REFERENCE_A, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for interrupt generation.[get]
+  *         LSB = ~16@2g / ~31@4g / ~63@8g / ~127@16g
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_filter_reference_get(lsm303agr_ctx_t *ctx,
+                                          uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_REFERENCE_A, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Acceleration set of data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxda in reg STATUS_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_status_reg_a_t status_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_A,
+                           (uint8_t*)&status_reg_a, 1);
+  *val = status_reg_a.zyxda;
+
+  return ret;
+}
+
+/**
+  * @brief  Acceleration set of data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxor in reg STATUS_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_status_reg_a_t status_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_A,
+                           (uint8_t*)&status_reg_a, 1);
+  *val = status_reg_a.zyxor;
+
+  return ret;
+}
+
+/**
+  * @brief  Acceleration output value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_acceleration_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_OUT_X_L_A, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  These registers comprise a 3 group of
+  *         16-bit number and represent hard-iron
+  *         offset in order to compensate environmental
+  *         effects. Data format is the same of
+  *         output data raw: two’s complement with
+  *         1LSb = 1.5mG. These values act on the
+  *         magnetic output data value in order to
+  *         delete the environmental offset.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_user_offset_set(lsm303agr_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_OFFSET_X_REG_L_M, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  These registers comprise a 3 group of
+  *         16-bit number and represent hard-iron
+  *         offset in order to compensate environmental
+  *         effects. Data format is the same of
+  *         output data raw: two’s complement with
+  *         1LSb = 1.5mG. These values act on the
+  *         magnetic output data value in order to
+  *         delete the environmental offset.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_user_offset_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_OFFSET_X_REG_L_M, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of md in reg CFG_REG_A_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_operating_mode_set(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_md_m_t val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.md = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Operating mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of md in reg CFG_REG_A_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_operating_mode_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_md_m_t *val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+
+    switch (cfg_reg_a_m.md){
+    case LSM303AGR_CONTINUOUS_MODE:
+      *val = LSM303AGR_CONTINUOUS_MODE;
+      break;
+    case LSM303AGR_SINGLE_TRIGGER:
+      *val = LSM303AGR_SINGLE_TRIGGER;
+      break;
+    case LSM303AGR_POWER_DOWN:
+      *val = LSM303AGR_POWER_DOWN;
+      break;
+    default:
+      *val = LSM303AGR_CONTINUOUS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr in reg CFG_REG_A_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_data_rate_set(lsm303agr_ctx_t *ctx,
+                                    lsm303agr_mg_odr_m_t val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.odr = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CFG_REG_A_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_data_rate_get(lsm303agr_ctx_t *ctx,
+                                    lsm303agr_mg_odr_m_t *val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+
+    switch (cfg_reg_a_m.odr){
+    case LSM303AGR_MG_ODR_10Hz:
+      *val = LSM303AGR_MG_ODR_10Hz;
+      break;
+    case LSM303AGR_MG_ODR_20Hz:
+      *val = LSM303AGR_MG_ODR_20Hz;
+      break;
+    case LSM303AGR_MG_ODR_50Hz:
+      *val = LSM303AGR_MG_ODR_50Hz;
+      break;
+    case LSM303AGR_MG_ODR_100Hz:
+      *val = LSM303AGR_MG_ODR_100Hz;
+      break;
+    default:
+      *val = LSM303AGR_MG_ODR_10Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables high-resolution/low-power mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lp in reg CFG_REG_A_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_power_mode_set(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_lp_m_t val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.lp = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables high-resolution/low-power mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lp in reg CFG_REG_A_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_power_mode_get(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_lp_m_t *val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+
+    switch (cfg_reg_a_m.lp){
+    case LSM303AGR_HIGH_RESOLUTION:
+      *val = LSM303AGR_HIGH_RESOLUTION;
+      break;
+    case LSM303AGR_LOW_POWER:
+      *val = LSM303AGR_LOW_POWER;
+      break;
+    default:
+      *val = LSM303AGR_HIGH_RESOLUTION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the magnetometer temperature compensation.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of comp_temp_en in reg CFG_REG_A_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_offset_temp_comp_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.comp_temp_en = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the magnetometer temperature compensation.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of comp_temp_en in reg CFG_REG_A_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_offset_temp_comp_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.comp_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf in reg CFG_REG_B_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_low_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
+                                             lsm303agr_lpf_m_t val)
+{
+  lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
+    cfg_reg_b_m.lpf = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                              (uint8_t*)&cfg_reg_b_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lpf in reg CFG_REG_B_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_low_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
+                                             lsm303agr_lpf_m_t *val)
+{
+  lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+
+    switch (cfg_reg_b_m.lpf){
+    case LSM303AGR_ODR_DIV_2:
+      *val = LSM303AGR_ODR_DIV_2;
+      break;
+    case LSM303AGR_ODR_DIV_4:
+      *val = LSM303AGR_ODR_DIV_4;
+      break;
+    default:
+      *val = LSM303AGR_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer sampling mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of set_rst in reg CFG_REG_B_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_set_rst_mode_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_set_rst_m_t val)
+{
+  lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
+    cfg_reg_b_m.set_rst = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                              (uint8_t*)&cfg_reg_b_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer sampling mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of set_rst in reg CFG_REG_B_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_set_rst_mode_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_set_rst_m_t *val)
+{
+  lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+
+    switch (cfg_reg_b_m.set_rst){
+    case LSM303AGR_SET_SENS_ODR_DIV_63:
+      *val = LSM303AGR_SET_SENS_ODR_DIV_63;
+      break;
+    case LSM303AGR_SENS_OFF_CANC_EVERY_ODR:
+      *val = LSM303AGR_SENS_OFF_CANC_EVERY_ODR;
+      break;
+    case LSM303AGR_SET_SENS_ONLY_AT_POWER_ON:
+      *val = LSM303AGR_SET_SENS_ONLY_AT_POWER_ON;
+      break;
+    default:
+      *val = LSM303AGR_SET_SENS_ODR_DIV_63;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables offset cancellation in single measurement mode.
+  *         The OFF_CANC bit must be set
+  *         to 1 when enabling offset
+  *         cancellation in single measurement
+  *         mode this means a call function:
+  *         mag_set_rst_mode
+  *         (SENS_OFF_CANC_EVERY_ODR) is need.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of off_canc_one_shot in reg CFG_REG_B_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_set_rst_sensor_single_set(lsm303agr_ctx_t *ctx,
+                                                uint8_t val)
+{
+  lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
+    cfg_reg_b_m.off_canc_one_shot = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                              (uint8_t*)&cfg_reg_b_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables offset cancellation in single measurement mode.
+  *         The OFF_CANC bit must be set to
+  *         1 when enabling offset cancellation
+  *         in single measurement mode this
+  *         means a call function:
+  *         mag_set_rst_mode
+  *         (SENS_OFF_CANC_EVERY_ODR) is need.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of off_canc_one_shot in
+  *                reg CFG_REG_B_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_set_rst_sensor_single_get(lsm303agr_ctx_t *ctx,
+                                                uint8_t *val)
+{
+  lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  *val = cfg_reg_b_m.off_canc_one_shot;
+
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_block_data_update_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.bdu = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_block_data_update_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic set of data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxda in reg STATUS_REG_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_status_reg_m_t status_reg_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_M,
+                           (uint8_t*)&status_reg_m, 1);
+  *val = status_reg_m.zyxda;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic set of data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxor in reg STATUS_REG_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_status_reg_m_t status_reg_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_M,
+                           (uint8_t*)&status_reg_m, 1);
+  *val = status_reg_m.zyxor;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetic output value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_magnetic_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_OUTX_L_REG_M, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  common
+  * @brief   This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_WHO_AM_I_A, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Self-test.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st in reg CTRL_REG4_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_self_test_set(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_st_a_t val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+  if(ret == 0){
+    ctrl_reg4_a.st = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                              (uint8_t*)&ctrl_reg4_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Self-test.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL_REG4_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_self_test_get(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_st_a_t *val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+
+    switch (ctrl_reg4_a.st){
+    case LSM303AGR_ST_DISABLE:
+      *val = LSM303AGR_ST_DISABLE;
+      break;
+    case LSM303AGR_ST_POSITIVE:
+      *val = LSM303AGR_ST_POSITIVE;
+      break;
+    case LSM303AGR_ST_NEGATIVE:
+      *val = LSM303AGR_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM303AGR_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ble in reg CTRL_REG4_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_data_format_set(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_ble_a_t val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+  if(ret == 0){
+    ctrl_reg4_a.ble = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                              (uint8_t*)&ctrl_reg4_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ble in reg CTRL_REG4_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_data_format_get(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_ble_a_t *val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+
+    switch (ctrl_reg4_a.ble){
+    case LSM303AGR_XL_LSB_AT_LOW_ADD:
+      *val = LSM303AGR_XL_LSB_AT_LOW_ADD;
+      break;
+    case LSM303AGR_XL_MSB_AT_LOW_ADD:
+      *val = LSM303AGR_XL_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LSM303AGR_XL_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL_REG5_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_boot_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  if(ret == 0){
+    ctrl_reg5_a.boot = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                              (uint8_t*)&ctrl_reg5_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL_REG5_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  *val = ctrl_reg5_a.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get register STATUS_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_status_get(lsm303agr_ctx_t *ctx,
+                                lsm303agr_status_reg_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_WHO_AM_I_M, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of soft_rst in reg CFG_REG_A_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_reset_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.soft_rst = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of soft_rst in reg CFG_REG_A_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_reset_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.soft_rst;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of reboot in reg CFG_REG_A_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_boot_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.reboot = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of reboot in reg CFG_REG_A_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.reboot;
+
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of self_test in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_self_test_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.self_test = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of self_test in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_self_test_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.self_test;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ble in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_data_format_set(lsm303agr_ctx_t *ctx,
+                                      lsm303agr_ble_m_t val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.ble = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ble in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_data_format_get(lsm303agr_ctx_t *ctx,
+                                      lsm303agr_ble_m_t *val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+
+    switch (cfg_reg_c_m.ble){
+    case LSM303AGR_MG_LSB_AT_LOW_ADD:
+      *val = LSM303AGR_MG_LSB_AT_LOW_ADD;
+      break;
+    case LSM303AGR_MG_MSB_AT_LOW_ADD:
+      *val = LSM303AGR_MG_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LSM303AGR_MG_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Info about device status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS_REG_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_status_get(lsm303agr_ctx_t *ctx,
+                                 lsm303agr_status_reg_m_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_M, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup   interrupts_generator_1_for_xl
+  * @brief   This section group all the functions that manage the first
+  *          interrupts generator of accelerometer
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change register INT1_CFG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_gen_conf_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int1_cfg_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_INT1_CFG_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 configuration register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get register INT1_CFG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_gen_conf_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int1_cfg_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT1_CFG_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 1 source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers INT1_SRC_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_gen_source_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_int1_src_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT1_SRC_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl
+  *         interrupt event on generator 1.[set]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ths in reg INT1_THS_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_gen_threshold_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val)
+{
+  lsm303agr_int1_ths_a_t int1_ths_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT1_THS_A,
+                           (uint8_t*)&int1_ths_a, 1);
+  if(ret == 0){
+    int1_ths_a.ths = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_INT1_THS_A,
+                              (uint8_t*)&int1_ths_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl
+  *         interrupt event on generator 1.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ths in reg INT1_THS_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_gen_threshold_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  lsm303agr_int1_ths_a_t int1_ths_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT1_THS_A,
+                           (uint8_t*)&int1_ths_a, 1);
+  *val = int1_ths_a.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d in reg INT1_DURATION_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_gen_duration_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_int1_duration_a_t int1_duration_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT1_DURATION_A,
+                           (uint8_t*)&int1_duration_a, 1);
+  if(ret == 0){
+    int1_duration_a.d = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_INT1_DURATION_A,
+                              (uint8_t*)&int1_duration_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of d in reg INT1_DURATION_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_gen_duration_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_int1_duration_a_t int1_duration_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT1_DURATION_A,
+                           (uint8_t*)&int1_duration_a, 1);
+  *val = int1_duration_a.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup   interrupts_generator_2_for_xl
+  * @brief   This section group all the functions that manage the second
+  *          interrupts generator for accelerometer
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change registers INT2_CFG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_gen_conf_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int2_cfg_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_INT2_CFG_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 2 configuration register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers INT2_CFG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_gen_conf_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int2_cfg_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT2_CFG_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator 2 source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers INT2_SRC_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_gen_source_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_int2_src_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT2_SRC_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl
+  *         interrupt event on generator 2.[set]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ths in reg INT2_THS_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_gen_threshold_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val)
+{
+  lsm303agr_int2_ths_a_t int2_ths_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT2_THS_A,
+                           (uint8_t*)&int2_ths_a, 1);
+  if(ret == 0){
+    int2_ths_a.ths = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_INT2_THS_A,
+                              (uint8_t*)&int2_ths_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for
+  *         xl interrupt event on generator 2.[get]
+  *         LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ths in reg INT2_THS_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_gen_threshold_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  lsm303agr_int2_ths_a_t int2_ths_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT2_THS_A,
+                           (uint8_t*)&int2_ths_a, 1);
+  *val = int2_ths_a.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d in reg INT2_DURATION_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_gen_duration_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_int2_duration_a_t int2_duration_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT2_DURATION_A,
+                           (uint8_t*)&int2_duration_a, 1);
+  if(ret == 0){
+    int2_duration_a.d = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_INT2_DURATION_A,
+                              (uint8_t*)&int2_duration_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The minimum duration (LSb = 1/ODR) of the Interrupt 1 event to be
+  *         recognized.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of d in reg INT2_DURATION_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_gen_duration_get(lsm303agr_ctx_t *ctx,
+                                           uint8_t *val)
+{
+  lsm303agr_int2_duration_a_t int2_duration_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT2_DURATION_A,
+                           (uint8_t*)&int2_duration_a, 1);
+  *val = int2_duration_a.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  interrupt_pins_xl
+  * @brief   This section group all the functions that manage interrupt
+  *          pins of accelerometer
+  * @{
+  *
+  */
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hp in reg CTRL_REG2_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_high_pass_int_conf_set(lsm303agr_ctx_t *ctx,
+                                            lsm303agr_hp_a_t val)
+{
+  lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                           (uint8_t*)&ctrl_reg2_a, 1);
+  if(ret == 0){
+    ctrl_reg2_a.hp = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                              (uint8_t*)&ctrl_reg2_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-pass filter on interrupts/tap generator.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp in reg CTRL_REG2_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_high_pass_int_conf_get(lsm303agr_ctx_t *ctx,
+                                            lsm303agr_hp_a_t *val)
+{
+  lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG2_A,
+                           (uint8_t*)&ctrl_reg2_a, 1);
+
+    switch (ctrl_reg2_a.hp){
+    case LSM303AGR_DISC_FROM_INT_GENERATOR:
+      *val = LSM303AGR_DISC_FROM_INT_GENERATOR;
+      break;
+    case LSM303AGR_ON_INT1_GEN:
+      *val = LSM303AGR_ON_INT1_GEN;
+      break;
+    case LSM303AGR_ON_INT2_GEN:
+      *val = LSM303AGR_ON_INT2_GEN;
+      break;
+    case LSM303AGR_ON_TAP_GEN:
+      *val = LSM303AGR_ON_TAP_GEN;
+      break;
+    case LSM303AGR_ON_INT1_INT2_GEN:
+      *val = LSM303AGR_ON_INT1_INT2_GEN;
+      break;
+    case LSM303AGR_ON_INT1_TAP_GEN:
+      *val = LSM303AGR_ON_INT1_TAP_GEN;
+      break;
+    case LSM303AGR_ON_INT2_TAP_GEN:
+      *val = LSM303AGR_ON_INT2_TAP_GEN;
+      break;
+    case LSM303AGR_ON_INT1_INT2_TAP_GEN:
+      *val = LSM303AGR_ON_INT1_INT2_TAP_GEN;
+      break;
+    default:
+      *val = LSM303AGR_DISC_FROM_INT_GENERATOR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change registers CTRL_REG3_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_pin_int1_config_set(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_ctrl_reg3_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG3_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int1 pin routing configuration register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers CTRL_REG3_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_pin_int1_config_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_ctrl_reg3_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG3_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  4D detection is enabled on INT2 pin when 6D bit on
+  *         INT2_CFG_A (34h) is set to 1.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_int2 in reg CTRL_REG5_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_pin_detect_4d_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  if(ret == 0){
+    ctrl_reg5_a.d4d_int2 = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                              (uint8_t*)&ctrl_reg5_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D detection is enabled on INT2 pin when 6D bit on
+  *         INT2_CFG_A (34h) is set to 1.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_int2 in reg CTRL_REG5_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2_pin_detect_4d_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  *val = ctrl_reg5_a.d4d_int2;
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC_A (35h) register, with
+  *         INT2_SRC_A (35h) register cleared by reading
+  *         INT2_SRC_A (35h) itself.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir_int2 in reg CTRL_REG5_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2pin_notification_mode_set(lsm303agr_ctx_t *ctx,
+                                                   lsm303agr_lir_int2_a_t val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  if(ret == 0){
+    ctrl_reg5_a.lir_int2 = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                              (uint8_t*)&ctrl_reg5_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT2_SRC_A (35h) register, with
+  *         INT2_SRC_A (35h) register cleared by reading
+  *         INT2_SRC_A (35h) itself.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir_int2 in reg CTRL_REG5_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int2pin_notification_mode_get(lsm303agr_ctx_t *ctx,
+                                                lsm303agr_lir_int2_a_t *val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+
+    switch (ctrl_reg5_a.lir_int2){
+    case LSM303AGR_INT2_PULSED:
+      *val = LSM303AGR_INT2_PULSED;
+      break;
+    case LSM303AGR_INT2_LATCHED:
+      *val = LSM303AGR_INT2_LATCHED;
+      break;
+    default:
+      *val = LSM303AGR_INT2_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D detection is enabled on INT1 pin when 6D bit on
+  *         INT1_CFG_A (30h) is set to 1.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_int1 in reg CTRL_REG5_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_pin_detect_4d_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  if(ret == 0){
+    ctrl_reg5_a.d4d_int1 = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                              (uint8_t*)&ctrl_reg5_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D detection is enabled on INT1 pin when 6D bit on
+  *         INT1_CFG_A (30h) is set to 1.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of d4d_int1 in reg CTRL_REG5_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1_pin_detect_4d_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  *val = ctrl_reg5_a.d4d_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC_A (31h), with
+  *         INT1_SRC_A(31h) register cleared by reading
+  *         INT1_SRC_A (31h) itself.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir_int1 in reg CTRL_REG5_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1pin_notification_mode_set(lsm303agr_ctx_t *ctx,
+                                                   lsm303agr_lir_int1_a_t val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  if(ret == 0){
+    ctrl_reg5_a.lir_int1 = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                              (uint8_t*)&ctrl_reg5_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request on INT1_SRC_A (31h), with
+  *         INT1_SRC_A(31h) register cleared by reading
+  *         INT1_SRC_A (31h) itself.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir_int1 in reg CTRL_REG5_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_int1pin_notification_mode_get(lsm303agr_ctx_t *ctx,
+                                                   lsm303agr_lir_int1_a_t *val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+
+    switch (ctrl_reg5_a.lir_int1){
+    case LSM303AGR_INT1_PULSED:
+      *val = LSM303AGR_INT1_PULSED;
+      break;
+    case LSM303AGR_INT1_LATCHED:
+      *val = LSM303AGR_INT1_LATCHED;
+      break;
+    default:
+      *val = LSM303AGR_INT1_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change registers CTRL_REG6_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_pin_int2_config_set(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_ctrl_reg6_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG6_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Int2 pin routing configuration register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers CTRL_REG6_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_pin_int2_config_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_ctrl_reg6_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG6_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @addtogroup  magnetometer interrupts
+  * @brief       This section group all the functions that manage the
+  *              magnetometer interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  The interrupt block recognition checks
+  *         data after/before the hard-iron correction
+  *         to discover the interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int_on_dataoff in reg CFG_REG_B_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_offset_int_conf_set(lsm303agr_ctx_t *ctx,
+                                          lsm303agr_int_on_dataoff_m_t val)
+{
+  lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
+    cfg_reg_b_m.int_on_dataoff = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                              (uint8_t*)&cfg_reg_b_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The interrupt block recognition checks
+  *         data after/before the hard-iron correction
+  *         to discover the interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_on_dataoff in reg CFG_REG_B_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_offset_int_conf_get(lsm303agr_ctx_t *ctx,
+                                          lsm303agr_int_on_dataoff_m_t *val)
+{
+  lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+
+    switch (cfg_reg_b_m.int_on_dataoff){
+    case LSM303AGR_CHECK_BEFORE:
+      *val = LSM303AGR_CHECK_BEFORE;
+      break;
+    case LSM303AGR_CHECK_AFTER:
+      *val = LSM303AGR_CHECK_AFTER;
+      break;
+    default:
+      *val = LSM303AGR_CHECK_BEFORE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_on_pin in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_drdy_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.int_mag = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_on_pin in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_drdy_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.int_mag;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int_on_pin in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_int_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.int_mag_pin = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_on_pin in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_int_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.int_mag_pin;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator configuration register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change registers INT_CRTL_REG_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_int_gen_conf_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int_crtl_reg_m_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_INT_CRTL_REG_M, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator configuration register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers INT_CRTL_REG_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_int_gen_conf_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int_crtl_reg_m_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT_CRTL_REG_M,
+                           (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Interrupt generator source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers INT_SOURCE_REG_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_int_gen_source_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_int_source_reg_m_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT_SOURCE_REG_M,
+                           (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output
+  *         data raw: two’s complement with
+  *         1LSb = 1.5mG.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_int_gen_treshold_set(lsm303agr_ctx_t *ctx,
+                                           uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_INT_THS_L_REG_M, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output
+  *         data raw: two’s complement with
+  *         1LSb = 1.5mG.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_int_gen_treshold_get(lsm303agr_ctx_t *ctx,
+                                           uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_INT_THS_L_REG_M, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  accelerometer_fifo
+  * @brief       This section group all the functions concerning the xl
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFOenable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_en in reg CTRL_REG5_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  if(ret == 0){
+    ctrl_reg5_a.fifo_en = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                              (uint8_t*)&ctrl_reg5_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFOenable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL_REG5_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG5_A,
+                           (uint8_t*)&ctrl_reg5_a, 1);
+  *val = ctrl_reg5_a.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fth in reg FIFO_CTRL_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_watermark_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                           (uint8_t*)&fifo_ctrl_reg_a, 1);
+  if(ret == 0){
+    fifo_ctrl_reg_a.fth = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                              (uint8_t*)&fifo_ctrl_reg_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_CTRL_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_watermark_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                           (uint8_t*)&fifo_ctrl_reg_a, 1);
+  *val = fifo_ctrl_reg_a.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tr in reg FIFO_CTRL_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_trigger_event_set(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_tr_a_t val)
+{
+  lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                           (uint8_t*)&fifo_ctrl_reg_a, 1);
+  if(ret == 0){
+    fifo_ctrl_reg_a.tr = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                              (uint8_t*)&fifo_ctrl_reg_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger FIFO selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tr in reg FIFO_CTRL_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_trigger_event_get(lsm303agr_ctx_t *ctx,
+                                            lsm303agr_tr_a_t *val)
+{
+  lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                           (uint8_t*)&fifo_ctrl_reg_a, 1);
+
+    switch (fifo_ctrl_reg_a.tr){
+    case LSM303AGR_INT1_GEN:
+      *val = LSM303AGR_INT1_GEN;
+      break;
+    case LSM303AGR_INT2_GEN:
+      *val = LSM303AGR_INT2_GEN;
+      break;
+    default:
+      *val = LSM303AGR_INT1_GEN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fm in reg FIFO_CTRL_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_mode_set(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_fm_a_t val)
+{
+  lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                           (uint8_t*)&fifo_ctrl_reg_a, 1);
+  if(ret == 0){
+    fifo_ctrl_reg_a.fm = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                              (uint8_t*)&fifo_ctrl_reg_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fm in reg FIFO_CTRL_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_mode_get(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_fm_a_t *val)
+{
+  lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_CTRL_REG_A,
+                           (uint8_t*)&fifo_ctrl_reg_a, 1);
+
+    switch (fifo_ctrl_reg_a.fm){
+    case LSM303AGR_BYPASS_MODE:
+      *val = LSM303AGR_BYPASS_MODE;
+      break;
+    case LSM303AGR_FIFO_MODE:
+      *val = LSM303AGR_FIFO_MODE;
+      break;
+    case LSM303AGR_DYNAMIC_STREAM_MODE:
+      *val = LSM303AGR_DYNAMIC_STREAM_MODE;
+      break;
+    case LSM303AGR_STREAM_TO_FIFO_MODE:
+      *val = LSM303AGR_STREAM_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LSM303AGR_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO status register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers FIFO_SRC_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_status_get(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_fifo_src_reg_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_SRC_REG_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fss in reg FIFO_SRC_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_data_level_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_fifo_src_reg_a_t fifo_src_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_SRC_REG_A,
+                           (uint8_t*)&fifo_src_reg_a, 1);
+  *val = fifo_src_reg_a.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  Empty FIFO status flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of empty in reg FIFO_SRC_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_empty_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_fifo_src_reg_a_t fifo_src_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_SRC_REG_A,
+                           (uint8_t*)&fifo_src_reg_a, 1);
+  *val = fifo_src_reg_a.empty;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ovrn_fifo in reg FIFO_SRC_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_ovr_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_fifo_src_reg_a_t fifo_src_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_SRC_REG_A,
+                           (uint8_t*)&fifo_src_reg_a, 1);
+  *val = fifo_src_reg_a.ovrn_fifo;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wtm in reg FIFO_SRC_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_fifo_fth_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_fifo_src_reg_a_t fifo_src_reg_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_FIFO_SRC_REG_A,
+                           (uint8_t*)&fifo_src_reg_a, 1);
+  *val = fifo_src_reg_a.wtm;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  tap_generator
+  * @brief       This section group all the functions that manage the tap and
+  *              double tap event generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change registers CLICK_CFG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_tap_conf_set(lsm303agr_ctx_t *ctx,
+                               lsm303agr_click_cfg_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_write_reg(ctx, LSM303AGR_CLICK_CFG_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Tap/Double Tap generator configuration register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers CLICK_CFG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_tap_conf_get(lsm303agr_ctx_t *ctx,
+                               lsm303agr_click_cfg_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CLICK_CFG_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Tap/Double Tap generator source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers CLICK_SRC_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_tap_source_get(lsm303agr_ctx_t *ctx,
+                                 lsm303agr_click_src_a_t *val)
+{
+  int32_t ret;
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CLICK_SRC_A, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.
+  *         (1 LSB = full scale/128)[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ths in reg CLICK_THS_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_tap_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_click_ths_a_t click_ths_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CLICK_THS_A,
+                           (uint8_t*)&click_ths_a, 1);
+  if(ret == 0){
+    click_ths_a.ths = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CLICK_THS_A,
+                              (uint8_t*)&click_ths_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for Tap/Double Tap event.
+  *         (1 LSB = full scale/128)[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ths in reg CLICK_THS_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_tap_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_click_ths_a_t click_ths_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CLICK_THS_A,
+                           (uint8_t*)&click_ths_a, 1);
+  *val = click_ths_a.ths;
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can
+  *         elapse between the start of the click-detection procedure
+  *         and when the acceleration falls back below the threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tli in reg TIME_LIMIT_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_shock_dur_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_time_limit_a_t time_limit_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_TIME_LIMIT_A,
+                           (uint8_t*)&time_limit_a, 1);
+  if(ret == 0){
+    time_limit_a.tli = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_TIME_LIMIT_A,
+                              (uint8_t*)&time_limit_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum time (1 LSB = 1/ODR) interval that can
+  *         elapse between the start of the click-detection procedure
+  *         and when the acceleration falls back below the threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tli in reg TIME_LIMIT_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_shock_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_time_limit_a_t time_limit_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_TIME_LIMIT_A,
+                           (uint8_t*)&time_limit_a, 1);
+  *val = time_limit_a.tli;
+
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the
+  *         first click detection where the click-detection procedure
+  *         is disabled, in cases where the device is configured for
+  *         double-click detection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tla in reg TIME_LATENCY_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_quiet_dur_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_time_latency_a_t time_latency_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_TIME_LATENCY_A,
+                           (uint8_t*)&time_latency_a, 1);
+  if(ret == 0){
+    time_latency_a.tla = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_TIME_LATENCY_A,
+                              (uint8_t*)&time_latency_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The time (1 LSB = 1/ODR) interval that starts after the first click
+  *         detection where the click-detection procedure is disabled, in cases
+  *         where the device is configured for double-click detection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tla in reg TIME_LATENCY_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_quiet_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_time_latency_a_t time_latency_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_TIME_LATENCY_A,
+                           (uint8_t*)&time_latency_a, 1);
+  *val = time_latency_a.tla;
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse after
+  *         the end of the latency interval in which the click-detection
+  *         procedure can start, in cases where the device is configured for
+  *         double-click detection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tw in reg TIME_WINDOW_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_double_tap_timeout_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_time_window_a_t time_window_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_TIME_WINDOW_A,
+                           (uint8_t*)&time_window_a, 1);
+  if(ret == 0){
+    time_window_a.tw = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_TIME_WINDOW_A,
+                              (uint8_t*)&time_window_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The maximum interval of time (1 LSB = 1/ODR) that can elapse after
+  *         the end of the latency interval in which the click-detection
+  *         procedure can start, in cases where the device is configured for
+  *         double-click detection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tw in reg TIME_WINDOW_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_double_tap_timeout_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_time_window_a_t time_window_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_TIME_WINDOW_A,
+                           (uint8_t*)&time_window_a, 1);
+  *val = time_window_a.tw;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup   activity_inactivity_xl
+  * @brief        This section group all the functions concerning activity
+  *               inactivity functionality foe accelerometer
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep activation
+  *         threshold in low-power mode.[set]
+  *         1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of acth in reg ACT_THS_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_act_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_act_ths_a_t act_ths_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_ACT_THS_A,
+                           (uint8_t*)&act_ths_a, 1);
+  if(ret == 0){
+    act_ths_a.acth = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_ACT_THS_A,
+                              (uint8_t*)&act_ths_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep activation
+  *          threshold in low-power mode.[get]
+  *          1 LSb = 16mg@2g / 32mg@4g / 62mg@8g / 186mg@16g
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of acth in reg ACT_THS_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_act_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_act_ths_a_t act_ths_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_ACT_THS_A,
+                           (uint8_t*)&act_ths_a, 1);
+  *val = act_ths_a.acth;
+
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep duration = (8*1[LSb]+1)/ODR.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of actd in reg ACT_DUR_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_act_timeout_set(lsm303agr_ctx_t *ctx, uint8_t val)
+{
+  lsm303agr_act_dur_a_t act_dur_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_ACT_DUR_A,
+                           (uint8_t*)&act_dur_a, 1);
+  if(ret == 0){
+    act_dur_a.actd = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_ACT_DUR_A,
+                              (uint8_t*)&act_dur_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sleep-to-wake, return-to-sleep duration = (8*1[LSb]+1)/ODR.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of actd in reg ACT_DUR_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_act_timeout_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+{
+  lsm303agr_act_dur_a_t act_dur_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_ACT_DUR_A,
+                           (uint8_t*)&act_dur_a, 1);
+  *val = act_dur_a.actd;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  serial_interface
+  * @brief       This section group all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL_REG4_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_spi_mode_set(lsm303agr_ctx_t *ctx,
+                                  lsm303agr_sim_a_t val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+  if(ret == 0){
+    ctrl_reg4_a.spi_enable = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                              (uint8_t*)&ctrl_reg4_a, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL_REG4_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_xl_spi_mode_get(lsm303agr_ctx_t *ctx,
+                                  lsm303agr_sim_a_t *val)
+{
+  lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CTRL_REG4_A,
+                           (uint8_t*)&ctrl_reg4_a, 1);
+
+    switch (ctrl_reg4_a.spi_enable){
+    case LSM303AGR_SPI_4_WIRE:
+      *val = LSM303AGR_SPI_4_WIRE;
+      break;
+    case LSM303AGR_SPI_3_WIRE:
+      *val = LSM303AGR_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM303AGR_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_dis in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_i2c_interface_set(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_i2c_dis_m_t val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.i2c_dis = (uint8_t)val;
+    ret = lsm303agr_write_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_dis in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303agr_mag_i2c_interface_get(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_i2c_dis_m_t *val)
+{
+  lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = lsm303agr_read_reg(ctx, LSM303AGR_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+
+    switch (cfg_reg_c_m.i2c_dis){
+    case LSM303AGR_I2C_ENABLE:
+      *val = LSM303AGR_I2C_ENABLE;
+      break;
+    case LSM303AGR_I2C_DISABLE:
+      *val = LSM303AGR_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM303AGR_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm303agr_STdC/driver/lsm303agr_reg.h
+++ b/sensor/stmemsc/lsm303agr_STdC/driver/lsm303agr_reg.h
@@ -1,0 +1,1003 @@
+/*
+ ******************************************************************************
+ * @file    lsm303agr_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm303agr_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM303AGR_REGS_H
+#define LSM303AGR_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM303AGR
+  * @{
+  *
+  */
+
+/** @defgroup LSM303AGR_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+  /** @addtogroup  LSM303AGR_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lsm303agr_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lsm303agr_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lsm303agr_write_ptr  write_reg;
+  lsm303agr_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lsm303agr_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup lsm303agr_Infos
+  * @{
+  *
+  */
+
+  /** I2C Device Address 8 bit format**/
+#define LSM303AGR_I2C_ADD_XL       0x33U
+#define LSM303AGR_I2C_ADD_MG       0x3DU
+
+/** Device Identification (Who am I) **/
+#define LSM303AGR_ID_XL            0x33U
+#define LSM303AGR_ID_MG            0x40U
+
+/**
+  * @}
+  *
+  */
+
+#define LSM303AGR_STATUS_REG_AUX_A           0x07U
+typedef struct {
+  uint8_t not_used_01            : 2;
+  uint8_t tda                    : 1;
+  uint8_t not_used_02            : 3;
+  uint8_t tor                    : 1;
+  uint8_t not_used_03            : 1;
+} lsm303agr_status_reg_aux_a_t;
+
+#define LSM303AGR_OUT_TEMP_L_A               0x0CU
+#define LSM303AGR_OUT_TEMP_H_A               0x0DU
+#define LSM303AGR_INT_COUNTER_REG_A          0x0EU
+#define LSM303AGR_WHO_AM_I_A                 0x0FU
+
+#define LSM303AGR_TEMP_CFG_REG_A             0x1FU
+typedef struct {
+  uint8_t not_used_01            : 6;
+  uint8_t temp_en                : 2;
+} lsm303agr_temp_cfg_reg_a_t;
+
+#define LSM303AGR_CTRL_REG1_A                0x20U
+typedef struct {
+  uint8_t xen                    : 1;
+  uint8_t yen                    : 1;
+  uint8_t zen                    : 1;
+  uint8_t lpen                   : 1;
+  uint8_t odr                    : 4;
+} lsm303agr_ctrl_reg1_a_t;
+
+#define LSM303AGR_CTRL_REG2_A                0x21U
+typedef struct {
+  uint8_t hp                     : 3; /* HPCLICK + HPIS2 + HPIS1 -> HP */
+  uint8_t fds                    : 1;
+  uint8_t hpcf                   : 2;
+  uint8_t hpm                    : 2;
+} lsm303agr_ctrl_reg2_a_t;
+
+#define LSM303AGR_CTRL_REG3_A                0x22U
+typedef struct {
+  uint8_t not_used_01            : 1;
+  uint8_t i1_overrun             : 1;
+  uint8_t i1_wtm                 : 1;
+  uint8_t i1_drdy2               : 1;
+  uint8_t i1_drdy1               : 1;
+  uint8_t i1_aoi2                : 1;
+  uint8_t i1_aoi1                : 1;
+  uint8_t i1_click               : 1;
+} lsm303agr_ctrl_reg3_a_t;
+
+#define LSM303AGR_CTRL_REG4_A                0x23U
+typedef struct {
+  uint8_t spi_enable             : 1;
+  uint8_t st                     : 2;
+  uint8_t hr                     : 1;
+  uint8_t fs                     : 2;
+  uint8_t ble                    : 1;
+  uint8_t bdu                    : 1;
+} lsm303agr_ctrl_reg4_a_t;
+
+#define LSM303AGR_CTRL_REG5_A                0x24U
+typedef struct {
+  uint8_t d4d_int2               : 1;
+  uint8_t lir_int2               : 1;
+  uint8_t d4d_int1               : 1;
+  uint8_t lir_int1               : 1;
+  uint8_t not_used_01            : 2;
+  uint8_t fifo_en                : 1;
+  uint8_t boot                   : 1;
+} lsm303agr_ctrl_reg5_a_t;
+
+#define LSM303AGR_CTRL_REG6_A               0x25U
+typedef struct {
+  uint8_t not_used_01            : 1;
+  uint8_t h_lactive              : 1;
+  uint8_t not_used_02            : 1;
+  uint8_t p2_act                 : 1;
+  uint8_t boot_i2                : 1;
+  uint8_t i2_int2                : 1;
+  uint8_t i2_int1                : 1;
+  uint8_t i2_clicken             : 1;
+} lsm303agr_ctrl_reg6_a_t;
+
+#define LSM303AGR_REFERENCE_A               0x26U
+#define LSM303AGR_STATUS_REG_A              0x27U
+typedef struct {
+  uint8_t xda                    : 1;
+  uint8_t yda                    : 1;
+  uint8_t zda                    : 1;
+  uint8_t zyxda                  : 1;
+  uint8_t _xor                   : 1;
+  uint8_t yor                    : 1;
+  uint8_t zor                    : 1;
+  uint8_t zyxor                  : 1;
+} lsm303agr_status_reg_a_t;
+
+#define LSM303AGR_OUT_X_L_A                 0x28U
+#define LSM303AGR_OUT_X_H_A                 0x29U
+#define LSM303AGR_OUT_Y_L_A                 0x2AU
+#define LSM303AGR_OUT_Y_H_A                 0x2BU
+#define LSM303AGR_OUT_Z_L_A                 0x2CU
+#define LSM303AGR_OUT_Z_H_A                 0x2DU
+#define LSM303AGR_FIFO_CTRL_REG_A           0x2EU
+typedef struct {
+  uint8_t fth                    : 5;
+  uint8_t tr                     : 1;
+  uint8_t fm                     : 2;
+} lsm303agr_fifo_ctrl_reg_a_t;
+
+#define LSM303AGR_FIFO_SRC_REG_A            0x2FU
+typedef struct {
+  uint8_t fss                    : 5;
+  uint8_t empty                  : 1;
+  uint8_t ovrn_fifo              : 1;
+  uint8_t wtm                    : 1;
+} lsm303agr_fifo_src_reg_a_t;
+
+#define LSM303AGR_INT1_CFG_A                0x30U
+typedef struct {
+  uint8_t xlie                   : 1; /* or XDOWNE */
+  uint8_t xhie                   : 1; /* or XUPE */
+  uint8_t ylie                   : 1; /* or YDOWNE */
+  uint8_t yhie                   : 1; /* or YUPE */
+  uint8_t zlie                   : 1; /* or ZDOWNE */
+  uint8_t zhie                   : 1; /* or ZUPE */
+  uint8_t _6d                    : 1;
+  uint8_t aoi                    : 1;
+} lsm303agr_int1_cfg_a_t;
+
+#define LSM303AGR_INT1_SRC_A                0x31U
+typedef struct {
+  uint8_t xl                     : 1;
+  uint8_t xh                     : 1;
+  uint8_t yl                     : 1;
+  uint8_t yh                     : 1;
+  uint8_t zl                     : 1;
+  uint8_t zh                     : 1;
+  uint8_t ia                     : 1;
+  uint8_t not_used_01            : 1;
+} lsm303agr_int1_src_a_t;
+
+#define LSM303AGR_INT1_THS_A                0x32U
+typedef struct {
+  uint8_t ths                    : 7;
+  uint8_t not_used_01            : 1;
+} lsm303agr_int1_ths_a_t;
+
+#define LSM303AGR_INT1_DURATION_A           0x33U
+typedef struct {
+  uint8_t d                      : 7;
+  uint8_t not_used_01            : 1;
+} lsm303agr_int1_duration_a_t;
+
+#define LSM303AGR_INT2_CFG_A                0x34U
+typedef struct {
+  uint8_t xlie                   : 1;
+  uint8_t xhie                   : 1;
+  uint8_t ylie                   : 1;
+  uint8_t yhie                   : 1;
+  uint8_t zlie                   : 1;
+  uint8_t zhie                   : 1;
+  uint8_t _6d                    : 1;
+  uint8_t aoi                    : 1;
+} lsm303agr_int2_cfg_a_t;
+
+#define LSM303AGR_INT2_SRC_A                0x35U
+typedef struct {
+  uint8_t xl                     : 1;
+  uint8_t xh                     : 1;
+  uint8_t yl                     : 1;
+  uint8_t yh                     : 1;
+  uint8_t zl                     : 1;
+  uint8_t zh                     : 1;
+  uint8_t ia                     : 1;
+  uint8_t not_used_01            : 1;
+} lsm303agr_int2_src_a_t;
+
+#define LSM303AGR_INT2_THS_A                0x36U
+typedef struct {
+  uint8_t ths                    : 7;
+  uint8_t not_used_01            : 1;
+} lsm303agr_int2_ths_a_t;
+
+#define LSM303AGR_INT2_DURATION_A           0x37U
+typedef struct {
+  uint8_t d                      : 7;
+  uint8_t not_used_01            : 1;
+} lsm303agr_int2_duration_a_t;
+
+#define LSM303AGR_CLICK_CFG_A               0x38U
+typedef struct {
+  uint8_t xs                     : 1;
+  uint8_t xd                     : 1;
+  uint8_t ys                     : 1;
+  uint8_t yd                     : 1;
+  uint8_t zs                     : 1;
+  uint8_t zd                     : 1;
+  uint8_t not_used_01            : 2;
+} lsm303agr_click_cfg_a_t;
+
+#define LSM303AGR_CLICK_SRC_A               0x39U
+typedef struct {
+  uint8_t x                      : 1;
+  uint8_t y                      : 1;
+  uint8_t z                      : 1;
+  uint8_t sign                   : 1;
+  uint8_t sclick                 : 1;
+  uint8_t dclick                 : 1;
+  uint8_t ia                     : 1;
+  uint8_t not_used_01            : 1;
+} lsm303agr_click_src_a_t;
+
+#define LSM303AGR_CLICK_THS_A               0x3AU
+typedef struct {
+  uint8_t ths                    : 7;
+  uint8_t not_used_01            : 1;
+} lsm303agr_click_ths_a_t;
+
+#define LSM303AGR_TIME_LIMIT_A              0x3BU
+typedef struct {
+  uint8_t tli                    : 7;
+  uint8_t not_used_01            : 1;
+} lsm303agr_time_limit_a_t;
+
+#define LSM303AGR_TIME_LATENCY_A            0x3CU
+typedef struct {
+  uint8_t tla                    : 8;
+} lsm303agr_time_latency_a_t;
+
+#define LSM303AGR_TIME_WINDOW_A             0x3DU
+typedef struct {
+  uint8_t tw                     : 8;
+} lsm303agr_time_window_a_t;
+
+#define LSM303AGR_ACT_THS_A                 0x3EU
+typedef struct {
+  uint8_t acth                   : 7;
+  uint8_t not_used_01            : 1;
+} lsm303agr_act_ths_a_t;
+
+#define LSM303AGR_ACT_DUR_A                 0x3FU
+typedef struct {
+  uint8_t actd                   : 8;
+} lsm303agr_act_dur_a_t;
+
+#define LSM303AGR_OFFSET_X_REG_L_M          0x45U
+#define LSM303AGR_OFFSET_X_REG_H_M          0x46U
+#define LSM303AGR_OFFSET_Y_REG_L_M          0x47U
+#define LSM303AGR_OFFSET_Y_REG_H_M          0x48U
+#define LSM303AGR_OFFSET_Z_REG_L_M          0x49U
+#define LSM303AGR_OFFSET_Z_REG_H_M          0x4AU
+#define LSM303AGR_WHO_AM_I_M                0x4FU
+#define LSM303AGR_CFG_REG_A_M               0x60U
+typedef struct {
+  uint8_t md                     : 2;
+  uint8_t odr                    : 2;
+  uint8_t lp                     : 1;
+  uint8_t soft_rst               : 1;
+  uint8_t reboot                 : 1;
+  uint8_t comp_temp_en           : 1;
+} lsm303agr_cfg_reg_a_m_t;
+
+#define LSM303AGR_CFG_REG_B_M               0x61U
+typedef struct {
+  uint8_t lpf                    : 1;
+  uint8_t set_rst                : 2; /* OFF_CANC + Set_FREQ */
+  uint8_t int_on_dataoff         : 1;
+  uint8_t off_canc_one_shot      : 1;
+  uint8_t not_used_01            : 3;
+} lsm303agr_cfg_reg_b_m_t;
+
+#define LSM303AGR_CFG_REG_C_M               0x62U
+typedef struct {
+  uint8_t int_mag                : 1;
+  uint8_t self_test              : 1;
+  uint8_t not_used_01            : 1;
+  uint8_t ble                    : 1;
+  uint8_t bdu                    : 1;
+  uint8_t i2c_dis                : 1;
+  uint8_t int_mag_pin            : 1;
+  uint8_t not_used_02            : 1;
+} lsm303agr_cfg_reg_c_m_t;
+
+#define LSM303AGR_INT_CRTL_REG_M            0x63U
+typedef struct {
+  uint8_t ien                    : 1;
+  uint8_t iel                    : 1;
+  uint8_t iea                    : 1;
+  uint8_t not_used_01            : 2;
+  uint8_t zien                   : 1;
+  uint8_t yien                   : 1;
+  uint8_t xien                   : 1;
+} lsm303agr_int_crtl_reg_m_t;
+
+#define LSM303AGR_INT_SOURCE_REG_M          0x64U
+typedef struct {
+  uint8_t _int                    : 1;
+  uint8_t mroi                   : 1;
+  uint8_t n_th_s_z               : 1;
+  uint8_t n_th_s_y               : 1;
+  uint8_t n_th_s_x               : 1;
+  uint8_t p_th_s_z               : 1;
+  uint8_t p_th_s_y               : 1;
+  uint8_t p_th_s_x               : 1;
+} lsm303agr_int_source_reg_m_t;
+
+#define LSM303AGR_INT_THS_L_REG_M           0x65U
+#define LSM303AGR_INT_THS_H_REG_M           0x66U
+#define LSM303AGR_STATUS_REG_M              0x67U
+typedef struct {
+  uint8_t xda                    : 1;
+  uint8_t yda                    : 1;
+  uint8_t zda                    : 1;
+  uint8_t zyxda                  : 1;
+  uint8_t _xor                   : 1;
+  uint8_t yor                    : 1;
+  uint8_t zor                    : 1;
+  uint8_t zyxor                  : 1;
+} lsm303agr_status_reg_m_t;
+
+#define LSM303AGR_OUTX_L_REG_M              0x68U
+#define LSM303AGR_OUTX_H_REG_M              0x69U
+#define LSM303AGR_OUTY_L_REG_M              0x6AU
+#define LSM303AGR_OUTY_H_REG_M              0x6BU
+#define LSM303AGR_OUTZ_L_REG_M              0x6CU
+#define LSM303AGR_OUTZ_H_REG_M              0x6DU
+
+/**
+  * @defgroup LSM303AGR_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lsm303agr_status_reg_aux_a_t       status_reg_aux_a;
+  lsm303agr_temp_cfg_reg_a_t         temp_cfg_reg_a;
+  lsm303agr_ctrl_reg1_a_t            ctrl_reg1_a;
+  lsm303agr_ctrl_reg2_a_t            ctrl_reg2_a;
+  lsm303agr_ctrl_reg3_a_t            ctrl_reg3_a;
+  lsm303agr_ctrl_reg4_a_t            ctrl_reg4_a;
+  lsm303agr_ctrl_reg5_a_t            ctrl_reg5_a;
+  lsm303agr_ctrl_reg6_a_t            ctrl_reg6_a;
+  lsm303agr_status_reg_a_t           status_reg_a;
+  lsm303agr_fifo_ctrl_reg_a_t        fifo_ctrl_reg_a;
+  lsm303agr_fifo_src_reg_a_t         fifo_src_reg_a;
+  lsm303agr_int1_cfg_a_t             int1_cfg_a;
+  lsm303agr_int1_src_a_t             int1_src_a;
+  lsm303agr_int1_ths_a_t             int1_ths_a;
+  lsm303agr_int1_duration_a_t        int1_duration_a;
+  lsm303agr_int2_cfg_a_t             int2_cfg_a;
+  lsm303agr_int2_src_a_t             int2_src_a;
+  lsm303agr_int2_ths_a_t             int2_ths_a;
+  lsm303agr_int2_duration_a_t        int2_duration_a;
+  lsm303agr_click_cfg_a_t            click_cfg_a;
+  lsm303agr_click_src_a_t            click_src_a;
+  lsm303agr_click_ths_a_t            click_ths_a;
+  lsm303agr_time_limit_a_t           time_limit_a;
+  lsm303agr_time_latency_a_t         time_latency_a;
+  lsm303agr_time_window_a_t          time_window_a;
+  lsm303agr_act_ths_a_t              act_ths_a;
+  lsm303agr_act_dur_a_t              act_dur_a;
+  lsm303agr_cfg_reg_a_m_t            cfg_reg_a_m;
+  lsm303agr_cfg_reg_b_m_t            cfg_reg_b_m;
+  lsm303agr_cfg_reg_c_m_t            cfg_reg_c_m;
+  lsm303agr_int_crtl_reg_m_t         int_crtl_reg_m;
+  lsm303agr_int_source_reg_m_t       int_source_reg_m;
+  lsm303agr_status_reg_m_t           status_reg_m;
+  bitwise_t                          bitwise;
+  uint8_t                            byte;
+} lsm303agr_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm303agr_read_reg(lsm303agr_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+int32_t lsm303agr_write_reg(lsm303agr_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t lsm303agr_from_fs_2g_hr_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_4g_hr_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_8g_hr_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_16g_hr_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_lsb_hr_to_celsius(int16_t lsb);
+
+extern float_t lsm303agr_from_fs_2g_nm_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_4g_nm_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_8g_nm_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_16g_nm_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_lsb_nm_to_celsius(int16_t lsb);
+
+extern float_t lsm303agr_from_fs_2g_lp_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_4g_lp_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_8g_lp_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_fs_16g_lp_to_mg(int16_t lsb);
+extern float_t lsm303agr_from_lsb_lp_to_celsius(int16_t lsb);
+
+extern float_t lsm303agr_from_lsb_to_mgauss(int16_t lsb);
+
+int32_t lsm303agr_temp_status_reg_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303agr_temp_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_temp_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_temperature_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM303AGR_TEMP_DISABLE  = 0,
+  LSM303AGR_TEMP_ENABLE   = 3,
+} lsm303agr_temp_en_a_t;
+int32_t lsm303agr_temperature_meas_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_temp_en_a_t val);
+int32_t lsm303agr_temperature_meas_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_temp_en_a_t *val);
+
+typedef enum {
+  LSM303AGR_HR_12bit   = 0,
+  LSM303AGR_NM_10bit   = 1,
+  LSM303AGR_LP_8bit    = 2,
+} lsm303agr_op_md_a_t;
+int32_t lsm303agr_xl_operating_mode_set(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_op_md_a_t val);
+int32_t lsm303agr_xl_operating_mode_get(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_op_md_a_t *val);
+
+typedef enum {
+  LSM303AGR_XL_POWER_DOWN                      = 0,
+  LSM303AGR_XL_ODR_1Hz                         = 1,
+  LSM303AGR_XL_ODR_10Hz                        = 2,
+  LSM303AGR_XL_ODR_25Hz                        = 3,
+  LSM303AGR_XL_ODR_50Hz                        = 4,
+  LSM303AGR_XL_ODR_100Hz                       = 5,
+  LSM303AGR_XL_ODR_200Hz                       = 6,
+  LSM303AGR_XL_ODR_400Hz                       = 7,
+  LSM303AGR_XL_ODR_1kHz620_LP                  = 8,
+  LSM303AGR_XL_ODR_1kHz344_NM_HP_5kHz376_LP    = 9,
+} lsm303agr_odr_a_t;
+int32_t lsm303agr_xl_data_rate_set(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_odr_a_t val);
+int32_t lsm303agr_xl_data_rate_get(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_odr_a_t *val);
+
+int32_t lsm303agr_xl_high_pass_on_outputs_set(lsm303agr_ctx_t *ctx,
+                                              uint8_t val);
+int32_t lsm303agr_xl_high_pass_on_outputs_get(lsm303agr_ctx_t *ctx,
+                                              uint8_t *val);
+
+typedef enum {
+  LSM303AGR_AGGRESSIVE  = 0,
+  LSM303AGR_STRONG      = 1,
+  LSM303AGR_MEDIUM      = 2,
+  LSM303AGR_LIGHT       = 3,
+} lsm303agr_hpcf_a_t;
+int32_t lsm303agr_xl_high_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
+                                             lsm303agr_hpcf_a_t val);
+int32_t lsm303agr_xl_high_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
+                                             lsm303agr_hpcf_a_t *val);
+
+typedef enum {
+  LSM303AGR_NORMAL_WITH_RST  = 0,
+  LSM303AGR_REFERENCE_MODE   = 1,
+  LSM303AGR_NORMAL           = 2,
+  LSM303AGR_AUTORST_ON_INT   = 3,
+} lsm303agr_hpm_a_t;
+int32_t lsm303agr_xl_high_pass_mode_set(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_hpm_a_t val);
+int32_t lsm303agr_xl_high_pass_mode_get(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_hpm_a_t *val);
+
+typedef enum {
+  LSM303AGR_2g   = 0,
+  LSM303AGR_4g   = 1,
+  LSM303AGR_8g   = 2,
+  LSM303AGR_16g  = 3,
+} lsm303agr_fs_a_t;
+int32_t lsm303agr_xl_full_scale_set(lsm303agr_ctx_t *ctx,
+                                    lsm303agr_fs_a_t val);
+int32_t lsm303agr_xl_full_scale_get(lsm303agr_ctx_t *ctx,
+                                    lsm303agr_fs_a_t *val);
+
+int32_t lsm303agr_xl_block_data_update_set(lsm303agr_ctx_t *ctx,
+                                           uint8_t val);
+int32_t lsm303agr_xl_block_data_update_get(lsm303agr_ctx_t *ctx,
+                                           uint8_t *val);
+
+int32_t lsm303agr_xl_filter_reference_set(lsm303agr_ctx_t *ctx,
+                                          uint8_t *buff);
+int32_t lsm303agr_xl_filter_reference_get(lsm303agr_ctx_t *ctx,
+                                          uint8_t *buff);
+
+int32_t lsm303agr_xl_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_xl_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_acceleration_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303agr_xl_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM303AGR_ST_DISABLE   = 0,
+  LSM303AGR_ST_POSITIVE  = 1,
+  LSM303AGR_ST_NEGATIVE  = 2,
+} lsm303agr_st_a_t;
+int32_t lsm303agr_xl_self_test_set(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_st_a_t val);
+int32_t lsm303agr_xl_self_test_get(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_st_a_t *val);
+
+typedef enum {
+  LSM303AGR_XL_LSB_AT_LOW_ADD = 0,
+  LSM303AGR_XL_MSB_AT_LOW_ADD = 1,
+} lsm303agr_ble_a_t;
+int32_t lsm303agr_xl_data_format_set(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_ble_a_t val);
+int32_t lsm303agr_xl_data_format_get(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_ble_a_t *val);
+
+int32_t lsm303agr_xl_boot_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_xl_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_xl_status_get(lsm303agr_ctx_t *ctx,
+                                lsm303agr_status_reg_a_t *val);
+
+int32_t lsm303agr_xl_int1_gen_conf_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int1_cfg_a_t *val);
+int32_t lsm303agr_xl_int1_gen_conf_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int1_cfg_a_t *val);
+
+int32_t lsm303agr_xl_int1_gen_source_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_int1_src_a_t *val);
+
+int32_t lsm303agr_xl_int1_gen_threshold_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val);
+int32_t lsm303agr_xl_int1_gen_threshold_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t lsm303agr_xl_int1_gen_duration_set(lsm303agr_ctx_t *ctx,
+                                           uint8_t val);
+int32_t lsm303agr_xl_int1_gen_duration_get(lsm303agr_ctx_t *ctx,
+                                           uint8_t *val);
+
+int32_t lsm303agr_xl_int2_gen_conf_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int2_cfg_a_t *val);
+int32_t lsm303agr_xl_int2_gen_conf_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int2_cfg_a_t *val);
+
+int32_t lsm303agr_xl_int2_gen_source_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_int2_src_a_t *val);
+
+int32_t lsm303agr_xl_int2_gen_threshold_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val);
+int32_t lsm303agr_xl_int2_gen_threshold_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t lsm303agr_xl_int2_gen_duration_set(lsm303agr_ctx_t *ctx,
+                                           uint8_t val);
+int32_t lsm303agr_xl_int2_gen_duration_get(lsm303agr_ctx_t *ctx,
+                                           uint8_t *val);
+
+typedef enum {
+  LSM303AGR_DISC_FROM_INT_GENERATOR  = 0,
+  LSM303AGR_ON_INT1_GEN              = 1,
+  LSM303AGR_ON_INT2_GEN              = 2,
+  LSM303AGR_ON_TAP_GEN               = 4,
+  LSM303AGR_ON_INT1_INT2_GEN         = 3,
+  LSM303AGR_ON_INT1_TAP_GEN          = 5,
+  LSM303AGR_ON_INT2_TAP_GEN          = 6,
+  LSM303AGR_ON_INT1_INT2_TAP_GEN     = 7,
+} lsm303agr_hp_a_t;
+int32_t lsm303agr_xl_high_pass_int_conf_set(lsm303agr_ctx_t *ctx,
+                                            lsm303agr_hp_a_t val);
+int32_t lsm303agr_xl_high_pass_int_conf_get(lsm303agr_ctx_t *ctx,
+                                            lsm303agr_hp_a_t *val);
+
+int32_t lsm303agr_xl_pin_int1_config_set(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_ctrl_reg3_a_t *val);
+int32_t lsm303agr_xl_pin_int1_config_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_ctrl_reg3_a_t *val);
+
+int32_t lsm303agr_xl_int2_pin_detect_4d_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val);
+int32_t lsm303agr_xl_int2_pin_detect_4d_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val);
+
+typedef enum {
+  LSM303AGR_INT2_PULSED   = 0,
+  LSM303AGR_INT2_LATCHED  = 1,
+} lsm303agr_lir_int2_a_t;
+int32_t lsm303agr_xl_int2pin_notification_mode_set(lsm303agr_ctx_t *ctx,
+                                                   lsm303agr_lir_int2_a_t val);
+int32_t lsm303agr_xl_int2pin_notification_mode_get(lsm303agr_ctx_t *ctx,
+                                                   lsm303agr_lir_int2_a_t *val);
+
+int32_t lsm303agr_xl_int1_pin_detect_4d_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val);
+int32_t lsm303agr_xl_int1_pin_detect_4d_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val);
+
+typedef enum {
+  LSM303AGR_INT1_PULSED   = 0,
+  LSM303AGR_INT1_LATCHED  = 1,
+} lsm303agr_lir_int1_a_t;
+int32_t lsm303agr_xl_int1pin_notification_mode_set(lsm303agr_ctx_t *ctx,
+                                                   lsm303agr_lir_int1_a_t val);
+int32_t lsm303agr_xl_int1pin_notification_mode_get(lsm303agr_ctx_t *ctx,
+                                                   lsm303agr_lir_int1_a_t *val);
+
+int32_t lsm303agr_xl_pin_int2_config_set(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_ctrl_reg6_a_t *val);
+int32_t lsm303agr_xl_pin_int2_config_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_ctrl_reg6_a_t *val);
+
+int32_t lsm303agr_xl_fifo_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_xl_fifo_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_xl_fifo_watermark_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_xl_fifo_watermark_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AGR_INT1_GEN = 0,
+  LSM303AGR_INT2_GEN = 1,
+} lsm303agr_tr_a_t;
+int32_t lsm303agr_xl_fifo_trigger_event_set(lsm303agr_ctx_t *ctx,
+                                            lsm303agr_tr_a_t val);
+int32_t lsm303agr_xl_fifo_trigger_event_get(lsm303agr_ctx_t *ctx,
+                                            lsm303agr_tr_a_t *val);
+
+typedef enum {
+  LSM303AGR_BYPASS_MODE           = 0,
+  LSM303AGR_FIFO_MODE             = 1,
+  LSM303AGR_DYNAMIC_STREAM_MODE   = 2,
+  LSM303AGR_STREAM_TO_FIFO_MODE   = 3,
+} lsm303agr_fm_a_t;
+int32_t lsm303agr_xl_fifo_mode_set(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_fm_a_t val);
+int32_t lsm303agr_xl_fifo_mode_get(lsm303agr_ctx_t *ctx,
+                                   lsm303agr_fm_a_t *val);
+
+int32_t lsm303agr_xl_fifo_status_get(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_fifo_src_reg_a_t *val);
+
+int32_t lsm303agr_xl_fifo_data_level_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_xl_fifo_empty_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_xl_fifo_ovr_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_xl_fifo_fth_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_tap_conf_set(lsm303agr_ctx_t *ctx,
+                               lsm303agr_click_cfg_a_t *val);
+int32_t lsm303agr_tap_conf_get(lsm303agr_ctx_t *ctx,
+                               lsm303agr_click_cfg_a_t *val);
+
+int32_t lsm303agr_tap_source_get(lsm303agr_ctx_t *ctx,
+                                lsm303agr_click_src_a_t *val);
+
+int32_t lsm303agr_tap_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_tap_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_shock_dur_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_shock_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_quiet_dur_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_quiet_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_double_tap_timeout_set(lsm303agr_ctx_t *ctx,
+                                         uint8_t val);
+int32_t lsm303agr_double_tap_timeout_get(lsm303agr_ctx_t *ctx,
+                                         uint8_t *val);
+
+int32_t lsm303agr_act_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_act_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_act_timeout_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_act_timeout_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AGR_SPI_4_WIRE = 0,
+  LSM303AGR_SPI_3_WIRE = 1,
+} lsm303agr_sim_a_t;
+int32_t lsm303agr_xl_spi_mode_set(lsm303agr_ctx_t *ctx,
+                                  lsm303agr_sim_a_t val);
+int32_t lsm303agr_xl_spi_mode_get(lsm303agr_ctx_t *ctx,
+                                  lsm303agr_sim_a_t *val);
+
+int32_t lsm303agr_mag_user_offset_set(lsm303agr_ctx_t *ctx,
+                                      uint8_t *buff);
+int32_t lsm303agr_mag_user_offset_get(lsm303agr_ctx_t *ctx,
+                                      uint8_t *buff);
+
+typedef enum {
+  LSM303AGR_CONTINUOUS_MODE  = 0,
+  LSM303AGR_SINGLE_TRIGGER   = 1,
+  LSM303AGR_POWER_DOWN       = 2,
+} lsm303agr_md_m_t;
+int32_t lsm303agr_mag_operating_mode_set(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_md_m_t val);
+int32_t lsm303agr_mag_operating_mode_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_md_m_t *val);
+
+typedef enum {
+  LSM303AGR_MG_ODR_10Hz   = 0,
+  LSM303AGR_MG_ODR_20Hz   = 1,
+  LSM303AGR_MG_ODR_50Hz   = 2,
+  LSM303AGR_MG_ODR_100Hz  = 3,
+} lsm303agr_mg_odr_m_t;
+int32_t lsm303agr_mag_data_rate_set(lsm303agr_ctx_t *ctx,
+                                    lsm303agr_mg_odr_m_t val);
+int32_t lsm303agr_mag_data_rate_get(lsm303agr_ctx_t *ctx,
+                                    lsm303agr_mg_odr_m_t *val);
+
+typedef enum {
+  LSM303AGR_HIGH_RESOLUTION  = 0,
+  LSM303AGR_LOW_POWER        = 1,
+} lsm303agr_lp_m_t;
+int32_t lsm303agr_mag_power_mode_set(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_lp_m_t val);
+int32_t lsm303agr_mag_power_mode_get(lsm303agr_ctx_t *ctx,
+                                     lsm303agr_lp_m_t *val);
+
+int32_t lsm303agr_mag_offset_temp_comp_set(lsm303agr_ctx_t *ctx,
+                                           uint8_t val);
+int32_t lsm303agr_mag_offset_temp_comp_get(lsm303agr_ctx_t *ctx,
+                                           uint8_t *val);
+
+typedef enum {
+  LSM303AGR_ODR_DIV_2  = 0,
+  LSM303AGR_ODR_DIV_4  = 1,
+} lsm303agr_lpf_m_t;
+int32_t lsm303agr_mag_low_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
+                                             lsm303agr_lpf_m_t val);
+int32_t lsm303agr_mag_low_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
+                                             lsm303agr_lpf_m_t *val);
+
+typedef enum {
+  LSM303AGR_SET_SENS_ODR_DIV_63        = 0,
+  LSM303AGR_SENS_OFF_CANC_EVERY_ODR    = 1,
+  LSM303AGR_SET_SENS_ONLY_AT_POWER_ON  = 2,
+} lsm303agr_set_rst_m_t;
+int32_t lsm303agr_mag_set_rst_mode_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_set_rst_m_t val);
+int32_t lsm303agr_mag_set_rst_mode_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_set_rst_m_t *val);
+
+int32_t lsm303agr_mag_set_rst_sensor_single_set(lsm303agr_ctx_t *ctx,
+                                                uint8_t val);
+int32_t lsm303agr_mag_set_rst_sensor_single_get(lsm303agr_ctx_t *ctx,
+                                                uint8_t *val);
+
+int32_t lsm303agr_mag_block_data_update_set(lsm303agr_ctx_t *ctx,
+                                            uint8_t val);
+int32_t lsm303agr_mag_block_data_update_get(lsm303agr_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t lsm303agr_mag_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_mag_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_magnetic_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303agr_mag_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303agr_mag_reset_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_mag_reset_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_mag_boot_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_mag_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_mag_self_test_set(lsm303agr_ctx_t *ctx,
+                                    uint8_t val);
+int32_t lsm303agr_mag_self_test_get(lsm303agr_ctx_t *ctx,
+                                    uint8_t *val);
+
+typedef enum {
+  LSM303AGR_MG_LSB_AT_LOW_ADD  = 0,
+  LSM303AGR_MG_MSB_AT_LOW_ADD  = 1,
+} lsm303agr_ble_m_t;
+int32_t lsm303agr_mag_data_format_set(lsm303agr_ctx_t *ctx,
+                                      lsm303agr_ble_m_t val);
+int32_t lsm303agr_mag_data_format_get(lsm303agr_ctx_t *ctx,
+                                      lsm303agr_ble_m_t *val);
+
+int32_t lsm303agr_mag_status_get(lsm303agr_ctx_t *ctx,
+                                 lsm303agr_status_reg_m_t *val);
+
+typedef enum {
+  LSM303AGR_CHECK_BEFORE  = 0,
+  LSM303AGR_CHECK_AFTER   = 1,
+} lsm303agr_int_on_dataoff_m_t;
+int32_t lsm303agr_mag_offset_int_conf_set(lsm303agr_ctx_t *ctx,
+                                          lsm303agr_int_on_dataoff_m_t val);
+int32_t lsm303agr_mag_offset_int_conf_get(lsm303agr_ctx_t *ctx,
+                                          lsm303agr_int_on_dataoff_m_t *val);
+
+int32_t lsm303agr_mag_drdy_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_mag_drdy_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_mag_int_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_mag_int_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303agr_mag_int_gen_conf_set(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int_crtl_reg_m_t *val);
+int32_t lsm303agr_mag_int_gen_conf_get(lsm303agr_ctx_t *ctx,
+                                       lsm303agr_int_crtl_reg_m_t *val);
+
+int32_t lsm303agr_mag_int_gen_source_get(lsm303agr_ctx_t *ctx,
+                                         lsm303agr_int_source_reg_m_t *val);
+
+int32_t lsm303agr_mag_int_gen_treshold_set(lsm303agr_ctx_t *ctx,
+                                           uint8_t *buff);
+int32_t lsm303agr_mag_int_gen_treshold_get(lsm303agr_ctx_t *ctx,
+                                           uint8_t *buff);
+typedef enum {
+  LSM303AGR_I2C_ENABLE   = 0,
+  LSM303AGR_I2C_DISABLE  = 1,
+} lsm303agr_i2c_dis_m_t;
+int32_t lsm303agr_mag_i2c_interface_set(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_i2c_dis_m_t val);
+int32_t lsm303agr_mag_i2c_interface_get(lsm303agr_ctx_t *ctx,
+                                        lsm303agr_i2c_dis_m_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSM303AGR_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm303ah_STdC/driver/lsm303ah_reg.c
+++ b/sensor/stmemsc/lsm303ah_STdC/driver/lsm303ah_reg.c
@@ -1,0 +1,3355 @@
+/*
+ ******************************************************************************
+ * @file    lsm303ah_reg.c
+ * @author  MEMS Software Solution Team
+ * @date    19-December-2017
+ * @brief   LSM303AH driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "lsm303ah_reg.h"
+
+/**
+  * @addtogroup  lsm303ah
+  * @brief  This file provides a set of functions needed to drive the
+  *         lsm303ah enanced inertial module.
+  * @{
+  */
+
+/**
+  * @addtogroup  interfaces_functions
+  * @brief  This section provide a set of functions used to read and write
+  *         a generic register of the device.
+  * @{
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  lsm303ah_ctx_t* ctx: read / write interface definitions
+  * @param  uint8_t reg: register to read
+  * @param  uint8_t* data: pointer to buffer that store the data read
+  * @param  uint16_t len: number of consecutive register to read
+  *
+  */
+int32_t lsm303ah_read_reg(lsm303ah_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  return ctx->read_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t reg: register to write
+  * @param  uint8_t* data: pointer to data to write in register reg
+  * @param  uint16_t len: number of consecutive register to write
+  *
+*/
+int32_t lsm303ah_write_reg(lsm303ah_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  return ctx->write_reg(ctx->handle, reg, data, len);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  data_generation_c
+  * @brief   This section groups all the functions concerning data generation
+  * @{
+  */
+
+/**
+  * @brief  all_sources: [get] Read all the interrupt/status flag of
+  *                            the device.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_all_sources: FIFO_SRC, STATUS_DUP, WAKE_UP_SRC,
+  *                               TAP_SRC, 6D_SRC, FUNC_CK_GATE, FUNC_SRC.
+  *
+  */
+int32_t lsm303ah_xl_all_sources_get(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_xl_all_sources_t *val)
+{
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A,
+                               &(val->byte[0]), 1);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STATUS_DUP_A,
+                               &(val->byte[1]), 4);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A,
+                               &(val->byte[5]), 2);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [set] Blockdataupdate.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of bdu in reg CTRL1
+  *
+  */
+int32_t lsm303ah_xl_block_data_update_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  reg.ctrl1_a.bdu = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [get] Blockdataupdate.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of bdu in reg CTRL1
+  *
+  */
+int32_t lsm303ah_xl_block_data_update_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  *val = reg.ctrl1_a.bdu;
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [set] Blockdataupdate.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of bdu in reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_block_data_update_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.bdu = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  block_data_update: [get] Blockdataupdate.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of bdu in reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_block_data_update_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  *val = reg.cfg_reg_c_m.bdu;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_format: [set]  Big/Little Endian data selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_ble_t: change the values of ble in reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_data_format_set(lsm303ah_ctx_t *ctx, lsm303ah_mg_ble_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.ble = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_format: [get]  Big/Little Endian data selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_ble_t: Get the values of ble in reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_data_format_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_mg_ble_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  *val = (lsm303ah_mg_ble_t) reg.cfg_reg_c_m.ble;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_full_scale: [set]   Accelerometer full-scale selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_fs_t: change the values of fs in reg CTRL1
+  *
+  */
+int32_t lsm303ah_xl_full_scale_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_fs_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  reg.ctrl1_a.fs = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_full_scale: [get]   Accelerometer full-scale selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_fs_t: Get the values of fs in reg CTRL1
+  *
+  */
+int32_t lsm303ah_xl_full_scale_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_fs_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_fs_t) reg.ctrl1_a.fs;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_data_rate: [set]  Accelerometer data rate selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_odr_t: change the values of odr in reg CTRL1
+  *
+  */
+int32_t lsm303ah_xl_data_rate_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_odr_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  reg.ctrl1_a.odr = val & 0x0F;
+  reg.ctrl1_a.hf_odr = (val & 0x10) >> 4;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_data_rate: [get]  Accelerometer data rate selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_odr_t: Get the values of odr in reg CTRL1
+  *
+  */
+int32_t lsm303ah_xl_data_rate_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_odr_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_odr_t) ((reg.ctrl1_a.hf_odr << 4) + reg.ctrl1_a.odr);
+
+  return mm_error;
+}
+
+/**
+  * @brief  status_reg: [get]  The STATUS_REG register.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_status_reg_t: registers STATUS
+  *
+  */
+int32_t lsm303ah_xl_status_reg_get(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_status_a_t *val)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_STATUS_A, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  status: [get]  Info about device status.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_status_reg_t: registers STATUS_REG
+  *
+  */
+int32_t lsm303ah_mg_status_get(lsm303ah_ctx_t *ctx,
+                               lsm303ah_status_reg_m_t *val)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  xl_flag_data_ready: [get]  Accelerometer new data available.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of drdy in reg STATUS
+  *
+  */
+int32_t lsm303ah_xl_flag_data_ready_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STATUS_A, &reg.byte, 1);
+  *val = reg.status_a.drdy;
+
+  return mm_error;
+}
+
+/**
+  * @brief  mag_data_ready: [get]  Magnetic set of data available.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of zyxda in reg STATUS_REG
+  *
+  */
+int32_t lsm303ah_mg_data_ready_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, &reg.byte, 1);
+  *val = reg.status_reg_m.zyxda;
+
+  return mm_error;
+}
+
+/**
+  * @brief  mag_data_ovr: [get]  Magnetic set of data overrun.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of zyxor in reg STATUS_REG
+  *
+  */
+int32_t lsm303ah_mg_data_ovr_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, &reg.byte, 1);
+  *val = reg.status_reg_m.zyxor;
+
+  return mm_error;
+}
+
+/**
+  * @brief  mag_user_offset: [set]  These registers comprise a 3 group of
+  *                                 16-bit number and represent hard-iron
+  *                                 offset in order to compensate environmental
+  *                                 effects. Data format is the same of
+  *                                 output data raw: two’s complement with
+  *                                 1LSb = 1.5mG. These values act on the
+  *                                 magnetic output data value in order to
+  *                                 delete the environmental offset.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t lsm303ah_mg_user_offset_set(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_write_reg(ctx, LSM303AH_OFFSET_X_REG_L_M, buff, 6);
+}
+
+/**
+  * @brief  mag_user_offset: [get]  These registers comprise a 3 group of
+  *                                 16-bit number and represent hard-iron
+  *                                 offset in order to compensate environmental
+  *                                 effects. Data format is the same of
+  *                                 output data raw: two’s complement with
+  *                                 1LSb = 1.5mG. These values act on the
+  *                                 magnetic output data value in order to
+  *                                 delete the environmental offset.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_mg_user_offset_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_OFFSET_X_REG_L_M, buff, 6);
+}
+
+/**
+  * @brief  operating_mode: [set]  Operating mode selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_md_t: change the values of md in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_operating_mode_set(lsm303ah_ctx_t *ctx,
+                                       lsm303ah_mg_md_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.md = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  operating_mode: [get]  Operating mode selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_md_t: Get the values of md in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_operating_mode_get(lsm303ah_ctx_t *ctx,
+                                       lsm303ah_mg_md_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  *val = (lsm303ah_mg_md_t) reg.cfg_reg_a_m.md;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_rate: [set]  Output data rate selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_odr_t: change the values of odr in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_data_rate_set(lsm303ah_ctx_t *ctx, lsm303ah_mg_odr_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.odr = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_rate: [get]  Output data rate selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_odr_t: Get the values of odr in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_data_rate_get(lsm303ah_ctx_t *ctx, lsm303ah_mg_odr_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  *val = (lsm303ah_mg_odr_t) reg.cfg_reg_a_m.odr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  power_mode: [set]  Enables high-resolution/low-power mode.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_lp_t: change the values of lp in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_power_mode_set(lsm303ah_ctx_t *ctx, lsm303ah_mg_lp_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.lp = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  power_mode: [get]  Enables high-resolution/low-power mode.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_lp_t: Get the values of lp in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_power_mode_get(lsm303ah_ctx_t *ctx, lsm303ah_mg_lp_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  *val = (lsm303ah_mg_lp_t) reg.cfg_reg_a_m.lp;
+
+  return mm_error;
+}
+
+/**
+  * @brief  offset_temp_comp: [set]  Enables the magnetometer temperature
+  *                                  compensation.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of comp_temp_en in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_offset_temp_comp_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.comp_temp_en = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  offset_temp_comp: [get]  Enables the magnetometer temperature
+  *                                  compensation.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of comp_temp_en in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_offset_temp_comp_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  *val = reg.cfg_reg_a_m.comp_temp_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  set_rst_mode: [set]
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_set_rst_t: change the values of set_rst in
+  *                            reg CFG_REG_B
+  *
+  */
+int32_t lsm303ah_mg_set_rst_mode_set(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_mg_set_rst_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  reg.cfg_reg_b_m.set_rst = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  set_rst_mode: [get]
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_set_rst_t: Get the values of set_rst in reg CFG_REG_B
+  *
+  */
+int32_t lsm303ah_mg_set_rst_mode_get(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_mg_set_rst_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  *val = (lsm303ah_mg_set_rst_t) reg.cfg_reg_b_m.set_rst;
+
+  return mm_error;
+}
+
+/**
+  * @brief   set_rst_sensor_single: [set] Enables offset cancellation
+  *                                       in single measurement mode.
+  *                                       The OFF_CANC bit must be set
+  *                                       to 1 when enabling offset
+  *                                       cancellation in single measurement
+  *                                       mode this means a call function:
+  *                                       set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
+  *                                       is need.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of off_canc_one_shot in
+  *                      reg CFG_REG_B
+  *
+  */
+int32_t lsm303ah_mg_set_rst_sensor_single_set(lsm303ah_ctx_t *ctx,
+                                              uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  reg.cfg_reg_b_m.off_canc_one_shot = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   set_rst_sensor_single: [get] Enables offset cancellation
+  *                                       in single measurement mode.
+  *                                       The OFF_CANC bit must be set to
+  *                                       1 when enabling offset cancellation
+  *                                       in single measurement mode this
+  *                                       means a call function:
+  *                                       set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
+  *                                       is need.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of off_canc_one_shot in reg CFG_REG_B
+  *
+  */
+int32_t lsm303ah_mg_set_rst_sensor_single_get(lsm303ah_ctx_t *ctx,
+                                              uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  *val = reg.cfg_reg_b_m.off_canc_one_shot;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Dataoutput
+  * @brief   This section groups all the data output functions.
+  * @{
+  */
+
+/**
+  * @brief   acceleration_module_raw: [get]   Module output value (8-bit).
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_acceleration_module_raw_get(lsm303ah_ctx_t *ctx,
+                                             uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_MODULE_8BIT_A, buff, 1);
+}
+
+/**
+  * @brief  temperature_raw: [get] Temperature data output register (r).
+  *                                L and H registers together express a 16-bit
+  *                                word in two’s complement.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_xl_temperature_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_OUT_T_A, buff, 1);
+}
+
+/**
+  * @brief  acceleration_raw: [get] Linear acceleration output register.
+  *                                 The value is expressed as a 16-bit word
+  *                                 in two’s complement.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_acceleration_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_OUT_X_L_A, buff, 6);
+}
+
+/**
+  * @brief  magnetic_raw: [get]  Magnetic output value.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_magnetic_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_OUTX_L_REG_M, buff, 6);
+}
+
+/**
+  * @brief  number_of_steps: [get] Number of steps detected by step
+  *                                counter routine.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_number_of_steps_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_L_A, buff, 2);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  common
+  * @brief   This section groups common usefull functions.
+  * @{
+  */
+
+/**
+  * @brief  device_id: [get] DeviceWhoamI.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_xl_device_id_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_WHO_AM_I_A, buff, 1);
+}
+
+/**
+  * @brief  device_id: [get] DeviceWhoamI.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_mg_device_id_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_WHO_AM_I_M, buff, 1);
+}
+
+/**
+  * @brief  auto_increment: [set] Register address automatically
+  *                               incremented during a multiple byte
+  *                               access with a serial interface.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of if_add_inc in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_auto_increment_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.if_add_inc = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  auto_increment: [get] Register address automatically incremented
+  *                               during a multiple byte access with a
+  *                               serial interface.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of if_add_inc in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_auto_increment_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  *val = reg.ctrl2_a.if_add_inc;
+
+  return mm_error;
+}
+
+/**
+  * @brief  mem_bank: [set] Enable access to the embedded functions/sensor
+  *                         hub configuration registers.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_func_cfg_en_t: change the values of func_cfg_en in
+  *                                 reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_mem_bank_set(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_xl_func_cfg_en_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  if (val == LSM303AH_XL_ADV_BANK){
+    mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+    reg.ctrl2_a.func_cfg_en = val;
+    mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  }
+  else {
+    mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_ADV_A, &reg.byte, 1);
+    reg.ctrl2_a.func_cfg_en = val;
+    mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_ADV_A, &reg.byte, 1);
+  }
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [set] Software reset. Restore the default values in
+  *                      user registers.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of soft_reset in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_reset_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.soft_reset = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [get] Software reset. Restore the default values in
+  *                      user registers.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of soft_reset in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  *val = reg.ctrl2_a.soft_reset;
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [set]  Software reset. Restore the default values in
+  *                       user registers.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of soft_rst in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_reset_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.soft_rst = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  reset: [get]  Software reset. Restore the default values
+  *                       in user registers.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of soft_rst in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  *val = reg.cfg_reg_a_m.soft_rst;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [set] Reboot memory content. Reload the calibration
+  *                     parameters.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of boot in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_boot_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.boot = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [get] Reboot memory content. Reload the calibration
+  *                     parameters.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of boot in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_boot_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  *val = reg.ctrl2_a.boot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [set]  Reboot memory content. Reload the calibration
+  *                      parameters.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of reboot in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_boot_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  reg.cfg_reg_a_m.reboot = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  boot: [get]  Reboot memory content. Reload the
+  *                      calibration parameters.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of reboot in reg CFG_REG_A
+  *
+  */
+int32_t lsm303ah_mg_boot_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  *val = reg.cfg_reg_a_m.reboot;
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_self_test: [set]
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_st_t: change the values of st in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_self_test_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_st_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.st = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_self_test: [get]
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_st_t: Get the values of st in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_self_test_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_st_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_st_t) reg.ctrl3_a.st;
+
+  return mm_error;
+}
+
+/**
+  * @brief  self_test: [set] Selftest.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of self_test in reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_self_test_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.self_test = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  self_test: [get] Selftest.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of self_test in reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_self_test_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  *val = reg.cfg_reg_c_m.self_test;
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_ready_mode: [set]
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_drdy_pulsed_t: change the values of drdy_pulsed in
+  *                                 reg CTRL5
+  *
+  */
+int32_t lsm303ah_xl_data_ready_mode_set(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_drdy_pulsed_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  reg.ctrl5_a.drdy_pulsed = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  data_ready_mode: [get]
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_drdy_pulsed_t: Get the values of drdy_pulsed in
+  *                                    reg CTRL5
+  *
+  */
+int32_t lsm303ah_xl_data_ready_mode_get(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_drdy_pulsed_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_drdy_pulsed_t) reg.ctrl5_a.drdy_pulsed;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Filters
+  * @brief   This section group all the functions concerning the filters
+  *          configuration.
+  * @{
+  */
+
+/**
+  * @brief  xl_hp_path: [set] High-pass filter data selection on output
+  *                           register and FIFO.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_fds_slope_t: change the values of fds_slope in
+  *                                  reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_hp_path_set(lsm303ah_ctx_t *ctx,
+                                lsm303ah_xl_fds_slope_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.fds_slope = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  xl_hp_path: [get] High-pass filter data selection on output
+  *                           register and FIFO.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_fds_slope_t: Get the values of fds_slope in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_hp_path_get(lsm303ah_ctx_t *ctx,
+                                lsm303ah_xl_fds_slope_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_fds_slope_t) reg.ctrl2_a.fds_slope;
+
+  return mm_error;
+}
+
+/**
+  * @brief  low_pass_bandwidth: [set]  Low-pass bandwidth selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_lpf_t: change the values of lpf in reg CFG_REG_B
+  *
+  */
+int32_t lsm303ah_mg_low_pass_bandwidth_set(lsm303ah_ctx_t *ctx,
+                                       lsm303ah_mg_lpf_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  reg.cfg_reg_b_m.lpf = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  low_pass_bandwidth: [get]  Low-pass bandwidth selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_lpf_t: Get the values of lpf in reg CFG_REG_B
+  *
+  */
+int32_t lsm303ah_mg_low_pass_bandwidth_get(lsm303ah_ctx_t *ctx,
+                                       lsm303ah_mg_lpf_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  *val = (lsm303ah_mg_lpf_t) reg.cfg_reg_b_m.lpf;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Auxiliary_interface
+  * @brief   This section groups all the functions concerning auxiliary
+  *          interface.
+  * @{
+  */
+
+/**
+  * @brief  spi_mode: [set]  SPI Serial Interface Mode selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_sim_t: change the values of sim in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_spi_mode_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_sim_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.sim = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  spi_mode: [get]  SPI Serial Interface Mode selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_sim_t: Get the values of sim in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_spi_mode_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_sim_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_sim_t) reg.ctrl2_a.sim;
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [set]  Disable / Enable I2C interface.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_i2c_disable_t: change the values of i2c_disable
+  *                                 in reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_i2c_interface_set(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_xl_i2c_disable_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  reg.ctrl2_a.i2c_disable = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [get]  Disable / Enable I2C interface.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_i2c_disable_t: Get the values of i2c_disable in
+  *                                 reg CTRL2
+  *
+  */
+int32_t lsm303ah_xl_i2c_interface_get(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_xl_i2c_disable_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_i2c_disable_t) reg.ctrl2_a.i2c_disable;
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [set]  Enable/Disable I2C interface.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_i2c_dis_t: change the values of i2c_dis in
+  *                                reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_i2c_interface_set(lsm303ah_ctx_t *ctx,
+                                      lsm303ah_mg_i2c_dis_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.i2c_dis = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  i2c_interface: [get]  Enable/Disable I2C interface.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_i2c_dis_t: Get the values of i2c_dis in reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_i2c_interface_get(lsm303ah_ctx_t *ctx,
+                                      lsm303ah_mg_i2c_dis_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  *val = (lsm303ah_mg_i2c_dis_t) reg.cfg_reg_c_m.i2c_dis;
+
+  return mm_error;
+}
+
+/**
+  * @brief  cs_mode: [set]  Connect/Disconnects pull-up in if_cs pad.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_if_cs_pu_dis_t: change the values of if_cs_pu_dis
+  *                                  in reg FIFO_CTRL
+  *
+  */
+int32_t lsm303ah_xl_cs_mode_set(lsm303ah_ctx_t *ctx,
+                             lsm303ah_xl_if_cs_pu_dis_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  reg.fifo_ctrl_a.if_cs_pu_dis = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  cs_mode: [get]  Connect/Disconnects pull-up in if_cs pad.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_if_cs_pu_dis_t: Get the values of if_cs_pu_dis in
+  *                                  reg FIFO_CTRL
+  *
+  */
+int32_t lsm303ah_xl_cs_mode_get(lsm303ah_ctx_t *ctx,
+                             lsm303ah_xl_if_cs_pu_dis_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_if_cs_pu_dis_t) reg.fifo_ctrl_a.if_cs_pu_dis;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   main_serial_interface
+  * @brief   This section groups all the functions concerning main serial
+  *          interface management (not auxiliary)
+  * @{
+  */
+
+/**
+  * @brief  pin_mode: [set]  Push-pull/open-drain selection on interrupt pad.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_pp_od_t: change the values of pp_od in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_pin_mode_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_pp_od_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.pp_od = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_mode: [get]  Push-pull/open-drain selection on interrupt pad.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_pp_od_t: Get the values of pp_od in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_pin_mode_get(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_xl_pp_od_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_pp_od_t) reg.ctrl3_a.pp_od;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_polarity: [set]  Interrupt active-high/low.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_h_lactive_t: change the values of h_lactive in
+  *                                  reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_pin_polarity_set(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_xl_h_lactive_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.h_lactive = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_polarity: [get]  Interrupt active-high/low.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_h_lactive_t: Get the values of h_lactive in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_pin_polarity_get(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_xl_h_lactive_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_h_lactive_t) reg.ctrl3_a.h_lactive;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_notification: [set]  Latched/pulsed interrupt.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_lir_t: change the values of lir in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_int_notification_set(lsm303ah_ctx_t *ctx,
+                                      lsm303ah_xl_lir_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.lir = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_notification: [get]  Latched/pulsed interrupt.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_lir_t: Get the values of lir in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_int_notification_get(lsm303ah_ctx_t *ctx,
+                                      lsm303ah_xl_lir_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_lir_t) reg.ctrl3_a.lir;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int1_route: [set] Select the signal that need to route
+  *                               on int1 pad.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_pin_int1_route_t: union of registers from CTRL4 to
+  *
+  */
+int32_t lsm303ah_xl_pin_int1_route_set(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_pin_int1_route_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL4_A, &reg.byte, 1);
+  reg.ctrl4_a.int1_drdy         = val.int1_drdy;
+  reg.ctrl4_a.int1_fth          = val.int1_fth;
+  reg.ctrl4_a.int1_6d           = val.int1_6d;
+  reg.ctrl4_a.int1_tap          = val.int1_tap;
+  reg.ctrl4_a.int1_ff           = val.int1_ff;
+  reg.ctrl4_a.int1_wu           = val.int1_wu;
+  reg.ctrl4_a.int1_s_tap        = val.int1_s_tap;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL4_A, &reg.byte, 1);
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_dur_a.int1_fss7   = val.int1_fss7;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int1_route: [get] Select the signal that need to route on
+  *                               int1 pad.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_pin_int1_route_t: union of registers from CTRL4 to
+  *
+  */
+int32_t lsm303ah_xl_pin_int1_route_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_pin_int1_route_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL4_A, &reg.byte, 1);
+  val->int1_drdy          = reg.ctrl4_a.int1_drdy;
+  val->int1_fth           = reg.ctrl4_a.int1_fth;
+  val->int1_6d            = reg.ctrl4_a.int1_6d;
+  val->int1_tap           = reg.ctrl4_a.int1_tap;
+  val->int1_ff            = reg.ctrl4_a.int1_ff;
+  val->int1_wu            = reg.ctrl4_a.int1_wu;
+  val->int1_s_tap         = reg.ctrl4_a.int1_s_tap;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  val->int1_fss7 = reg.wake_up_dur_a.int1_fss7;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int2_route: [set] Select the signal that need to route on
+  *                               int2 pad.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_pin_int2_route_t: union of registers from CTRL5 to
+  *
+  */
+int32_t lsm303ah_xl_pin_int2_route_set(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_pin_int2_route_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  reg.ctrl5_a.int2_boot       = val.int2_boot;
+  reg.ctrl5_a.int2_tilt       = val.int2_tilt;
+  reg.ctrl5_a.int2_sig_mot    = val.int2_sig_mot;
+  reg.ctrl5_a.int2_step       = val.int2_step;
+  reg.ctrl5_a.int2_fth        = val.int2_fth;
+  reg.ctrl5_a.int2_drdy       = val.int2_drdy;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pin_int2_route: [get] Select the signal that need to route on
+  *                               int2 pad.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_pin_int2_route_t: union of registers from CTRL5 to
+  *
+  */
+int32_t lsm303ah_xl_pin_int2_route_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_pin_int2_route_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  val->int2_boot     = reg.ctrl5_a.int2_boot;
+  val->int2_tilt     = reg.ctrl5_a.int2_tilt;
+  val->int2_sig_mot  = reg.ctrl5_a.int2_sig_mot;
+  val->int2_step     = reg.ctrl5_a.int2_step;
+  val->int2_fth      = reg.ctrl5_a.int2_fth;
+  val->int2_drdy     = reg.ctrl5_a.int2_drdy;
+
+  return mm_error;
+}
+
+/**
+  * @brief  all_on_int1: [set] All interrupt signals become available on
+  *                            INT1 pin.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int2_on_int1 in reg CTRL5
+  *
+  */
+int32_t lsm303ah_xl_all_on_int1_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  reg.ctrl5_a.int2_on_int1 = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  all_on_int1: [get] All interrupt signals become available on
+  *                            INT1 pin.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int2_on_int1 in reg CTRL5
+  *
+  */
+int32_t lsm303ah_xl_all_on_int1_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  *val = reg.ctrl5_a.int2_on_int1;
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_pin: [set]  Data-ready signal on INT_DRDY pin.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of drdy_on_pin in reg CFG_REG_C
+  *
+  */
+int32_t lsm303ah_mg_drdy_on_pin_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.int_mag = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  drdy_on_pin: [get]  Data-ready signal on INT_DRDY pin.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of drdy_on_pin in reg CFG_REG_C_M
+  *
+  */
+int32_t lsm303ah_mg_drdy_on_pin_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  *val = reg.cfg_reg_c_m.int_mag;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_on_pin: [set]  Interrupt signal on INT_DRDY pin.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of int_on_pin in reg CFG_REG_C_M
+  *
+  */
+int32_t lsm303ah_mg_int_on_pin_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  reg.cfg_reg_c_m.int_mag_pin = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_on_pin: [get]  Interrupt signal on INT_DRDY pin.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of int_on_pin in reg CFG_REG_C_M
+  *
+  */
+int32_t lsm303ah_mg_int_on_pin_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  *val = reg.cfg_reg_c_m.int_mag_pin;
+
+  return mm_error;
+}
+
+/**
+  * @brief  int_gen_conf: [set]  Interrupt generator configuration register
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_int_crtl_reg_m_t: registers INT_CRTL_REG
+  *
+  */
+int32_t lsm303ah_mg_int_gen_conf_set(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_int_crtl_reg_m_t *val)
+{
+  return lsm303ah_write_reg(ctx, LSM303AH_INT_CRTL_REG_M, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  int_gen_conf: [get]  Interrupt generator configuration register
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_int_crtl_reg_m_t: registers INT_CRTL_REG
+  *
+  */
+int32_t lsm303ah_mg_int_gen_conf_get(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_int_crtl_reg_m_t *val)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_INT_CRTL_REG_M, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  int_gen_source: [get]  Interrupt generator source register
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_int_source_reg_m_t: registers INT_SOURCE_REG
+  *
+  */
+int32_t lsm303ah_mg_int_gen_source_get(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_int_source_reg_m_t *val)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_INT_SOURCE_REG_M, (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  int_gen_treshold: [set]  User-defined threshold value for xl
+  *                                  interrupt event on generator.
+  *                                  Data format is the same of output
+  *                                  data raw: two’s complement with
+  *                                  1LSb = 1.5mG.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t lsm303ah_mg_int_gen_treshold_set(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_write_reg(ctx, LSM303AH_INT_THS_L_REG_M, buff, 2);
+}
+
+/**
+  * @brief  int_gen_treshold: [get]  User-defined threshold value for
+  *                                  xl interrupt event on generator.
+  *                                  Data format is the same of output
+  *                                  data raw: two’s complement with
+  *                                  1LSb = 1.5mG.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_mg_int_gen_treshold_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_INT_THS_L_REG_M, buff, 2);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  interrupt_pins
+  * @brief   This section groups all the functions that manage interrup pins
+  * @{
+  */
+
+
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Wake_Up_event
+  * @brief   This section groups all the functions that manage the Wake Up
+  *          event generation.
+  * @{
+  */
+
+/**
+  * @brief  offset_int_conf: [set]  The interrupt block recognition checks
+  *                                 data after/before the hard-iron correction
+  *                                 to discover the interrupt.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_int_on_dataoff_t: change the values of int_on_dataoff
+  *                                       in reg CFG_REG_B
+  *
+  */
+int32_t lsm303ah_mg_offset_int_conf_set(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_mg_int_on_dataoff_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  reg.cfg_reg_b_m.int_on_dataoff = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  offset_int_conf: [get]  The interrupt block recognition checks
+  *                                 data after/before the hard-iron correction
+  *                                 to discover the interrupt.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_mg_int_on_dataoff_t: Get the values of int_on_dataoff in
+  *                                   reg CFG_REG_B
+  *
+  */
+int32_t lsm303ah_mg_offset_int_conf_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_mg_int_on_dataoff_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  *val = (lsm303ah_mg_int_on_dataoff_t) reg.cfg_reg_b_m.int_on_dataoff;
+
+  return mm_error;
+}
+
+  /**
+  * @brief  wkup_threshold: [set]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of wu_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm303ah_xl_wkup_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_ths_a.wu_ths = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_threshold: [get]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of wu_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm303ah_xl_wkup_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = reg.wake_up_ths_a.wu_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_dur: [set]  Wakeup duration [1 LSb = 1 / ODR].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of wu_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm303ah_xl_wkup_dur_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_dur_a.wu_dur = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  wkup_dur: [get]  Wakeup duration [1 LSb = 1 / ODR].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of wu_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm303ah_xl_wkup_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = reg.wake_up_dur_a.wu_dur;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Activity/Inactivity_detection
+  * @brief   This section groups all the functions concerning
+  *          activity/inactivity detection.
+  * @{
+  */
+/**
+  * @brief  sleep_mode: [set]  Enables gyroscope Sleep mode.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sleep_on in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm303ah_xl_sleep_mode_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_ths_a.sleep_on = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  sleep_mode: [get]  Enables gyroscope Sleep mode.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sleep_on in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm303ah_xl_sleep_mode_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = reg.wake_up_ths_a.sleep_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief  act_sleep_dur: [set] Duration to go in sleep mode
+  *                              [1 LSb = 512 / ODR].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm303ah_xl_act_sleep_dur_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_dur_a.sleep_dur = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  act_sleep_dur: [get] Duration to go in sleep mode
+  *                              [1 LSb = 512 / ODR].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm303ah_xl_act_sleep_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = reg.wake_up_dur_a.sleep_dur;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  tap_generator
+  * @brief   This section groups all the functions that manage the tap and
+  *          double tap event generation.
+  * @{
+  */
+
+/**
+  * @brief  tap_detection_on_z: [set]  Enable Z direction in tap recognition.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_z_en in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_tap_detection_on_z_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.tap_z_en = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_z: [get]  Enable Z direction in tap recognition.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_z_en in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_tap_detection_on_z_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  *val = reg.ctrl3_a.tap_z_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_y: [set]  Enable Y direction in tap recognition.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_y_en in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_tap_detection_on_y_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.tap_y_en = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_y: [get]  Enable Y direction in tap recognition.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_y_en in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_tap_detection_on_y_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  *val = reg.ctrl3_a.tap_y_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_x: [set]  Enable X direction in tap recognition.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_x_en in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_tap_detection_on_x_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  reg.ctrl3_a.tap_x_en = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_detection_on_x: [get]  Enable X direction in tap recognition.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_x_en in reg CTRL3
+  *
+  */
+int32_t lsm303ah_xl_tap_detection_on_x_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  *val = reg.ctrl3_a.tap_x_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_threshold: [set] Threshold for tap recognition
+  *                              [1 LSb = FS/32].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tap_ths in reg TAP_6D_THS
+  *
+  */
+int32_t lsm303ah_xl_tap_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  reg.tap_6d_ths_a.tap_ths = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_threshold: [get] Threshold for tap recognition
+  *                              [1 LSb = FS/32].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tap_ths in reg TAP_6D_THS
+  *
+  */
+int32_t lsm303ah_xl_tap_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  *val = reg.tap_6d_ths_a.tap_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_shock: [set] Maximum duration is the maximum time of
+  *                          an overthreshold signal detection to be
+  *                          recognized as a tap event. The default value
+  *                          of these bits is 00b which corresponds to
+  *                          4*ODR_XL time. If the SHOCK[1:0] bits are set
+  *                          to a different value, 1LSB corresponds to
+  *                          8*ODR_XL time.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of shock in reg INT_DUR
+  *
+  */
+int32_t lsm303ah_xl_tap_shock_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  reg.int_dur_a.shock = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_shock: [get] Maximum duration is the maximum time of an
+  *                          overthreshold signal detection to be recognized
+  *                          as a tap event. The default value of these bits
+  *                          is 00b which corresponds to 4*ODR_XL time.
+  *                          If the SHOCK[1:0] bits are set to a different
+                             value, 1LSB corresponds to 8*ODR_XL time.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of shock in reg INT_DUR
+  *
+  */
+int32_t lsm303ah_xl_tap_shock_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  *val = reg.int_dur_a.shock;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_quiet: [set] Quiet time is the time after the first
+  *                          detected tap in which there must not be any
+  *                          overthreshold event. The default value of these
+  *                          bits is 00b which corresponds to 2*ODR_XL time.
+  *                          If the QUIET[1:0] bits are set to a different
+  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of quiet in reg INT_DUR
+  *
+  */
+int32_t lsm303ah_xl_tap_quiet_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  reg.int_dur_a.quiet = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_quiet: [get] Quiet time is the time after the first detected
+  *                          tap in which there must not be any overthreshold
+  *                          event. The default value of these bits is 00b
+  *                          which corresponds to 2*ODR_XL time.
+  *                          If the QUIET[1:0] bits are set to a different
+  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of quiet in reg INT_DUR
+  *
+  */
+int32_t lsm303ah_xl_tap_quiet_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  *val = reg.int_dur_a.quiet;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_dur: [set] When double tap recognition is enabled, this
+  *                        register expresses the maximum time between two
+  *                        consecutive detected taps to determine a double
+  *                        tap event. The default value of these bits is
+  *                        0000b which corresponds to 16*ODR_XL time.
+  *                        If the DUR[3:0] bits are set to a different value,
+  *                        1LSB corresponds to 32*ODR_XL time.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of lat in reg INT_DUR
+  *
+  */
+int32_t lsm303ah_xl_tap_dur_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  reg.int_dur_a.lat = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_dur: [get] When double tap recognition is enabled,
+  *                        this register expresses the maximum time
+  *                        between two consecutive detected taps to
+  *                        determine a double tap event. The default
+  *                        value of these bits is 0000b which corresponds
+  *                        to 16*ODR_XL time. If the DUR[3:0] bits are set
+  *                        to a different value, 1LSB corresponds to
+  *                        32*ODR_XL time.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of lat in reg INT_DUR
+  *
+  */
+int32_t lsm303ah_xl_tap_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  *val = reg.int_dur_a.lat;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_mode: [set]  Single/double-tap event enable/disable.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_single_double_tap_t: change the values of
+  *                                       single_double_tap in regWAKE_UP_THS
+  *
+  */
+int32_t lsm303ah_xl_tap_mode_set(lsm303ah_ctx_t *ctx,
+                              lsm303ah_xl_single_double_tap_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  reg.wake_up_ths_a.single_double_tap = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_mode: [get]  Single/double-tap event enable/disable.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_single_double_tap_t: Get the values of
+  *                                        single_double_tap in
+  *                                        reg WAKE_UP_THS
+  *
+  */
+int32_t lsm303ah_xl_tap_mode_get(lsm303ah_ctx_t *ctx,
+                              lsm303ah_xl_single_double_tap_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_single_double_tap_t)reg.wake_up_ths_a.single_double_tap;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tap_src: [get]  TAP source register
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_tap_src_t: registers TAP_SRC
+  *
+  */
+int32_t lsm303ah_xl_tap_src_get(lsm303ah_ctx_t *ctx,
+                                lsm303ah_tap_src_a_t *val)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_TAP_SRC_A, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup   Six_position_detection(6D/4D)
+  * @brief   This section groups all the functions concerning six
+  *          position detection (6D).
+  * @{
+  */
+
+/**
+  * @brief  6d_threshold: [set]  Threshold for 4D/6D function.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_6d_ths_t: change the values of 6d_ths in reg TAP_6D_THS
+  *
+  */
+int32_t lsm303ah_xl_6d_threshold_set(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_6d_ths_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  reg.tap_6d_ths_a._6d_ths = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  6d_threshold: [get]  Threshold for 4D/6D function.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_6d_ths_t: Get the values of 6d_ths in reg TAP_6D_THS
+  *
+  */
+int32_t lsm303ah_xl_6d_threshold_get(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_6d_ths_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_6d_ths_t) reg.tap_6d_ths_a._6d_ths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  4d_mode: [set]  4D orientation detection enable.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of 4d_en in reg TAP_6D_THS
+  *
+  */
+int32_t lsm303ah_xl_4d_mode_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  reg.tap_6d_ths_a._4d_en = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  4d_mode: [get]  4D orientation detection enable.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of 4d_en in reg TAP_6D_THS
+  *
+  */
+int32_t lsm303ah_xl_4d_mode_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  *val = reg.tap_6d_ths_a._4d_en;
+
+  return mm_error;
+}
+
+/**
+  * @brief  6d_src: [get]  6D source register.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_6d_src_t: union of registers from 6D_SRC to
+  *
+  */
+int32_t lsm303ah_xl_6d_src_get(lsm303ah_ctx_t *ctx, lsm303ah_6d_src_a_t *val)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_6D_SRC_A, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  free_fall
+  * @brief   This section group all the functions concerning the
+  *          free fall detection.
+  * @{
+  */
+
+/**
+  * @brief  ff_dur: [set]  Free-fall duration [1 LSb = 1 / ODR].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of ff_dur in reg
+  *                      WAKE_UP_DUR/FREE_FALL
+  *
+  */
+int32_t lsm303ah_xl_ff_dur_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg[0].byte, 2);
+  reg[1].free_fall_a.ff_dur = 0x1F & val;
+  reg[0].wake_up_dur_a.ff_dur = (val & 0x20) >> 5;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg[0].byte, 2);
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_dur: [get]  Free-fall duration [1 LSb = 1 / ODR].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  *
+  */
+int32_t lsm303ah_xl_ff_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg[0].byte, 2);
+  *val = (reg[0].wake_up_dur_a.ff_dur << 5) + reg[1].free_fall_a.ff_dur;
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_threshold: [set]  Free-fall threshold [1 LSB = 31.25 mg].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lsm303ah_xl_ff_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FREE_FALL_A, &reg.byte, 1);
+  reg.free_fall_a.ff_ths = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FREE_FALL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  ff_threshold: [get]  Free-fall threshold [1 LSB = 31.25 mg].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lsm303ah_xl_ff_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FREE_FALL_A, &reg.byte, 1);
+  *val = reg.free_fall_a.ff_ths;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Fifo
+  * @brief   This section group all the functions concerning the fifo usage
+  * @{
+  */
+
+/**
+  * @brief   fifo_xl_module_batch: [set]  Module routine result is send to
+  *          FIFO instead of X,Y,Z acceleration data
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of module_to_fifo in reg FIFO_CTRL
+  *
+  */
+int32_t lsm303ah_xl_fifo_xl_module_batch_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  reg.fifo_ctrl_a.module_to_fifo = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief   fifo_xl_module_batch: [get]  Module routine result is send to
+  *                                       FIFO instead of X,Y,Z acceleration
+  *                                       data
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of module_to_fifo in reg FIFO_CTRL
+  *
+  */
+int32_t lsm303ah_xl_fifo_xl_module_batch_get(lsm303ah_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  *val = reg.fifo_ctrl_a.module_to_fifo;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [set]  FIFO mode selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_fmode_t: change the values of fmode in reg FIFO_CTRL
+  *
+  */
+int32_t lsm303ah_xl_fifo_mode_set(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_xl_fmode_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  reg.fifo_ctrl_a.fmode = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_mode: [get]  FIFO mode selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_fmode_t: Get the values of fmode in reg FIFO_CTRL
+  *
+  */
+int32_t lsm303ah_xl_fifo_mode_get(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_xl_fmode_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  *val = (lsm303ah_xl_fmode_t) reg.fifo_ctrl_a.fmode;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of fifo_watermark in reg FIFO_THS
+  *
+  */
+int32_t lsm303ah_xl_fifo_watermark_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  int32_t mm_error;
+
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FIFO_THS_A, &val, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_watermark in reg FIFO_THS
+  *
+  */
+int32_t lsm303ah_xl_fifo_watermark_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_THS_A, val, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_full_flag: [get]  FIFO full, 256 unread samples.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of diff in reg FIFO_SRC
+  *
+  */
+int32_t lsm303ah_xl_fifo_full_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &reg.byte, 1);
+  *val = reg.fifo_src_a.diff;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_ovr_flag: [get]  FIFO overrun status.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fifo_ovr in reg FIFO_SRC
+  *
+  */
+int32_t lsm303ah_xl_fifo_ovr_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &reg.byte, 1);
+  *val = reg.fifo_src_a.fifo_ovr;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_wtm_flag: [get]  FIFO threshold status.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of fth in reg FIFO_SRC
+  *
+  */
+int32_t lsm303ah_xl_fifo_wtm_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &reg.byte, 1);
+  *val = reg.fifo_src_a.fth;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_data_level: [get] The number of unread samples
+  *                                stored in FIFO.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint16_t: change the values of diff in reg FIFO_SAMPLES
+  *
+  */
+int32_t lsm303ah_xl_fifo_data_level_get(lsm303ah_ctx_t *ctx, uint16_t *val)
+{
+  lsm303ah_reg_t reg[2];
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &reg[0].byte, 2);
+  *val = (reg[1].fifo_src_a.diff << 7) + reg[0].byte;
+
+  return mm_error;
+}
+
+/**
+  * @brief  fifo_src: [get] FIFO_SRCregister.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_fifo_src_t: registers FIFO_SRC
+  *
+  */
+int32_t lsm303ah_xl_fifo_src_get(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_fifo_src_a_t *val)
+{
+  return lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, (uint8_t*) val, 1);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  Pedometer
+  * @brief   This section groups all the functions that manage pedometer.
+  * @{
+  */
+
+/**
+  * @brief  pedo_threshold: [set] Minimum threshold value for step
+  *                               counter routine.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sc_mths in
+  *                      reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lsm303ah_xl_pedo_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               &reg.byte, 1);
+  reg. step_counter_minths_a.sc_mths = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                                &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_threshold: [get] Minimum threshold value for step
+  *                               counter routine.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sc_mths in reg  STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lsm303ah_xl_pedo_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               &reg.byte, 1);
+  *val = reg. step_counter_minths_a.sc_mths;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_full_scale: [set]  Pedometer data range.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_pedo4g_t: change the values of pedo4g in
+  *                            reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lsm303ah_xl_pedo_full_scale_set(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_pedo4g_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               &reg.byte, 1);
+  reg. step_counter_minths_a.pedo4g = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                                &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_full_scale: [get]  Pedometer data range.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  lsm303ah_xl_pedo4g_t: Get the values of pedo4g in
+  *                            reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lsm303ah_xl_pedo_full_scale_get(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_pedo4g_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               &reg.byte, 1);
+  *val = (lsm303ah_xl_pedo4g_t) reg. step_counter_minths_a.pedo4g;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_step_reset: [set]  Reset pedometer step counter.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of rst_nstep in
+  *                      reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lsm303ah_xl_pedo_step_reset_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               &reg.byte, 1);
+  reg. step_counter_minths_a.rst_nstep = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                                &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_step_reset: [get]  Reset pedometer step counter.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of rst_nstep in
+  *                  reg STEP_COUNTER_MINTHS
+  *
+  */
+int32_t lsm303ah_xl_pedo_step_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               &reg.byte, 1);
+  *val = reg. step_counter_minths_a.rst_nstep;
+
+  return mm_error;
+}
+
+/**
+  * @brief   pedo_step_detect_flag: [get]  Step detection flag.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of step_detect in reg FUNC_CK_GATE
+  *
+  */
+int32_t lsm303ah_xl_pedo_step_detect_flag_get(lsm303ah_ctx_t *ctx,
+                                              uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, &reg.byte, 1);
+  *val = reg.func_ck_gate_a.step_detect;
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_sens: [set]  Enable pedometer algorithm.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of step_cnt_on in reg FUNC_CTRL
+  *
+  */
+int32_t lsm303ah_xl_pedo_sens_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  reg.func_ctrl_a.step_cnt_on = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_sens: [get]  Enable pedometer algorithm.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of step_cnt_on in reg FUNC_CTRL
+  *
+  */
+int32_t lsm303ah_xl_pedo_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  *val = reg.func_ctrl_a.step_cnt_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief   pedo_debounce_steps: [set] Minimum number of steps to start
+  *                                     the increment step counter.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of deb_step in reg PEDO_DEB_REG
+  *
+  */
+int32_t lsm303ah_xl_pedo_debounce_steps_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
+  reg.pedo_deb_reg_a.deb_step = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief   pedo_debounce_steps: [get] Minimum number of steps to start
+  *                                     the increment step counter.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of deb_step in reg PEDO_DEB_REG
+  *
+  */
+int32_t lsm303ah_xl_pedo_debounce_steps_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
+  *val = reg.pedo_deb_reg_a.deb_step;
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_timeout: [set] Debounce time. If the time between two
+  *                             consecutive steps is greater than
+  *                             DEB_TIME*80ms, the debouncer is reactivated.
+  *                             Default value: 01101
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of deb_time in reg PEDO_DEB_REG
+  *
+  */
+int32_t lsm303ah_xl_pedo_timeout_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
+  reg.pedo_deb_reg_a.deb_time = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_timeout: [get] Debounce time. If the time between two
+  *                             consecutive steps is greater than
+  *                             DEB_TIME*80ms, the debouncer is reactivated.
+  *                             Default value: 01101
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of deb_time in reg PEDO_DEB_REG
+  *
+  */
+int32_t lsm303ah_xl_pedo_timeout_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
+  *val = reg.pedo_deb_reg_a.deb_time;
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_steps_period: [set] Period of time to detect at
+  *                                  least one step to generate step
+  *                                  recognition [1 LSb = 1.6384 s].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that contains data to write
+  *
+  */
+int32_t lsm303ah_xl_pedo_steps_period_set(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t mm_error;
+
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNT_DELTA_A, buff, 1);
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  pedo_steps_period: [get] Period of time to detect at least
+  *                                  one step to generate step recognition
+  *                                  [1 LSb = 1.6384 s].
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm303ah_xl_pedo_steps_period_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t mm_error;
+
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNT_DELTA_A, buff, 1);
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  significant_motion
+  * @brief   This section groups all the functions that manage the
+  *          significant motion detection.
+  * @{
+  */
+
+/**
+  * @brief   motion_data_ready_flag: [get] Significant motion event
+  *                                        detection status.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sig_mot_detect in reg FUNC_CK_GATE
+  *
+  */
+int32_t lsm303ah_xl_motion_data_ready_flag_get(lsm303ah_ctx_t *ctx,
+                                               uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, &reg.byte, 1);
+  *val = reg.func_ck_gate_a.sig_mot_detect;
+
+  return mm_error;
+}
+
+/**
+  * @brief  motion_sens: [set]  Enable significant motion detection function.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sign_mot_on in reg FUNC_CTRL
+  *
+  */
+int32_t lsm303ah_xl_motion_sens_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  reg.func_ctrl_a.sign_mot_on = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  motion_sens: [get]  Enable significant motion detection function.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sign_mot_on in reg FUNC_CTRL
+  *
+  */
+int32_t lsm303ah_xl_motion_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  *val = reg.func_ctrl_a.sign_mot_on;
+
+  return mm_error;
+}
+
+/**
+  * @brief  motion_threshold: [set] These bits define the threshold value
+  *                                 which corresponds to the number of steps
+  *                                 to be performed by the user upon a change
+  *                                 of location before the significant motion
+  *                                 interrupt is generated. It is expressed
+  *                                 as an 8-bit unsigned value.
+  *                                 The default value of this field is equal
+  *                                 to 6 (= 00000110b).
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of sm_ths in reg SM_THS
+  *
+  */
+int32_t lsm303ah_xl_motion_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_SM_THS_A, &reg.byte, 1);
+  reg.sm_ths_a.sm_ths = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_SM_THS_A, &reg.byte, 1);
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @brief  motion_threshold: [get] These bits define the threshold value
+  *                                 which corresponds to the number of steps
+  *                                 to be performed by the user upon a change
+  *                                 of location before the significant motion
+  *                                 interrupt is generated. It is expressed as
+  *                                 an 8-bit unsigned value. The default value
+  *                                 of this field is equal to 6 (= 00000110b).
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of sm_ths in reg SM_THS
+  *
+  */
+int32_t lsm303ah_xl_motion_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_SM_THS_A, &reg.byte, 1);
+  *val = reg.sm_ths_a.sm_ths;
+  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  tilt_detection
+  * @brief   This section groups all the functions that manage the tilt
+  *          event detection.
+  * @{
+  */
+
+/**
+  * @brief   tilt_data_ready_flag: [get]  Tilt event detection status.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tilt_int in reg FUNC_CK_GATE
+  *
+  */
+int32_t lsm303ah_xl_tilt_data_ready_flag_get(lsm303ah_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, &reg.byte, 1);
+  *val = reg.func_ck_gate_a.tilt_int;
+
+  return mm_error;
+}
+
+/**
+  * @brief  tilt_sens: [set]  Enable tilt calculation.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of tilt_on in reg FUNC_CTRL
+  *
+  */
+int32_t lsm303ah_xl_tilt_sens_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  reg.func_ctrl_a.tilt_on = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  tilt_sens: [get]  Enable tilt calculation.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of tilt_on in reg FUNC_CTRL
+  *
+  */
+int32_t lsm303ah_xl_tilt_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  *val = reg.func_ctrl_a.tilt_on;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @addtogroup  module
+  * @brief   This section groups all the functions that manage
+  *          module calculation
+  * @{
+  */
+
+/**
+  * @brief  module_sens: [set]  Module processing enable.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of module_on in reg FUNC_CTRL
+  *
+  */
+int32_t lsm303ah_xl_module_sens_set(lsm303ah_ctx_t *ctx, uint8_t val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  reg.func_ctrl_a.module_on = val;
+  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+
+  return mm_error;
+}
+
+/**
+  * @brief  module_sens: [get]  Module processing enable.
+  *
+  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of module_on in reg FUNC_CTRL
+  *
+  */
+int32_t lsm303ah_xl_module_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+{
+  lsm303ah_reg_t reg;
+  int32_t mm_error;
+
+  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  *val = reg.func_ctrl_a.module_on;
+
+  return mm_error;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm303ah_STdC/driver/lsm303ah_reg.h
+++ b/sensor/stmemsc/lsm303ah_STdC/driver/lsm303ah_reg.h
@@ -1,0 +1,996 @@
+/*
+ ******************************************************************************
+ * @file    lsm303ah_reg.h
+ * @author  MEMS Software Solution Team
+ * @date    19-December-2017
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm303ah_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __LSM303AH_DRIVER__H
+#define __LSM303AH_DRIVER__H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM303AH
+  * @{
+  *
+  */
+
+/** @defgroup LSM303AH_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup lsm303ah_interface
+  * @{
+  */
+
+typedef int32_t (*lsm303ah_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lsm303ah_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lsm303ah_write_ptr  write_reg;
+  lsm303ah_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lsm303ah_ctx_t;
+
+/**
+  * @}
+  */
+
+/** @defgroup lsm303ah_Infos
+  * @{
+  */
+  /** I2C Device Address 8 bit format **/
+#define LSM303AH_I2C_ADD_XL     0x3B
+#define LSM303AH_I2C_ADD_MG       0x3D
+
+/** Device Identification (Who am I) **/
+#define LSM303AH_ID_XL            0x43
+#define LSM303AH_ID_MG            0x40
+
+/**
+  * @}
+  */
+
+/**
+  * @defgroup lsm303ah_Sensitivity
+  * @{
+  */
+
+#define LSM303AH_FROM_FS_2g_TO_mg(lsb)    (float)(lsb *  61.0f) / 1000.0f
+#define LSM303AH_FROM_FS_4g_TO_mg(lsb)    (float)(lsb * 122.0f) / 1000.0f
+#define LSM303AH_FROM_FS_8g_TO_mg(lsb)    (float)(lsb * 244.0f) / 1000.0f
+#define LSM303AH_FROM_FS_16g_TO_mg(lsb)   (float)(lsb * 488.0f) / 1000.0f
+
+#define LSM303AH_FROM_LSB_TO_mG(lsb)      (float)(lsb * 1.5f)
+
+#define LSM303AH_FROM_LSB_TO_degC(lsb)  ((float)((int16_t)lsb>>8)*1.0f + 25.0f)
+
+/**
+  * @}
+  */
+
+#define LSM303AH_MODULE_8BIT_A           0x0C
+#define LSM303AH_WHO_AM_I_A              0x0F
+#define LSM303AH_CTRL1_A                 0x20
+typedef struct {
+  uint8_t bdu                 : 1;
+  uint8_t hf_odr              : 1;
+  uint8_t fs                  : 2;
+  uint8_t odr                 : 4;
+} lsm303ah_ctrl1_a_t;
+
+#define LSM303AH_CTRL2_A                 0x21
+typedef struct {
+  uint8_t sim                 : 1;
+  uint8_t i2c_disable         : 1;
+  uint8_t if_add_inc          : 1;
+  uint8_t fds_slope           : 1;
+  uint8_t func_cfg_en         : 1;
+  uint8_t not_used_01         : 1;
+  uint8_t soft_reset          : 1;
+  uint8_t boot                : 1;
+} lsm303ah_ctrl2_a_t;
+
+#define LSM303AH_CTRL3_A                 0x22
+typedef struct {
+  uint8_t pp_od               : 1;
+  uint8_t h_lactive           : 1;
+  uint8_t lir                 : 1;
+  uint8_t tap_z_en            : 1;
+  uint8_t tap_y_en            : 1;
+  uint8_t tap_x_en            : 1;
+  uint8_t st                  : 2;
+} lsm303ah_ctrl3_a_t;
+
+#define LSM303AH_CTRL4_A                 0x23
+typedef struct {
+  uint8_t int1_drdy           : 1;
+  uint8_t int1_fth            : 1;
+  uint8_t int1_6d             : 1;
+  uint8_t int1_tap            : 1;
+  uint8_t int1_ff             : 1;
+  uint8_t int1_wu             : 1;
+  uint8_t int1_s_tap          : 1;
+  uint8_t not_used_01    : 1;
+} lsm303ah_ctrl4_a_t;
+
+#define LSM303AH_CTRL5_A                 0x24
+typedef struct {
+  uint8_t int2_drdy           : 1;
+  uint8_t int2_fth            : 1;
+  uint8_t int2_step           : 1;
+  uint8_t int2_sig_mot        : 1;
+  uint8_t int2_tilt           : 1;
+  uint8_t int2_on_int1        : 1;
+  uint8_t int2_boot           : 1;
+  uint8_t drdy_pulsed         : 1;
+} lsm303ah_ctrl5_a_t;
+
+#define LSM303AH_FIFO_CTRL_A             0x25
+typedef struct {
+  uint8_t if_cs_pu_dis        : 1;
+  uint8_t not_used_01         : 2;
+  uint8_t module_to_fifo      : 1;
+  uint8_t int2_step_count_ov  : 1;
+  uint8_t fmode               : 3;
+} lsm303ah_fifo_ctrl_a_t;
+
+#define LSM303AH_OUT_T_A                 0x26
+#define LSM303AH_STATUS_A                0x27
+typedef struct {
+  uint8_t drdy                : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t single_tap          : 1;
+  uint8_t double_tap          : 1;
+  uint8_t sleep_state         : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t fifo_ths            : 1;
+} lsm303ah_status_a_t;
+
+#define LSM303AH_OUT_X_L_A               0x28
+#define LSM303AH_OUT_X_H_A               0x29
+#define LSM303AH_OUT_Y_L_A               0x2A
+#define LSM303AH_OUT_Y_H_A               0x2B
+#define LSM303AH_OUT_Z_L_A               0x2C
+#define LSM303AH_OUT_Z_H_A               0x2D
+#define LSM303AH_FIFO_THS_A              0x2E
+#define LSM303AH_FIFO_SRC_A              0x2F
+typedef struct {
+  uint8_t not_used_01         : 5;
+  uint8_t diff                : 1;
+  uint8_t fifo_ovr            : 1;
+  uint8_t fth                 : 1;
+} lsm303ah_fifo_src_a_t;
+
+#define LSM303AH_FIFO_SAMPLES_A          0x30
+#define LSM303AH_TAP_6D_THS_A            0x31
+typedef struct {
+  uint8_t tap_ths             : 5;
+  uint8_t _6d_ths             : 2;
+  uint8_t _4d_en              : 1;
+} lsm303ah_tap_6d_ths_a_t;
+
+#define LSM303AH_INT_DUR_A               0x32
+typedef struct {
+  uint8_t shock               : 2;
+  uint8_t quiet               : 2;
+  uint8_t lat                 : 4;
+} lsm303ah_int_dur_a_t;
+
+#define LSM303AH_WAKE_UP_THS_A           0x33
+typedef struct {
+  uint8_t wu_ths              : 6;
+  uint8_t sleep_on            : 1;
+  uint8_t single_double_tap   : 1;
+} lsm303ah_wake_up_ths_a_t;
+
+#define LSM303AH_WAKE_UP_DUR_A           0x34
+typedef struct {
+  uint8_t sleep_dur           : 4;
+  uint8_t int1_fss7           : 1;
+  uint8_t wu_dur              : 2;
+  uint8_t ff_dur              : 1;
+} lsm303ah_wake_up_dur_a_t;
+
+#define LSM303AH_FREE_FALL_A             0x35
+typedef struct {
+  uint8_t ff_ths              : 3;
+  uint8_t ff_dur              : 5;
+} lsm303ah_free_fall_a_t;
+
+#define LSM303AH_STATUS_DUP_A            0x36
+typedef struct {
+  uint8_t drdy                : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t single_tap          : 1;
+  uint8_t double_tap          : 1;
+  uint8_t sleep_state         : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t ovr                 : 1;
+} lsm303ah_status_dup_a_t;
+
+#define LSM303AH_WAKE_UP_SRC_A           0x37
+typedef struct {
+  uint8_t z_wu                : 1;
+  uint8_t y_wu                : 1;
+  uint8_t x_wu                : 1;
+  uint8_t wu_ia               : 1;
+  uint8_t sleep_state_ia      : 1;
+  uint8_t ff_ia               : 1;
+  uint8_t not_used_01         : 2;
+} lsm303ah_wake_up_src_a_t;
+
+#define LSM303AH_TAP_SRC_A               0x38
+typedef struct {
+  uint8_t z_tap               : 1;
+  uint8_t y_tap               : 1;
+  uint8_t x_tap               : 1;
+  uint8_t tap_sign            : 1;
+  uint8_t double_tap          : 1;
+  uint8_t single_tap          : 1;
+  uint8_t tap_ia              : 1;
+  uint8_t not_used_01         : 1;
+} lsm303ah_tap_src_a_t;
+
+#define LSM303AH_6D_SRC_A                0x39
+typedef struct {
+  uint8_t xl                  : 1;
+  uint8_t xh                  : 1;
+  uint8_t yl                  : 1;
+  uint8_t yh                  : 1;
+  uint8_t zl                  : 1;
+  uint8_t zh                  : 1;
+  uint8_t _6d_ia              : 1;
+  uint8_t not_used_01         : 1;
+} lsm303ah_6d_src_a_t;
+
+#define LSM303AH_STEP_COUNTER_MINTHS_A   0x3A
+typedef struct {
+  uint8_t sc_mths             : 6;
+  uint8_t pedo4g              : 1;
+  uint8_t rst_nstep           : 1;
+} lsm303ah_step_counter_minths_a_t;
+
+#define LSM303AH_STEP_COUNTER_L_A        0x3B
+#define LSM303AH_STEP_COUNTER_H_A        0x3C
+#define LSM303AH_FUNC_CK_GATE_A          0x3D
+typedef struct {
+  uint8_t ck_gate_func        : 1;
+  uint8_t step_detect         : 1;
+  uint8_t rst_pedo            : 1;
+  uint8_t rst_sign_mot        : 1;
+  uint8_t sig_mot_detect      : 1;
+  uint8_t fs_src              : 2;
+  uint8_t tilt_int            : 1;
+} lsm303ah_func_ck_gate_a_t;
+
+#define LSM303AH_FUNC_SRC_A              0x3E
+typedef struct {
+  uint8_t not_used_01         : 1;
+  uint8_t module_ready        : 1;
+  uint8_t rst_tilt            : 1;
+  uint8_t not_used_02         : 5;
+} lsm303ah_func_src_a_t;
+
+#define LSM303AH_FUNC_CTRL_A             0x3F
+typedef struct {
+  uint8_t step_cnt_on         : 1;
+  uint8_t sign_mot_on         : 1;
+  uint8_t not_used_01         : 2;
+  uint8_t tilt_on             : 1;
+  uint8_t module_on           : 1;
+  uint8_t not_used_02         : 2;
+} lsm303ah_func_ctrl_a_t;
+
+#define LSM303AH_PEDO_DEB_REG_A          0x2B
+typedef struct {
+  uint8_t deb_step            : 3;
+  uint8_t deb_time            : 5;
+} lsm303ah_pedo_deb_reg_a_t;
+
+#define LSM303AH_SM_THS_A                0x34
+typedef struct {
+  uint8_t sm_ths              : 8;
+} lsm303ah_sm_ths_a_t;
+
+#define LSM303AH_STEP_COUNT_DELTA_A      0x3A
+typedef struct {
+  uint8_t step_count_d        : 8;
+} lsm303ah_step_count_delta_a_t;
+
+#define LSM303AH_CTRL2_ADV_A             0x3F
+typedef struct {
+  uint8_t sim                 : 1;
+  uint8_t i2c_disable         : 1;
+  uint8_t if_add_inc          : 1;
+  uint8_t fds_slope           : 1;
+  uint8_t func_cfg_en         : 1;
+  uint8_t not_used_01         : 1;
+  uint8_t soft_reset          : 1;
+  uint8_t boot                : 1;
+} lsm303ah_ctrl2_adv_a_t;
+
+#define LSM303AH_OFFSET_X_REG_L_M          0x45
+#define LSM303AH_OFFSET_X_REG_H_M          0x46
+#define LSM303AH_OFFSET_Y_REG_L_M          0x47
+#define LSM303AH_OFFSET_Y_REG_H_M          0x48
+#define LSM303AH_OFFSET_Z_REG_L_M          0x49
+#define LSM303AH_OFFSET_Z_REG_H_M          0x4A
+#define LSM303AH_WHO_AM_I_M                0x4F
+#define LSM303AH_CFG_REG_A_M               0x60
+typedef struct {
+  uint8_t md                     : 2;
+  uint8_t odr                    : 2;
+  uint8_t lp                     : 1;
+  uint8_t soft_rst               : 1;
+  uint8_t reboot                 : 1;
+  uint8_t comp_temp_en           : 1;
+} lsm303ah_cfg_reg_a_m_t;
+
+#define LSM303AH_CFG_REG_B_M               0x61
+typedef struct {
+  uint8_t lpf                    : 1;
+  uint8_t set_rst                : 2; /* off_canc + set_freq */
+  uint8_t int_on_dataoff         : 1;
+  uint8_t off_canc_one_shot      : 1;
+  uint8_t not_used_01            : 3;
+} lsm303ah_cfg_reg_b_m_t;
+
+#define LSM303AH_CFG_REG_C_M               0x62
+typedef struct {
+  uint8_t int_mag                : 1;
+  uint8_t self_test              : 1;
+  uint8_t not_used_01            : 1;
+  uint8_t ble                    : 1;
+  uint8_t bdu                    : 1;
+  uint8_t i2c_dis                : 1;
+  uint8_t int_mag_pin            : 1;
+  uint8_t not_used_02            : 1;
+} lsm303ah_cfg_reg_c_m_t;
+
+#define LSM303AH_INT_CRTL_REG_M            0x63
+typedef struct {
+  uint8_t ien                    : 1;
+  uint8_t iel                    : 1;
+  uint8_t iea                    : 1;
+  uint8_t not_used_01            : 2;
+  uint8_t zien                   : 1;
+  uint8_t yien                   : 1;
+  uint8_t xien                   : 1;
+} lsm303ah_int_crtl_reg_m_t;
+
+#define LSM303AH_INT_SOURCE_REG_M          0x64
+typedef struct {
+  uint8_t _int                    : 1;
+  uint8_t mroi                   : 1;
+  uint8_t n_th_s_z               : 1;
+  uint8_t n_th_s_y               : 1;
+  uint8_t n_th_s_x               : 1;
+  uint8_t p_th_s_z               : 1;
+  uint8_t p_th_s_y               : 1;
+  uint8_t p_th_s_x               : 1;
+} lsm303ah_int_source_reg_m_t;
+
+#define LSM303AH_INT_THS_L_REG_M           0x65
+#define LSM303AH_INT_THS_H_REG_M           0x66
+#define LSM303AH_STATUS_REG_M              0x67
+typedef struct {
+  uint8_t xda                    : 1;
+  uint8_t yda                    : 1;
+  uint8_t zda                    : 1;
+  uint8_t zyxda                  : 1;
+  uint8_t _xor                   : 1;
+  uint8_t yor                    : 1;
+  uint8_t zor                    : 1;
+  uint8_t zyxor                  : 1;
+} lsm303ah_status_reg_m_t;
+
+#define LSM303AH_OUTX_L_REG_M              0x68
+#define LSM303AH_OUTX_H_REG_M              0x69
+#define LSM303AH_OUTY_L_REG_M              0x6A
+#define LSM303AH_OUTY_H_REG_M              0x6B
+#define LSM303AH_OUTZ_L_REG_M              0x6C
+#define LSM303AH_OUTZ_H_REG_M              0x6D
+
+typedef union{
+  lsm303ah_ctrl1_a_t                      ctrl1_a;
+  lsm303ah_ctrl2_a_t                      ctrl2_a;
+  lsm303ah_ctrl3_a_t                      ctrl3_a;
+  lsm303ah_ctrl4_a_t                      ctrl4_a;
+  lsm303ah_ctrl5_a_t                      ctrl5_a;
+  lsm303ah_fifo_ctrl_a_t                  fifo_ctrl_a;
+  lsm303ah_status_a_t                     status_a;
+  lsm303ah_fifo_src_a_t                   fifo_src_a;
+  lsm303ah_tap_6d_ths_a_t                 tap_6d_ths_a;
+  lsm303ah_int_dur_a_t                    int_dur_a;
+  lsm303ah_wake_up_ths_a_t                wake_up_ths_a;
+  lsm303ah_wake_up_dur_a_t                wake_up_dur_a;
+  lsm303ah_free_fall_a_t                  free_fall_a;
+  lsm303ah_status_dup_a_t                 status_dup_a;
+  lsm303ah_wake_up_src_a_t                wake_up_src_a;
+  lsm303ah_tap_src_a_t                    tap_src_a;
+  lsm303ah_6d_src_a_t                     _6d_src_a;
+  lsm303ah_step_counter_minths_a_t        step_counter_minths_a;
+  lsm303ah_func_ck_gate_a_t               func_ck_gate_a;
+  lsm303ah_func_src_a_t                   func_src_a;
+  lsm303ah_func_ctrl_a_t                  func_ctrl_a;
+  lsm303ah_pedo_deb_reg_a_t               pedo_deb_reg_a;
+  lsm303ah_sm_ths_a_t                     sm_ths_a;
+  lsm303ah_step_count_delta_a_t           step_count_delta_a;
+  lsm303ah_ctrl2_adv_a_t                  ctrl2_adv_a;
+  lsm303ah_cfg_reg_a_m_t                  cfg_reg_a_m;
+  lsm303ah_cfg_reg_b_m_t                  cfg_reg_b_m;
+  lsm303ah_cfg_reg_c_m_t                  cfg_reg_c_m;
+  lsm303ah_int_crtl_reg_m_t               int_crtl_reg_m;
+  lsm303ah_int_source_reg_m_t             int_source_reg_m;
+  lsm303ah_status_reg_m_t                 status_reg_m;
+  bitwise_t                               bitwise;
+  uint8_t                                 byte;
+} lsm303ah_reg_t;
+int32_t lsm303ah_read_reg(lsm303ah_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lsm303ah_write_reg(lsm303ah_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+typedef union {
+  struct {
+  lsm303ah_fifo_src_a_t       fifo_src_a;
+  lsm303ah_status_dup_a_t     status_dup_a;
+  lsm303ah_wake_up_src_a_t    wake_up_src_a;
+  lsm303ah_tap_src_a_t        tap_src_a;
+  lsm303ah_6d_src_a_t         _6d_src_a;
+  lsm303ah_func_ck_gate_a_t   func_ck_gate_a;
+  lsm303ah_func_src_a_t       func_src_a;
+  } reg;
+  uint8_t byte[7];
+} lsm303ah_xl_all_sources_t;
+int32_t lsm303ah_xl_all_sources_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_all_sources_t *val);
+
+
+int32_t lsm303ah_xl_block_data_update_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_block_data_update_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_mg_block_data_update_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_block_data_update_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AH_MG_LSB_AT_LOW_ADD  = 0,
+  LSM303AH_MG_MSB_AT_LOW_ADD  = 1,
+} lsm303ah_mg_ble_t;
+int32_t lsm303ah_mg_data_format_set(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_mg_ble_t val);
+int32_t lsm303ah_mg_data_format_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_mg_ble_t *val);
+
+typedef enum {
+  LSM303AH_XL_2g = 0,
+  LSM303AH_XL_16g = 1,
+  LSM303AH_XL_4g = 2,
+  LSM303AH_XL_8g = 3,
+} lsm303ah_xl_fs_t;
+int32_t lsm303ah_xl_full_scale_set(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_xl_fs_t val);
+int32_t lsm303ah_xl_full_scale_get(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_xl_fs_t *val);
+
+typedef enum {
+  LSM303AH_XL_ODR_OFF         = 0x00,
+  LSM303AH_XL_ODR_1Hz_LP      = 0x08,
+  LSM303AH_XL_ODR_12Hz5_LP    = 0x09,
+  LSM303AH_XL_ODR_25Hz_LP     = 0x0A,
+  LSM303AH_XL_ODR_50Hz_LP     = 0x0B,
+  LSM303AH_XL_ODR_100Hz_LP    = 0x0C,
+  LSM303AH_XL_ODR_200Hz_LP    = 0x0D,
+  LSM303AH_XL_ODR_400Hz_LP    = 0x0E,
+  LSM303AH_XL_ODR_800Hz_LP    = 0x0F,
+  LSM303AH_XL_ODR_12Hz5_HR    = 0x01,
+  LSM303AH_XL_ODR_25Hz_HR     = 0x02,
+  LSM303AH_XL_ODR_50Hz_HR     = 0x03,
+  LSM303AH_XL_ODR_100Hz_HR    = 0x04,
+  LSM303AH_XL_ODR_200Hz_HR    = 0x05,
+  LSM303AH_XL_ODR_400Hz_HR    = 0x06,
+  LSM303AH_XL_ODR_800Hz_HR    = 0x07,
+  LSM303AH_XL_ODR_1k6Hz_HF    = 0x15,
+  LSM303AH_XL_ODR_3k2Hz_HF    = 0x16,
+  LSM303AH_XL_ODR_6k4Hz_HF    = 0x17,
+} lsm303ah_xl_odr_t;
+int32_t lsm303ah_xl_data_rate_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_odr_t val);
+int32_t lsm303ah_xl_data_rate_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_odr_t *val);
+
+int32_t lsm303ah_xl_status_reg_get(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_status_a_t *val);
+
+int32_t lsm303ah_mg_status_get(lsm303ah_ctx_t *ctx,
+                               lsm303ah_status_reg_m_t *val);
+
+int32_t lsm303ah_xl_flag_data_ready_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_mg_data_ready_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_data_ovr_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_mg_user_offset_set(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_mg_user_offset_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM303AH_MG_CONTINUOUS_MODE  = 0,
+  LSM303AH_MG_SINGLE_TRIGGER   = 1,
+  LSM303AH_MG_POWER_DOWN       = 2,
+} lsm303ah_mg_md_t;
+int32_t lsm303ah_mg_operating_mode_set(lsm303ah_ctx_t *ctx,
+                                       lsm303ah_mg_md_t val);
+int32_t lsm303ah_mg_operating_mode_get(lsm303ah_ctx_t *ctx,
+                                       lsm303ah_mg_md_t *val);
+
+typedef enum {
+  LSM303AH_MG_ODR_10Hz   = 0,
+  LSM303AH_MG_ODR_20Hz   = 1,
+  LSM303AH_MG_ODR_50Hz   = 2,
+  LSM303AH_MG_ODR_100Hz  = 3,
+} lsm303ah_mg_odr_t;
+int32_t lsm303ah_mg_data_rate_set(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_mg_odr_t val);
+int32_t lsm303ah_mg_data_rate_get(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_mg_odr_t *val);
+
+typedef enum {
+  LSM303AH_MG_HIGH_RESOLUTION  = 0,
+  LSM303AH_MG_LOW_POWER        = 1,
+} lsm303ah_mg_lp_t;
+int32_t lsm303ah_mg_power_mode_set(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_mg_lp_t val);
+int32_t lsm303ah_mg_power_mode_get(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_mg_lp_t *val);
+
+int32_t lsm303ah_mg_offset_temp_comp_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_offset_temp_comp_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AH_MG_SET_SENS_ODR_DIV_63        = 0,
+  LSM303AH_MG_SENS_OFF_CANC_EVERY_ODR    = 1,
+  LSM303AH_MG_SET_SENS_ONLY_AT_POWER_ON  = 2,
+} lsm303ah_mg_set_rst_t;
+int32_t lsm303ah_mg_set_rst_mode_set(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_mg_set_rst_t val);
+int32_t lsm303ah_mg_set_rst_mode_get(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_mg_set_rst_t *val);
+
+int32_t lsm303ah_mg_set_rst_sensor_single_set(lsm303ah_ctx_t *ctx,
+                                          uint8_t val);
+int32_t lsm303ah_mg_set_rst_sensor_single_get(lsm303ah_ctx_t *ctx,
+                                          uint8_t *val);
+
+int32_t lsm303ah_acceleration_module_raw_get(lsm303ah_ctx_t *ctx,
+                                             uint8_t *buff);
+
+int32_t lsm303ah_magnetic_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303ah_xl_temperature_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303ah_acceleration_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303ah_number_of_steps_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303ah_xl_device_id_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303ah_mg_device_id_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm303ah_xl_auto_increment_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_auto_increment_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AH_XL_USER_BANK   = 0,
+  LSM303AH_XL_ADV_BANK    = 1,
+} lsm303ah_xl_func_cfg_en_t;
+int32_t lsm303ah_xl_mem_bank_set(lsm303ah_ctx_t *ctx,
+                              lsm303ah_xl_func_cfg_en_t val);
+
+int32_t lsm303ah_xl_reset_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_mg_reset_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_boot_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_boot_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_mg_boot_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_boot_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AH_XL_ST_DISABLE     = 0,
+  LSM303AH_XL_ST_POSITIVE    = 1,
+  LSM303AH_XL_ST_NEGATIVE    = 2,
+} lsm303ah_xl_st_t;
+int32_t lsm303ah_xl_self_test_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_st_t val);
+int32_t lsm303ah_xl_self_test_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_st_t *val);
+
+int32_t lsm303ah_mg_self_test_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_self_test_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AH_XL_DRDY_LATCHED   = 0,
+  LSM303AH_XL_DRDY_PULSED    = 1,
+} lsm303ah_xl_drdy_pulsed_t;
+int32_t lsm303ah_xl_data_ready_mode_set(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_drdy_pulsed_t val);
+int32_t lsm303ah_xl_data_ready_mode_get(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_drdy_pulsed_t *val);
+
+typedef enum {
+  LSM303AH_XL_HP_INTERNAL_ONLY  = 0,
+  LSM303AH_XL_HP_ON_OUTPUTS     = 1,
+} lsm303ah_xl_fds_slope_t;
+int32_t lsm303ah_xl_hp_path_set(lsm303ah_ctx_t *ctx,
+                                lsm303ah_xl_fds_slope_t val);
+int32_t lsm303ah_xl_hp_path_get(lsm303ah_ctx_t *ctx,
+                                lsm303ah_xl_fds_slope_t *val);
+
+typedef enum {
+  LSM303AH_MG_ODR_DIV_2  = 0,
+  LSM303AH_MG_ODR_DIV_4  = 1,
+} lsm303ah_mg_lpf_t;
+int32_t lsm303ah_mg_low_pass_bandwidth_set(lsm303ah_ctx_t *ctx,
+                                       lsm303ah_mg_lpf_t val);
+int32_t lsm303ah_mg_low_pass_bandwidth_get(lsm303ah_ctx_t *ctx,
+                                       lsm303ah_mg_lpf_t *val);
+
+typedef enum {
+  LSM303AH_XL_SPI_4_WIRE   = 0,
+  LSM303AH_XL_SPI_3_WIRE   = 1,
+} lsm303ah_xl_sim_t;
+int32_t lsm303ah_xl_spi_mode_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_sim_t val);
+int32_t lsm303ah_xl_spi_mode_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_sim_t *val);
+
+typedef enum {
+  LSM303AH_XL_I2C_ENABLE   = 0,
+  LSM303AH_XL_I2C_DISABLE  = 1,
+} lsm303ah_xl_i2c_disable_t;
+int32_t lsm303ah_xl_i2c_interface_set(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_xl_i2c_disable_t val);
+int32_t lsm303ah_xl_i2c_interface_get(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_xl_i2c_disable_t *val);
+
+typedef enum {
+  LSM303AH_MG_I2C_ENABLE   = 0,
+  LSM303AH_MG_I2C_DISABLE  = 1,
+} lsm303ah_mg_i2c_dis_t;
+int32_t lsm303ah_mg_i2c_interface_set(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_mg_i2c_dis_t val);
+int32_t lsm303ah_mg_i2c_interface_get(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_mg_i2c_dis_t *val);
+
+typedef enum {
+  LSM303AH_XL_PULL_UP_CONNECTED     = 0,
+  LSM303AH_XL_PULL_UP_DISCONNECTED  = 1,
+} lsm303ah_xl_if_cs_pu_dis_t;
+int32_t lsm303ah_xl_cs_mode_set(lsm303ah_ctx_t *ctx,
+                             lsm303ah_xl_if_cs_pu_dis_t val);
+int32_t lsm303ah_xl_cs_mode_get(lsm303ah_ctx_t *ctx,
+                             lsm303ah_xl_if_cs_pu_dis_t *val);
+
+typedef enum {
+  LSM303AH_XL_PUSH_PULL   = 0,
+  LSM303AH_XL_OPEN_DRAIN  = 1,
+} lsm303ah_xl_pp_od_t;
+int32_t lsm303ah_xl_pin_mode_set(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_xl_pp_od_t val);
+int32_t lsm303ah_xl_pin_mode_get(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_xl_pp_od_t *val);
+
+typedef enum {
+  LSM303AH_XL_ACTIVE_HIGH  = 0,
+  LSM303AH_XL_ACTIVE_LOW   = 1,
+} lsm303ah_xl_h_lactive_t;
+int32_t lsm303ah_xl_pin_polarity_set(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_xl_h_lactive_t val);
+int32_t lsm303ah_xl_pin_polarity_get(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_xl_h_lactive_t *val);
+
+typedef enum {
+  LSM303AH_XL_INT_PULSED   = 0,
+  LSM303AH_XL_INT_LATCHED  = 1,
+} lsm303ah_xl_lir_t;
+int32_t lsm303ah_xl_int_notification_set(lsm303ah_ctx_t *ctx,
+                                      lsm303ah_xl_lir_t val);
+int32_t lsm303ah_xl_int_notification_get(lsm303ah_ctx_t *ctx,
+                                      lsm303ah_xl_lir_t *val);
+
+typedef struct{
+  uint8_t int1_drdy               : 1;
+  uint8_t int1_fth                : 1;
+  uint8_t int1_6d                 : 1;
+  uint8_t int1_tap                : 1;
+  uint8_t int1_ff                 : 1;
+  uint8_t int1_wu                 : 1;
+  uint8_t int1_s_tap              : 1;
+  uint8_t int1_fss7               : 1;
+} lsm303ah_xl_pin_int1_route_t;
+int32_t lsm303ah_xl_pin_int1_route_set(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_pin_int1_route_t val);
+int32_t lsm303ah_xl_pin_int1_route_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_pin_int1_route_t *val);
+
+typedef struct{
+  uint8_t int2_boot               : 1;
+  uint8_t int2_tilt               : 1;
+  uint8_t int2_sig_mot            : 1;
+  uint8_t int2_step               : 1;
+  uint8_t int2_fth                : 1;
+  uint8_t int2_drdy               : 1;
+} lsm303ah_xl_pin_int2_route_t;
+int32_t lsm303ah_xl_pin_int2_route_set(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_pin_int2_route_t val);
+int32_t lsm303ah_xl_pin_int2_route_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_xl_pin_int2_route_t *val);
+
+int32_t lsm303ah_xl_all_on_int1_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_all_on_int1_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_mg_drdy_on_pin_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_drdy_on_pin_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_mg_int_on_pin_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_int_on_pin_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_mg_int_gen_conf_set(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_int_crtl_reg_m_t *val);
+int32_t lsm303ah_mg_int_gen_conf_get(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_int_crtl_reg_m_t *val);
+
+int32_t lsm303ah_mg_int_gen_source_get(lsm303ah_ctx_t *ctx,
+                                   lsm303ah_int_source_reg_m_t *val);
+
+int32_t lsm303ah_mg_int_gen_treshold_set(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_mg_int_gen_treshold_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM303AH_MG_CHECK_BEFORE  = 0,
+  LSM303AH_MG_CHECK_AFTER   = 1,
+} lsm303ah_mg_int_on_dataoff_t;
+int32_t lsm303ah_mg_offset_int_conf_set(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_mg_int_on_dataoff_t val);
+int32_t lsm303ah_mg_offset_int_conf_get(lsm303ah_ctx_t *ctx,
+                                    lsm303ah_mg_int_on_dataoff_t *val);
+
+int32_t lsm303ah_xl_wkup_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_wkup_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_wkup_dur_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_wkup_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_sleep_mode_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_sleep_mode_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_act_sleep_dur_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_act_sleep_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_tap_detection_on_z_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_detection_on_z_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_tap_detection_on_y_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_detection_on_y_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_tap_detection_on_x_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_detection_on_x_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_tap_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_tap_shock_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_shock_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_tap_quiet_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_quiet_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_tap_dur_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AH_XL_ONLY_SINGLE  = 0,
+  LSM303AH_XL_ONLY_DOUBLE  = 1,
+} lsm303ah_xl_single_double_tap_t;
+int32_t lsm303ah_xl_tap_mode_set(lsm303ah_ctx_t *ctx,
+                              lsm303ah_xl_single_double_tap_t val);
+int32_t lsm303ah_xl_tap_mode_get(lsm303ah_ctx_t *ctx,
+                              lsm303ah_xl_single_double_tap_t *val);
+
+int32_t lsm303ah_xl_tap_src_get(lsm303ah_ctx_t *ctx,
+                                lsm303ah_tap_src_a_t *val);
+
+typedef enum {
+  LSM303AH_XL_DEG_80   = 0,
+  LSM303AH_XL_DEG_70   = 1,
+  LSM303AH_XL_DEG_60   = 2,
+  LSM303AH_XL_DEG_50   = 3,
+} lsm303ah_xl_6d_ths_t;
+int32_t lsm303ah_xl_6d_threshold_set(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_6d_ths_t val);
+int32_t lsm303ah_xl_6d_threshold_get(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_6d_ths_t *val);
+
+int32_t lsm303ah_xl_4d_mode_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_4d_mode_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_6d_src_get(lsm303ah_ctx_t *ctx, lsm303ah_6d_src_a_t *val);
+
+int32_t lsm303ah_xl_ff_dur_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_ff_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_ff_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_ff_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_fifo_xl_module_batch_set(lsm303ah_ctx_t *ctx,
+                                             uint8_t val);
+int32_t lsm303ah_xl_fifo_xl_module_batch_get(lsm303ah_ctx_t *ctx,
+                                             uint8_t *val);
+
+typedef enum {
+  LSM303AH_XL_BYPASS_MODE            = 0,
+  LSM303AH_XL_FIFO_MODE              = 1,
+  LSM303AH_XL_STREAM_TO_FIFO_MODE    = 3,
+  LSM303AH_XL_BYPASS_TO_STREAM_MODE  = 4,
+  LSM303AH_XL_STREAM_MODE            = 6,
+} lsm303ah_xl_fmode_t;
+int32_t lsm303ah_xl_fifo_mode_set(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_xl_fmode_t val);
+int32_t lsm303ah_xl_fifo_mode_get(lsm303ah_ctx_t *ctx,
+                                  lsm303ah_xl_fmode_t *val);
+
+int32_t lsm303ah_xl_fifo_watermark_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_fifo_watermark_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_fifo_full_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_fifo_ovr_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_fifo_wtm_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_fifo_data_level_get(lsm303ah_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm303ah_xl_fifo_src_get(lsm303ah_ctx_t *ctx,
+                                 lsm303ah_fifo_src_a_t *val);
+
+int32_t lsm303ah_xl_pedo_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM303AH_XL_PEDO_AT_2g  = 0,
+  LSM303AH_XL_PEDO_AT_4g  = 1,
+} lsm303ah_xl_pedo4g_t;
+int32_t lsm303ah_xl_pedo_full_scale_set(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_pedo4g_t val);
+int32_t lsm303ah_xl_pedo_full_scale_get(lsm303ah_ctx_t *ctx,
+                                     lsm303ah_xl_pedo4g_t *val);
+
+int32_t lsm303ah_xl_pedo_step_reset_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_step_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_pedo_step_detect_flag_get(lsm303ah_ctx_t *ctx,
+                                              uint8_t *val);
+
+int32_t lsm303ah_xl_pedo_sens_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_pedo_debounce_steps_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_debounce_steps_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_pedo_timeout_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_timeout_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_pedo_steps_period_set(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_xl_pedo_steps_period_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_xl_motion_data_ready_flag_get(lsm303ah_ctx_t *ctx,
+                                               uint8_t *val);
+
+int32_t lsm303ah_xl_motion_sens_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_motion_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_motion_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_motion_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_tilt_data_ready_flag_get(lsm303ah_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t lsm303ah_xl_tilt_sens_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tilt_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm303ah_xl_module_sens_set(lsm303ah_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_module_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__LSM303AH_DRIVER__H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.c
+++ b/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.c
@@ -1,0 +1,5922 @@
+/*
+ ******************************************************************************
+ * @file    lsm6ds3_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LSM6DS3 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "lsm6ds3_reg.h"
+
+/**
+  * @defgroup    LSM6DS3
+  * @brief       This file provides a set of functions needed to drive the
+  *              lsm6ds3 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_read_reg(lsm6ds3_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_write_reg(lsm6ds3_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lsm6ds3_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 61.0f / 1000.0f);
+}
+
+float_t lsm6ds3_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 122.0f / 1000.0f);
+}
+
+float_t lsm6ds3_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 244.0f / 1000.0f);
+}
+
+float_t lsm6ds3_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 488.0f / 1000.0f);
+}
+
+float_t lsm6ds3_from_fs125dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb   * 4375.0f / 1000.0f);
+}
+
+float_t lsm6ds3_from_fs250dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb  * 8750.0f / 1000.0f);
+}
+
+float_t lsm6ds3_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 1750.0f / 100.0f);
+}
+
+float_t lsm6ds3_from_fs1000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 35.0f);
+}
+
+float_t lsm6ds3_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t lsm6ds3_from_lsb_to_celsius(int16_t lsb)
+{
+  return ((float_t)lsb / 16.0f + 25.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Data_generation
+  * @brief       This section groups all the functions concerning
+  *              data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief   Gyroscope directional user-orientation selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of orient in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_data_orient_set(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_orient_t val)
+{
+  lsm6ds3_orient_cfg_g_t orient_cfg_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_ORIENT_CFG_G,
+                         (uint8_t*)&orient_cfg_g, 1);
+  if(ret == 0){
+    orient_cfg_g.orient = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_ORIENT_CFG_G,
+                            (uint8_t*)&orient_cfg_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope directional user-orientation selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of orient in reg ORIENT_CFG_G
+  *
+  */
+int32_t lsm6ds3_gy_data_orient_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_gy_orient_t *val)
+{
+  lsm6ds3_orient_cfg_g_t orient_cfg_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_ORIENT_CFG_G,
+                         (uint8_t*)&orient_cfg_g, 1);
+
+  switch (orient_cfg_g.orient)
+  {
+    case LSM6DS3_GY_ORIENT_XYZ:
+      *val = LSM6DS3_GY_ORIENT_XYZ;
+      break;
+    case LSM6DS3_GY_ORIENT_XZY:
+      *val = LSM6DS3_GY_ORIENT_XZY;
+      break;
+    case LSM6DS3_GY_ORIENT_YXZ:
+      *val = LSM6DS3_GY_ORIENT_YXZ;
+      break;
+    case LSM6DS3_GY_ORIENT_YZX:
+      *val = LSM6DS3_GY_ORIENT_YZX;
+      break;
+    case LSM6DS3_GY_ORIENT_ZXY:
+      *val = LSM6DS3_GY_ORIENT_ZXY;
+      break;
+    case LSM6DS3_GY_ORIENT_ZYX:
+      *val = LSM6DS3_GY_ORIENT_ZYX;
+      break;
+    default:
+      *val = LSM6DS3_GY_ORIENT_XYZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  angular rate sign.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sign_g in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_data_sign_set(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t val)
+{
+  lsm6ds3_orient_cfg_g_t orient_cfg_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_ORIENT_CFG_G,
+                         (uint8_t*)&orient_cfg_g, 1);
+  if(ret == 0){
+    orient_cfg_g.sign_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_ORIENT_CFG_G,
+                            (uint8_t*)&orient_cfg_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  angularratesign.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of sign_g in reg ORIENT_CFG_G
+  *
+  */
+int32_t lsm6ds3_gy_data_sign_get(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t *val)
+{
+  lsm6ds3_orient_cfg_g_t orient_cfg_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_ORIENT_CFG_G,
+                         (uint8_t*)&orient_cfg_g, 1);
+
+  switch (orient_cfg_g.sign_g)
+  {
+    case LSM6DS3_GY_SIGN_PPP:
+      *val =LSM6DS3_GY_SIGN_PPP;
+      break;
+    case LSM6DS3_GY_SIGN_PPN:
+      *val = LSM6DS3_GY_SIGN_PPN;
+      break;
+    case LSM6DS3_GY_SIGN_PNP:
+      *val = LSM6DS3_GY_SIGN_PNP;
+      break;
+    case LSM6DS3_GY_SIGN_NPP:
+      *val = LSM6DS3_GY_SIGN_NPP;
+      break;
+    case LSM6DS3_GY_SIGN_NNP:
+      *val = LSM6DS3_GY_SIGN_NNP;
+      break;
+    case LSM6DS3_GY_SIGN_NPN:
+      *val = LSM6DS3_GY_SIGN_NPN;
+      break;
+    case LSM6DS3_GY_SIGN_PNN:
+      *val = LSM6DS3_GY_SIGN_PNN;
+      break;
+    case LSM6DS3_GY_SIGN_NNN:
+      *val = LSM6DS3_GY_SIGN_NNN;
+      break;
+    default:
+      *val = LSM6DS3_GY_SIGN_PPP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of fs_xl in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t val)
+{
+  lsm6ds3_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of fs_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6ds3_xl_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t *val)
+{
+  lsm6ds3_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+
+  switch (ctrl1_xl.fs_xl)
+  {
+    case LSM6DS3_2g:
+      *val = LSM6DS3_2g;
+      break;
+    case LSM6DS3_16g:
+      *val = LSM6DS3_16g;
+      break;
+    case LSM6DS3_4g:
+      *val = LSM6DS3_4g;
+      break;
+    case LSM6DS3_8g:
+      *val = LSM6DS3_8g;
+      break;
+    default:
+      *val = LSM6DS3_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of odr_xl in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t val)
+{
+  lsm6ds3_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.odr_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer data rate selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of odr_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6ds3_xl_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t *val)
+{
+  lsm6ds3_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+
+  switch (ctrl1_xl.odr_xl)
+  {
+    case LSM6DS3_XL_ODR_OFF:
+      *val = LSM6DS3_XL_ODR_OFF;
+      break;
+    case LSM6DS3_XL_ODR_12Hz5:
+      *val = LSM6DS3_XL_ODR_12Hz5;
+      break;
+    case LSM6DS3_XL_ODR_26Hz:
+      *val = LSM6DS3_XL_ODR_26Hz;
+      break;
+    case LSM6DS3_XL_ODR_52Hz:
+      *val = LSM6DS3_XL_ODR_52Hz;
+      break;
+    case LSM6DS3_XL_ODR_104Hz:
+      *val = LSM6DS3_XL_ODR_104Hz;
+      break;
+    case LSM6DS3_XL_ODR_208Hz:
+      *val = LSM6DS3_XL_ODR_208Hz;
+      break;
+    case LSM6DS3_XL_ODR_416Hz:
+      *val = LSM6DS3_XL_ODR_416Hz;
+      break;
+    case LSM6DS3_XL_ODR_833Hz:
+      *val = LSM6DS3_XL_ODR_833Hz;
+      break;
+    case LSM6DS3_XL_ODR_1k66Hz:
+      *val = LSM6DS3_XL_ODR_1k66Hz;
+      break;
+    case LSM6DS3_XL_ODR_3k33Hz:
+      *val = LSM6DS3_XL_ODR_3k33Hz;
+      break;
+    case LSM6DS3_XL_ODR_6k66Hz:
+      *val = LSM6DS3_XL_ODR_6k66Hz;
+      break;
+    default:
+      *val = LSM6DS3_XL_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope UI chain full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of fs_g in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t val)
+{
+  lsm6ds3_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.fs_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of fs_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6ds3_gy_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t *val)
+{
+  lsm6ds3_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+
+  switch (ctrl2_g.fs_g)
+  {
+    case LSM6DS3_250dps:
+      *val = LSM6DS3_250dps;
+      break;
+    case LSM6DS3_125dps:
+      *val = LSM6DS3_125dps;
+      break;
+    case LSM6DS3_500dps:
+      *val = LSM6DS3_500dps;
+      break;
+    case LSM6DS3_1000dps:
+      *val = LSM6DS3_1000dps;
+      break;
+    case LSM6DS3_2000dps:
+      *val = LSM6DS3_2000dps;
+      break;
+    default:
+      *val = LSM6DS3_250dps;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope UI data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of odr_g in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t val)
+{
+  lsm6ds3_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.odr_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope UI data rate selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of odr_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6ds3_gy_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t *val)
+{
+  lsm6ds3_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+
+  switch (ctrl2_g.odr_g)
+  {
+    case LSM6DS3_GY_ODR_OFF:
+      *val = LSM6DS3_GY_ODR_OFF;
+      break;
+    case LSM6DS3_GY_ODR_12Hz5:
+      *val = LSM6DS3_GY_ODR_12Hz5;
+      break;
+    case LSM6DS3_GY_ODR_26Hz:
+      *val = LSM6DS3_GY_ODR_26Hz;
+      break;
+    case LSM6DS3_GY_ODR_52Hz:
+      *val = LSM6DS3_GY_ODR_52Hz;
+      break;
+    case LSM6DS3_GY_ODR_104Hz:
+      *val = LSM6DS3_GY_ODR_104Hz;
+      break;
+    case LSM6DS3_GY_ODR_208Hz:
+      *val = LSM6DS3_GY_ODR_208Hz;
+      break;
+    case LSM6DS3_GY_ODR_416Hz:
+      *val = LSM6DS3_GY_ODR_416Hz;
+      break;
+    case LSM6DS3_GY_ODR_833Hz:
+      *val = LSM6DS3_GY_ODR_833Hz;
+      break;
+    case LSM6DS3_GY_ODR_1k66Hz:
+      *val = LSM6DS3_GY_ODR_1k66Hz;
+      break;
+    default:
+      *val = LSM6DS3_GY_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of bdu in reg CTRL3_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_block_data_update_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of bdu in reg CTRL3_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_block_data_update_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = (uint8_t)ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief   High-performance operating mode for accelerometer.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of xl_hm_mode in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_power_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_hm_mode_t val)
+{
+  lsm6ds3_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.xl_hm_mode = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High-performance operating mode for accelerometer.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of xl_hm_mode in reg CTRL6_C
+  *
+  */
+int32_t lsm6ds3_xl_power_mode_get(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_xl_hm_mode_t *val)
+{
+  lsm6ds3_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.xl_hm_mode)
+  {
+    case  LSM6DS3_XL_HIGH_PERFORMANCE:
+      *val =  LSM6DS3_XL_HIGH_PERFORMANCE;
+      break;
+    case LSM6DS3_XL_NORMAL:
+      *val = LSM6DS3_XL_NORMAL;
+      break;
+    default:
+      *val =  LSM6DS3_XL_HIGH_PERFORMANCE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Source register rounding function on ADD HERE ROUNDING REGISTERS.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of rounding_status in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_rounding_on_status_set(lsm6ds3_ctx_t *ctx, lsm6ds3_rnd_stat_t val)
+{
+  lsm6ds3_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.rounding_status = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Source register rounding function on ADD HERE ROUNDING REGISTERS.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of rounding_status in reg CTRL7_G
+  *
+  */
+int32_t lsm6ds3_rounding_on_status_get(lsm6ds3_ctx_t *ctx,
+                                       lsm6ds3_rnd_stat_t *val)
+{
+  lsm6ds3_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  switch (ctrl7_g.rounding_status)
+  {
+    case LSM6DS3_STAT_RND_DISABLE:
+      *val = LSM6DS3_STAT_RND_DISABLE;
+      break;
+    case LSM6DS3_STAT_RND_ENABLE:
+      *val = LSM6DS3_STAT_RND_ENABLE;
+      break;
+    default:
+      *val = LSM6DS3_STAT_RND_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   High-performance operating mode disable for gyroscope.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of g_hm_mode in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_power_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_g_hm_mode_t val)
+{
+  lsm6ds3_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.g_hm_mode = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   High-performance operating mode disable for gyroscope.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of g_hm_mode in reg CTRL7_G
+  *
+  */
+int32_t lsm6ds3_gy_power_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_g_hm_mode_t *val)
+{
+  lsm6ds3_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  switch (ctrl7_g.g_hm_mode)
+  {
+    case  LSM6DS3_GY_HIGH_PERFORMANCE:
+      *val =  LSM6DS3_GY_HIGH_PERFORMANCE;
+      break;
+    case LSM6DS3_GY_NORMAL:
+      *val = LSM6DS3_GY_NORMAL;
+      break;
+    default:
+      *val =  LSM6DS3_GY_HIGH_PERFORMANCE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer X-axis output enable/disable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of xen_xl in reg CTRL9_XL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.xen_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer X-axis output enable/disable.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of xen_xl in reg CTRL9_XL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = (uint8_t)ctrl9_xl.xen_xl;
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer Y-axis output enable/disable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of yen_xl in reg CTRL9_XL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.yen_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer Y-axis output enable/disable.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of yen_xl in reg CTRL9_XL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = (uint8_t)ctrl9_xl.yen_xl;
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer Z-axis output enable/disable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of zen_xl in reg CTRL9_XL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.zen_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer Z-axis output enable/disable.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of zen_xl in reg CTRL9_XL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = (uint8_t)ctrl9_xl.zen_xl;
+
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope pitch axis (X) output enable/disable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of xen_g in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.xen_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope pitch axis (X) output enable/disable.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of xen_g in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = (uint8_t)ctrl10_c.xen_g;
+
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope pitch axis (Y) output enable/disable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of yen_g in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.yen_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope pitch axis (Y) output enable/disable.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of yen_g in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = (uint8_t)ctrl10_c.yen_g;
+
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope pitch axis (Z) output enable/disable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of zen_g in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.zen_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope pitch axis (Z) output enable/disable.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of zen_g in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = (uint8_t)ctrl10_c.zen_g;
+
+  return ret;
+}
+
+/**
+  * @brief   Read all the interrupt/status flag of the device. ELENCA I REGISTRI[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Read all the interrupt flag of the device:
+  *                     WAKE_UP_SRC, TAP_SRC, D6D_SRC, FUNC_SRC.
+  *
+  */
+int32_t lsm6ds3_all_sources_get(lsm6ds3_ctx_t *ctx, lsm6ds3_all_src_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_SRC,
+                         (uint8_t*)&(val->wake_up_src), 1);
+  if(ret == 0) {
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_SRC,
+                           (uint8_t*)&(val->tap_src), 1);
+  }
+  if(ret == 0) {
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_D6D_SRC,
+                           (uint8_t*)&(val->d6d_src), 1);
+  }
+  if(ret == 0) {
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_FUNC_SRC,
+                           (uint8_t*)&(val->func_src), 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   The STATUS_REG register of the device.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val          The STATUS_REG register of the device.
+  *
+  */
+int32_t lsm6ds3_status_reg_get(lsm6ds3_ctx_t *ctx, lsm6ds3_status_reg_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_STATUS_REG, (uint8_t*)&val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of xlda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = (uint8_t)status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of gda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = (uint8_t)status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief   Temperature new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of tda in reg STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_temp_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = (uint8_t)status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Timestamp
+  * @brief       This section groups all the functions that manage the
+  *              timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Timestamp first byte data output register (r). The value is
+  *          expressed as a 24-bit word and the bit resolution is defined
+  *          by setting the value in WAKE_UP_DUR (5Ch).[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TIMESTAMP0_REG, buff,
+                            3);
+  return ret;
+}
+
+/**
+  * @brief  Reset the timer.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data to be write
+  *
+  */
+int32_t lsm6ds3_timestamp_rst_set(lsm6ds3_ctx_t *ctx)
+{
+  int32_t ret;
+  uint8_t rst_val = 0xAA;
+
+  ret = lsm6ds3_write_reg(ctx, LSM6DS3_TIMESTAMP2_REG, &rst_val, 1);
+  return ret;
+}
+
+/**
+  * @brief   Timestamp count enable, output data are collected in
+  *          TIMESTAMP0_REG (40h), TIMESTAMP1_REG (41h),
+  *          TIMESTAMP2_REG (42h) register.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of timer_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_timestamp_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.timer_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Timestamp count enable, output data are collected in
+  *          TIMESTAMP0_REG (40h), TIMESTAMP1_REG (41h),
+  *          TIMESTAMP2_REG (42h) register.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of timer_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_timestamp_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = (uint8_t)tap_cfg.timer_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Timestamp register resolution setting.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of timer_hr in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_timestamp_res_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t val)
+{
+  lsm6ds3_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.timer_hr = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Timestamp register resolution setting.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of timer_hr in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6ds3_timestamp_res_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t *val)
+{
+  lsm6ds3_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+
+  switch (wake_up_dur.timer_hr)
+  {
+    case LSM6DS3_LSB_6ms4:
+      *val = LSM6DS3_LSB_6ms4;
+      break;
+    case LSM6DS3_LSB_25us:
+      *val = LSM6DS3_LSB_25us;
+      break;
+    default:
+      *val = LSM6DS3_LSB_6ms4;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Dataoutput
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Circular burst-mode (rounding) read from output registers
+  *          through the primary interface.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of rounding in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_rounding_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_rounding_t val)
+{
+  lsm6ds3_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Circular burst-mode (rounding) read from output registers
+  *          through the primary interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of rounding in reg CTRL5_C
+  *
+  */
+int32_t lsm6ds3_rounding_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_rounding_t *val)
+{
+  lsm6ds3_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.rounding)
+  {
+    case LSM6DS3_ROUND_DISABLE:
+      *val = LSM6DS3_ROUND_DISABLE;
+      break;
+    case LSM6DS3_ROUND_XL:
+      *val = LSM6DS3_ROUND_XL;
+      break;
+    case LSM6DS3_ROUND_GY:
+      *val = LSM6DS3_ROUND_GY;
+      break;
+    case LSM6DS3_ROUND_GY_XL:
+      *val = LSM6DS3_ROUND_GY_XL;
+      break;
+    case LSM6DS3_ROUND_SH1_TO_SH6:
+      *val = LSM6DS3_ROUND_SH1_TO_SH6;
+      break;
+    case  LSM6DS3_ROUND_XL_SH1_TO_SH6:
+      *val =  LSM6DS3_ROUND_XL_SH1_TO_SH6;
+      break;
+    case  LSM6DS3_ROUND_GY_XL_SH1_TO_SH12:
+      *val =  LSM6DS3_ROUND_GY_XL_SH1_TO_SH12;
+      break;
+    case  LSM6DS3_ROUND_GY_XL_SH1_TO_SH6:
+      *val =  LSM6DS3_ROUND_GY_XL_SH1_TO_SH6;
+      break;
+    default:
+      *val = LSM6DS3_ROUND_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Temperature data output register (r). L and H registers together
+  *          express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_temperature_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief   Angular rate sensor. The value is expressed as a 16-bit word
+  *          in two’s complement..[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_angular_rate_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief   Linear acceleration output register. The value is expressed
+  *          as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_acceleration_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_OUTX_L_XL, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief   fifo_raw_data: [get]  read data in FIFO.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t *: data buffer to store FIFO data.
+  * @param  uint8_t : number of data to read from FIFO.
+  *
+  */
+int32_t lsm6ds3_fifo_raw_data_get(lsm6ds3_ctx_t *ctx, uint8_t *buffer, uint8_t len)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_DATA_OUT_L, buffer, len);
+  return ret;
+}
+
+/**
+  * @brief   Step counter output register..[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_number_of_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_STEP_COUNTER_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief   magnetometer raw data.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_mag_calibrated_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_OUT_MAG_RAW_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Enable access to the embedded functions.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of func_cfg_en in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_mem_bank_set(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t val)
+{
+  lsm6ds3_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  if(ret == 0){
+    func_cfg_access.func_cfg_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FUNC_CFG_ACCESS,
+                            (uint8_t*)&func_cfg_access, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable access to the embedded functions.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  *
+  */
+int32_t lsm6ds3_mem_bank_get(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t *val)
+{
+  lsm6ds3_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FUNC_CFG_ACCESS,
+                            (uint8_t*)&func_cfg_access, 1);
+
+  switch (func_cfg_access.func_cfg_en)
+  {
+    case LSM6DS3_USER_BANK:
+      *val = LSM6DS3_USER_BANK;
+      break;
+    case LSM6DS3_EMBEDDED_FUNC_BANK:
+      *val = LSM6DS3_EMBEDDED_FUNC_BANK;
+      break;
+    default:
+      *val = LSM6DS3_USER_BANK;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DeviceWhoamI..[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_device_id_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief   Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sw_reset in reg CTRL3_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sw_reset in reg CTRL3_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = (uint8_t)ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief   Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of ble in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_data_format_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.ble = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of ble in reg CTRL3_C
+  *
+  */
+int32_t lsm6ds3_data_format_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t *val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.ble)
+  {
+    case LSM6DS3_LSB_AT_LOW_ADD:
+      *val = LSM6DS3_LSB_AT_LOW_ADD;
+      break;
+    case LSM6DS3_MSB_AT_LOW_ADD:
+      *val = LSM6DS3_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LSM6DS3_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Register address automatically incremented during a multiple
+  *          byte access with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of if_inc in reg CTRL3_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_auto_increment_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Register address automatically incremented during a multiple
+  *          byte access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of if_inc in reg CTRL3_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_auto_increment_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = (uint8_t)ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief   Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of boot in reg CTRL3_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_boot_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of boot in reg CTRL3_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_boot_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = (uint8_t)ctrl3_c.boot;
+
+  return ret;
+}
+
+/**
+  * @brief   Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of st_xl in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t val)
+{
+  lsm6ds3_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of st_xl in reg CTRL5_C
+  *
+  */
+int32_t lsm6ds3_xl_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t *val)
+{
+  lsm6ds3_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_xl)
+  {
+    case LSM6DS3_XL_ST_DISABLE:
+      *val = LSM6DS3_XL_ST_DISABLE;
+      break;
+    case LSM6DS3_XL_ST_POSITIVE:
+      *val = LSM6DS3_XL_ST_POSITIVE;
+      break;
+    case LSM6DS3_XL_ST_NEGATIVE:
+      *val = LSM6DS3_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DS3_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of st_g in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t val)
+{
+  lsm6ds3_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of st_g in reg CTRL5_C
+  *
+  */
+int32_t lsm6ds3_gy_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t *val)
+{
+  lsm6ds3_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_g)
+  {
+    case LSM6DS3_GY_ST_DISABLE:
+      *val = LSM6DS3_GY_ST_DISABLE;
+      break;
+    case LSM6DS3_GY_ST_POSITIVE:
+      *val = LSM6DS3_GY_ST_POSITIVE;
+      break;
+    case LSM6DS3_GY_ST_NEGATIVE:
+      *val = LSM6DS3_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DS3_GY_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Filters
+  * @brief       This section group all the functions concerning the
+  *              filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief   Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *          (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of drdy_mask in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_filter_settling_mask_set(lsm6ds3_ctx_t *ctx,
+                                         uint8_t val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *          (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of drdy_mask in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_filter_settling_mask_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = (uint8_t)ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope high-pass filter cutoff frequency selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of hpcf_g in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t val)
+{
+  lsm6ds3_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hpcf_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope high-pass filter cutoff frequency selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of hpcf_g in reg CTRL7_G
+  *
+  */
+int32_t lsm6ds3_gy_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t *val)
+{
+  lsm6ds3_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  switch (ctrl7_g.hpcf_g)
+  {
+    case LSM6DS3_HP_CUT_OFF_8mHz1:
+      *val = LSM6DS3_HP_CUT_OFF_8mHz1;
+      break;
+    case LSM6DS3_HP_CUT_OFF_32mHz4:
+      *val = LSM6DS3_HP_CUT_OFF_32mHz4;
+      break;
+    case LSM6DS3_HP_CUT_OFF_2Hz07:
+      *val = LSM6DS3_HP_CUT_OFF_2Hz07;
+      break;
+    case LSM6DS3_HP_CUT_OFF_16Hz32:
+      *val = LSM6DS3_HP_CUT_OFF_16Hz32;
+      break;
+    default:
+      *val = LSM6DS3_HP_CUT_OFF_8mHz1;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyro digital HP filter reset.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of hp_g_rst in reg CTRL7_G
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_hp_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hp_g_rst = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyro digital HP filter reset.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of hp_g_rst in reg CTRL7_G
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_hp_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  *val = (uint8_t)ctrl7_g.hp_g_rst;
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer slope filter and high-pass filter configuration
+  *          and cut-off setting.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of hp_slope_xl_en in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t val)
+{
+  lsm6ds3_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+	ctrl8_xl.hp_slope_xl_en = PROPERTY_ENABLE;
+    ctrl8_xl.hpcf_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer slope filter and high-pass filter configuration
+  *          and cut-off setting.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of hp_slope_xl_en in reg CTRL8_XL
+  *
+  */
+int32_t lsm6ds3_xl_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t *val)
+{
+  lsm6ds3_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+
+  switch (ctrl8_xl.hpcf_xl)
+  {
+    case LSM6DS3_XL_HP_ODR_DIV_4:
+      *val = LSM6DS3_XL_HP_ODR_DIV_4;
+      break;
+    case LSM6DS3_XL_HP_ODR_DIV_100:
+      *val = LSM6DS3_XL_HP_ODR_DIV_100;
+      break;
+    case LSM6DS3_XL_HP_ODR_DIV_9:
+      *val = LSM6DS3_XL_HP_ODR_DIV_9;
+      break;
+    case LSM6DS3_XL_HP_ODR_DIV_400:
+      *val = LSM6DS3_XL_HP_ODR_DIV_400;
+      break;
+    default:
+      *val = LSM6DS3_XL_HP_ODR_DIV_4;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief    Accelerometer low-pass filter configuration and
+  *           cut-off setting.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of lpf2_xl_en in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_lp2_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t val)
+{
+  lsm6ds3_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.lpf2_xl_en = PROPERTY_ENABLE;
+    ctrl8_xl.hpcf_xl= (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Accelerometer low-pass filter configuration and cut-off
+  *           setting.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of lpf2_xl_en in reg CTRL8_XL
+  *
+  */
+int32_t lsm6ds3_xl_lp2_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t *val)
+{
+  lsm6ds3_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+
+  switch (ctrl8_xl.hpcf_xl)
+  {
+    case LSM6DS3_XL_LP_ODR_DIV_50:
+      *val = LSM6DS3_XL_LP_ODR_DIV_50;
+      break;
+    case LSM6DS3_XL_LP_ODR_DIV_100:
+      *val = LSM6DS3_XL_LP_ODR_DIV_100;
+      break;
+    case LSM6DS3_XL_LP_ODR_DIV_9:
+      *val = LSM6DS3_XL_LP_ODR_DIV_9;
+      break;
+    case LSM6DS3_XL_LP_ODR_DIV_400:
+      *val = LSM6DS3_XL_LP_ODR_DIV_400;
+      break;
+    default:
+      *val = LSM6DS3_XL_LP_ODR_DIV_50;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Anti-aliasing filter bandwidth selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of bw_xl in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_xl_filter_analog_set(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t val)
+{
+  lsm6ds3_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.bw_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Anti-aliasing filter bandwidth selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of bw_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6ds3_xl_filter_analog_get(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t *val)
+{
+  lsm6ds3_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+
+  switch (ctrl1_xl.bw_xl)
+  {
+    case  LSM6DS3_ANTI_ALIASING_400Hz:
+      *val =  LSM6DS3_ANTI_ALIASING_400Hz;
+      break;
+    case  LSM6DS3_ANTI_ALIASING_200Hz:
+      *val =  LSM6DS3_ANTI_ALIASING_200Hz;
+      break;
+    case  LSM6DS3_ANTI_ALIASING_100Hz:
+      *val =  LSM6DS3_ANTI_ALIASING_100Hz;
+      break;
+    case LSM6DS3_ANTI_ALIASING_50Hz:
+      *val = LSM6DS3_ANTI_ALIASING_50Hz;
+      break;
+    default:
+      *val =  LSM6DS3_ANTI_ALIASING_400Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Serial_interface
+  * @brief       This section groups all the functions concerning main
+  *              serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief   SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sim in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_spi_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of sim in reg CTRL3_C
+  *
+  */
+int32_t lsm6ds3_spi_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t *val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.sim)
+  {
+    case LSM6DS3_SPI_4_WIRE:
+      *val = LSM6DS3_SPI_4_WIRE;
+      break;
+    case LSM6DS3_SPI_3_WIRE:
+      *val = LSM6DS3_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DS3_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of i2c_disable in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_i2c_interface_set(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of i2c_disable in reg CTRL4_C
+  *
+  */
+int32_t lsm6ds3_i2c_interface_get(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t *val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+
+  switch (ctrl4_c.i2c_disable)
+  {
+    case LSM6DS3_I2C_ENABLE:
+      *val = LSM6DS3_I2C_ENABLE;
+      break;
+    case LSM6DS3_I2C_DISABLE:
+      *val = LSM6DS3_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM6DS3_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Interrupt_pins
+  * @brief       This section groups all the functions that manage
+  *              interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief   Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val          Select the signal that need to route on int1 pad.
+  *
+  */
+int32_t lsm6ds3_pin_int1_route_set(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_int1_route_t *val)
+{
+  lsm6ds3_int1_ctrl_t int1_ctrl;
+  lsm6ds3_md1_cfg_t md1_cfg;
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+
+  if(ret == 0) {
+    int1_ctrl.int1_drdy_xl        = val->int1_drdy_xl;
+    int1_ctrl.int1_drdy_g         = val->int1_drdy_g;
+    int1_ctrl.int1_boot           = val->int1_boot;
+    int1_ctrl.int1_fth            = val->int1_fth;
+    int1_ctrl.int1_fifo_ovr       = val->int1_fifo_ovr;
+    int1_ctrl.int1_full_flag      = val->int1_full_flag;
+    int1_ctrl.int1_sign_mot       = val->int1_sign_mot;
+    int1_ctrl.int1_step_detector  = val->int1_step_detector;
+    md1_cfg.int1_timer            = val->int1_timer;
+    md1_cfg.int1_tilt             = val->int1_tilt;
+    md1_cfg.int1_6d               = val->int1_6d;
+    md1_cfg.int1_double_tap       = val->int1_double_tap;
+    md1_cfg.int1_ff               = val->int1_ff;
+    md1_cfg.int1_wu               = val->int1_wu;
+    md1_cfg.int1_single_tap       = val->int1_single_tap;
+    md1_cfg.int1_inact_state      = val->int1_inact_state;
+    master_config.drdy_on_int1    = val->drdy_on_int1;
+
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+    if(ret == 0) {
+      ret = lsm6ds3_write_reg(ctx, LSM6DS3_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+    }
+    if(ret == 0) {
+      ret = lsm6ds3_write_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val          Select the signal that need to route on int1 pad.
+  *
+  */
+int32_t lsm6ds3_pin_int1_route_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_int1_route_t *val)
+{
+  lsm6ds3_int1_ctrl_t int1_ctrl;
+  lsm6ds3_md1_cfg_t md1_cfg;
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0) {
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0) {
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0) {
+    val->int1_drdy_xl        = int1_ctrl.int1_drdy_xl;
+    val->int1_drdy_g         = int1_ctrl.int1_drdy_g;
+    val->int1_boot           = int1_ctrl.int1_boot;
+    val->int1_fth            = int1_ctrl.int1_fth;
+    val->int1_fifo_ovr       = int1_ctrl.int1_fifo_ovr;
+    val->int1_full_flag      = int1_ctrl.int1_full_flag;
+    val->int1_sign_mot       = int1_ctrl.int1_sign_mot;
+    val->int1_step_detector  = int1_ctrl.int1_step_detector;
+    val->int1_timer          = md1_cfg.int1_timer;
+    val->int1_tilt           = md1_cfg.int1_tilt;
+    val->int1_6d             = md1_cfg.int1_6d;
+    val->int1_double_tap     = md1_cfg.int1_double_tap;
+    val->int1_ff             = md1_cfg.int1_ff;
+    val->int1_wu             = md1_cfg.int1_wu;
+    val->int1_single_tap     = md1_cfg.int1_single_tap;
+    val->int1_inact_state    = md1_cfg.int1_inact_state;
+    val->drdy_on_int1        = master_config.drdy_on_int1;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Select the signal that need to route on int1 pad.
+  *
+  */
+int32_t lsm6ds3_pin_int2_route_set(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_int2_route_t *val)
+{
+  lsm6ds3_int2_ctrl_t int2_ctrl;
+  lsm6ds3_md2_cfg_t md2_cfg;
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+
+  if(ret == 0) {
+    int2_ctrl.int2_drdy_xl       = val->int2_drdy_xl;
+    int2_ctrl.int2_drdy_g        = val->int2_drdy_g;
+    int2_ctrl.int2_drdy_temp     = val->int2_drdy_temp;
+    int2_ctrl.int2_fth           = val->int2_fth;
+    int2_ctrl.int2_fifo_ovr      = val->int2_fifo_ovr;
+    int2_ctrl.int2_full_flag     = val->int2_full_flag;
+    int2_ctrl.int2_step_count_ov = val->int2_step_count_ov;
+    int2_ctrl.int2_step_delta    = val->int2_step_delta;
+    md2_cfg.int2_iron            = val->int2_iron;
+    md2_cfg.int2_tilt            = val->int2_tilt;
+    md2_cfg.int2_6d              = val->int2_6d;
+    md2_cfg.int2_double_tap      = val->int2_double_tap;
+    md2_cfg.int2_ff              = val->int2_ff;
+    md2_cfg.int2_wu              = val->int2_wu;
+    md2_cfg.int2_single_tap      = val->int2_single_tap;
+    md2_cfg.int2_inact_state     = val->int2_inact_state;
+    master_config.start_config   = val->start_config;
+
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+  if(ret == 0) {
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0) {
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         Select the signal that need to route on int1 pad.
+  *
+  */
+int32_t lsm6ds3_pin_int2_route_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_int2_route_t *val)
+{
+  lsm6ds3_int2_ctrl_t int2_ctrl;
+  lsm6ds3_md2_cfg_t md2_cfg;
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0) {
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0) {
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+
+    val->int2_drdy_xl       = int2_ctrl.int2_drdy_xl;
+    val->int2_drdy_g        = int2_ctrl.int2_drdy_g;
+    val->int2_drdy_temp     = int2_ctrl.int2_drdy_temp;
+    val->int2_fth           = int2_ctrl.int2_fth;
+    val->int2_fifo_ovr      = int2_ctrl.int2_fifo_ovr;
+    val->int2_full_flag     = int2_ctrl.int2_full_flag;
+    val->int2_step_count_ov = int2_ctrl.int2_step_count_ov;
+    val->int2_step_delta    = int2_ctrl.int2_step_delta;
+    val->int2_iron          = md2_cfg.int2_iron;
+    val->int2_tilt          = md2_cfg.int2_tilt;
+    val->int2_6d            = md2_cfg.int2_6d;
+    val->int2_double_tap    = md2_cfg.int2_double_tap;
+    val->int2_ff            = md2_cfg.int2_ff;
+    val->int2_wu            = md2_cfg.int2_wu;
+    val->int2_single_tap    = md2_cfg.int2_single_tap;
+    val->int2_inact_state   = md2_cfg.int2_inact_state;
+    val->start_config       = master_config.start_config;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pp_od in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of pp_od in reg CTRL3_C
+  *
+  */
+int32_t lsm6ds3_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t *val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.pp_od)
+  {
+    case LSM6DS3_PUSH_PULL:
+      *val = LSM6DS3_PUSH_PULL;
+      break;
+    case LSM6DS3_OPEN_DRAIN:
+      *val = LSM6DS3_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM6DS3_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt active-high/low.Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of h_lactive in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pin_polarity_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pin_pol_t val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt active-high/low.Interrupt active-high/low.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of h_lactive in reg CTRL3_C
+  *
+  */
+int32_t lsm6ds3_pin_polarity_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pin_pol_t *val)
+{
+  lsm6ds3_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.h_lactive)
+  {
+    case LSM6DS3_ACTIVE_HIGH:
+      *val = LSM6DS3_ACTIVE_HIGH;
+      break;
+    case LSM6DS3_ACTIVE_LOW:
+      *val = LSM6DS3_ACTIVE_LOW;
+      break;
+    default:
+      *val = LSM6DS3_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of int2_on_int1 in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_all_on_int1_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1 = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of int2_on_int1 in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_all_on_int1_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = (uint8_t)ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief   Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of lir in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_int_notification_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.lir = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of lir in reg TAP_CFG
+  *
+  */
+int32_t lsm6ds3_int_notification_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t *val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+
+  switch (tap_cfg.lir)
+  {
+    case LSM6DS3_INT_PULSED:
+      *val = LSM6DS3_INT_PULSED;
+      break;
+    case LSM6DS3_INT_LATCHED:
+      *val = LSM6DS3_INT_LATCHED;
+      break;
+    default:
+      *val = LSM6DS3_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Wake_Up_event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Read the wake_up_src status flag of the device.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val          Read the wake_up_src status flag of the device.
+  *
+  */
+int32_t lsm6ds3_wkup_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_wake_up_src_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_SRC, (uint8_t*)val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief   Threshold for wakeup (1 LSB = FS_XL / 64).[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_wkup_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Threshold for wakeup (1 LSB = FS_XL / 64).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_wkup_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  *val = (uint8_t)wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief   Wake up duration event.1LSb = 1 / ODR[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_wkup_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Wake up duration event.1LSb = 1 / ODR[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_wkup_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  *val = (uint8_t)wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Activity/Inactivity_detection
+  * @brief       This section groups all the functions concerning
+  *              activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sleep_g in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_sleep_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.sleep_g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sleep_g in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_gy_sleep_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = (uint8_t)ctrl4_c.sleep_g;
+
+  return ret;
+}
+
+/**
+  * @brief   Enable/Disable inactivity function.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of inactivity in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_act_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.inactivity = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable/Disable inactivity function.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of inactivity in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6ds3_act_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.inactivity;
+
+  return ret;
+}
+
+/**
+  * @brief   Duration to go in sleep mode. 1 LSb = 512 / ODR[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_act_sleep_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Duration to go in sleep mode. 1 LSb = 512 / ODR[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_act_sleep_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  *val = (uint8_t)wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Tap_generator
+  * @brief       This section groups all the functions that manage the
+  *              tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Read the tap_src status flag of the device.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val          Read the tap_src status flag of the device.
+  *
+  */
+int32_t lsm6ds3_tap_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_src_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_SRC, (uint8_t*)val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief   Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of tap_z_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_detection_on_z_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_z_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of tap_z_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_detection_on_z_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = (uint8_t)tap_cfg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of tap_y_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_detection_on_y_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_y_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of tap_y_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_detection_on_y_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = (uint8_t)tap_cfg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of tap_x_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_detection_on_x_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_x_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of tap_x_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_detection_on_x_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = (uint8_t)tap_cfg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of tap_ths in reg TAP_THS_6D
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.tap_ths = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of tap_ths in reg TAP_THS_6D
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  *val = (uint8_t)tap_ths_6d.tap_ths;
+
+  return ret;
+}
+
+/**
+  * @brief   Maximum duration is the maximum time of an overthreshold signal
+  *          detection to be recognized as a tap event. The default value
+  *          of these bits is 00b which corresponds to 4*ODR_XL time.
+  *          If the SHOCK[1:0] bits are set to a different value,
+  *          1LSB corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of shock in reg INT_DUR2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_shock_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.shock = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Maximum duration is the maximum time of an overthreshold signal
+  *          detection to be recognized as a tap event.
+  *          The default value of these bits is 00b which corresponds
+  *          to 4*ODR_XL time. If the SHOCK[1:0] bits are set to a different
+  *          value, 1LSB corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of shock in reg INT_DUR2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_shock_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = (uint8_t)int_dur2.shock;
+
+  return ret;
+}
+
+/**
+  * @brief   Quiet time is the time after the first detected tap in
+  *          which there must not be any over-threshold event.
+  *          The default value of these bits is 00b which corresponds
+  *          to 2*ODR_XL time. If the QUIET[1:0] bits are set to a
+  *          different value, 1LSB corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of quiet in reg INT_DUR2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_quiet_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.quiet = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Quiet time is the time after the first detected tap in which
+  *          there must not be any over-threshold event. The default value
+  *          of these bits is 00b which corresponds to 2*ODR_XL time.
+  *          If the QUIET[1:0] bits are set to a different value,
+  *          1LSB corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of quiet in reg INT_DUR2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_quiet_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = (uint8_t)int_dur2.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief   When double tap recognition is enabled, this register
+  *          expresses the maximum time between two consecutive detected
+  *          taps to determine a double tap event. The default value of
+  *          these bits is 0000b which corresponds to 16*ODR_XL time.
+  *          If the DUR[3:0] bits are set to a different value,
+  *          1LSB corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of dur in reg INT_DUR2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.dur = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   When double tap recognition is enabled, this register
+  *          expresses the maximum time between two consecutive detected
+  *          taps to determine a double tap event.
+  *          The default value of these bits is 0000b which corresponds
+  *          to 16*ODR_XL time. If the DUR[3:0] bits are set to a
+  *          different value, 1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of dur in reg INT_DUR2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = (uint8_t)int_dur2.dur;
+
+  return ret;
+}
+
+/**
+  * @brief   Single/double-tap event enable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of single_double_tap in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tap_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t val)
+{
+  lsm6ds3_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.single_double_tap = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Single/double-tap event enable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of single_double_tap in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6ds3_tap_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t *val)
+{
+  lsm6ds3_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+
+  switch (wake_up_ths.single_double_tap)
+  {
+    case LSM6DS3_ONLY_DOUBLE:
+      *val = LSM6DS3_ONLY_DOUBLE;
+      break;
+    case LSM6DS3_SINGLE_DOUBLE:
+      *val = LSM6DS3_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LSM6DS3_ONLY_DOUBLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Six_position_detection(6D/4D)
+  * @brief       This section groups all the functions concerning
+  *              six position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief   LPF2 feed 6D function selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of low_pass_on_6d in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_6d_feed_data_set(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_low_pass_on_6d_t val)
+{
+  lsm6ds3_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.low_pass_on_6d = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   LPF2 feed 6D function selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of low_pass_on_6d in reg CTRL8_XL
+  *
+  */
+int32_t lsm6ds3_6d_feed_data_get(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_low_pass_on_6d_t *val)
+{
+  lsm6ds3_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+
+  switch (ctrl8_xl.low_pass_on_6d)
+  {
+    case LSM6DS3_ODR_DIV_2_FEED:
+      *val = LSM6DS3_ODR_DIV_2_FEED;
+      break;
+    case LSM6DS3_LPF2_FEED:
+      *val = LSM6DS3_LPF2_FEED;
+      break;
+    default:
+      *val = LSM6DS3_ODR_DIV_2_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Read the d6d_src status flag of the device.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val          Read the d6d_src status flag of the device.
+  *
+  */
+int32_t lsm6ds3_6d_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_d6d_src_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_D6D_SRC, (uint8_t*)val, 1);
+
+  return ret;
+}
+
+/**
+  * @brief   Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sixd_ths in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_6d_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t val)
+{
+  lsm6ds3_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.sixd_ths = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of sixd_ths in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6ds3_6d_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t *val)
+{
+  lsm6ds3_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+
+  switch (tap_ths_6d.sixd_ths)
+  {
+    case LSM6DS3_DEG_80:
+      *val = LSM6DS3_DEG_80;
+      break;
+    case LSM6DS3_DEG_70:
+      *val = LSM6DS3_DEG_70;
+      break;
+    case LSM6DS3_DEG_60:
+      *val = LSM6DS3_DEG_60;
+      break;
+    case LSM6DS3_DEG_50:
+      *val = LSM6DS3_DEG_50;
+      break;
+    default:
+      *val = LSM6DS3_DEG_80;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   4D orientation detection enable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of d4d_en in reg TAP_THS_6D
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_4d_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.d4d_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   4D orientation detection enable.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of d4d_en in reg TAP_THS_6D
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_4d_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  *val = (uint8_t)tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Free_fall
+  * @brief       This section group all the functions concerning the
+  *              free fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of ff_ths in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_ff_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t val)
+{
+  lsm6ds3_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Free fall threshold setting.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lsm6ds3_ff_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t *val)
+{
+  lsm6ds3_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FREE_FALL, (uint8_t*)&free_fall, 1);
+
+  switch (free_fall.ff_ths)
+  {
+    case LSM6DS3_156_mg:
+      *val = LSM6DS3_156_mg;
+      break;
+    case LSM6DS3_219_mg:
+      *val = LSM6DS3_219_mg;
+      break;
+    case LSM6DS3_250_mg:
+      *val = LSM6DS3_250_mg;
+      break;
+    case LSM6DS3_312_mg:
+      *val = LSM6DS3_312_mg;
+      break;
+    case LSM6DS3_344_mg:
+      *val = LSM6DS3_344_mg;
+      break;
+    case LSM6DS3_406_mg:
+      *val = LSM6DS3_406_mg;
+      break;
+    case LSM6DS3_469_mg:
+      *val = LSM6DS3_469_mg;
+      break;
+    case LSM6DS3_500_mg:
+      *val = LSM6DS3_500_mg;
+      break;
+    default:
+      *val = LSM6DS3_156_mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Free-fall duration event. 1LSb = 1 / ODR[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of ff_dur in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_ff_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_dur = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Free-fall duration event. 1LSb = 1 / ODR[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of ff_dur in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_ff_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FREE_FALL, (uint8_t*)&free_fall, 1);
+  *val = (uint8_t)free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Fifo
+  * @brief       This section group all the functions concerning the
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief   FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of fth in reg FIFO_CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_watermark_set(lsm6ds3_ctx_t *ctx, uint16_t val)
+{
+  lsm6ds3_fifo_ctrl1_t fifo_ctrl1;
+  lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl2.fth = (uint8_t)((val & 0x0F00U) >> 8);
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl1.fth = (uint8_t)(val & 0x00FF0U);
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of fth in reg FIFO_CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_watermark_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
+{
+  lsm6ds3_fifo_ctrl1_t fifo_ctrl1;
+  lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+    *val = (uint16_t)fifo_ctrl2.fth << 8;
+    *val |= fifo_ctrl1.fth;
+  }
+  return ret;
+}
+
+/**
+  * @brief   trigger signal for FIFO write operation.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of  timer_pedo_fifo_drdy in reg LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_write_trigger_set(lsm6ds3_ctx_t *ctx,
+                               lsm6ds3_tmr_ped_fifo_drdy_t val)
+{
+  lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2. timer_pedo_fifo_drdy = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   trigger signal for FIFO write operation.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of  timer_pedo_fifo_drdy in
+  *                     reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6ds3_fifo_write_trigger_get(lsm6ds3_ctx_t *ctx,
+                                       lsm6ds3_tmr_ped_fifo_drdy_t *val)
+{
+  lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+
+  switch (fifo_ctrl2. timer_pedo_fifo_drdy)
+  {
+    case LSM6DS3_TRG_XL_GY_DRDY:
+      *val = LSM6DS3_TRG_XL_GY_DRDY;
+      break;
+    case LSM6DS3_TRG_STEP_DETECT:
+      *val = LSM6DS3_TRG_STEP_DETECT;
+      break;
+    default:
+      *val = LSM6DS3_TRG_XL_GY_DRDY;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Pedometer step counter and timestamp as 4th FIFO data set.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of timer_pedo_fifo_en in reg FIFO_CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_pedo_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.timer_pedo_fifo_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Pedometer step counter and timestamp as 4th FIFO data set.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of timer_pedo_fifo_en in reg FIFO_CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_pedo_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  *val = (uint8_t)fifo_ctrl2.timer_pedo_fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO) for
+  *          accelerometer data.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of dec_fifo_xl in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_xl_batch_set(lsm6ds3_ctx_t *ctx, lsm6ds3_dec_fifo_xl_t val)
+{
+  lsm6ds3_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_xl = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL3,
+                            (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO) for
+  *          accelerometer data.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of dec_fifo_xl in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6ds3_fifo_xl_batch_get(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_dec_fifo_xl_t *val)
+{
+  lsm6ds3_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.dec_fifo_xl)
+  {
+    case LSM6DS3_FIFO_XL_DISABLE:
+      *val = LSM6DS3_FIFO_XL_DISABLE;
+      break;
+    case LSM6DS3_FIFO_XL_NO_DEC:
+      *val = LSM6DS3_FIFO_XL_NO_DEC;
+      break;
+    case LSM6DS3_FIFO_XL_DEC_2:
+      *val = LSM6DS3_FIFO_XL_DEC_2;
+      break;
+    case LSM6DS3_FIFO_XL_DEC_3:
+      *val = LSM6DS3_FIFO_XL_DEC_3;
+      break;
+    case LSM6DS3_FIFO_XL_DEC_4:
+      *val = LSM6DS3_FIFO_XL_DEC_4;
+      break;
+    case LSM6DS3_FIFO_XL_DEC_8:
+      *val = LSM6DS3_FIFO_XL_DEC_8;
+      break;
+    case LSM6DS3_FIFO_XL_DEC_16:
+      *val = LSM6DS3_FIFO_XL_DEC_16;
+      break;
+    case LSM6DS3_FIFO_XL_DEC_32:
+      *val = LSM6DS3_FIFO_XL_DEC_32;
+      break;
+    default:
+      *val = LSM6DS3_FIFO_XL_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for gyroscope data.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of dec_fifo_gyro in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_gy_batch_set(lsm6ds3_ctx_t *ctx, lsm6ds3_dec_fifo_gyro_t val)
+{
+  lsm6ds3_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_gyro = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL3,
+                            (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for gyroscope data.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of dec_fifo_gyro in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6ds3_fifo_gy_batch_get(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_dec_fifo_gyro_t *val)
+{
+  lsm6ds3_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.dec_fifo_gyro)
+  {
+    case LSM6DS3_FIFO_GY_DISABLE:
+      *val = LSM6DS3_FIFO_GY_DISABLE;
+      break;
+    case LSM6DS3_FIFO_GY_NO_DEC:
+      *val = LSM6DS3_FIFO_GY_NO_DEC;
+      break;
+    case LSM6DS3_FIFO_GY_DEC_2:
+      *val = LSM6DS3_FIFO_GY_DEC_2;
+      break;
+    case LSM6DS3_FIFO_GY_DEC_3:
+      *val = LSM6DS3_FIFO_GY_DEC_3;
+      break;
+    case LSM6DS3_FIFO_GY_DEC_4:
+      *val = LSM6DS3_FIFO_GY_DEC_4;
+      break;
+    case LSM6DS3_FIFO_GY_DEC_8:
+      *val = LSM6DS3_FIFO_GY_DEC_8;
+      break;
+    case LSM6DS3_FIFO_GY_DEC_16:
+      *val = LSM6DS3_FIFO_GY_DEC_16;
+      break;
+    case LSM6DS3_FIFO_GY_DEC_32:
+      *val = LSM6DS3_FIFO_GY_DEC_32;
+      break;
+    default:
+      *val = LSM6DS3_FIFO_GY_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of dec_ds3_fifo in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_dataset_3_batch_set(lsm6ds3_ctx_t *ctx,
+                                         lsm6ds3_dec_ds3_fifo_t val)
+{
+  lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds3_fifo = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of dec_ds3_fifo in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6ds3_fifo_dataset_3_batch_get(lsm6ds3_ctx_t *ctx,
+                                          lsm6ds3_dec_ds3_fifo_t *val)
+{
+  lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.dec_ds3_fifo)
+  {
+    case LSM6DS3_FIFO_DS3_DISABLE:
+      *val = LSM6DS3_FIFO_DS3_DISABLE;
+      break;
+    case LSM6DS3_FIFO_DS3_NO_DEC:
+      *val = LSM6DS3_FIFO_DS3_NO_DEC;
+      break;
+    case LSM6DS3_FIFO_DS3_DEC_2:
+      *val = LSM6DS3_FIFO_DS3_DEC_2;
+      break;
+    case LSM6DS3_FIFO_DS3_DEC_3:
+      *val = LSM6DS3_FIFO_DS3_DEC_3;
+      break;
+    case LSM6DS3_FIFO_DS3_DEC_4:
+      *val = LSM6DS3_FIFO_DS3_DEC_4;
+      break;
+    case LSM6DS3_FIFO_DS3_DEC_8:
+      *val = LSM6DS3_FIFO_DS3_DEC_8;
+      break;
+    case LSM6DS3_FIFO_DS3_DEC_16:
+      *val = LSM6DS3_FIFO_DS3_DEC_16;
+      break;
+    case LSM6DS3_FIFO_DS3_DEC_32:
+      *val = LSM6DS3_FIFO_DS3_DEC_32;
+      break;
+    default:
+      *val = LSM6DS3_FIFO_DS3_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for fourth data set.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of dec_ds4_fifo in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_dataset_4_batch_set(lsm6ds3_ctx_t *ctx,
+                                         lsm6ds3_dec_ds4_fifo_t val)
+{
+  lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds4_fifo = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for fourth data set.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of dec_ds4_fifo in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6ds3_fifo_dataset_4_batch_get(lsm6ds3_ctx_t *ctx,
+                                         lsm6ds3_dec_ds4_fifo_t *val)
+{
+  lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.dec_ds4_fifo)
+  {
+    case LSM6DS3_FIFO_DS4_DISABLE:
+      *val = LSM6DS3_FIFO_DS4_DISABLE;
+      break;
+    case LSM6DS3_FIFO_DS4_NO_DEC:
+      *val = LSM6DS3_FIFO_DS4_NO_DEC;
+      break;
+    case LSM6DS3_FIFO_DS4_DEC_2:
+      *val = LSM6DS3_FIFO_DS4_DEC_2;
+      break;
+    case LSM6DS3_FIFO_DS4_DEC_3:
+      *val = LSM6DS3_FIFO_DS4_DEC_3;
+      break;
+    case LSM6DS3_FIFO_DS4_DEC_4:
+      *val = LSM6DS3_FIFO_DS4_DEC_4;
+      break;
+    case LSM6DS3_FIFO_DS4_DEC_8:
+      *val = LSM6DS3_FIFO_DS4_DEC_8;
+      break;
+    case LSM6DS3_FIFO_DS4_DEC_16:
+      *val = LSM6DS3_FIFO_DS4_DEC_16;
+      break;
+    case LSM6DS3_FIFO_DS4_DEC_32:
+      *val = LSM6DS3_FIFO_DS4_DEC_32;
+      break;
+    default:
+      *val = LSM6DS3_FIFO_DS4_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   8-bit data storage in FIFO.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of only_high_data in reg FIFO_CTRL4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_xl_gy_8bit_format_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.only_high_data = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   8-bit data storage in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of only_high_data in reg FIFO_CTRL4
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_xl_gy_8bit_format_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  *val = (uint8_t)fifo_ctrl4.only_high_data;
+
+  return ret;
+}
+
+/**
+  * @brief   FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of fifo_mode in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t val)
+{
+  lsm6ds3_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.fifo_mode = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL5,
+                            (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   FIFO mode selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of fifo_mode in reg FIFO_CTRL5
+  *
+  */
+int32_t lsm6ds3_fifo_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t *val)
+{
+  lsm6ds3_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+
+  switch (fifo_ctrl5.fifo_mode)
+  {
+    case LSM6DS3_BYPASS_MODE:
+      *val = LSM6DS3_BYPASS_MODE;
+      break;
+    case LSM6DS3_FIFO_MODE:
+      *val = LSM6DS3_FIFO_MODE;
+      break;
+    case  LSM6DS3_STREAM_TO_FIFO_MODE:
+      *val =  LSM6DS3_STREAM_TO_FIFO_MODE;
+      break;
+    case  LSM6DS3_BYPASS_TO_STREAM_MODE:
+      *val =  LSM6DS3_BYPASS_TO_STREAM_MODE;
+      break;
+    default:
+      *val = LSM6DS3_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   FIFO ODR selection, setting FIFO_MODE also.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of odr_fifo in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_fifo_t val)
+{
+  lsm6ds3_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.odr_fifo = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_FIFO_CTRL5,
+                            (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   FIFO ODR selection, setting FIFO_MODE also.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of odr_fifo in reg FIFO_CTRL5
+  *
+  */
+int32_t lsm6ds3_fifo_data_rate_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_odr_fifo_t *val)
+{
+  lsm6ds3_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+
+  switch (fifo_ctrl5.odr_fifo)
+  {
+    case LSM6DS3_FIFO_DISABLE:
+      *val = LSM6DS3_FIFO_DISABLE;
+      break;
+    case LSM6DS3_FIFO_12Hz5:
+      *val = LSM6DS3_FIFO_12Hz5;
+      break;
+    case LSM6DS3_FIFO_26Hz:
+      *val = LSM6DS3_FIFO_26Hz;
+      break;
+    case LSM6DS3_FIFO_52Hz:
+      *val = LSM6DS3_FIFO_52Hz;
+      break;
+    case LSM6DS3_FIFO_104Hz:
+      *val = LSM6DS3_FIFO_104Hz;
+      break;
+    case LSM6DS3_FIFO_208Hz:
+      *val = LSM6DS3_FIFO_208Hz;
+      break;
+    case LSM6DS3_FIFO_416Hz:
+      *val = LSM6DS3_FIFO_416Hz;
+      break;
+    case LSM6DS3_FIFO_833Hz:
+      *val = LSM6DS3_FIFO_833Hz;
+      break;
+    case LSM6DS3_FIFO_1k66Hz:
+      *val = LSM6DS3_FIFO_1k66Hz;
+      break;
+    case LSM6DS3_FIFO_3k33Hz:
+      *val = LSM6DS3_FIFO_3k33Hz;
+      break;
+    case LSM6DS3_FIFO_6k66Hz:
+      *val = LSM6DS3_FIFO_6k66Hz;
+      break;
+    default:
+      *val = LSM6DS3_FIFO_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensing chain FIFO stop values memorization at
+  *          threshold level.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of stop_on_fth in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_stop_on_wtm_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.stop_on_fth = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensing chain FIFO stop values memorization at
+  *          threshold level.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of stop_on_fth in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_stop_on_wtm_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = (uint8_t)ctrl4_c.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief   batching of temperature data.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of fifo_temp_en in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_temp_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.fifo_temp_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   batching of temperature data.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of fifo_temp_en in reg CTRL4_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_temp_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = (uint8_t)ctrl4_c.fifo_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Number of unread words (16-bit axes) stored in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of diff_fifo in reg FIFO_STATUS1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_data_level_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
+{
+  lsm6ds3_fifo_status1_t fifo_status1;
+  lsm6ds3_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_STATUS1,
+                         (uint8_t*)&fifo_status1, 1);
+
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+
+    *val = (uint16_t)fifo_status2.diff_fifo << 8;
+    *val |= fifo_status1.diff_fifo;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Smart FIFO full status.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of fifo_empty in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_full_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_STATUS2,
+                         (uint8_t*)&fifo_status2, 1);
+  *val = (uint8_t)fifo_status2.fifo_empty;
+
+  return ret;
+}
+
+/**
+  * @brief   FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of fifo_full in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_ovr_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_STATUS2,
+                         (uint8_t*)&fifo_status2, 1);
+  *val = (uint8_t)fifo_status2.fifo_full;
+
+  return ret;
+}
+
+/**
+  * @brief   FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of fth in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_wtm_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_STATUS2,
+                         (uint8_t*)&fifo_status2, 1);
+  *val = (uint8_t)fifo_status2.fth;
+
+  return ret;
+}
+
+/**
+  * @brief   Word of recursive pattern read at the next reading.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of fifo_pattern in reg FIFO_STATUS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_fifo_pattern_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
+{
+  lsm6ds3_fifo_status3_t fifo_status3;
+  lsm6ds3_fifo_status4_t fifo_status4;
+
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_STATUS3,
+                         (uint8_t*)&fifo_status3, 1);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_STATUS4,
+                           (uint8_t*)&fifo_status4, 1);
+
+    *val = (uint16_t)fifo_status4.fifo_pattern << 8;
+    *val |= fifo_status3.fifo_pattern;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_DEN_functionality
+  * @brief       This section groups all the functions concerning DEN
+  *              functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief   DEN functionality marking mode.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of den_mode in reg CTRL6_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_den_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t val)
+{
+  lsm6ds3_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  if(ret == 0){
+    ctrl6_c.den_mode = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   DEN functionality marking mode.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of den_mode in reg CTRL6_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_den_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t *val)
+{
+  lsm6ds3_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.den_mode)
+  {
+    case LSM6DS3_DEN_DISABLE:
+      *val = LSM6DS3_DEN_DISABLE;
+      break;
+    case LSM6DS3_LEVEL_FIFO:
+      *val = LSM6DS3_LEVEL_FIFO;
+      break;
+    case LSM6DS3_LEVEL_LETCHED:
+      *val = LSM6DS3_LEVEL_LETCHED;
+      break;
+    case LSM6DS3_LEVEL_TRIGGER:
+      *val = LSM6DS3_LEVEL_TRIGGER;
+      break;
+    case LSM6DS3_EDGE_TRIGGER:
+      *val = LSM6DS3_EDGE_TRIGGER;
+      break;
+    default:
+      *val = LSM6DS3_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Pedometer
+  * @brief       This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Reset pedometer step counter.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pedo_rst_step in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_step_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.pedo_rst_step = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Reset pedometer step counter.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of pedo_rst_step in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_step_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = (uint8_t)ctrl10_c.pedo_rst_step;
+
+  return ret;
+}
+
+/**
+  * @brief   Step counter timestamp information register (r). When a step is
+  *          detected, the value of TIMESTAMP_REG register is copied in
+  *          STEP_TIMESTAMP_L..[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_pedo_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_STEP_TIMESTAMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief   Step detector event detection status
+  *          (0:not detected / 1:detected).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of step_detected in reg FUNC_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_step_detect_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_func_src_t func_src;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FUNC_SRC, (uint8_t*)&func_src, 1);
+  *val = (uint8_t)func_src.step_detected;
+
+  return ret;
+}
+
+/**
+  * @brief   Enable pedometer algorithm.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pedo_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = 0;
+  if (val == PROPERTY_ENABLE){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    if(ret == 0){
+      ctrl10_c.func_en = PROPERTY_ENABLE;
+      ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  if(ret == 0){
+    tap_cfg.pedo_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable pedometer algorithm.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of pedo_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = (uint8_t)tap_cfg.pedo_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Configurable minimum threshold (PEDO_4G 1LSB = 16 mg ,
+  *          PEDO_2G 1LSB = 32 mg).[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of ths_min in reg PEDO_THS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_pedo_ths_reg_t pedo_ths_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_PEDO_THS_REG,
+                           (uint8_t*)&pedo_ths_reg, 1);
+  }
+  if(ret == 0){
+    pedo_ths_reg.ths_min = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_PEDO_THS_REG,
+                            (uint8_t*)&pedo_ths_reg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Configurable minimum threshold (PEDO_4G 1LSB = 16 mg,
+  *          PEDO_2G 1LSB = 32 mg).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of ths_min in reg PEDO_THS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_pedo_ths_reg_t pedo_ths_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_PEDO_THS_REG,
+                           (uint8_t*)&pedo_ths_reg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+    *val = (uint8_t)pedo_ths_reg.ths_min;
+  }
+  return ret;
+}
+
+/**
+  * @brief   This bit sets the internal full scale used in
+  *          pedometer functions.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pedo_4g in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pedo_fs_t val)
+{
+  lsm6ds3_pedo_ths_reg_t pedo_ths_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_PEDO_THS_REG,
+                           (uint8_t*)&pedo_ths_reg, 1);
+  }
+  if(ret == 0){
+    pedo_ths_reg.pedo_4g = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_PEDO_THS_REG,
+                            (uint8_t*)&pedo_ths_reg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   This bit sets the internal full scale used in pedometer
+  *          functions.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of pedo_4g in reg PEDO_THS_REG
+  *
+  */
+int32_t lsm6ds3_pedo_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pedo_fs_t *val)
+{
+  lsm6ds3_pedo_ths_reg_t pedo_ths_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_PEDO_THS_REG,
+                           (uint8_t*)&pedo_ths_reg, 1);
+    switch (pedo_ths_reg.pedo_4g)
+    {
+      case LSM6DS3_PEDO_AT_2g:
+        *val = LSM6DS3_PEDO_AT_2g;
+        break;
+      case LSM6DS3_PEDO_AT_4g:
+        *val = LSM6DS3_PEDO_AT_4g;
+        break;
+      default:
+        *val = LSM6DS3_PEDO_AT_2g;
+        break;
+    }
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Pedometer debounce configuration register (r/w).[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of deb_step in reg PEDO_DEB_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_debounce_steps_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    pedo_deb_reg.deb_step = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_PEDO_DEB_REG,
+                            (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Pedometer debounce configuration register (r/w).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of deb_step in reg PEDO_DEB_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_debounce_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+    *val = (uint8_t)pedo_deb_reg.deb_step;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Debounce time. If the time between two consecutive steps is
+  *          greater than DEB_TIME*80ms, the debounce is reactivated.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of deb_time in reg PEDO_DEB_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_timeout_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    pedo_deb_reg.deb_time = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_PEDO_DEB_REG,
+                            (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Debounce time. If the time between two consecutive steps is
+  *          greater than DEB_TIME*80ms, the debounce is reactivated.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of deb_time in reg PEDO_DEB_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_pedo_timeout_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    *val = (uint8_t)pedo_deb_reg.deb_time;
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Significant_motion
+  * @brief       This section groups all the functions that manage the
+  *              significant motion detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Enable significant motion detection function.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sign_motion_en in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_motion_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.sign_motion_en = (uint8_t)val;
+    if (val == PROPERTY_ENABLE){
+      ctrl10_c.func_en = PROPERTY_ENABLE;
+    }
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable significant motion detection function.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sign_motion_en in reg CTRL10_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_motion_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = (uint8_t)ctrl10_c.sign_motion_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Significant motion event detection status
+  *          (0:not detected / 1:detected).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sign_motion_ia in reg FUNC_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_motion_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_func_src_t func_src;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FUNC_SRC, (uint8_t*)&func_src, 1);
+  *val = (uint8_t)func_src.sign_motion_ia;
+
+  return ret;
+}
+
+/**
+  * @brief   Significant motion threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sm_ths in reg SM_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_motion_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_sm_ths_t sm_ths;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SM_THS, (uint8_t*)&sm_ths, 1);
+  }
+  if(ret == 0){
+    sm_ths.sm_ths = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SM_THS, (uint8_t*)&sm_ths, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Significant motion threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sm_ths in reg SM_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_motion_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_sm_ths_t sm_ths;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SM_THS, (uint8_t*)&sm_ths, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+    *val = (uint8_t)sm_ths.sm_ths;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Time period register for step detection on delta time
+  *          (1LSB = 1.6384 s).[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of sc_delta in reg STEP_COUNT_DELTA
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sc_delta_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_step_count_delta_t  step_count_delta;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_STEP_COUNT_DELTA,
+                           (uint8_t*)& step_count_delta, 1);
+  }
+  if(ret == 0){
+    step_count_delta.sc_delta = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_STEP_COUNT_DELTA,
+                            (uint8_t*)& step_count_delta, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Time period register for step detection on delta time
+  *          (1LSB = 1.6384 s).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sc_delta in reg  STEP_COUNT_DELTA
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sc_delta_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_step_count_delta_t  step_count_delta;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_STEP_COUNT_DELTA,
+                           (uint8_t*)& step_count_delta, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+    *val = (uint8_t) step_count_delta.sc_delta;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Tilt_detection
+  * @brief       This section groups all the functions that manage
+  *              the tilt event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Tilt event detection status(0:not detected / 1:detected).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of tilt_ia in reg FUNC_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tilt_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_func_src_t func_src;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FUNC_SRC, (uint8_t*)&func_src, 1);
+  *val = (uint8_t)func_src.tilt_ia;
+
+  return ret;
+}
+
+/**
+  * @brief   Enable tilt calculation.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of tilt_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tilt_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = 0;
+  if (val == PROPERTY_ENABLE){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    if(ret == 0){
+      ctrl10_c.func_en = PROPERTY_ENABLE;
+      ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  if(ret == 0){
+    tap_cfg.tilt_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable tilt calculation.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of tilt_en in reg TAP_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_tilt_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = (uint8_t)tap_cfg.tilt_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Magnetometer_sensor
+  * @brief       This section groups all the functions that manage
+  *              additional magnetometer sensor.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Enable soft-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of soft_en in reg CTRL9_XL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_mag_soft_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  lsm6ds3_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = 0;
+  if (val == PROPERTY_ENABLE){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    if(ret == 0){
+      ctrl10_c.func_en = PROPERTY_ENABLE;
+      ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  if(ret == 0){
+    ctrl9_xl.soft_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable soft-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of soft_en in reg CTRL9_XL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_mag_soft_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = (uint8_t)ctrl9_xl.soft_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Enable hard-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of iron_en in reg MASTER_CONFIG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_mag_hard_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = 0;
+  if (val == PROPERTY_ENABLE){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    ctrl10_c.func_en = PROPERTY_ENABLE;
+    if(ret == 0){
+      ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.iron_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable hard-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of iron_en in reg MASTER_CONFIG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_mag_hard_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = (uint8_t)master_config.iron_en;
+
+  return ret;
+}
+
+/**
+  * @brief   Hard/soft-iron calculation status (0: on-going / 1: idle).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of si_end_op in reg FUNC_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_mag_soft_iron_end_op_flag_get(lsm6ds3_ctx_t *ctx,
+                                               uint8_t *val)
+{
+  lsm6ds3_func_src_t func_src;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FUNC_SRC, (uint8_t*)&func_src, 1);
+  *val = (uint8_t)func_src.si_end_op;
+
+  return ret;
+}
+
+/**
+  * @brief   Soft-iron matrix correction registers[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data to be write
+  *
+  */
+int32_t lsm6ds3_mag_soft_iron_coeff_set(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_MAG_SI_XX, buff, 9);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Soft-iron matrix correction registers[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_mag_soft_iron_coeff_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_MAG_SI_XX, buff, 9);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Offset for hard-iron compensation register (r/w).
+  *          The value is expressed as a 16-bit word in two’s complement.[set]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data to be write
+  *
+  */
+int32_t lsm6ds3_mag_offset_set(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+   ret = lsm6ds3_write_reg(ctx, LSM6DS3_MAG_OFFX_L, buff, 6);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Offset for hard-iron compensation register(r/w).
+  *          The value is expressed as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_mag_offset_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_MAG_OFFX_L, buff, 6);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3_Sensor_hub
+  * @brief       This section groups all the functions that manage the
+  *              sensor hub functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Sensor synchronization time frame with the step of 500 ms
+  *          and full range of 5 s. Unsigned 8-bit.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of tph in reg  SENSOR_SYNC_TIME_FRAME
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_sync_sens_frame_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_sensor_sync_time_frame_t  sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_SENSOR_SYNC_TIME_FRAME,
+                            (uint8_t*)& sensor_sync_time_frame, 1);
+  if(ret == 0){
+     sensor_sync_time_frame.tph = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SENSOR_SYNC_TIME_FRAME,
+                               (uint8_t*)& sensor_sync_time_frame, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensor synchronization time frame with the step of 500 ms and
+  *          full range of 5 s. Unsigned 8-bit.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of tph in reg  SENSOR_SYNC_TIME_FRAME
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_sync_sens_frame_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_sensor_sync_time_frame_t  sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_SENSOR_SYNC_TIME_FRAME,
+                         (uint8_t*)& sensor_sync_time_frame, 1);
+  *val = (uint8_t) sensor_sync_time_frame.tph;
+
+  return ret;
+}
+/**
+  * @brief   Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of master_on in reg MASTER_CONFIG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_master_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_ctrl10_c_t ctrl10_c;
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = 0;
+  if (val == PROPERTY_ENABLE){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    if(ret == 0){
+      ctrl10_c.func_en = PROPERTY_ENABLE;
+      ret = lsm6ds3_write_reg(ctx, LSM6DS3_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.master_on = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of master_on in reg MASTER_CONFIG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_master_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = (uint8_t)master_config.master_on;
+
+  return ret;
+}
+/**
+  * @brief   I2C interface pass-through.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pass_through_mode in
+  *                  reg MASTER_CONFIG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_pass_through_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pass_through_mode = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   I2C interface pass-through.[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_pass_through_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = (uint8_t)master_config.pass_through_mode;
+
+  return ret;
+}
+/**
+  * @brief   Master I2C pull-up enable/disable.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of pull_up_en in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t val)
+{
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pull_up_en = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Master I2C pull-up enable/disable.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of pull_up_en in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6ds3_sh_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t *val)
+{
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+
+  switch (master_config.pull_up_en)
+  {
+    case LSM6DS3_EXT_PULL_UP:
+      *val = LSM6DS3_EXT_PULL_UP;
+      break;
+    case LSM6DS3_INTERNAL_PULL_UP:
+      *val = LSM6DS3_INTERNAL_PULL_UP;
+      break;
+    default:
+      *val = LSM6DS3_EXT_PULL_UP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      change the values of start_config in reg  LSM6DS3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_syncro_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_start_cfg_t val)
+{
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.start_config = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  val         get the values of start_config in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6ds3_sh_syncro_mode_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_start_cfg_t *val)
+{
+  lsm6ds3_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+
+  switch (master_config.start_config)
+  {
+    case LSM6DS3_XL_GY_DRDY:
+      *val = LSM6DS3_XL_GY_DRDY;
+      break;
+    case LSM6DS3_EXT_ON_INT2_PIN:
+      *val = LSM6DS3_EXT_ON_INT2_PIN;
+      break;
+    default:
+      *val = LSM6DS3_XL_GY_DRDY;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensor hub output registers.[get]
+  *
+  * @param  ctx         read / write interface definitions(ptr)
+  * @param  buff        buffer that stores data read
+  *
+  */
+int32_t lsm6ds3_sh_read_data_raw_get(lsm6ds3_ctx_t *ctx,
+                                     lsm6ds3_sh_read_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_SENSORHUB1_REG,
+                         (uint8_t*)&(buff->sh_byte_1), 12);
+
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SENSORHUB13_REG,
+                           (uint8_t*)&(buff->sh_byte_13), 6);
+  }
+  return ret;
+}
+
+/**
+  * @brief  sh_cfg_write: Configure slave 0 for perform a write.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_sh_cfg_write_t: a structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_data;   8 bit data to write
+  *
+  */
+int32_t lsm6ds3_sh_cfg_write(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_cfg_write_t *val)
+{
+  lsm6ds3_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv0_add >> 1;
+    slv0_add.rw_0 = 0;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV0_SUBADD,
+                            &(val->slv0_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_DATAWRITE_SRC_MODE_SUB_SLV0,
+                            &(val->slv0_data), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  sh_slv0_cfg_read: [get] Configure slave 0 for perform a write/read.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_sh_cfg_read_t: a structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_len;    num of bit to read
+  *
+  */
+int32_t lsm6ds3_sh_slv0_cfg_read(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_sh_cfg_read_t *val)
+{
+  lsm6ds3_slv0_add_t slv0_add;
+  lsm6ds3_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv_add >> 1;
+    slv0_add.rw_0 = 1;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV0_SUBADD,
+                            &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+  }
+  if(ret == 0){
+    slave0_config.slave0_numop = val->slv_len;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLAVE0_CONFIG,
+                            (uint8_t*)&slave0_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  sh_slv1_cfg_read: [get] Configure slave 0 for perform a write/read.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_sh_cfg_read_t: a structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_len;    num of bit to read
+  *
+  */
+int32_t lsm6ds3_sh_slv1_cfg_read(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_sh_cfg_read_t *val)
+{
+  lsm6ds3_slv1_add_t slv1_add;
+  lsm6ds3_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    slv1_add.slave1_add = val->slv_add >> 1;;
+    slv1_add.r_1 = 1;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV1_ADD, (uint8_t*)&slv1_add, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV1_SUBADD,
+                            &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SLAVE1_CONFIG, (uint8_t*)&slave1_config, 1);
+  }
+  if(ret == 0){
+    slave1_config.slave1_numop = val->slv_len;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLAVE1_CONFIG, (uint8_t*)&slave1_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  sh_slv2_cfg_read: [get] Configure slave 0 for perform a write/read.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_sh_cfg_read_t: a structure that contain
+  *                      - uint8_t slv2_add;    8 bit i2c device address
+  *                      - uint8_t slv2_subadd; 8 bit register device address
+  *                      - uint8_t slv2_len;    num of bit to read
+  *
+  */
+int32_t lsm6ds3_sh_slv2_cfg_read(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_sh_cfg_read_t *val)
+{
+  lsm6ds3_slv2_add_t slv2_add;
+  lsm6ds3_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    slv2_add.slave2_add = val->slv_add >> 1;
+    slv2_add.r_2 = 1;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV2_ADD,
+                            (uint8_t*)&slv2_add, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV2_SUBADD,
+                            &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SLAVE2_CONFIG,
+                           (uint8_t*)&slave2_config, 1);
+  }
+  if(ret == 0){
+    slave2_config.slave2_numop = val->slv_len;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLAVE2_CONFIG,
+                            (uint8_t*)&slave2_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  sh_slv3_cfg_read: [get] Configure slave 0 for perform a write/read.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_sh_cfg_read_t: a structure that contain
+  *                      - uint8_t slv3_add;    8 bit i2c device address
+  *                      - uint8_t slv3_subadd; 8 bit register device address
+  *                      - uint8_t slv3_len;    num of bit to read
+  *
+  */
+int32_t lsm6ds3_sh_slv3_cfg_read(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_sh_cfg_read_t *val)
+{
+  lsm6ds3_slv3_add_t slv3_add;
+  lsm6ds3_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    slv3_add.slave3_add = val->slv_add >> 1;
+    slv3_add.r_3 = 1;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV3_ADD, (uint8_t*)&slv3_add, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLV3_SUBADD,
+                            &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SLAVE3_CONFIG,
+                           (uint8_t*)&slave3_config, 1);
+  }
+  if(ret == 0){
+    slave3_config.slave3_numop = val->slv_len;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLAVE3_CONFIG,
+                            (uint8_t*)&slave3_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensor hub communication status (0: on-going / 1: idle).[get]
+  *
+  * @param  ctx      read / write interface definitions(ptr)
+  * @param  val      get the values of sensor_hub_end_op in reg FUNC_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3_sh_end_op_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3_func_src_t func_src;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_FUNC_SRC, (uint8_t*)&func_src, 1);
+  *val = (uint8_t)func_src.sensor_hub_end_op;
+
+  return ret;
+}
+
+/**
+  * @brief   xl_hp_path_internal: [set] HPF or SLOPE filter selection on
+  *                                     wake-up and Activity/Inactivity
+  *                                     functions.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_slope_fds_t: change the values of slope_fds in reg TAP_CFG
+  *
+  */
+int32_t lsm6ds3_xl_hp_path_internal_set(lsm6ds3_ctx_t *ctx,
+                                        lsm6ds3_slope_fds_t val)
+{
+  lsm6ds3_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.slope_fds = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   xl_hp_path_internal: [get] HPF or SLOPE filter selection on
+  *                                     wake-up and Activity/Inactivity
+  *                                     functions.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_slope_fds_t: Get the values of slope_fds in reg TAP_CFG
+  *
+  */
+int32_t lsm6ds3_xl_hp_path_internal_get(lsm6ds3_ctx_t *ctx,
+                                        lsm6ds3_slope_fds_t *val)
+{
+  lsm6ds3_tap_cfg_t reg;
+  int32_t ret;
+
+  ret = lsm6ds3_read_reg(ctx, LSM6DS3_TAP_CFG, (uint8_t*)&reg, 1);
+  switch (reg.slope_fds)
+  {
+    case LSM6DS3_USE_SLOPE:
+      *val = LSM6DS3_USE_SLOPE;
+      break;
+    case LSM6DS3_USE_HPF:
+      *val = LSM6DS3_USE_HPF;
+      break;
+    default:
+      *val = LSM6DS3_USE_SLOPE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   sh_num_of_dev_connected: [set] Number of external sensors to
+  *                                         be read by the sensor hub.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_aux_sens_on_t: change the values of aux_sens_on in
+  *                                reg SLAVE0_CONFIG
+  *
+  */
+int32_t lsm6ds3_sh_num_of_dev_connected_set(lsm6ds3_ctx_t *ctx,
+                                            lsm6ds3_aux_sens_on_t val)
+{
+  lsm6ds3_slave0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SLAVE0_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if(ret == 0){
+    reg.aux_sens_on = (uint8_t)val;
+    ret = lsm6ds3_write_reg(ctx, LSM6DS3_SLAVE0_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   sh_num_of_dev_connected: [get] Number of external sensors to
+  *                                         be read by the sensor hub.
+  *
+  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  lsm6ds3_aux_sens_on_t: Get the values of aux_sens_on in
+  *                                reg SLAVE0_CONFIG
+  *
+  */
+int32_t lsm6ds3_sh_num_of_dev_connected_get(lsm6ds3_ctx_t *ctx,
+                                            lsm6ds3_aux_sens_on_t *val)
+{
+  lsm6ds3_slave0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6ds3_read_reg(ctx, LSM6DS3_SLAVE0_CONFIG, (uint8_t*)&reg, 1);
+    switch (reg.aux_sens_on)
+    {
+      case LSM6DS3_SLV_0:
+        *val = LSM6DS3_SLV_0;
+        break;
+      case LSM6DS3_SLV_0_1:
+        *val = LSM6DS3_SLV_0_1;
+        break;
+      case LSM6DS3_SLV_0_1_2:
+        *val = LSM6DS3_SLV_0_1_2;
+        break;
+        case LSM6DS3_SLV_0_1_2_3:
+        *val = LSM6DS3_SLV_0_1_2_3;
+        break;
+      default:
+        *val = LSM6DS3_SLV_0;
+        break;
+    }
+  }
+  if(ret == 0){
+    ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.h
+++ b/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.h
@@ -1,0 +1,1696 @@
+/*
+ ******************************************************************************
+ * @file    lsm6ds3_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm6ds3_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DS3_REGS_H
+#define LSM6DS3_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM6DS3
+  * @{
+  *
+  */
+
+/** @defgroup LSM6DS3_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LSM6DS3_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lsm6ds3_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lsm6ds3_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lsm6ds3_write_ptr  write_reg;
+  lsm6ds3_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lsm6ds3_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DS3_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0xD5 if SA0=1 -> 0xD7 **/
+#define LSM6DS3_I2C_ADD_L                          0xD5U
+#define LSM6DS3_I2C_ADD_H                          0xD7U
+/** Device Identification (Who am I) **/
+#define LSM6DS3_ID                                 0x69U
+
+/**
+  * @}
+  *
+  */
+
+#define LSM6DS3_FUNC_CFG_ACCESS                    0x01U
+typedef struct {
+  uint8_t not_used_01                 : 7;
+  uint8_t func_cfg_en                 : 1;
+} lsm6ds3_func_cfg_access_t;
+
+#define LSM6DS3_SENSOR_SYNC_TIME_FRAME             0x04U
+typedef struct {
+  uint8_t tph                         : 8;
+} lsm6ds3_sensor_sync_time_frame_t;
+
+#define LSM6DS3_FIFO_CTRL1                         0x06U
+typedef struct {
+  uint8_t fth                         : 8;
+} lsm6ds3_fifo_ctrl1_t;
+
+#define LSM6DS3_FIFO_CTRL2                         0x07U
+typedef struct {
+  uint8_t fth                         : 4;
+  uint8_t not_used_01                 : 2;
+  uint8_t  timer_pedo_fifo_drdy       : 1;
+  uint8_t timer_pedo_fifo_en          : 1;
+} lsm6ds3_fifo_ctrl2_t;
+
+#define LSM6DS3_FIFO_CTRL3                         0x08U
+typedef struct {
+  uint8_t dec_fifo_xl                 : 3;
+  uint8_t dec_fifo_gyro               : 3;
+  uint8_t not_used_01                 : 2;
+} lsm6ds3_fifo_ctrl3_t;
+
+#define LSM6DS3_FIFO_CTRL4                         0x09U
+typedef struct {
+  uint8_t dec_ds3_fifo                : 3;
+  uint8_t dec_ds4_fifo                : 3;
+  uint8_t only_high_data              : 1;
+  uint8_t not_used_01                 : 1;
+} lsm6ds3_fifo_ctrl4_t;
+
+#define LSM6DS3_FIFO_CTRL5                         0x0AU
+typedef struct {
+  uint8_t fifo_mode                   : 3;
+  uint8_t odr_fifo                    : 4;
+  uint8_t not_used_01                 : 1;
+} lsm6ds3_fifo_ctrl5_t;
+
+#define LSM6DS3_ORIENT_CFG_G                       0x0BU
+typedef struct {
+  uint8_t orient                      : 3;
+  uint8_t sign_g                      : 3;  /* SignX_G) + SignY_G + SignZ_G */
+  uint8_t not_used_01                 : 2;
+} lsm6ds3_orient_cfg_g_t;
+
+#define LSM6DS3_INT1_CTRL                          0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl                : 1;
+  uint8_t int1_drdy_g                 : 1;
+  uint8_t int1_boot                   : 1;
+  uint8_t int1_fth                    : 1;
+  uint8_t int1_fifo_ovr               : 1;
+  uint8_t int1_full_flag              : 1;
+  uint8_t int1_sign_mot               : 1;
+  uint8_t int1_step_detector          : 1;
+} lsm6ds3_int1_ctrl_t;
+
+#define LSM6DS3_INT2_CTRL                          0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl                : 1;
+  uint8_t int2_drdy_g                 : 1;
+  uint8_t int2_drdy_temp              : 1;
+  uint8_t int2_fth                    : 1;
+  uint8_t int2_fifo_ovr               : 1;
+  uint8_t int2_full_flag              : 1;
+  uint8_t int2_step_count_ov          : 1;
+  uint8_t int2_step_delta             : 1;
+} lsm6ds3_int2_ctrl_t;
+
+#define LSM6DS3_WHO_AM_I                           0x0FU
+#define LSM6DS3_CTRL1_XL                           0x10U
+typedef struct {
+  uint8_t bw_xl                       : 2;
+  uint8_t fs_xl                       : 2;
+  uint8_t odr_xl                      : 4;
+} lsm6ds3_ctrl1_xl_t;
+
+#define LSM6DS3_CTRL2_G                            0x11U
+typedef struct {
+  uint8_t not_used_01                 : 1;
+  uint8_t fs_g                        : 3;    /* FS_G + FS_125 */
+  uint8_t odr_g                       : 4;
+} lsm6ds3_ctrl2_g_t;
+
+#define LSM6DS3_CTRL3_C                            0x12U
+typedef struct {
+  uint8_t sw_reset                    : 1;
+  uint8_t ble                         : 1;
+  uint8_t if_inc                      : 1;
+  uint8_t sim                         : 1;
+  uint8_t pp_od                       : 1;
+  uint8_t h_lactive                   : 1;
+  uint8_t bdu                         : 1;
+  uint8_t boot                        : 1;
+} lsm6ds3_ctrl3_c_t;
+
+#define LSM6DS3_CTRL4_C                            0x13U
+typedef struct {
+  uint8_t stop_on_fth                 : 1;
+  uint8_t not_used_01                 : 1;
+  uint8_t i2c_disable                 : 1;
+  uint8_t drdy_mask                   : 1;
+  uint8_t fifo_temp_en                : 1;
+  uint8_t int2_on_int1                : 1;
+  uint8_t sleep_g                     : 1;
+  uint8_t xl_bw_scal_odr              : 1;
+} lsm6ds3_ctrl4_c_t;
+
+#define LSM6DS3_CTRL5_C                            0x14U
+typedef struct {
+  uint8_t st_xl                       : 2;
+  uint8_t st_g                        : 2;
+  uint8_t not_used_01                 : 1;
+  uint8_t rounding                    : 3;
+} lsm6ds3_ctrl5_c_t;
+
+#define LSM6DS3_CTRL6_C                            0x15U
+typedef struct {
+  uint8_t not_used_01                 : 4;
+  uint8_t xl_hm_mode                  : 1;
+  uint8_t den_mode                    : 3;  /* trig_en + lvl1_en + lvl2_en */
+} lsm6ds3_ctrl6_c_t;
+
+#define LSM6DS3_CTRL7_G                            0x16U
+typedef struct {
+  uint8_t not_used_01                 : 2;
+  uint8_t rounding_status             : 1;
+  uint8_t hpcf_g                      : 2;
+  uint8_t hp_g_rst                    : 1;
+  uint8_t hp_g_en                     : 1;
+  uint8_t g_hm_mode                   : 1;
+} lsm6ds3_ctrl7_g_t;
+
+#define LSM6DS3_CTRL8_XL                           0x17U
+typedef struct {
+  uint8_t low_pass_on_6d              : 1;
+  uint8_t not_used_01                 : 1;
+  uint8_t hp_slope_xl_en              : 1;
+  uint8_t not_used_02                 : 2;
+  uint8_t hpcf_xl                     : 2;
+  uint8_t lpf2_xl_en                  : 1;
+} lsm6ds3_ctrl8_xl_t;
+
+#define LSM6DS3_CTRL9_XL                           0x18U
+typedef struct {
+  uint8_t not_used_01                 : 2;
+  uint8_t soft_en                     : 1;
+  uint8_t xen_xl                      : 1;
+  uint8_t yen_xl                      : 1;
+  uint8_t zen_xl                      : 1;
+  uint8_t not_used_02                 : 2;
+} lsm6ds3_ctrl9_xl_t;
+
+#define LSM6DS3_CTRL10_C                           0x19U
+typedef struct {
+  uint8_t sign_motion_en              : 1;
+  uint8_t pedo_rst_step               : 1;
+  uint8_t func_en                     : 1;
+  uint8_t xen_g                       : 1;
+  uint8_t yen_g                       : 1;
+  uint8_t zen_g                       : 1;
+  uint8_t not_used_01                 : 2;
+} lsm6ds3_ctrl10_c_t;
+
+#define LSM6DS3_MASTER_CONFIG                      0x1AU
+typedef struct {
+  uint8_t master_on                   : 1;
+  uint8_t iron_en                     : 1;
+  uint8_t pass_through_mode           : 1;
+  uint8_t pull_up_en                  : 1;
+  uint8_t start_config                : 1;
+  uint8_t not_used_01                 : 1;
+  uint8_t data_valid_sel_fifo         : 1;
+  uint8_t drdy_on_int1                : 1;
+} lsm6ds3_master_config_t;
+
+#define LSM6DS3_WAKE_UP_SRC                        0x1BU
+typedef struct {
+  uint8_t z_wu                        : 1;
+  uint8_t y_wu                        : 1;
+  uint8_t x_wu                        : 1;
+  uint8_t wu_ia                       : 1;
+  uint8_t sleep_state_ia              : 1;
+  uint8_t ff_ia                       : 1;
+  uint8_t not_used_01                 : 2;
+} lsm6ds3_wake_up_src_t;
+
+#define LSM6DS3_TAP_SRC                            0x1CU
+typedef struct {
+  uint8_t z_tap                       : 1;
+  uint8_t y_tap                       : 1;
+  uint8_t x_tap                       : 1;
+  uint8_t tap_sign                    : 1;
+  uint8_t double_tap                  : 1;
+  uint8_t single_tap                  : 1;
+  uint8_t tap_ia                      : 1;
+  uint8_t not_used_01                 : 1;
+} lsm6ds3_tap_src_t;
+
+#define LSM6DS3_D6D_SRC                            0x1DU
+typedef struct {
+  uint8_t xl                          : 1;
+  uint8_t xh                          : 1;
+  uint8_t yl                          : 1;
+  uint8_t yh                          : 1;
+  uint8_t zl                          : 1;
+  uint8_t zh                          : 1;
+  uint8_t d6d_ia                      : 1;
+  uint8_t not_used_01                 : 1;
+} lsm6ds3_d6d_src_t;
+
+#define LSM6DS3_STATUS_REG                         0x1EU
+typedef struct {
+  uint8_t xlda                        : 1;
+  uint8_t gda                         : 1;
+  uint8_t tda                         : 1;
+  uint8_t not_used_01                 : 5;
+} lsm6ds3_status_reg_t;
+
+#define LSM6DS3_OUT_TEMP_L                         0x20U
+#define LSM6DS3_OUT_TEMP_H                         0x21U
+#define LSM6DS3_OUTX_L_G                           0x22U
+#define LSM6DS3_OUTX_H_G                           0x23U
+#define LSM6DS3_OUTY_L_G                           0x24U
+#define LSM6DS3_OUTY_H_G                           0x25U
+#define LSM6DS3_OUTZ_L_G                           0x26U
+#define LSM6DS3_OUTZ_H_G                           0x27U
+#define LSM6DS3_OUTX_L_XL                          0x28U
+#define LSM6DS3_OUTX_H_XL                          0x29U
+#define LSM6DS3_OUTY_L_XL                          0x2AU
+#define LSM6DS3_OUTY_H_XL                          0x2BU
+#define LSM6DS3_OUTZ_L_XL                          0x2CU
+#define LSM6DS3_OUTZ_H_XL                          0x2DU
+#define LSM6DS3_SENSORHUB1_REG                     0x2EU
+typedef struct {
+  uint8_t shub1_0                     : 1;
+  uint8_t shub1_1                     : 1;
+  uint8_t shub1_2                     : 1;
+  uint8_t shub1_3                     : 1;
+  uint8_t shub1_4                     : 1;
+  uint8_t shub1_5                     : 1;
+  uint8_t shub1_6                     : 1;
+  uint8_t shub1_7                     : 1;
+} lsm6ds3_sensorhub1_reg_t;
+
+#define LSM6DS3_SENSORHUB2_REG                     0x2FU
+typedef struct {
+  uint8_t shub2_0                     : 1;
+  uint8_t shub2_1                     : 1;
+  uint8_t shub2_2                     : 1;
+  uint8_t shub2_3                     : 1;
+  uint8_t shub2_4                     : 1;
+  uint8_t shub2_5                     : 1;
+  uint8_t shub2_6                     : 1;
+  uint8_t shub2_7                     : 1;
+} lsm6ds3_sensorhub2_reg_t;
+
+#define LSM6DS3_SENSORHUB3_REG                     0x30U
+typedef struct {
+  uint8_t shub3_0                     : 1;
+  uint8_t shub3_1                     : 1;
+  uint8_t shub3_2                     : 1;
+  uint8_t shub3_3                     : 1;
+  uint8_t shub3_4                     : 1;
+  uint8_t shub3_5                     : 1;
+  uint8_t shub3_6                     : 1;
+  uint8_t shub3_7                     : 1;
+} lsm6ds3_sensorhub3_reg_t;
+
+#define LSM6DS3_SENSORHUB4_REG                     0x31U
+typedef struct {
+  uint8_t shub4_0                     : 1;
+  uint8_t shub4_1                     : 1;
+  uint8_t shub4_2                     : 1;
+  uint8_t shub4_3                     : 1;
+  uint8_t shub4_4                     : 1;
+  uint8_t shub4_5                     : 1;
+  uint8_t shub4_6                     : 1;
+  uint8_t shub4_7                     : 1;
+} lsm6ds3_sensorhub4_reg_t;
+
+#define LSM6DS3_SENSORHUB5_REG                     0x32U
+typedef struct {
+  uint8_t shub5_0                     : 1;
+  uint8_t shub5_1                     : 1;
+  uint8_t shub5_2                     : 1;
+  uint8_t shub5_3                     : 1;
+  uint8_t shub5_4                     : 1;
+  uint8_t shub5_5                     : 1;
+  uint8_t shub5_6                     : 1;
+  uint8_t shub5_7                     : 1;
+} lsm6ds3_sensorhub5_reg_t;
+
+#define LSM6DS3_SENSORHUB6_REG                     0x33U
+typedef struct {
+  uint8_t shub6_0                     : 1;
+  uint8_t shub6_1                     : 1;
+  uint8_t shub6_2                     : 1;
+  uint8_t shub6_3                     : 1;
+  uint8_t shub6_4                     : 1;
+  uint8_t shub6_5                     : 1;
+  uint8_t shub6_6                     : 1;
+  uint8_t shub6_7                     : 1;
+} lsm6ds3_sensorhub6_reg_t;
+
+#define LSM6DS3_SENSORHUB7_REG                     0x34U
+typedef struct {
+  uint8_t shub7_0                     : 1;
+  uint8_t shub7_1                     : 1;
+  uint8_t shub7_2                     : 1;
+  uint8_t shub7_3                     : 1;
+  uint8_t shub7_4                     : 1;
+  uint8_t shub7_5                     : 1;
+  uint8_t shub7_6                     : 1;
+  uint8_t shub7_7                     : 1;
+} lsm6ds3_sensorhub7_reg_t;
+
+#define LSM6DS3_SENSORHUB8_REG                     0x35U
+typedef struct {
+  uint8_t shub8_0                     : 1;
+  uint8_t shub8_1                     : 1;
+  uint8_t shub8_2                     : 1;
+  uint8_t shub8_3                     : 1;
+  uint8_t shub8_4                     : 1;
+  uint8_t shub8_5                     : 1;
+  uint8_t shub8_6                     : 1;
+  uint8_t shub8_7                     : 1;
+} lsm6ds3_sensorhub8_reg_t;
+
+#define LSM6DS3_SENSORHUB9_REG                     0x36U
+typedef struct {
+  uint8_t shub9_0                     : 1;
+  uint8_t shub9_1                     : 1;
+  uint8_t shub9_2                     : 1;
+  uint8_t shub9_3                     : 1;
+  uint8_t shub9_4                     : 1;
+  uint8_t shub9_5                     : 1;
+  uint8_t shub9_6                     : 1;
+  uint8_t shub9_7                     : 1;
+} lsm6ds3_sensorhub9_reg_t;
+
+#define LSM6DS3_SENSORHUB10_REG                    0x37U
+typedef struct {
+  uint8_t shub10_0                    : 1;
+  uint8_t shub10_1                    : 1;
+  uint8_t shub10_2                    : 1;
+  uint8_t shub10_3                    : 1;
+  uint8_t shub10_4                    : 1;
+  uint8_t shub10_5                    : 1;
+  uint8_t shub10_6                    : 1;
+  uint8_t shub10_7                    : 1;
+} lsm6ds3_sensorhub10_reg_t;
+
+#define LSM6DS3_SENSORHUB11_REG                    0x38U
+typedef struct {
+  uint8_t shub11_0                    : 1;
+  uint8_t shub11_1                    : 1;
+  uint8_t shub11_2                    : 1;
+  uint8_t shub11_3                    : 1;
+  uint8_t shub11_4                    : 1;
+  uint8_t shub11_5                    : 1;
+  uint8_t shub11_6                    : 1;
+  uint8_t shub11_7                    : 1;
+} lsm6ds3_sensorhub11_reg_t;
+
+#define LSM6DS3_SENSORHUB12_REG                    0x39U
+typedef struct {
+  uint8_t shub12_0                    : 1;
+  uint8_t shub12_1                    : 1;
+  uint8_t shub12_2                    : 1;
+  uint8_t shub12_3                    : 1;
+  uint8_t shub12_4                    : 1;
+  uint8_t shub12_5                    : 1;
+  uint8_t shub12_6                    : 1;
+  uint8_t shub12_7                    : 1;
+} lsm6ds3_sensorhub12_reg_t;
+
+#define LSM6DS3_FIFO_STATUS1                       0x3AU
+typedef struct {
+  uint8_t diff_fifo                   : 8;
+} lsm6ds3_fifo_status1_t;
+
+#define LSM6DS3_FIFO_STATUS2                       0x3BU
+typedef struct {
+  uint8_t diff_fifo                   : 4;
+  uint8_t fifo_empty                  : 1;
+  uint8_t fifo_full                   : 1;
+  uint8_t fifo_over_run               : 1;
+  uint8_t fth                         : 1;
+} lsm6ds3_fifo_status2_t;
+
+#define LSM6DS3_FIFO_STATUS3                        0x3CU
+typedef struct {
+  uint8_t fifo_pattern                : 8;
+} lsm6ds3_fifo_status3_t;
+
+#define LSM6DS3_FIFO_STATUS4                       0x3DU
+typedef struct {
+  uint8_t fifo_pattern                : 2;
+  uint8_t not_used_01                 : 6;
+} lsm6ds3_fifo_status4_t;
+
+#define LSM6DS3_FIFO_DATA_OUT_L                    0x3EU
+#define LSM6DS3_FIFO_DATA_OUT_H                    0x3FU
+#define LSM6DS3_TIMESTAMP0_REG                     0x40U
+#define LSM6DS3_TIMESTAMP1_REG                     0x41U
+#define LSM6DS3_TIMESTAMP2_REG                     0x42U
+#define LSM6DS3_STEP_TIMESTAMP_L                   0x49U
+#define LSM6DS3_STEP_TIMESTAMP_H                   0x4AU
+#define LSM6DS3_STEP_COUNTER_L                     0x4BU
+#define LSM6DS3_STEP_COUNTER_H                     0x4CU
+#define LSM6DS3_SENSORHUB13_REG                    0x4DU
+typedef struct {
+  uint8_t shub13_0                    : 1;
+  uint8_t shub13_1                    : 1;
+  uint8_t shub13_2                    : 1;
+  uint8_t shub13_3                    : 1;
+  uint8_t shub13_4                    : 1;
+  uint8_t shub13_5                    : 1;
+  uint8_t shub13_6                    : 1;
+  uint8_t shub13_7                    : 1;
+} lsm6ds3_sensorhub13_reg_t;
+
+#define LSM6DS3_SENSORHUB14_REG                    0x4EU
+typedef struct {
+  uint8_t shub14_0                    : 1;
+  uint8_t shub14_1                    : 1;
+  uint8_t shub14_2                    : 1;
+  uint8_t shub14_3                    : 1;
+  uint8_t shub14_4                    : 1;
+  uint8_t shub14_5                    : 1;
+  uint8_t shub14_6                    : 1;
+  uint8_t shub14_7                    : 1;
+} lsm6ds3_sensorhub14_reg_t;
+
+#define LSM6DS3_SENSORHUB15_REG                    0x4FU
+typedef struct {
+  uint8_t shub15_0                    : 1;
+  uint8_t shub15_1                    : 1;
+  uint8_t shub15_2                    : 1;
+  uint8_t shub15_3                    : 1;
+  uint8_t shub15_4                    : 1;
+  uint8_t shub15_5                    : 1;
+  uint8_t shub15_6                    : 1;
+  uint8_t shub15_7                    : 1;
+} lsm6ds3_sensorhub15_reg_t;
+
+#define LSM6DS3_SENSORHUB16_REG                    0x50U
+typedef struct {
+  uint8_t shub16_0                    : 1;
+  uint8_t shub16_1                    : 1;
+  uint8_t shub16_2                    : 1;
+  uint8_t shub16_3                    : 1;
+  uint8_t shub16_4                    : 1;
+  uint8_t shub16_5                    : 1;
+  uint8_t shub16_6                    : 1;
+  uint8_t shub16_7                    : 1;
+} lsm6ds3_sensorhub16_reg_t;
+
+#define LSM6DS3_SENSORHUB17_REG                    0x51U
+typedef struct {
+  uint8_t shub17_0                    : 1;
+  uint8_t shub17_1                    : 1;
+  uint8_t shub17_2                    : 1;
+  uint8_t shub17_3                    : 1;
+  uint8_t shub17_4                    : 1;
+  uint8_t shub17_5                    : 1;
+  uint8_t shub17_6                    : 1;
+  uint8_t shub17_7                    : 1;
+} lsm6ds3_sensorhub17_reg_t;
+
+#define LSM6DS3_SENSORHUB18_REG                    0x52U
+typedef struct {
+  uint8_t shub18_0                    : 1;
+  uint8_t shub18_1                    : 1;
+  uint8_t shub18_2                    : 1;
+  uint8_t shub18_3                    : 1;
+  uint8_t shub18_4                    : 1;
+  uint8_t shub18_5                    : 1;
+  uint8_t shub18_6                    : 1;
+  uint8_t shub18_7                    : 1;
+} lsm6ds3_sensorhub18_reg_t;
+
+#define LSM6DS3_FUNC_SRC                           0x53U
+typedef struct {
+  uint8_t sensor_hub_end_op           : 1;
+  uint8_t si_end_op                   : 1;
+  uint8_t not_used_01                 : 1;
+  uint8_t step_overflow               : 1;
+  uint8_t step_detected               : 1;
+  uint8_t tilt_ia                     : 1;
+  uint8_t sign_motion_ia              : 1;
+  uint8_t step_count_delta_ia         : 1;
+} lsm6ds3_func_src_t;
+
+#define LSM6DS3_TAP_CFG                            0x58U
+typedef struct {
+  uint8_t lir                         : 1;
+  uint8_t tap_z_en                    : 1;
+  uint8_t tap_y_en                    : 1;
+  uint8_t tap_x_en                    : 1;
+  uint8_t slope_fds                   : 1;
+  uint8_t tilt_en                     : 1;
+  uint8_t pedo_en                     : 1;
+  uint8_t timer_en                    : 1;
+} lsm6ds3_tap_cfg_t;
+
+#define LSM6DS3_TAP_THS_6D                         0x59U
+typedef struct {
+  uint8_t tap_ths                     : 5;
+  uint8_t sixd_ths                    : 2;
+  uint8_t d4d_en                      : 1;
+} lsm6ds3_tap_ths_6d_t;
+
+#define LSM6DS3_INT_DUR2                           0x5AU
+typedef struct {
+  uint8_t shock                       : 2;
+  uint8_t quiet                       : 2;
+  uint8_t dur                         : 4;
+} lsm6ds3_int_dur2_t;
+
+#define LSM6DS3_WAKE_UP_THS                        0x5BU
+typedef struct {
+  uint8_t wk_ths                      : 6;
+  uint8_t inactivity                  : 1;
+  uint8_t single_double_tap           : 1;
+} lsm6ds3_wake_up_ths_t;
+
+#define LSM6DS3_WAKE_UP_DUR                        0x5CU
+typedef struct {
+  uint8_t sleep_dur                   : 4;
+  uint8_t timer_hr                    : 1;
+  uint8_t wake_dur                    : 2;
+  uint8_t ff_dur                      : 1;
+} lsm6ds3_wake_up_dur_t;
+
+#define LSM6DS3_FREE_FALL                          0x5DU
+typedef struct {
+  uint8_t ff_ths                      : 3;
+  uint8_t ff_dur                      : 5;
+} lsm6ds3_free_fall_t;
+
+#define LSM6DS3_MD1_CFG                            0x5EU
+typedef struct {
+  uint8_t int1_timer                  : 1;
+  uint8_t int1_tilt                   : 1;
+  uint8_t int1_6d                     : 1;
+  uint8_t int1_double_tap             : 1;
+  uint8_t int1_ff                     : 1;
+  uint8_t int1_wu                     : 1;
+  uint8_t int1_single_tap             : 1;
+  uint8_t int1_inact_state            : 1;
+} lsm6ds3_md1_cfg_t;
+
+#define LSM6DS3_MD2_CFG                            0x5FU
+typedef struct {
+  uint8_t int2_iron                   : 1;
+  uint8_t int2_tilt                   : 1;
+  uint8_t int2_6d                     : 1;
+  uint8_t int2_double_tap             : 1;
+  uint8_t int2_ff                     : 1;
+  uint8_t int2_wu                     : 1;
+  uint8_t int2_single_tap             : 1;
+  uint8_t int2_inact_state            : 1;
+} lsm6ds3_md2_cfg_t;
+
+#define LSM6DS3_OUT_MAG_RAW_X_L                    0x66U
+#define LSM6DS3_OUT_MAG_RAW_X_H                    0x67U
+#define LSM6DS3_OUT_MAG_RAW_Y_L                    0x68U
+#define LSM6DS3_OUT_MAG_RAW_Y_H                    0x69U
+#define LSM6DS3_OUT_MAG_RAW_Z_L                    0x6AU
+#define LSM6DS3_OUT_MAG_RAW_Z_H                    0x6BU
+#define LSM6DS3_SLV0_ADD                           0x02U
+typedef struct {
+  uint8_t rw_0                        : 1;
+  uint8_t slave0_add                  : 7;
+} lsm6ds3_slv0_add_t;
+
+#define LSM6DS3_SLV0_SUBADD                        0x03U
+typedef struct {
+  uint8_t slave0_reg                  : 8;
+} lsm6ds3_slv0_subadd_t;
+
+#define LSM6DS3_SLAVE0_CONFIG                      0x04U
+typedef struct {
+  uint8_t slave0_numop                : 3;
+  uint8_t src_mode                    : 1;
+  uint8_t aux_sens_on                 : 2;
+  uint8_t slave0_rate                 : 2;
+} lsm6ds3_slave0_config_t;
+
+#define LSM6DS3_SLV1_ADD                           0x05U
+typedef struct {
+  uint8_t r_1                         : 1;
+  uint8_t slave1_add                  : 7;
+} lsm6ds3_slv1_add_t;
+
+#define LSM6DS3_SLV1_SUBADD                        0x06U
+typedef struct {
+  uint8_t slave1_reg                  : 8;
+} lsm6ds3_slv1_subadd_t;
+
+#define LSM6DS3_SLAVE1_CONFIG                      0x07U
+typedef struct {
+  uint8_t slave1_numop                : 3;
+  uint8_t not_used_01                 : 3;
+  uint8_t slave1_rate                 : 2;
+} lsm6ds3_slave1_config_t;
+
+#define LSM6DS3_SLV2_ADD                           0x08U
+typedef struct {
+  uint8_t r_2                         : 1;
+  uint8_t slave2_add                  : 7;
+} lsm6ds3_slv2_add_t;
+
+#define LSM6DS3_SLV2_SUBADD                        0x09U
+typedef struct {
+  uint8_t slave2_reg                  : 8;
+} lsm6ds3_slv2_subadd_t;
+
+#define LSM6DS3_SLAVE2_CONFIG                      0x0AU
+typedef struct {
+  uint8_t slave2_numop                : 3;
+  uint8_t not_used_01                 : 3;
+  uint8_t slave2_rate                 : 2;
+} lsm6ds3_slave2_config_t;
+
+#define LSM6DS3_SLV3_ADD                           0x0BU
+typedef struct {
+  uint8_t r_3                         : 1;
+  uint8_t slave3_add                  : 7;
+} lsm6ds3_slv3_add_t;
+
+#define LSM6DS3_SLV3_SUBADD                        0x0CU
+typedef struct {
+  uint8_t slave3_reg                  : 8;
+} lsm6ds3_slv3_subadd_t;
+
+#define LSM6DS3_SLAVE3_CONFIG                      0x0DU
+typedef struct {
+  uint8_t slave3_numop                : 3;
+  uint8_t not_used_01                 : 3;
+  uint8_t slave3_rate                 : 2;
+} lsm6ds3_slave3_config_t;
+
+#define LSM6DS3_DATAWRITE_SRC_MODE_SUB_SLV0        0x0EU
+typedef struct {
+  uint8_t slave_dataw                 : 8;
+} lsm6ds3_datawrite_src_mode_sub_slv0_t;
+
+#define LSM6DS3_PEDO_THS_REG                       0x0FU
+typedef struct {
+  uint8_t ths_min                     : 5;
+  uint8_t not_used_01                 : 2;
+  uint8_t pedo_4g                     : 1;
+} lsm6ds3_pedo_ths_reg_t;
+
+#define LSM6DS3_SM_THS                             0x13U
+typedef struct {
+  uint8_t sm_ths                      : 8;
+} lsm6ds3_sm_ths_t;
+
+#define LSM6DS3_PEDO_DEB_REG                       0x14U
+typedef struct {
+  uint8_t deb_step                    : 3;
+  uint8_t deb_time                    : 5;
+} lsm6ds3_pedo_deb_reg_t;
+
+#define LSM6DS3_STEP_COUNT_DELTA                   0x15U
+typedef struct {
+  uint8_t sc_delta                    : 8;
+} lsm6ds3_step_count_delta_t;
+
+#define LSM6DS3_MAG_SI_XX                          0x24U
+#define LSM6DS3_MAG_SI_XY                          0x25U
+#define LSM6DS3_MAG_SI_XZ                          0x26U
+#define LSM6DS3_MAG_SI_YX                          0x27U
+#define LSM6DS3_MAG_SI_YY                          0x28U
+#define LSM6DS3_MAG_SI_YZ                          0x29U
+#define LSM6DS3_MAG_SI_ZX                          0x2AU
+#define LSM6DS3_MAG_SI_ZY                          0x2BU
+#define LSM6DS3_MAG_SI_ZZ                          0x2CU
+#define LSM6DS3_MAG_OFFX_L                         0x2DU
+#define LSM6DS3_MAG_OFFX_H                         0x2EU
+#define LSM6DS3_MAG_OFFY_L                         0x2FU
+#define LSM6DS3_MAG_OFFY_H                         0x30U
+#define LSM6DS3_MAG_OFFZ_L                         0x31U
+#define LSM6DS3_MAG_OFFZ_H                         0x32U
+
+/**
+  * @defgroup LSM6DS3_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  lsm6ds3_func_cfg_access_t                  func_cfg_access;
+  lsm6ds3_sensor_sync_time_frame_t           sensor_sync_time_frame;
+  lsm6ds3_fifo_ctrl1_t                       fifo_ctrl1;
+  lsm6ds3_fifo_ctrl2_t                       fifo_ctrl2;
+  lsm6ds3_fifo_ctrl3_t                       fifo_ctrl3;
+  lsm6ds3_fifo_ctrl4_t                       fifo_ctrl4;
+  lsm6ds3_fifo_ctrl5_t                       fifo_ctrl5;
+  lsm6ds3_orient_cfg_g_t                     orient_cfg_g;
+  lsm6ds3_int1_ctrl_t                        int1_ctrl;
+  lsm6ds3_int2_ctrl_t                        int2_ctrl;
+  lsm6ds3_ctrl1_xl_t                         ctrl1_xl;
+  lsm6ds3_ctrl2_g_t                          ctrl2_g;
+  lsm6ds3_ctrl3_c_t                          ctrl3_c;
+  lsm6ds3_ctrl4_c_t                          ctrl4_c;
+  lsm6ds3_ctrl5_c_t                          ctrl5_c;
+  lsm6ds3_ctrl6_c_t                          ctrl6_c;
+  lsm6ds3_ctrl7_g_t                          ctrl7_g;
+  lsm6ds3_ctrl8_xl_t                         ctrl8_xl;
+  lsm6ds3_ctrl9_xl_t                         ctrl9_xl;
+  lsm6ds3_ctrl10_c_t                         ctrl10_c;
+  lsm6ds3_master_config_t                    master_config;
+  lsm6ds3_wake_up_src_t                      wake_up_src;
+  lsm6ds3_tap_src_t                          tap_src;
+  lsm6ds3_d6d_src_t                          d6d_src;
+  lsm6ds3_status_reg_t                       status_reg;
+  lsm6ds3_sensorhub1_reg_t                   sensorhub1_reg;
+  lsm6ds3_sensorhub2_reg_t                   sensorhub2_reg;
+  lsm6ds3_sensorhub3_reg_t                   sensorhub3_reg;
+  lsm6ds3_sensorhub4_reg_t                   sensorhub4_reg;
+  lsm6ds3_sensorhub5_reg_t                   sensorhub5_reg;
+  lsm6ds3_sensorhub6_reg_t                   sensorhub6_reg;
+  lsm6ds3_sensorhub7_reg_t                   sensorhub7_reg;
+  lsm6ds3_sensorhub8_reg_t                   sensorhub8_reg;
+  lsm6ds3_sensorhub9_reg_t                   sensorhub9_reg;
+  lsm6ds3_sensorhub10_reg_t                  sensorhub10_reg;
+  lsm6ds3_sensorhub11_reg_t                  sensorhub11_reg;
+  lsm6ds3_sensorhub12_reg_t                  sensorhub12_reg;
+  lsm6ds3_fifo_status1_t                     fifo_status1;
+  lsm6ds3_fifo_status2_t                     fifo_status2;
+  lsm6ds3_fifo_status3_t                     fifo_status3;
+  lsm6ds3_fifo_status4_t                     fifo_status4;
+  lsm6ds3_sensorhub13_reg_t                  sensorhub13_reg;
+  lsm6ds3_sensorhub14_reg_t                  sensorhub14_reg;
+  lsm6ds3_sensorhub15_reg_t                  sensorhub15_reg;
+  lsm6ds3_sensorhub16_reg_t                  sensorhub16_reg;
+  lsm6ds3_sensorhub17_reg_t                  sensorhub17_reg;
+  lsm6ds3_sensorhub18_reg_t                  sensorhub18_reg;
+  lsm6ds3_func_src_t                         func_src;
+  lsm6ds3_tap_cfg_t                          tap_cfg;
+  lsm6ds3_tap_ths_6d_t                       tap_ths_6d;
+  lsm6ds3_int_dur2_t                         int_dur2;
+  lsm6ds3_wake_up_ths_t                      wake_up_ths;
+  lsm6ds3_wake_up_dur_t                      wake_up_dur;
+  lsm6ds3_free_fall_t                        free_fall;
+  lsm6ds3_md1_cfg_t                          md1_cfg;
+  lsm6ds3_md2_cfg_t                          md2_cfg;
+  lsm6ds3_slv0_add_t                         slv0_add;
+  lsm6ds3_slv0_subadd_t                      slv0_subadd;
+  lsm6ds3_slave0_config_t                    slave0_config;
+  lsm6ds3_slv1_add_t                         slv1_add;
+  lsm6ds3_slv1_subadd_t                      slv1_subadd;
+  lsm6ds3_slave1_config_t                    slave1_config;
+  lsm6ds3_slv2_add_t                         slv2_add;
+  lsm6ds3_slv2_subadd_t                      slv2_subadd;
+  lsm6ds3_slave2_config_t                    slave2_config;
+  lsm6ds3_slv3_add_t                         slv3_add;
+  lsm6ds3_slv3_subadd_t                      slv3_subadd;
+  lsm6ds3_slave3_config_t                    slave3_config;
+  lsm6ds3_datawrite_src_mode_sub_slv0_t      datawrite_src_mode_sub_slv0;
+  lsm6ds3_pedo_ths_reg_t                     pedo_ths_reg;
+  lsm6ds3_sm_ths_t                           sm_ths;
+  lsm6ds3_pedo_deb_reg_t                     pedo_deb_reg;
+  lsm6ds3_step_count_delta_t                 step_count_delta;
+  bitwise_t                                  bitwise;
+  uint8_t                                    byte;
+} lsm6ds3_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm6ds3_read_reg(lsm6ds3_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lsm6ds3_write_reg(lsm6ds3_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lsm6ds3_from_fs2g_to_mg(int16_t lsb);
+extern float_t lsm6ds3_from_fs4g_to_mg(int16_t lsb);
+extern float_t lsm6ds3_from_fs8g_to_mg(int16_t lsb);
+extern float_t lsm6ds3_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t lsm6ds3_from_fs125dps_to_mdps(int16_t lsb);
+extern float_t lsm6ds3_from_fs250dps_to_mdps(int16_t lsb);
+extern float_t lsm6ds3_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t lsm6ds3_from_fs1000dps_to_mdps(int16_t lsb);
+extern float_t lsm6ds3_from_fs2000dps_to_mdps(int16_t lsb);
+
+extern float_t lsm6ds3_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  LSM6DS3_GY_ORIENT_XYZ = 0,
+  LSM6DS3_GY_ORIENT_XZY = 1,
+  LSM6DS3_GY_ORIENT_YXZ = 2,
+  LSM6DS3_GY_ORIENT_YZX = 3,
+  LSM6DS3_GY_ORIENT_ZXY = 4,
+  LSM6DS3_GY_ORIENT_ZYX = 5,
+} lsm6ds3_gy_orient_t;
+int32_t lsm6ds3_gy_data_orient_set(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_gy_orient_t val);
+int32_t lsm6ds3_gy_data_orient_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_gy_orient_t *val);
+
+typedef enum {
+  LSM6DS3_GY_SIGN_PPP = 0,
+  LSM6DS3_GY_SIGN_PPN = 1,
+  LSM6DS3_GY_SIGN_PNP = 2,
+  LSM6DS3_GY_SIGN_NPP = 4,
+  LSM6DS3_GY_SIGN_NNP = 6,
+  LSM6DS3_GY_SIGN_NPN = 5,
+  LSM6DS3_GY_SIGN_PNN = 3,
+  LSM6DS3_GY_SIGN_NNN = 7,
+} lsm6ds3_gy_sgn_t;
+int32_t lsm6ds3_gy_data_sign_set(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t val);
+int32_t lsm6ds3_gy_data_sign_get(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t *val);
+
+typedef enum {
+  LSM6DS3_2g  = 0,
+  LSM6DS3_16g = 1,
+  LSM6DS3_4g  = 2,
+  LSM6DS3_8g  = 3,
+} lsm6ds3_xl_fs_t;
+int32_t lsm6ds3_xl_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t val);
+int32_t lsm6ds3_xl_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t *val);
+
+typedef enum {
+  LSM6DS3_XL_ODR_OFF    = 0,
+  LSM6DS3_XL_ODR_12Hz5  = 1,
+  LSM6DS3_XL_ODR_26Hz   = 2,
+  LSM6DS3_XL_ODR_52Hz   = 3,
+  LSM6DS3_XL_ODR_104Hz  = 4,
+  LSM6DS3_XL_ODR_208Hz  = 5,
+  LSM6DS3_XL_ODR_416Hz  = 6,
+  LSM6DS3_XL_ODR_833Hz  = 7,
+  LSM6DS3_XL_ODR_1k66Hz = 8,
+  LSM6DS3_XL_ODR_3k33Hz = 9,
+  LSM6DS3_XL_ODR_6k66Hz = 10,
+} lsm6ds3_odr_xl_t;
+int32_t lsm6ds3_xl_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t val);
+int32_t lsm6ds3_xl_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t *val);
+
+typedef enum {
+  LSM6DS3_250dps   = 0,
+  LSM6DS3_125dps   = 1,
+  LSM6DS3_500dps   = 2,
+  LSM6DS3_1000dps  = 4,
+  LSM6DS3_2000dps  = 6,
+} lsm6ds3_fs_g_t;
+int32_t lsm6ds3_gy_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t val);
+int32_t lsm6ds3_gy_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t *val);
+
+typedef enum {
+  LSM6DS3_GY_ODR_OFF    = 0,
+  LSM6DS3_GY_ODR_12Hz5  = 1,
+  LSM6DS3_GY_ODR_26Hz   = 2,
+  LSM6DS3_GY_ODR_52Hz   = 3,
+  LSM6DS3_GY_ODR_104Hz  = 4,
+  LSM6DS3_GY_ODR_208Hz  = 5,
+  LSM6DS3_GY_ODR_416Hz  = 6,
+  LSM6DS3_GY_ODR_833Hz  = 7,
+  LSM6DS3_GY_ODR_1k66Hz = 8,
+} lsm6ds3_odr_g_t;
+int32_t lsm6ds3_gy_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t val);
+int32_t lsm6ds3_gy_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t *val);
+
+int32_t lsm6ds3_block_data_update_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_block_data_update_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_XL_HIGH_PERFORMANCE = 0,
+  LSM6DS3_XL_NORMAL           = 1,
+} lsm6ds3_xl_hm_mode_t;
+int32_t lsm6ds3_xl_power_mode_set(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_xl_hm_mode_t val);
+int32_t lsm6ds3_xl_power_mode_get(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_xl_hm_mode_t *val);
+
+typedef enum {
+  LSM6DS3_STAT_RND_DISABLE = 0,
+  LSM6DS3_STAT_RND_ENABLE  = 1,
+} lsm6ds3_rnd_stat_t;
+int32_t lsm6ds3_rounding_on_status_set(lsm6ds3_ctx_t *ctx,
+                                       lsm6ds3_rnd_stat_t val);
+int32_t lsm6ds3_rounding_on_status_get(lsm6ds3_ctx_t *ctx,
+                                       lsm6ds3_rnd_stat_t *val);
+
+typedef enum {
+  LSM6DS3_GY_HIGH_PERFORMANCE = 0,
+  LSM6DS3_GY_NORMAL           = 1,
+} lsm6ds3_g_hm_mode_t;
+int32_t lsm6ds3_gy_power_mode_set(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_g_hm_mode_t val);
+int32_t lsm6ds3_gy_power_mode_get(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_g_hm_mode_t *val);
+
+int32_t lsm6ds3_xl_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_xl_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_xl_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_xl_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_xl_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_xl_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_gy_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_gy_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_gy_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  lsm6ds3_wake_up_src_t  wake_up_src;
+  lsm6ds3_tap_src_t      tap_src;
+  lsm6ds3_d6d_src_t      d6d_src;
+  lsm6ds3_func_src_t     func_src;
+} lsm6ds3_all_src_t;
+int32_t lsm6ds3_all_sources_get(lsm6ds3_ctx_t *ctx, lsm6ds3_all_src_t *val);
+
+int32_t lsm6ds3_status_reg_get(lsm6ds3_ctx_t *ctx, lsm6ds3_status_reg_t *val);
+
+int32_t lsm6ds3_xl_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_gy_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_temp_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_timestamp_rst_set(lsm6ds3_ctx_t *ctx);
+
+int32_t lsm6ds3_timestamp_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_timestamp_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+typedef enum {
+  LSM6DS3_LSB_6ms4 = 0,
+  LSM6DS3_LSB_25us = 1,
+} lsm6ds3_ts_res_t;
+int32_t lsm6ds3_timestamp_res_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t val);
+int32_t lsm6ds3_timestamp_res_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t *val);
+
+typedef enum {
+  LSM6DS3_ROUND_DISABLE             = 0,
+  LSM6DS3_ROUND_XL                  = 1,
+  LSM6DS3_ROUND_GY                  = 2,
+  LSM6DS3_ROUND_GY_XL               = 3,
+  LSM6DS3_ROUND_SH1_TO_SH6          = 4,
+  LSM6DS3_ROUND_XL_SH1_TO_SH6       = 5,
+  LSM6DS3_ROUND_GY_XL_SH1_TO_SH12   = 6,
+  LSM6DS3_ROUND_GY_XL_SH1_TO_SH6    = 7,
+} lsm6ds3_rounding_t;
+int32_t lsm6ds3_rounding_mode_set(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_rounding_t val);
+int32_t lsm6ds3_rounding_mode_get(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_rounding_t *val);
+
+int32_t lsm6ds3_temperature_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_angular_rate_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_acceleration_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_fifo_raw_data_get(lsm6ds3_ctx_t *ctx, uint8_t *buffer, uint8_t len);
+
+int32_t lsm6ds3_number_of_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_mag_calibrated_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DS3_USER_BANK                                = 0,
+  LSM6DS3_EMBEDDED_FUNC_BANK                       = 1,
+} lsm6ds3_func_cfg_en_t;
+int32_t lsm6ds3_mem_bank_set(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t val);
+int32_t lsm6ds3_mem_bank_get(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t *val);
+
+int32_t lsm6ds3_device_id_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_LSB_AT_LOW_ADD = 0,
+  LSM6DS3_MSB_AT_LOW_ADD = 1,
+} lsm6ds3_ble_t;
+int32_t lsm6ds3_data_format_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t val);
+int32_t lsm6ds3_data_format_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t *val);
+
+int32_t lsm6ds3_auto_increment_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_auto_increment_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_boot_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_boot_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_XL_ST_DISABLE  = 0,
+  LSM6DS3_XL_ST_POSITIVE = 1,
+  LSM6DS3_XL_ST_NEGATIVE = 2,
+} lsm6ds3_st_xl_t;
+int32_t lsm6ds3_xl_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t val);
+int32_t lsm6ds3_xl_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t *val);
+
+typedef enum {
+  LSM6DS3_GY_ST_DISABLE  = 0,
+  LSM6DS3_GY_ST_POSITIVE = 1,
+  LSM6DS3_GY_ST_NEGATIVE = 3,
+} lsm6ds3_st_g_t;
+int32_t lsm6ds3_gy_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t val);
+int32_t lsm6ds3_gy_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t *val);
+
+int32_t lsm6ds3_filter_settling_mask_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_filter_settling_mask_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_HP_CUT_OFF_8mHz1   = 0,
+  LSM6DS3_HP_CUT_OFF_32mHz4  = 1,
+  LSM6DS3_HP_CUT_OFF_2Hz07   = 2,
+  LSM6DS3_HP_CUT_OFF_16Hz32  = 3,
+} lsm6ds3_hpcf_g_t;
+int32_t lsm6ds3_gy_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t val);
+int32_t lsm6ds3_gy_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t *val);
+
+int32_t lsm6ds3_gy_hp_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_hp_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_XL_HP_ODR_DIV_4   = 0,
+  LSM6DS3_XL_HP_ODR_DIV_100 = 1,
+  LSM6DS3_XL_HP_ODR_DIV_9   = 2,
+  LSM6DS3_XL_HP_ODR_DIV_400 = 3,
+} lsm6ds3_hp_bw_t;
+int32_t lsm6ds3_xl_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t val);
+int32_t lsm6ds3_xl_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t *val);
+
+typedef enum {
+  LSM6DS3_XL_LP_ODR_DIV_50  = 0,
+  LSM6DS3_XL_LP_ODR_DIV_100 = 1,
+  LSM6DS3_XL_LP_ODR_DIV_9   = 2,
+  LSM6DS3_XL_LP_ODR_DIV_400 = 3,
+} lsm6ds3_lp_bw_t;
+int32_t lsm6ds3_xl_lp2_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t val);
+int32_t lsm6ds3_xl_lp2_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t *val);
+
+typedef enum {
+  LSM6DS3_ANTI_ALIASING_400Hz = 0,
+  LSM6DS3_ANTI_ALIASING_200Hz = 1,
+  LSM6DS3_ANTI_ALIASING_100Hz = 2,
+  LSM6DS3_ANTI_ALIASING_50Hz  = 3,
+} lsm6ds3_bw_xl_t;
+int32_t lsm6ds3_xl_filter_analog_set(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t val);
+int32_t lsm6ds3_xl_filter_analog_get(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t *val);
+
+typedef enum {
+  LSM6DS3_SPI_4_WIRE = 0,
+  LSM6DS3_SPI_3_WIRE = 1,
+} lsm6ds3_sim_t;
+int32_t lsm6ds3_spi_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t val);
+int32_t lsm6ds3_spi_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t *val);
+
+typedef enum {
+  LSM6DS3_I2C_ENABLE  = 0,
+  LSM6DS3_I2C_DISABLE = 1,
+} lsm6ds3_i2c_dis_t;
+int32_t lsm6ds3_i2c_interface_set(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t val);
+int32_t lsm6ds3_i2c_interface_get(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t *val);
+
+typedef struct {
+  uint8_t  int1_drdy_xl         : 1;
+  uint8_t  int1_drdy_g          : 1;
+  uint8_t  int1_boot            : 1;
+  uint8_t  int1_fth             : 1;
+  uint8_t  int1_fifo_ovr        : 1;
+  uint8_t  int1_full_flag       : 1;
+  uint8_t  int1_sign_mot        : 1;
+  uint8_t  int1_step_detector   : 1;
+  uint8_t  int1_timer           : 1;
+  uint8_t  int1_tilt            : 1;
+  uint8_t  int1_6d              : 1;
+  uint8_t  int1_double_tap      : 1;
+  uint8_t  int1_ff              : 1;
+  uint8_t  int1_wu              : 1;
+  uint8_t  int1_single_tap      : 1;
+  uint8_t  int1_inact_state     : 1;
+  uint8_t  drdy_on_int1         : 1;
+} lsm6ds3_int1_route_t;
+int32_t lsm6ds3_pin_int1_route_set(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_int1_route_t *val);
+int32_t lsm6ds3_pin_int1_route_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_int1_route_t *val);
+
+typedef struct {
+  uint8_t int2_drdy_xl          : 1;
+  uint8_t int2_drdy_g           : 1;
+  uint8_t int2_drdy_temp        : 1;
+  uint8_t int2_fth              : 1;
+  uint8_t int2_fifo_ovr         : 1;
+  uint8_t int2_full_flag        : 1;
+  uint8_t int2_step_count_ov    : 1;
+  uint8_t int2_step_delta       : 1;
+  uint8_t int2_iron             : 1;
+  uint8_t int2_tilt             : 1;
+  uint8_t int2_6d               : 1;
+  uint8_t int2_double_tap       : 1;
+  uint8_t int2_ff               : 1;
+  uint8_t int2_wu               : 1;
+  uint8_t int2_single_tap       : 1;
+  uint8_t int2_inact_state      : 1;
+  uint8_t start_config          : 1;
+} lsm6ds3_int2_route_t;
+int32_t lsm6ds3_pin_int2_route_set(lsm6ds3_ctx_t *ctx, lsm6ds3_int2_route_t *val);
+int32_t lsm6ds3_pin_int2_route_get(lsm6ds3_ctx_t *ctx, lsm6ds3_int2_route_t *val);
+
+typedef enum {
+  LSM6DS3_PUSH_PULL  = 0,
+  LSM6DS3_OPEN_DRAIN = 1,
+} lsm6ds3_pp_od_t;
+int32_t lsm6ds3_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t val);
+int32_t lsm6ds3_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t *val);
+
+typedef enum {
+  LSM6DS3_ACTIVE_HIGH = 0,
+  LSM6DS3_ACTIVE_LOW  = 1,
+} lsm6ds3_pin_pol_t;
+int32_t lsm6ds3_pin_polarity_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pin_pol_t val);
+int32_t lsm6ds3_pin_polarity_get(lsm6ds3_ctx_t *ctx,  lsm6ds3_pin_pol_t *val);
+
+int32_t lsm6ds3_all_on_int1_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_all_on_int1_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_INT_PULSED  = 0,
+  LSM6DS3_INT_LATCHED = 1,
+} lsm6ds3_lir_t;
+int32_t lsm6ds3_int_notification_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t val);
+int32_t lsm6ds3_int_notification_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t *val);
+
+int32_t lsm6ds3_wkup_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_wake_up_src_t *val);
+
+int32_t lsm6ds3_wkup_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_wkup_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_wkup_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_wkup_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_gy_sleep_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_sleep_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_act_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_act_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_act_sleep_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_act_sleep_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tap_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_src_t *val);
+
+int32_t lsm6ds3_tap_detection_on_z_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_detection_on_z_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tap_detection_on_y_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_detection_on_y_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tap_detection_on_x_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_detection_on_x_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tap_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tap_shock_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_shock_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tap_quiet_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_quiet_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tap_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_ONLY_DOUBLE = 1,
+  LSM6DS3_SINGLE_DOUBLE = 0,
+} lsm6ds3_tap_md_t;
+int32_t lsm6ds3_tap_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t val);
+int32_t lsm6ds3_tap_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t *val);
+
+typedef enum {
+  LSM6DS3_ODR_DIV_2_FEED = 0,
+  LSM6DS3_LPF2_FEED = 1,
+} lsm6ds3_low_pass_on_6d_t;
+int32_t lsm6ds3_6d_feed_data_set(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_low_pass_on_6d_t val);
+int32_t lsm6ds3_6d_feed_data_get(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_low_pass_on_6d_t *val);
+
+int32_t lsm6ds3_6d_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_d6d_src_t *val);
+
+typedef enum {
+  LSM6DS3_DEG_80 = 0,
+  LSM6DS3_DEG_70 = 1,
+  LSM6DS3_DEG_60 = 2,
+  LSM6DS3_DEG_50 = 3,
+} lsm6ds3_sixd_ths_t;
+int32_t lsm6ds3_6d_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t val);
+int32_t lsm6ds3_6d_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t *val);
+
+int32_t lsm6ds3_4d_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_4d_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_156_mg = 0,
+  LSM6DS3_219_mg = 1,
+  LSM6DS3_250_mg = 2,
+  LSM6DS3_312_mg = 3,
+  LSM6DS3_344_mg = 4,
+  LSM6DS3_406_mg = 5,
+  LSM6DS3_469_mg = 6,
+  LSM6DS3_500_mg = 7,
+} lsm6ds3_ff_ths_t;
+int32_t lsm6ds3_ff_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t val);
+int32_t lsm6ds3_ff_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t *val);
+
+int32_t lsm6ds3_ff_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_ff_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_fifo_watermark_set(lsm6ds3_ctx_t *ctx, uint16_t val);
+int32_t lsm6ds3_fifo_watermark_get(lsm6ds3_ctx_t *ctx, uint16_t *val);
+
+typedef enum {
+  LSM6DS3_TRG_XL_GY_DRDY   = 0,
+  LSM6DS3_TRG_STEP_DETECT  = 1,
+} lsm6ds3_tmr_ped_fifo_drdy_t;
+int32_t lsm6ds3_fifo_write_trigger_set(lsm6ds3_ctx_t *ctx,
+                                       lsm6ds3_tmr_ped_fifo_drdy_t val);
+int32_t lsm6ds3_fifo_write_trigger_get(lsm6ds3_ctx_t *ctx,
+                                       lsm6ds3_tmr_ped_fifo_drdy_t *val);
+
+int32_t lsm6ds3_fifo_pedo_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_fifo_pedo_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_FIFO_XL_DISABLE = 0,
+  LSM6DS3_FIFO_XL_NO_DEC  = 1,
+  LSM6DS3_FIFO_XL_DEC_2   = 2,
+  LSM6DS3_FIFO_XL_DEC_3   = 3,
+  LSM6DS3_FIFO_XL_DEC_4   = 4,
+  LSM6DS3_FIFO_XL_DEC_8   = 5,
+  LSM6DS3_FIFO_XL_DEC_16  = 6,
+  LSM6DS3_FIFO_XL_DEC_32  = 7,
+} lsm6ds3_dec_fifo_xl_t;
+int32_t lsm6ds3_fifo_xl_batch_set(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_dec_fifo_xl_t val);
+int32_t lsm6ds3_fifo_xl_batch_get(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_dec_fifo_xl_t *val);
+
+typedef enum {
+  LSM6DS3_FIFO_GY_DISABLE = 0,
+  LSM6DS3_FIFO_GY_NO_DEC  = 1,
+  LSM6DS3_FIFO_GY_DEC_2   = 2,
+  LSM6DS3_FIFO_GY_DEC_3   = 3,
+  LSM6DS3_FIFO_GY_DEC_4   = 4,
+  LSM6DS3_FIFO_GY_DEC_8   = 5,
+  LSM6DS3_FIFO_GY_DEC_16  = 6,
+  LSM6DS3_FIFO_GY_DEC_32  = 7,
+} lsm6ds3_dec_fifo_gyro_t;
+int32_t lsm6ds3_fifo_gy_batch_set(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_dec_fifo_gyro_t val);
+int32_t lsm6ds3_fifo_gy_batch_get(lsm6ds3_ctx_t *ctx,
+                                  lsm6ds3_dec_fifo_gyro_t *val);
+
+typedef enum {
+  LSM6DS3_FIFO_DS3_DISABLE = 0,
+  LSM6DS3_FIFO_DS3_NO_DEC  = 1,
+  LSM6DS3_FIFO_DS3_DEC_2   = 2,
+  LSM6DS3_FIFO_DS3_DEC_3   = 3,
+  LSM6DS3_FIFO_DS3_DEC_4   = 4,
+  LSM6DS3_FIFO_DS3_DEC_8   = 5,
+  LSM6DS3_FIFO_DS3_DEC_16  = 6,
+  LSM6DS3_FIFO_DS3_DEC_32  = 7,
+} lsm6ds3_dec_ds3_fifo_t;
+int32_t lsm6ds3_fifo_dataset_3_batch_set(lsm6ds3_ctx_t *ctx,
+                                         lsm6ds3_dec_ds3_fifo_t val);
+int32_t lsm6ds3_fifo_dataset_3_batch_get(lsm6ds3_ctx_t *ctx,
+                                         lsm6ds3_dec_ds3_fifo_t *val);
+
+typedef enum {
+  LSM6DS3_FIFO_DS4_DISABLE = 0,
+  LSM6DS3_FIFO_DS4_NO_DEC  = 1,
+  LSM6DS3_FIFO_DS4_DEC_2   = 2,
+  LSM6DS3_FIFO_DS4_DEC_3   = 3,
+  LSM6DS3_FIFO_DS4_DEC_4   = 4,
+  LSM6DS3_FIFO_DS4_DEC_8   = 5,
+  LSM6DS3_FIFO_DS4_DEC_16  = 6,
+  LSM6DS3_FIFO_DS4_DEC_32  = 7,
+} lsm6ds3_dec_ds4_fifo_t;
+int32_t lsm6ds3_fifo_dataset_4_batch_set(lsm6ds3_ctx_t *ctx,
+                                         lsm6ds3_dec_ds4_fifo_t val);
+int32_t lsm6ds3_fifo_dataset_4_batch_get(lsm6ds3_ctx_t *ctx,
+                                         lsm6ds3_dec_ds4_fifo_t *val);
+
+int32_t lsm6ds3_fifo_xl_gy_8bit_format_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_fifo_xl_gy_8bit_format_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_BYPASS_MODE            = 0,
+  LSM6DS3_FIFO_MODE              = 1,
+  LSM6DS3_STREAM_TO_FIFO_MODE    = 3,
+  LSM6DS3_BYPASS_TO_STREAM_MODE  = 4,
+  LSM6DS3_STREAM_MODE            = 6,
+} lsm6ds3_fifo_md_t;
+int32_t lsm6ds3_fifo_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t val);
+int32_t lsm6ds3_fifo_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t *val);
+
+typedef enum {
+  LSM6DS3_FIFO_DISABLE = 0,
+  LSM6DS3_FIFO_12Hz5   = 1,
+  LSM6DS3_FIFO_26Hz    = 2,
+  LSM6DS3_FIFO_52Hz    = 3,
+  LSM6DS3_FIFO_104Hz   = 4,
+  LSM6DS3_FIFO_208Hz   = 5,
+  LSM6DS3_FIFO_416Hz   = 6,
+  LSM6DS3_FIFO_833Hz   = 7,
+  LSM6DS3_FIFO_1k66Hz  = 8,
+  LSM6DS3_FIFO_3k33Hz  = 9,
+  LSM6DS3_FIFO_6k66Hz  = 10,
+} lsm6ds3_odr_fifo_t;
+int32_t lsm6ds3_fifo_data_rate_set(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_odr_fifo_t val);
+int32_t lsm6ds3_fifo_data_rate_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_odr_fifo_t *val);
+
+int32_t lsm6ds3_fifo_stop_on_wtm_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_fifo_stop_on_wtm_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_fifo_temp_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_fifo_temp_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_fifo_data_level_get(lsm6ds3_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6ds3_fifo_full_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_fifo_ovr_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_fifo_wtm_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_fifo_pattern_get(lsm6ds3_ctx_t *ctx, uint16_t *val);
+
+typedef enum {
+  LSM6DS3_DEN_DISABLE    = 0,
+  LSM6DS3_LEVEL_FIFO     = 6,
+  LSM6DS3_LEVEL_LETCHED  = 3,
+  LSM6DS3_LEVEL_TRIGGER  = 2,
+  LSM6DS3_EDGE_TRIGGER   = 4,
+} lsm6ds3_den_mode_t;
+int32_t lsm6ds3_den_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t val);
+int32_t lsm6ds3_den_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t *val);
+
+int32_t lsm6ds3_pedo_step_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_step_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_pedo_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_pedo_step_detect_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_pedo_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_pedo_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_PEDO_AT_2g = 0,
+  LSM6DS3_PEDO_AT_4g = 1,
+} lsm6ds3_pedo_fs_t;
+int32_t lsm6ds3_pedo_full_scale_set(lsm6ds3_ctx_t *ctx,
+                                    lsm6ds3_pedo_fs_t val);
+int32_t lsm6ds3_pedo_full_scale_get(lsm6ds3_ctx_t *ctx,
+                                    lsm6ds3_pedo_fs_t *val);
+
+int32_t lsm6ds3_pedo_debounce_steps_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_debounce_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_pedo_timeout_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_timeout_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_motion_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_motion_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_motion_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_motion_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_motion_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_sc_delta_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_sc_delta_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tilt_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_tilt_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tilt_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_mag_soft_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_mag_soft_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_mag_hard_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_mag_hard_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_mag_soft_iron_end_op_flag_get(lsm6ds3_ctx_t *ctx,
+                                              uint8_t *val);
+
+int32_t lsm6ds3_mag_soft_iron_coeff_set(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_mag_soft_iron_coeff_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_mag_offset_set(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_mag_offset_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3_sh_sync_sens_frame_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_sh_sync_sens_frame_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_sh_master_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_sh_master_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3_sh_pass_through_set(lsm6ds3_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_sh_pass_through_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_EXT_PULL_UP      = 0,
+  LSM6DS3_INTERNAL_PULL_UP = 1,
+} lsm6ds3_sh_pin_md_t;
+int32_t lsm6ds3_sh_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t val);
+int32_t lsm6ds3_sh_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t *val);
+
+typedef enum {
+  LSM6DS3_XL_GY_DRDY      = 0,
+  LSM6DS3_EXT_ON_INT2_PIN = 1,
+} lsm6ds3_start_cfg_t;
+int32_t lsm6ds3_sh_syncro_mode_set(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_start_cfg_t val);
+int32_t lsm6ds3_sh_syncro_mode_get(lsm6ds3_ctx_t *ctx,
+                                   lsm6ds3_start_cfg_t *val);
+
+typedef struct {
+    lsm6ds3_sensorhub1_reg_t   sh_byte_1;
+    lsm6ds3_sensorhub2_reg_t   sh_byte_2;
+    lsm6ds3_sensorhub3_reg_t   sh_byte_3;
+    lsm6ds3_sensorhub4_reg_t   sh_byte_4;
+    lsm6ds3_sensorhub5_reg_t   sh_byte_5;
+    lsm6ds3_sensorhub6_reg_t   sh_byte_6;
+    lsm6ds3_sensorhub7_reg_t   sh_byte_7;
+    lsm6ds3_sensorhub8_reg_t   sh_byte_8;
+    lsm6ds3_sensorhub9_reg_t   sh_byte_9;
+    lsm6ds3_sensorhub10_reg_t  sh_byte_10;
+    lsm6ds3_sensorhub11_reg_t  sh_byte_11;
+    lsm6ds3_sensorhub12_reg_t  sh_byte_12;
+    lsm6ds3_sensorhub13_reg_t  sh_byte_13;
+    lsm6ds3_sensorhub14_reg_t  sh_byte_14;
+    lsm6ds3_sensorhub15_reg_t  sh_byte_15;
+    lsm6ds3_sensorhub16_reg_t  sh_byte_16;
+    lsm6ds3_sensorhub17_reg_t  sh_byte_17;
+    lsm6ds3_sensorhub18_reg_t  sh_byte_18;
+} lsm6ds3_sh_read_t;
+int32_t lsm6ds3_sh_read_data_raw_get(lsm6ds3_ctx_t *ctx,
+                                     lsm6ds3_sh_read_t *buff);
+
+typedef enum {
+  LSM6DS3_SLV_0        = 0,
+  LSM6DS3_SLV_0_1      = 1,
+  LSM6DS3_SLV_0_1_2    = 2,
+  LSM6DS3_SLV_0_1_2_3  = 3,
+} lsm6ds3_aux_sens_on_t;
+int32_t lsm6ds3_sh_num_of_dev_connected_set(lsm6ds3_ctx_t *ctx,
+                                            lsm6ds3_aux_sens_on_t val);
+int32_t lsm6ds3_sh_num_of_dev_connected_get(lsm6ds3_ctx_t *ctx,
+                                            lsm6ds3_aux_sens_on_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} lsm6ds3_sh_cfg_write_t;
+int32_t lsm6ds3_sh_cfg_write(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} lsm6ds3_sh_cfg_read_t;
+int32_t lsm6ds3_sh_slv0_cfg_read(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_sh_cfg_read_t *val);
+int32_t lsm6ds3_sh_slv1_cfg_read(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_sh_cfg_read_t *val);
+int32_t lsm6ds3_sh_slv2_cfg_read(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_sh_cfg_read_t *val);
+int32_t lsm6ds3_sh_slv3_cfg_read(lsm6ds3_ctx_t *ctx,
+                                 lsm6ds3_sh_cfg_read_t *val);
+
+int32_t lsm6ds3_sh_end_op_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3_USE_SLOPE = 0,
+  LSM6DS3_USE_HPF   = 1,
+} lsm6ds3_slope_fds_t;
+int32_t lsm6ds3_xl_hp_path_internal_set(lsm6ds3_ctx_t *ctx,
+                                        lsm6ds3_slope_fds_t val);
+int32_t lsm6ds3_xl_hp_path_internal_get(lsm6ds3_ctx_t *ctx,
+                                        lsm6ds3_slope_fds_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSM6DS3_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsl_STdC/driver/lsm6dsl_reg.c
+++ b/sensor/stmemsc/lsm6dsl_STdC/driver/lsm6dsl_reg.c
@@ -1,0 +1,6812 @@
+/*
+ ******************************************************************************
+ * @file    lsm6dsl_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LSM6DSL driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+#include "lsm6dsl_reg.h"
+
+/**
+  * @defgroup    LSM6DSL
+  * @brief       This file provides a set of functions needed to drive the
+  *              lsm6dsl enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_interfaces_functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsl_read_reg(lsm6dsl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsl_write_reg(lsm6dsl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lsm6dsl_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t lsm6dsl_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t lsm6dsl_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t lsm6dsl_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t lsm6dsl_from_fs125dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 4.375f);
+}
+
+float_t lsm6dsl_from_fs250dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 8.750f);
+}
+
+float_t lsm6dsl_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 17.50f);
+}
+
+float_t lsm6dsl_from_fs1000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 35.0f);
+}
+
+float_t lsm6dsl_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t lsm6dsl_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+
+/**
+  * @defgroup    LSM6DSL_data_generation
+  * @brief       This section groups all the functions concerning data
+  *              generation
+  * @{
+  *
+*/
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t val)
+{
+  lsm6dsl_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t *val)
+{
+  lsm6dsl_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.fs_xl) {
+    case LSM6DSL_2g:
+      *val = LSM6DSL_2g;
+      break;
+    case LSM6DSL_16g:
+      *val = LSM6DSL_16g;
+      break;
+    case LSM6DSL_4g:
+      *val = LSM6DSL_4g;
+      break;
+    case LSM6DSL_8g:
+      *val = LSM6DSL_8g;
+      break;
+    default:
+      *val = LSM6DSL_XL_FS_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t val)
+{
+  lsm6dsl_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.odr_xl = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t *val)
+{
+  lsm6dsl_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.odr_xl) {
+    case LSM6DSL_XL_ODR_OFF:
+      *val = LSM6DSL_XL_ODR_OFF;
+      break;
+    case LSM6DSL_XL_ODR_12Hz5:
+      *val = LSM6DSL_XL_ODR_12Hz5;
+      break;
+    case LSM6DSL_XL_ODR_26Hz:
+      *val = LSM6DSL_XL_ODR_26Hz;
+      break;
+    case LSM6DSL_XL_ODR_52Hz:
+      *val = LSM6DSL_XL_ODR_52Hz;
+      break;
+    case LSM6DSL_XL_ODR_104Hz:
+      *val = LSM6DSL_XL_ODR_104Hz;
+      break;
+    case LSM6DSL_XL_ODR_208Hz:
+      *val = LSM6DSL_XL_ODR_208Hz;
+      break;
+    case LSM6DSL_XL_ODR_416Hz:
+      *val = LSM6DSL_XL_ODR_416Hz;
+      break;
+    case LSM6DSL_XL_ODR_833Hz:
+      *val = LSM6DSL_XL_ODR_833Hz;
+      break;
+    case LSM6DSL_XL_ODR_1k66Hz:
+      *val = LSM6DSL_XL_ODR_1k66Hz;
+      break;
+    case LSM6DSL_XL_ODR_3k33Hz:
+      *val = LSM6DSL_XL_ODR_3k33Hz;
+      break;
+    case LSM6DSL_XL_ODR_6k66Hz:
+      *val = LSM6DSL_XL_ODR_6k66Hz;
+      break;
+    case LSM6DSL_XL_ODR_1Hz6:
+      *val = LSM6DSL_XL_ODR_1Hz6;
+      break;
+    default:
+      *val = LSM6DSL_XL_ODR_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope chain full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t val)
+{
+  lsm6dsl_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.fs_g = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t *val)
+{
+  lsm6dsl_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.fs_g) {
+    case LSM6DSL_250dps:
+      *val = LSM6DSL_250dps;
+      break;
+    case LSM6DSL_125dps:
+      *val = LSM6DSL_125dps;
+      break;
+    case LSM6DSL_500dps:
+      *val = LSM6DSL_500dps;
+      break;
+    case LSM6DSL_1000dps:
+      *val = LSM6DSL_1000dps;
+      break;
+    case LSM6DSL_2000dps:
+      *val = LSM6DSL_2000dps;
+      break;
+    default:
+      *val = LSM6DSL_GY_FS_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t val)
+{
+  lsm6dsl_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.odr_g = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t *val)
+{
+  lsm6dsl_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.odr_g) {
+    case LSM6DSL_GY_ODR_OFF:
+      *val = LSM6DSL_GY_ODR_OFF;
+      break;
+    case LSM6DSL_GY_ODR_12Hz5:
+      *val = LSM6DSL_GY_ODR_12Hz5;
+      break;
+    case LSM6DSL_GY_ODR_26Hz:
+      *val = LSM6DSL_GY_ODR_26Hz;
+      break;
+    case LSM6DSL_GY_ODR_52Hz:
+      *val = LSM6DSL_GY_ODR_52Hz;
+      break;
+    case LSM6DSL_GY_ODR_104Hz:
+      *val = LSM6DSL_GY_ODR_104Hz;
+      break;
+    case LSM6DSL_GY_ODR_208Hz:
+      *val = LSM6DSL_GY_ODR_208Hz;
+      break;
+    case LSM6DSL_GY_ODR_416Hz:
+      *val = LSM6DSL_GY_ODR_416Hz;
+      break;
+    case LSM6DSL_GY_ODR_833Hz:
+      *val = LSM6DSL_GY_ODR_833Hz;
+      break;
+    case LSM6DSL_GY_ODR_1k66Hz:
+      *val = LSM6DSL_GY_ODR_1k66Hz;
+      break;
+    case LSM6DSL_GY_ODR_3k33Hz:
+      *val = LSM6DSL_GY_ODR_3k33Hz;
+      break;
+    case LSM6DSL_GY_ODR_6k66Hz:
+      *val = LSM6DSL_GY_ODR_6k66Hz;
+      break;
+    default:
+      *val = LSM6DSL_GY_ODR_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_block_data_update_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_block_data_update_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers
+  *         X_OFS_USR(73h), Y_OFS_USR(74h), Z_OFS_USR(75h).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_offset_weight_set(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_usr_off_w_t val)
+{
+  lsm6dsl_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.usr_off_w = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers
+  *         X_OFS_USR(73h), Y_OFS_USR(74h), Z_OFS_USR(75h).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_offset_weight_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_usr_off_w_t *val)
+{
+  lsm6dsl_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.usr_off_w) {
+    case LSM6DSL_LSb_1mg:
+      *val = LSM6DSL_LSb_1mg;
+      break;
+    case LSM6DSL_LSb_16mg:
+      *val = LSM6DSL_LSb_16mg;
+      break;
+    default:
+      *val = LSM6DSL_WEIGHT_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode for accelerometer[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_power_mode_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_xl_hm_mode_t val)
+{
+  lsm6dsl_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.xl_hm_mode = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode for accelerometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_power_mode_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_xl_hm_mode_t *val)
+{
+  lsm6dsl_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.xl_hm_mode) {
+    case LSM6DSL_XL_HIGH_PERFORMANCE:
+      *val = LSM6DSL_XL_HIGH_PERFORMANCE;
+      break;
+    case LSM6DSL_XL_NORMAL:
+      *val = LSM6DSL_XL_NORMAL;
+      break;
+    default:
+      *val = LSM6DSL_XL_PW_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Source register rounding function on WAKE_UP_SRC (1Bh),
+  *         TAP_SRC (1Ch), D6D_SRC (1Dh), STATUS_REG (1Eh) and
+  *         FUNC_SRC1 (53h) registers in the primary interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rounding_status in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_rounding_on_status_set(lsm6dsl_ctx_t *ctx,
+                                       lsm6dsl_rounding_status_t val)
+{
+  lsm6dsl_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.rounding_status = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Source register rounding function on WAKE_UP_SRC (1Bh),
+  *         TAP_SRC (1Ch), D6D_SRC (1Dh), STATUS_REG (1Eh) and
+  *         FUNC_SRC1 (53h) registers in the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rounding_status in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_rounding_on_status_get(lsm6dsl_ctx_t *ctx,
+                                       lsm6dsl_rounding_status_t *val)
+{
+  lsm6dsl_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.rounding_status) {
+    case LSM6DSL_STAT_RND_DISABLE:
+      *val = LSM6DSL_STAT_RND_DISABLE;
+      break;
+    case LSM6DSL_STAT_RND_ENABLE:
+      *val = LSM6DSL_STAT_RND_ENABLE;
+      break;
+    default:
+      *val = LSM6DSL_STAT_RND_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode disable for gyroscope.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_power_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_g_hm_mode_t val)
+{
+  lsm6dsl_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.g_hm_mode = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode disable for gyroscope.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_power_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_g_hm_mode_t *val)
+{
+  lsm6dsl_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.g_hm_mode) {
+    case LSM6DSL_GY_HIGH_PERFORMANCE:
+      *val = LSM6DSL_GY_HIGH_PERFORMANCE;
+      break;
+    case LSM6DSL_GY_NORMAL:
+      *val = LSM6DSL_GY_NORMAL;
+      break;
+    default:
+      *val = LSM6DSL_GY_PW_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    WAKE_UP_SRC, TAP_SRC, D6D_SRC, STATUS_REG,
+  *                FUNC_SRC1, FUNC_SRC2, WRIST_TILT_IA, A_WRIST_TILT_Mask
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_all_sources_get(lsm6dsl_ctx_t *ctx,
+                                lsm6dsl_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_SRC,
+                         (uint8_t*)&(val->wake_up_src), 1);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_SRC,
+                           (uint8_t*)&(val->tap_src), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_D6D_SRC,
+                           (uint8_t*)&(val->d6d_src), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_STATUS_REG,
+                           (uint8_t*)&(val->status_reg), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_FUNC_SRC1,
+                           (uint8_t*)&(val->func_src1), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_FUNC_SRC2,
+                           (uint8_t*)&(val->func_src2), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_WRIST_TILT_IA,
+                           (uint8_t*)&(val->wrist_tilt_ia), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_B);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_A_WRIST_TILT_MASK,
+                           (uint8_t*)&(val->a_wrist_tilt_mask), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+  }
+
+  return ret;
+}
+/**
+  * @brief  The STATUS_REG register is read by the primary interface[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_status_reg_get(lsm6dsl_ctx_t *ctx, lsm6dsl_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of gda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_temp_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C.
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_usr_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsl_write_reg(ctx, LSM6DSL_X_OFS_USR, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer axis user offset correction xpressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C.
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_usr_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_X_OFS_USR, buff, 3);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_Timestamp
+  * @brief       This section groups all the functions that manage the
+  *              timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable timestamp count. The count is saved in TIMESTAMP0_REG (40h),
+  *         TIMESTAMP1_REG (41h) and TIMESTAMP2_REG (42h).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_timestamp_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.timer_en = val;
+    if ( val != 0x00U) {
+      ctrl10_c.func_en = val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable timestamp count. The count is saved in TIMESTAMP0_REG (40h),
+  *         TIMESTAMP1_REG (41h) and TIMESTAMP2_REG (42h).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_timestamp_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.timer_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp register resolution setting.
+  *         Configuration of this bit affects
+  *         TIMESTAMP0_REG(40h), TIMESTAMP1_REG(41h),
+  *         TIMESTAMP2_REG(42h), STEP_TIMESTAMP_L(49h),
+  *         STEP_TIMESTAMP_H(4Ah) and
+  *         STEP_COUNT_DELTA(15h) registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_hr in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_timestamp_res_set(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t val)
+{
+  lsm6dsl_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.timer_hr = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Timestamp register resolution setting.
+  *         Configuration of this bit affects
+  *         TIMESTAMP0_REG(40h), TIMESTAMP1_REG(41h),
+  *         TIMESTAMP2_REG(42h), STEP_TIMESTAMP_L(49h),
+  *         STEP_TIMESTAMP_H(4Ah) and
+  *         STEP_COUNT_DELTA(15h) registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of timer_hr in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_timestamp_res_get(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t *val)
+{
+  lsm6dsl_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  switch (wake_up_dur.timer_hr) {
+    case LSM6DSL_LSB_6ms4:
+      *val = LSM6DSL_LSB_6ms4;
+      break;
+    case LSM6DSL_LSB_25us:
+      *val = LSM6DSL_LSB_25us;
+      break;
+    default:
+      *val = LSM6DSL_TS_RES_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_Dataoutput
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read from output registers
+  *         through the primary interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_rounding_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t val)
+{
+  lsm6dsl_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Circular burst-mode (rounding) read from output registers
+  *         through the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_rounding_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t *val)
+{
+  lsm6dsl_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.rounding) {
+    case LSM6DSL_ROUND_DISABLE:
+      *val = LSM6DSL_ROUND_DISABLE;
+      break;
+    case LSM6DSL_ROUND_XL:
+      *val = LSM6DSL_ROUND_XL;
+      break;
+    case LSM6DSL_ROUND_GY:
+      *val = LSM6DSL_ROUND_GY;
+      break;
+    case LSM6DSL_ROUND_GY_XL:
+      *val = LSM6DSL_ROUND_GY_XL;
+      break;
+    case LSM6DSL_ROUND_SH1_TO_SH6:
+      *val = LSM6DSL_ROUND_SH1_TO_SH6;
+      break;
+    case LSM6DSL_ROUND_XL_SH1_TO_SH6:
+      *val = LSM6DSL_ROUND_XL_SH1_TO_SH6;
+      break;
+    case LSM6DSL_ROUND_GY_XL_SH1_TO_SH12:
+      *val = LSM6DSL_ROUND_GY_XL_SH1_TO_SH12;
+      break;
+    case LSM6DSL_ROUND_GY_XL_SH1_TO_SH6:
+      *val = LSM6DSL_ROUND_GY_XL_SH1_TO_SH6;
+      break;
+    default:
+      *val = LSM6DSL_ROUND_OUT_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r). L and H registers together
+  *         express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_temperature_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_angular_rate_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_acceleration_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_OUTX_L_XL, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer raw data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_calibrated_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_OUT_MAG_RAW_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Read data in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buffer Data buffer to store FIFO data.
+  * @param  len    Number of data to read from FIFO.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_raw_data_get(lsm6dsl_ctx_t *ctx, uint8_t *buffer,
+                                  uint8_t len)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_DATA_OUT_L, buffer, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub
+  *         configuration registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mem_bank_set(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t val)
+{
+  lsm6dsl_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  if(ret == 0){
+    func_cfg_access.func_cfg_en = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FUNC_CFG_ACCESS,
+                            (uint8_t*)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mem_bank_get(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t *val)
+{
+  lsm6dsl_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  switch (func_cfg_access.func_cfg_en) {
+    case LSM6DSL_USER_BANK:
+      *val = LSM6DSL_USER_BANK;
+      break;
+    case LSM6DSL_BANK_B:
+      *val = LSM6DSL_BANK_B;
+      break;
+    default:
+      *val = LSM6DSL_BANK_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_pulsed in reg DRDY_PULSE_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_data_ready_mode_set(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_drdy_pulsed_g_t val)
+{
+  lsm6dsl_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_DRDY_PULSE_CFG_G,
+                         (uint8_t*)&drdy_pulse_cfg_g, 1);
+  if(ret == 0){
+    drdy_pulse_cfg_g.drdy_pulsed = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_DRDY_PULSE_CFG_G,
+                            (uint8_t*)&drdy_pulse_cfg_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of drdy_pulsed in reg DRDY_PULSE_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_data_ready_mode_get(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_drdy_pulsed_g_t *val)
+{
+  lsm6dsl_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_DRDY_PULSE_CFG_G,
+                         (uint8_t*)&drdy_pulse_cfg_g, 1);
+  switch (drdy_pulse_cfg_g.drdy_pulsed) {
+    case LSM6DSL_DRDY_LATCHED:
+      *val = LSM6DSL_DRDY_LATCHED;
+      break;
+    case LSM6DSL_DRDY_PULSED:
+      *val = LSM6DSL_DRDY_PULSED;
+      break;
+    default:
+      *val = LSM6DSL_DRDY_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_device_id_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ble in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_data_format_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.ble = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ble in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_data_format_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t *val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.ble) {
+    case LSM6DSL_LSB_AT_LOW_ADD:
+      *val = LSM6DSL_LSB_AT_LOW_ADD;
+      break;
+    case LSM6DSL_MSB_AT_LOW_ADD:
+      *val = LSM6DSL_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LSM6DSL_DATA_FMT_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_auto_increment_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_auto_increment_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_boot_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_boot_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t val)
+{
+  lsm6dsl_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t *val)
+{
+  lsm6dsl_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.st_xl) {
+    case LSM6DSL_XL_ST_DISABLE:
+      *val = LSM6DSL_XL_ST_DISABLE;
+      break;
+    case LSM6DSL_XL_ST_POSITIVE:
+      *val = LSM6DSL_XL_ST_POSITIVE;
+      break;
+    case LSM6DSL_XL_ST_NEGATIVE:
+      *val = LSM6DSL_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSL_XL_ST_ND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t val)
+{
+  lsm6dsl_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_g = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t *val)
+{
+  lsm6dsl_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.st_g) {
+    case LSM6DSL_GY_ST_DISABLE:
+      *val = LSM6DSL_GY_ST_DISABLE;
+      break;
+    case LSM6DSL_GY_ST_POSITIVE:
+      *val = LSM6DSL_GY_ST_POSITIVE;
+      break;
+    case LSM6DSL_GY_ST_NEGATIVE:
+      *val = LSM6DSL_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSL_GY_ST_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact both accelerometer and gyro.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_filter_settling_mask_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_filter_settling_mask_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slope_fds in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_hp_path_internal_set(lsm6dsl_ctx_t *ctx,
+                                        lsm6dsl_slope_fds_t val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.slope_fds = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slope_fds in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_hp_path_internal_get(lsm6dsl_ctx_t *ctx,
+                                        lsm6dsl_slope_fds_t *val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.slope_fds) {
+    case LSM6DSL_USE_SLOPE:
+      *val = LSM6DSL_USE_SLOPE;
+      break;
+    case LSM6DSL_USE_HPF:
+      *val = LSM6DSL_USE_HPF;
+      break;
+    default:
+      *val = LSM6DSL_HP_PATH_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_accelerometer_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer in every mode.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer analog chain bandwidth selection (only for
+  *         accelerometer ODR ≥ 1.67 kHz).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bw0_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_filter_analog_set(lsm6dsl_ctx_t *ctx, lsm6dsl_bw0_xl_t val)
+{
+  lsm6dsl_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.bw0_xl = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer analog chain bandwidth selection (only for
+  *         accelerometer ODR ≥ 1.67 kHz).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of bw0_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_filter_analog_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_bw0_xl_t *val)
+{
+  lsm6dsl_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.bw0_xl) {
+    case LSM6DSL_XL_ANA_BW_1k5Hz:
+      *val = LSM6DSL_XL_ANA_BW_1k5Hz;
+      break;
+    case LSM6DSL_XL_ANA_BW_400Hz:
+      *val = LSM6DSL_XL_ANA_BW_400Hz;
+      break;
+    default:
+      *val = LSM6DSL_XL_ANA_BW_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_accelerometer_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection LPF2 is
+  *         not used.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_lp1_bandwidth_set(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_lpf1_bw_sel_t val)
+{
+  lsm6dsl_ctrl1_xl_t ctrl1_xl;
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf1_bw_sel = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+    if(ret == 0){
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+      if(ret == 0){
+        ctrl8_xl.lpf2_xl_en = 0;
+        ctrl8_xl.hp_slope_xl_en = 0;
+        ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection LPF2
+  *         is not used.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_lp1_bandwidth_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_lpf1_bw_sel_t *val)
+{
+  lsm6dsl_ctrl1_xl_t ctrl1_xl;
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if ((ctrl8_xl.lpf2_xl_en != 0x00U) ||
+        (ctrl8_xl.hp_slope_xl_en != 0x00U)){
+      *val = LSM6DSL_XL_LP1_NA;
+    }
+    else{
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+      switch ( ctrl1_xl.lpf1_bw_sel) {
+        case LSM6DSL_XL_LP1_ODR_DIV_2:
+          *val = LSM6DSL_XL_LP1_ODR_DIV_2;
+          break;
+        case LSM6DSL_XL_LP1_ODR_DIV_4:
+          *val = LSM6DSL_XL_LP1_ODR_DIV_4;
+          break;
+        default:
+          *val = LSM6DSL_XL_LP1_NA;
+          break;
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 on outputs[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of input_composite in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_lp2_bandwidth_set(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_input_composite_t val)
+{
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.input_composite = ( (uint8_t) val & 0x10U ) >> 4;
+    ctrl8_xl.hpcf_xl = (uint8_t) val & 0x03U;
+    ctrl8_xl.lpf2_xl_en = 1;
+    ctrl8_xl.hp_slope_xl_en = 0;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 on outputs[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of input_composite in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_lp2_bandwidth_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_input_composite_t *val)
+{
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if ((ctrl8_xl.lpf2_xl_en == 0x00U) ||
+        (ctrl8_xl.hp_slope_xl_en != 0x00U)){
+      *val = LSM6DSL_XL_LP_NA;
+    }
+    else{
+      switch ((ctrl8_xl.input_composite << 4) + ctrl8_xl.hpcf_xl) {
+        case LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_50:
+          *val = LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_50;
+          break;
+        case LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_100:
+          *val = LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_100;
+          break;
+        case LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_9:
+          *val = LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_9;
+          break;
+        case LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_400:
+          *val = LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_400;
+          break;
+        case LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_50:
+          *val = LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_50;
+          break;
+        case LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_100:
+          *val = LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_100;
+          break;
+        case LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_9:
+          *val = LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_9;
+          break;
+        case LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_400:
+          *val = LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_400;
+          break;
+        default:
+          *val = LSM6DSL_XL_LP_NA;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hp_ref_mode in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_reference_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.hp_ref_mode = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hp_ref_mode in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_reference_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.hp_ref_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  High pass/Slope on outputs.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hpcf_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_hp_bandwidth_set(lsm6dsl_ctx_t *ctx, lsm6dsl_hpcf_xl_t val)
+{
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.input_composite = 0;
+    ctrl8_xl.hpcf_xl = (uint8_t)val & 0x03U;
+    ctrl8_xl.hp_slope_xl_en = 1;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass/Slope on outputs.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of hpcf_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_xl_hp_bandwidth_get(lsm6dsl_ctx_t *ctx, lsm6dsl_hpcf_xl_t *val)
+{
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if (ctrl8_xl.hp_slope_xl_en == 0x00U){
+    *val = LSM6DSL_XL_HP_NA;
+  }
+  switch (ctrl8_xl.hpcf_xl) {
+    case LSM6DSL_XL_HP_ODR_DIV_4:
+      *val = LSM6DSL_XL_HP_ODR_DIV_4;
+      break;
+    case LSM6DSL_XL_HP_ODR_DIV_100:
+      *val = LSM6DSL_XL_HP_ODR_DIV_100;
+      break;
+    case LSM6DSL_XL_HP_ODR_DIV_9:
+      *val = LSM6DSL_XL_HP_ODR_DIV_9;
+      break;
+    case LSM6DSL_XL_HP_ODR_DIV_400:
+      *val = LSM6DSL_XL_HP_ODR_DIV_400;
+      break;
+    default:
+      *val = LSM6DSL_XL_HP_NA;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_gyroscope_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact gyroscope.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Gyroscope low pass path bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope filtering chain configuration.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_band_pass_set(lsm6dsl_ctx_t *ctx, lsm6dsl_lpf1_sel_g_t val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  lsm6dsl_ctrl6_c_t ctrl6_c;
+  lsm6dsl_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hpm_g  =  ( (uint8_t)val & 0x30U ) >> 4;
+    ctrl7_g.hp_en_g = ( (uint8_t)val & 0x80U ) >> 7;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+    if(ret == 0){
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+      if(ret == 0){
+        ctrl6_c.ftype = (uint8_t)val & 0x03U;
+        ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+        if(ret == 0){
+          ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C,
+                                 (uint8_t*)&ctrl4_c, 1);
+          if(ret == 0){
+            ctrl4_c.lpf1_sel_g = ( (uint8_t)val & 0x08U ) >> 3;
+            ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL4_C,
+                                    (uint8_t*)&ctrl4_c, 1);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass path bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope filtering chain
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_band_pass_get(lsm6dsl_ctx_t *ctx, lsm6dsl_lpf1_sel_g_t *val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  lsm6dsl_ctrl6_c_t ctrl6_c;
+  lsm6dsl_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+    if(ret == 0){
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+      switch ( ( ctrl7_g.hp_en_g << 7 ) + ( ctrl7_g.hpm_g << 4 ) +
+               ( ctrl4_c.lpf1_sel_g << 3) + ctrl6_c.ftype ) {
+        case LSM6DSL_HP_16mHz_LP2:
+          *val = LSM6DSL_HP_16mHz_LP2;
+          break;
+        case LSM6DSL_HP_65mHz_LP2:
+          *val = LSM6DSL_HP_65mHz_LP2;
+          break;
+        case LSM6DSL_HP_260mHz_LP2:
+          *val = LSM6DSL_HP_260mHz_LP2;
+          break;
+        case LSM6DSL_HP_1Hz04_LP2:
+          *val = LSM6DSL_HP_1Hz04_LP2;
+          break;
+        case LSM6DSL_HP_DISABLE_LP1_LIGHT:
+          *val = LSM6DSL_HP_DISABLE_LP1_LIGHT;
+          break;
+        case LSM6DSL_HP_DISABLE_LP1_NORMAL:
+          *val = LSM6DSL_HP_DISABLE_LP1_NORMAL;
+          break;
+        case LSM6DSL_HP_DISABLE_LP_STRONG:
+          *val = LSM6DSL_HP_DISABLE_LP_STRONG;
+          break;
+        case LSM6DSL_HP_DISABLE_LP1_AGGRESSIVE:
+          *val = LSM6DSL_HP_DISABLE_LP1_AGGRESSIVE;
+          break;
+        case LSM6DSL_HP_16mHz_LP1_LIGHT:
+          *val = LSM6DSL_HP_16mHz_LP1_LIGHT;
+          break;
+        case LSM6DSL_HP_65mHz_LP1_NORMAL:
+          *val = LSM6DSL_HP_65mHz_LP1_NORMAL;
+          break;
+        case LSM6DSL_HP_260mHz_LP1_STRONG:
+          *val = LSM6DSL_HP_260mHz_LP1_STRONG;
+          break;
+        case LSM6DSL_HP_1Hz04_LP1_AGGRESSIVE:
+          *val = LSM6DSL_HP_1Hz04_LP1_AGGRESSIVE;
+          break;
+        default:
+          *val = LSM6DSL_HP_GY_BAND_NA;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_serial_interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_spi_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_spi_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t *val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.sim) {
+    case LSM6DSL_SPI_4_WIRE:
+      *val = LSM6DSL_SPI_4_WIRE;
+      break;
+    case LSM6DSL_SPI_3_WIRE:
+      *val = LSM6DSL_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSL_SPI_MODE_ND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_i2c_interface_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_i2c_disable_t val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_i2c_interface_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_i2c_disable_t *val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  switch (ctrl4_c.i2c_disable) {
+    case LSM6DSL_I2C_ENABLE:
+      *val = LSM6DSL_I2C_ENABLE;
+      break;
+    case LSM6DSL_I2C_DISABLE:
+      *val = LSM6DSL_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM6DSL_I2C_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_interrupt_pins
+  * @brief       This section groups all the functions that manage
+  *              interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select the signal that need to route on int1 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    configure INT1_CTRL, MD1_CFG, CTRL4_C(den_drdy_int1),
+  *                MASTER_CONFIG(drdy_on_int1)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pin_int1_route_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_int1_route_t val)
+{
+  lsm6dsl_master_config_t master_config;
+  lsm6dsl_int1_ctrl_t int1_ctrl;
+  lsm6dsl_md1_cfg_t md1_cfg;
+  lsm6dsl_md2_cfg_t md2_cfg;
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_drdy_xl        = val.int1_drdy_xl;
+    int1_ctrl.int1_drdy_g         = val.int1_drdy_g;
+    int1_ctrl.int1_boot           = val.int1_boot;
+    int1_ctrl.int1_fth            = val.int1_fth;
+    int1_ctrl.int1_fifo_ovr       = val.int1_fifo_ovr;
+    int1_ctrl.int1_full_flag      = val.int1_full_flag;
+    int1_ctrl.int1_sign_mot       = val.int1_sign_mot;
+    int1_ctrl.int1_step_detector  = val.int1_step_detector;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+        md1_cfg.int1_timer           = val.int1_timer;
+        md1_cfg.int1_tilt            = val.int1_tilt;
+        md1_cfg.int1_6d              = val.int1_6d;
+        md1_cfg.int1_double_tap      = val.int1_double_tap;
+        md1_cfg.int1_ff              = val.int1_ff;
+        md1_cfg.int1_wu              = val.int1_wu;
+        md1_cfg.int1_single_tap      = val.int1_single_tap;
+        md1_cfg.int1_inact_state     = val.int1_inact_state;
+        ret = lsm6dsl_write_reg(ctx, LSM6DSL_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ctrl4_c.den_drdy_int1 = val.den_drdy_int1;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+     master_config.drdy_on_int1   = val.den_drdy_int1;
+     ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+    if ((val.int1_6d != 0x00U) ||
+        (val.int1_ff != 0x00U) ||
+        (val.int1_wu != 0x00U) ||
+        (val.int1_single_tap != 0x00U) ||
+        (val.int1_double_tap != 0x00U) ||
+        (val.int1_inact_state != 0x00U)||
+        (md2_cfg.int2_6d != 0x00U) ||
+        (md2_cfg.int2_ff != 0x00U) ||
+        (md2_cfg.int2_wu != 0x00U) ||
+        (md2_cfg.int2_single_tap != 0x00U) ||
+        (md2_cfg.int2_double_tap != 0x00U) ||
+        (md2_cfg.int2_inact_state!= 0x00U) ){
+      tap_cfg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){    
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    read INT1_CTRL, MD1_CFG, CTRL4_C(den_drdy_int1),
+  *                MASTER_CONFIG(drdy_on_int1)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pin_int1_route_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_int1_route_t *val)
+{
+  lsm6dsl_master_config_t master_config;
+  lsm6dsl_int1_ctrl_t int1_ctrl;
+  lsm6dsl_md1_cfg_t md1_cfg;
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    val->int1_drdy_xl       = int1_ctrl.int1_drdy_xl;
+    val->int1_drdy_g        = int1_ctrl.int1_drdy_g;
+    val->int1_boot          = int1_ctrl.int1_boot;
+    val->int1_fth           = int1_ctrl.int1_fth;
+    val->int1_fifo_ovr      = int1_ctrl.int1_fifo_ovr;
+    val->int1_full_flag     = int1_ctrl.int1_full_flag;
+    val->int1_sign_mot      = int1_ctrl.int1_sign_mot;
+    val->int1_step_detector = int1_ctrl.int1_step_detector ;
+
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+    if(ret == 0){
+    val->int1_timer       = md1_cfg.int1_timer;
+    val->int1_tilt        = md1_cfg.int1_tilt;
+    val->int1_6d          = md1_cfg.int1_6d;
+    val->int1_double_tap  = md1_cfg.int1_double_tap;
+    val->int1_ff          = md1_cfg.int1_ff;
+    val->int1_wu          = md1_cfg.int1_wu;
+    val->int1_single_tap  = md1_cfg.int1_single_tap;
+    val->int1_inact_state = md1_cfg.int1_inact_state;
+
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      if(ret == 0){
+        val->den_drdy_int1 = ctrl4_c.den_drdy_int1;
+        ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                               (uint8_t*)&master_config, 1);
+        val->den_drdy_int1 = master_config.drdy_on_int1;
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    INT2_CTRL, DRDY_PULSE_CFG(int2_wrist_tilt), MD2_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pin_int2_route_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_int2_route_t val)
+{
+  lsm6dsl_int2_ctrl_t int2_ctrl;
+  lsm6dsl_md1_cfg_t md1_cfg;
+  lsm6dsl_md2_cfg_t md2_cfg;
+  lsm6dsl_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_drdy_xl        = val.int2_drdy_xl;
+    int2_ctrl.int2_drdy_g         = val.int2_drdy_g;
+    int2_ctrl.int2_drdy_temp      = val.int2_drdy_temp;
+    int2_ctrl.int2_fth            = val.int2_fth;
+    int2_ctrl.int2_fifo_ovr       = val.int2_fifo_ovr;
+    int2_ctrl.int2_full_flag      = val.int2_full_flag;
+    int2_ctrl.int2_step_count_ov  = val.int2_step_count_ov;
+    int2_ctrl.int2_step_delta     = val.int2_step_delta;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+    md2_cfg.int2_iron              = val.int2_iron;
+    md2_cfg.int2_tilt              = val.int2_tilt;
+    md2_cfg.int2_6d                = val.int2_6d;
+    md2_cfg.int2_double_tap        = val.int2_double_tap;
+    md2_cfg.int2_ff                = val.int2_ff;
+    md2_cfg.int2_wu                = val.int2_wu;
+    md2_cfg.int2_single_tap        = val.int2_single_tap;
+    md2_cfg.int2_inact_state       = val.int2_inact_state;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_DRDY_PULSE_CFG_G,
+                           (uint8_t*)&drdy_pulse_cfg_g, 1);
+  }
+  if(ret == 0){
+    drdy_pulse_cfg_g.int2_wrist_tilt = val.int2_wrist_tilt;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_DRDY_PULSE_CFG_G,
+                            (uint8_t*)&drdy_pulse_cfg_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+    if ((md1_cfg.int1_6d != 0x00U) ||
+        (md1_cfg.int1_ff != 0x00U) ||
+        (md1_cfg.int1_wu != 0x00U) ||
+        (md1_cfg.int1_single_tap != 0x00U) ||
+        (md1_cfg.int1_double_tap != 0x00U) ||
+        (md1_cfg.int1_inact_state != 0x00U) ||
+        (val.int2_6d != 0x00U) ||
+        (val.int2_ff != 0x00U) ||
+        (val.int2_wu != 0x00U) ||
+        (val.int2_single_tap != 0x00U) ||
+        (val.int2_double_tap != 0x00U) ||
+        (val.int2_inact_state!= 0x00U) ){
+      tap_cfg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    INT2_CTRL, DRDY_PULSE_CFG(int2_wrist_tilt), MD2_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pin_int2_route_get(lsm6dsl_ctx_t *ctx,
+lsm6dsl_int2_route_t *val)
+{
+  lsm6dsl_int2_ctrl_t int2_ctrl;
+  lsm6dsl_md2_cfg_t md2_cfg;
+  lsm6dsl_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
+
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    val->int2_drdy_xl         = int2_ctrl.int2_drdy_xl;
+    val->int2_drdy_g          = int2_ctrl.int2_drdy_g;
+    val->int2_drdy_temp       = int2_ctrl.int2_drdy_temp;
+    val->int2_fth             = int2_ctrl.int2_fth;
+    val->int2_fifo_ovr        = int2_ctrl.int2_fifo_ovr;
+    val->int2_full_flag       = int2_ctrl.int2_full_flag;
+    val->int2_step_count_ov   = int2_ctrl.int2_step_count_ov;
+    val->int2_step_delta      = int2_ctrl.int2_step_delta;
+
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+    if(ret == 0){
+      val->int2_iron           = md2_cfg.int2_iron;
+      val->int2_tilt           = md2_cfg.int2_tilt;
+      val->int2_6d             = md2_cfg.int2_6d;
+      val->int2_double_tap     = md2_cfg.int2_double_tap;
+      val->int2_ff             = md2_cfg.int2_ff;
+      val->int2_wu             = md2_cfg.int2_wu;
+      val->int2_single_tap     = md2_cfg.int2_single_tap;
+      val->int2_inact_state    = md2_cfg.int2_inact_state;
+
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_DRDY_PULSE_CFG_G,
+                             (uint8_t*)&drdy_pulse_cfg_g, 1);
+      val->int2_wrist_tilt = drdy_pulse_cfg_g.int2_wrist_tilt;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t *val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.pp_od) {
+    case LSM6DSL_PUSH_PULL:
+      *val = LSM6DSL_PUSH_PULL;
+      break;
+    case LSM6DSL_OPEN_DRAIN:
+      *val = LSM6DSL_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM6DSL_PIN_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pin_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pin_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t *val)
+{
+  lsm6dsl_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.h_lactive) {
+    case LSM6DSL_ACTIVE_HIGH:
+      *val = LSM6DSL_ACTIVE_HIGH;
+      break;
+    case LSM6DSL_ACTIVE_LOW:
+      *val = LSM6DSL_ACTIVE_LOW;
+      break;
+    default:
+      *val = LSM6DSL_POLARITY_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_all_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1 = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_all_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lir in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_int_notification_set(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.lir = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lir in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_int_notification_get(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t *val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.lir) {
+    case LSM6DSL_INT_PULSED:
+      *val = LSM6DSL_INT_PULSED;
+      break;
+    case LSM6DSL_INT_LATCHED:
+      *val = LSM6DSL_INT_LATCHED;
+      break;
+    default:
+      *val = LSM6DSL_INT_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_Wake_Up_event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_wkup_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_wkup_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_wkup_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_wkup_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_Activity/Inactivity_detection
+  * @brief       This section groups all the functions concerning
+  *              activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_sleep_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.sleep = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_gy_sleep_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.sleep;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of inact_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_act_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.inact_en = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of inact_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_act_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t *val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.inact_en) {
+    case LSM6DSL_PROPERTY_DISABLE:
+      *val = LSM6DSL_PROPERTY_DISABLE;
+      break;
+    case LSM6DSL_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = LSM6DSL_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case LSM6DSL_XL_12Hz5_GY_SLEEP:
+      *val = LSM6DSL_XL_12Hz5_GY_SLEEP;
+      break;
+    case LSM6DSL_XL_12Hz5_GY_PD:
+      *val = LSM6DSL_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = LSM6DSL_ACT_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.1 LSb = 512 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_act_sleep_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_WAKE_UP_DUR,
+          (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode. 1 LSb = 512 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_act_sleep_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_tap_generator
+  * @brief       This section groups all the functions that manage the
+  *              tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read the tap / double tap source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from TAP_SRC
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_src_get(lsm6dsl_ctx_t *ctx, lsm6dsl_tap_src_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG
+  *
+  */
+int32_t lsm6dsl_tap_detection_on_z_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_z_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_detection_on_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_detection_on_y_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_y_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_detection_on_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_detection_on_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_x_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_detection_on_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_threshold_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.tap_ths = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_threshold_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.tap_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event.
+  *         The default value of these bits is 00b which corresponds to
+  *         4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_shock_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.shock = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event.
+  *         The default value of these bits is 00b which corresponds to
+  *         4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_shock_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_quiet_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.quiet = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_quiet_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,1LSB corresponds
+  *         to 32*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.dur = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,1LSB corresponds
+  *         to 32*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of
+  *                                      single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_mode_set(lsm6dsl_ctx_t *ctx,
+                             lsm6dsl_single_double_tap_t val)
+{
+  lsm6dsl_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.single_double_tap = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of single_double_tap
+  *                                      in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tap_mode_get(lsm6dsl_ctx_t *ctx,
+                             lsm6dsl_single_double_tap_t *val)
+{
+  lsm6dsl_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  switch (wake_up_ths.single_double_tap) {
+    case LSM6DSL_ONLY_SINGLE:
+      *val = LSM6DSL_ONLY_SINGLE;
+      break;
+    case LSM6DSL_BOTH_SINGLE_DOUBLE:
+      *val = LSM6DSL_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LSM6DSL_TAP_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_ Six_position_detection(6D/4D)
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  LPF2 feed 6D function selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of low_pass_on_6d in
+  *                                   reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_6d_feed_data_set(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_low_pass_on_6d_t val)
+{
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.low_pass_on_6d = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 feed 6D function selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_6d_feed_data_get(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_low_pass_on_6d_t *val)
+{
+  lsm6dsl_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  switch (ctrl8_xl.low_pass_on_6d) {
+    case LSM6DSL_ODR_DIV_2_FEED:
+      *val = LSM6DSL_ODR_DIV_2_FEED;
+      break;
+    case LSM6DSL_LPF2_FEED:
+      *val = LSM6DSL_LPF2_FEED;
+      break;
+    default:
+      *val = LSM6DSL_6D_FEED_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_6d_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t val)
+{
+  lsm6dsl_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.sixd_ths = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_6d_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t *val)
+{
+  lsm6dsl_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  switch (tap_ths_6d.sixd_ths) {
+    case LSM6DSL_DEG_80:
+      *val = LSM6DSL_DEG_80;
+      break;
+    case LSM6DSL_DEG_70:
+      *val = LSM6DSL_DEG_70;
+      break;
+    case LSM6DSL_DEG_60:
+      *val = LSM6DSL_DEG_60;
+      break;
+    case LSM6DSL_DEG_50:
+      *val = LSM6DSL_DEG_50;
+      break;
+    default:
+      *val = LSM6DSL_6D_TH_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_4d_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.d4d_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_4d_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_free_fall
+  * @brief       This section group all the functions concerning the free
+  *              fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief Free-fall duration event. 1LSb = 1 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_ff_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_wake_up_dur_t wake_up_dur;
+  lsm6dsl_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_dur = (val & 0x1FU);
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FREE_FALL, (uint8_t*)&free_fall, 1);
+    if(ret == 0){
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_DUR,
+                             (uint8_t*)&wake_up_dur, 1);
+      if(ret == 0){
+        wake_up_dur.ff_dur = (val & 0x20U) >> 5;
+        ret = lsm6dsl_write_reg(ctx, LSM6DSL_WAKE_UP_DUR,
+                                (uint8_t*)&wake_up_dur, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event. 1LSb = 1 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_ff_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_wake_up_dur_t wake_up_dur;
+  lsm6dsl_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_ff_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t val)
+{
+  lsm6dsl_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_ff_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t *val)
+{
+  lsm6dsl_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FREE_FALL, (uint8_t*)&free_fall, 1);
+  switch (free_fall.ff_ths) {
+    case LSM6DSL_FF_TSH_156mg:
+      *val = LSM6DSL_FF_TSH_156mg;
+      break;
+    case LSM6DSL_FF_TSH_219mg:
+      *val = LSM6DSL_FF_TSH_219mg;
+      break;
+    case LSM6DSL_FF_TSH_250mg:
+      *val = LSM6DSL_FF_TSH_250mg;
+      break;
+    case LSM6DSL_FF_TSH_312mg:
+      *val = LSM6DSL_FF_TSH_312mg;
+      break;
+    case LSM6DSL_FF_TSH_344mg:
+      *val = LSM6DSL_FF_TSH_344mg;
+      break;
+    case LSM6DSL_FF_TSH_406mg:
+      *val = LSM6DSL_FF_TSH_406mg;
+      break;
+    case LSM6DSL_FF_TSH_469mg:
+      *val = LSM6DSL_FF_TSH_469mg;
+      break;
+    case LSM6DSL_FF_TSH_500mg:
+      *val = LSM6DSL_FF_TSH_500mg;
+      break;
+    default:
+      *val = LSM6DSL_FF_TSH_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_fifo
+  * @brief       This section group all the functions concerning the
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_watermark_set(lsm6dsl_ctx_t *ctx, uint16_t val)
+{
+  lsm6dsl_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl1.fth = (uint8_t) (0x00FFU & val);
+    fifo_ctrl2.fth = (uint8_t) (( 0x0700U & val ) >> 8);
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+    if(ret == 0){
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_watermark_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsl_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  }
+  *val = ((uint16_t)fifo_ctrl2.fth << 8) + (uint16_t)fifo_ctrl1.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of diff_fifo in reg  FIFO_STATUS1 and
+  *                FIFO_STATUS2(diff_fifo), it is recommended to set the
+  *                BDU bit.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_data_level_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsl_fifo_status1_t fifo_status1;
+  lsm6dsl_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_STATUS1,
+                         (uint8_t*)&fifo_status1, 1);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+    *val = ( (uint16_t) fifo_status2.diff_fifo << 8) +
+             (uint16_t) fifo_status1.diff_fifo;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of watermark in reg  FIFO_STATUS2 and
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_wtm_flag_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_STATUS2, (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.waterm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO pattern.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of fifo_pattern in reg  FIFO_STATUS3 and
+  *                FIFO_STATUS4, it is recommended to set the BDU bit
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_pattern_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsl_fifo_status3_t fifo_status3;
+  lsm6dsl_fifo_status4_t fifo_status4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_STATUS3,
+                         (uint8_t*)&fifo_status3, 1);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_STATUS4,
+                           (uint8_t*)&fifo_status4, 1);
+    *val = ( (uint16_t)fifo_status4.fifo_pattern << 8) +
+             fifo_status3.fifo_pattern;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_temp_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_temp_batch_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.fifo_temp_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_temp_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_temp_batch_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.fifo_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger signal for FIFO write operation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    act on FIFO_CTRL2(timer_pedo_fifo_drdy)
+  *                and MASTER_CONFIG(data_valid_sel_fifo)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_write_trigger_set(lsm6dsl_ctx_t *ctx,
+                                       lsm6dsl_trigger_fifo_t val)
+{
+  lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.timer_pedo_fifo_drdy = (uint8_t)val & 0x01U;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+    if(ret == 0){
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+      if(ret == 0){
+        master_config.data_valid_sel_fifo = (((uint8_t)val & 0x02U) >> 1);
+        ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                                (uint8_t*)&master_config, 1);
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger signal for FIFO write operation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    act on FIFO_CTRL2(timer_pedo_fifo_drdy)
+  *                and MASTER_CONFIG(data_valid_sel_fifo)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_write_trigger_get(lsm6dsl_ctx_t *ctx,
+                                       lsm6dsl_trigger_fifo_t *val)
+{
+  lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+
+    switch ( ( fifo_ctrl2.timer_pedo_fifo_drdy << 1 ) +
+             fifo_ctrl2. timer_pedo_fifo_drdy ) {
+      case LSM6DSL_TRG_XL_GY_DRDY:
+        *val = LSM6DSL_TRG_XL_GY_DRDY;
+        break;
+      case LSM6DSL_TRG_STEP_DETECT:
+        *val = LSM6DSL_TRG_STEP_DETECT;
+        break;
+      case LSM6DSL_TRG_SH_DRDY:
+        *val = LSM6DSL_TRG_SH_DRDY;
+        break;
+      default:
+        *val = LSM6DSL_TRG_SH_ND;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enable pedometer step counter and timestamp as 4th
+  *          FIFO data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_pedo_fifo_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_set(lsm6dsl_ctx_t *ctx,
+                                                  uint8_t val)
+{
+  lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.timer_pedo_fifo_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer step counter and timestamp as 4th
+  *         FIFO data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_pedo_fifo_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_get(lsm6dsl_ctx_t *ctx,
+                                                  uint8_t *val)
+{
+  lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.timer_pedo_fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO) for
+  *         accelerometer data.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_fifo_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_xl_batch_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_dec_fifo_xl_t val)
+{
+  lsm6dsl_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_xl = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL3,
+                            (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO) for
+  *         accelerometer data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_fifo_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_xl_batch_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_dec_fifo_xl_t *val)
+{
+  lsm6dsl_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  switch (fifo_ctrl3.dec_fifo_xl) {
+    case LSM6DSL_FIFO_XL_DISABLE:
+      *val = LSM6DSL_FIFO_XL_DISABLE;
+      break;
+    case LSM6DSL_FIFO_XL_NO_DEC:
+      *val = LSM6DSL_FIFO_XL_NO_DEC;
+      break;
+    case LSM6DSL_FIFO_XL_DEC_2:
+      *val = LSM6DSL_FIFO_XL_DEC_2;
+      break;
+    case LSM6DSL_FIFO_XL_DEC_3:
+      *val = LSM6DSL_FIFO_XL_DEC_3;
+      break;
+    case LSM6DSL_FIFO_XL_DEC_4:
+      *val = LSM6DSL_FIFO_XL_DEC_4;
+      break;
+    case LSM6DSL_FIFO_XL_DEC_8:
+      *val = LSM6DSL_FIFO_XL_DEC_8;
+      break;
+    case LSM6DSL_FIFO_XL_DEC_16:
+      *val = LSM6DSL_FIFO_XL_DEC_16;
+      break;
+    case LSM6DSL_FIFO_XL_DEC_32:
+      *val = LSM6DSL_FIFO_XL_DEC_32;
+      break;
+    default:
+      *val = LSM6DSL_FIFO_XL_DEC_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_fifo_gyro in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_gy_batch_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_dec_fifo_gyro_t val)
+{
+  lsm6dsl_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_gyro = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_fifo_gyro in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_gy_batch_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_dec_fifo_gyro_t *val)
+{
+  lsm6dsl_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  switch (fifo_ctrl3.dec_fifo_gyro) {
+    case LSM6DSL_FIFO_GY_DISABLE:
+      *val = LSM6DSL_FIFO_GY_DISABLE;
+      break;
+    case LSM6DSL_FIFO_GY_NO_DEC:
+      *val = LSM6DSL_FIFO_GY_NO_DEC;
+      break;
+    case LSM6DSL_FIFO_GY_DEC_2:
+      *val = LSM6DSL_FIFO_GY_DEC_2;
+      break;
+    case LSM6DSL_FIFO_GY_DEC_3:
+      *val = LSM6DSL_FIFO_GY_DEC_3;
+      break;
+    case LSM6DSL_FIFO_GY_DEC_4:
+      *val = LSM6DSL_FIFO_GY_DEC_4;
+      break;
+    case LSM6DSL_FIFO_GY_DEC_8:
+      *val = LSM6DSL_FIFO_GY_DEC_8;
+      break;
+    case LSM6DSL_FIFO_GY_DEC_16:
+      *val = LSM6DSL_FIFO_GY_DEC_16;
+      break;
+    case LSM6DSL_FIFO_GY_DEC_32:
+      *val = LSM6DSL_FIFO_GY_DEC_32;
+      break;
+    default:
+      *val = LSM6DSL_FIFO_GY_DEC_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_ds3_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_dataset_3_batch_set(lsm6dsl_ctx_t *ctx,
+                                         lsm6dsl_dec_ds3_fifo_t val)
+{
+  lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds3_fifo = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_ds3_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_dataset_3_batch_get(lsm6dsl_ctx_t *ctx,
+                                         lsm6dsl_dec_ds3_fifo_t *val)
+{
+  lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  switch (fifo_ctrl4.dec_ds3_fifo) {
+    case LSM6DSL_FIFO_DS3_DISABLE:
+      *val = LSM6DSL_FIFO_DS3_DISABLE;
+      break;
+    case LSM6DSL_FIFO_DS3_NO_DEC:
+      *val = LSM6DSL_FIFO_DS3_NO_DEC;
+      break;
+    case LSM6DSL_FIFO_DS3_DEC_2:
+      *val = LSM6DSL_FIFO_DS3_DEC_2;
+      break;
+    case LSM6DSL_FIFO_DS3_DEC_3:
+      *val = LSM6DSL_FIFO_DS3_DEC_3;
+      break;
+    case LSM6DSL_FIFO_DS3_DEC_4:
+      *val = LSM6DSL_FIFO_DS3_DEC_4;
+      break;
+    case LSM6DSL_FIFO_DS3_DEC_8:
+      *val = LSM6DSL_FIFO_DS3_DEC_8;
+      break;
+    case LSM6DSL_FIFO_DS3_DEC_16:
+      *val = LSM6DSL_FIFO_DS3_DEC_16;
+      break;
+    case LSM6DSL_FIFO_DS3_DEC_32:
+      *val = LSM6DSL_FIFO_DS3_DEC_32;
+      break;
+    default:
+      *val = LSM6DSL_FIFO_DS3_DEC_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for fourth data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_ds4_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_dataset_4_batch_set(lsm6dsl_ctx_t *ctx,
+                                         lsm6dsl_dec_ds4_fifo_t val)
+{
+  lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds4_fifo = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO) for
+  *          fourth data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_ds4_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_dataset_4_batch_get(lsm6dsl_ctx_t *ctx,
+                                         lsm6dsl_dec_ds4_fifo_t *val)
+{
+  lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  switch (fifo_ctrl4.dec_ds4_fifo) {
+    case LSM6DSL_FIFO_DS4_DISABLE:
+      *val = LSM6DSL_FIFO_DS4_DISABLE;
+      break;
+    case LSM6DSL_FIFO_DS4_NO_DEC:
+      *val = LSM6DSL_FIFO_DS4_NO_DEC;
+      break;
+    case LSM6DSL_FIFO_DS4_DEC_2:
+      *val = LSM6DSL_FIFO_DS4_DEC_2;
+      break;
+    case LSM6DSL_FIFO_DS4_DEC_3:
+      *val = LSM6DSL_FIFO_DS4_DEC_3;
+      break;
+    case LSM6DSL_FIFO_DS4_DEC_4:
+      *val = LSM6DSL_FIFO_DS4_DEC_4;
+      break;
+    case LSM6DSL_FIFO_DS4_DEC_8:
+      *val = LSM6DSL_FIFO_DS4_DEC_8;
+      break;
+    case LSM6DSL_FIFO_DS4_DEC_16:
+      *val = LSM6DSL_FIFO_DS4_DEC_16;
+      break;
+    case LSM6DSL_FIFO_DS4_DEC_32:
+      *val = LSM6DSL_FIFO_DS4_DEC_32;
+      break;
+    default:
+      *val = LSM6DSL_FIFO_DS4_DEC_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   8-bit data storage in FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of only_high_data in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_xl_gy_8bit_format_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.only_high_data = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  8-bit data storage in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of only_high_data in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_xl_gy_8bit_format_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.only_high_data;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_stop_on_wtm_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.stop_on_fth = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_stop_on_wtm_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_mode in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t val)
+{
+  lsm6dsl_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.fifo_mode = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fifo_mode in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t *val)
+{
+  lsm6dsl_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  switch (fifo_ctrl5.fifo_mode) {
+    case LSM6DSL_BYPASS_MODE:
+      *val = LSM6DSL_BYPASS_MODE;
+      break;
+    case LSM6DSL_FIFO_MODE:
+      *val = LSM6DSL_FIFO_MODE;
+      break;
+    case LSM6DSL_STREAM_TO_FIFO_MODE:
+      *val = LSM6DSL_STREAM_TO_FIFO_MODE;
+      break;
+    case LSM6DSL_BYPASS_TO_STREAM_MODE:
+      *val = LSM6DSL_BYPASS_TO_STREAM_MODE;
+      break;
+    case LSM6DSL_STREAM_MODE:
+      *val = LSM6DSL_STREAM_MODE;
+      break;
+    default:
+      *val = LSM6DSL_FIFO_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO ODR selection, setting FIFO_MODE also.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_fifo in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_fifo_t val)
+{
+  lsm6dsl_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.odr_fifo = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO ODR selection, setting FIFO_MODE also.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_fifo in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_fifo_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_fifo_t *val)
+{
+  lsm6dsl_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  switch (fifo_ctrl5.odr_fifo) {
+    case LSM6DSL_FIFO_DISABLE:
+      *val = LSM6DSL_FIFO_DISABLE;
+      break;
+    case LSM6DSL_FIFO_12Hz5:
+      *val = LSM6DSL_FIFO_12Hz5;
+      break;
+    case LSM6DSL_FIFO_26Hz:
+      *val = LSM6DSL_FIFO_26Hz;
+      break;
+    case LSM6DSL_FIFO_52Hz:
+      *val = LSM6DSL_FIFO_52Hz;
+      break;
+    case LSM6DSL_FIFO_104Hz:
+      *val = LSM6DSL_FIFO_104Hz;
+      break;
+    case LSM6DSL_FIFO_208Hz:
+      *val = LSM6DSL_FIFO_208Hz;
+      break;
+    case LSM6DSL_FIFO_416Hz:
+      *val = LSM6DSL_FIFO_416Hz;
+      break;
+    case LSM6DSL_FIFO_833Hz:
+      *val = LSM6DSL_FIFO_833Hz;
+      break;
+    case LSM6DSL_FIFO_1k66Hz:
+      *val = LSM6DSL_FIFO_1k66Hz;
+      break;
+    case LSM6DSL_FIFO_3k33Hz:
+      *val = LSM6DSL_FIFO_3k33Hz;
+      break;
+    case LSM6DSL_FIFO_6k66Hz:
+      *val = LSM6DSL_FIFO_6k66Hz;
+      break;
+    default:
+      *val = LSM6DSL_FIFO_RATE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_DEN_functionality
+  * @brief       This section groups all the functions concerning DEN
+  *              functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_lh in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+ int32_t lsm6dsl_den_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t val)
+{
+  lsm6dsl_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.den_lh = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_lh in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t *val)
+{
+  lsm6dsl_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.den_lh) {
+    case LSM6DSL_DEN_ACT_LOW:
+      *val = LSM6DSL_DEN_ACT_LOW;
+      break;
+    case LSM6DSL_DEN_ACT_HIGH:
+      *val = LSM6DSL_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = LSM6DSL_DEN_POL_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t val)
+{
+  lsm6dsl_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.den_mode = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t *val)
+{
+  lsm6dsl_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.den_mode) {
+    case LSM6DSL_DEN_DISABLE:
+      *val = LSM6DSL_DEN_DISABLE;
+      break;
+    case LSM6DSL_LEVEL_LETCHED:
+      *val = LSM6DSL_LEVEL_LETCHED;
+      break;
+    case LSM6DSL_LEVEL_TRIGGER:
+      *val = LSM6DSL_LEVEL_TRIGGER;
+      break;
+    case LSM6DSL_EDGE_TRIGGER:
+      *val = LSM6DSL_EDGE_TRIGGER;
+      break;
+    default:
+      *val = LSM6DSL_DEN_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Extend DEN functionality to accelerometer sensor.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_xl_g in reg CTRL9_XL
+  *                             and den_xl_en in CTRL4_C.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_enable_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_xl_g = (uint8_t)val & 0x01U;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+    if(ret == 0){
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      if(ret == 0){
+        ctrl4_c.den_xl_en = (uint8_t)val & 0x02U;
+        ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Extend DEN functionality to accelerometer sensor. [get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_xl_g in reg CTRL9_XL
+  *                             and den_xl_en in CTRL4_C.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_enable_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t *val)
+{
+  lsm6dsl_ctrl4_c_t ctrl4_c;
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+    switch ( ( ctrl4_c.den_xl_en << 1) + ctrl9_xl.den_xl_g ) {
+      case LSM6DSL_STAMP_IN_GY_DATA:
+        *val = LSM6DSL_STAMP_IN_GY_DATA;
+        break;
+      case LSM6DSL_STAMP_IN_XL_DATA:
+        *val = LSM6DSL_STAMP_IN_XL_DATA;
+        break;
+      case LSM6DSL_STAMP_IN_GY_XL_DATA:
+        *val = LSM6DSL_STAMP_IN_GY_XL_DATA;
+        break;
+      default:
+        *val = LSM6DSL_DEN_STAMP_ND;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_mark_axis_z_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_z = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_mark_axis_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_mark_axis_y_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_y = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_mark_axis_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_mark_axis_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_x = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_den_mark_axis_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_Pedometer
+  * @brief       This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Reset pedometer step counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_rst_step in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_step_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.pedo_rst_step = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset pedometer step counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_rst_step in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_step_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.pedo_rst_step;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer algorithm.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.pedo_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  pedo_sens:   Enable pedometer algorithm.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.pedo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Minimum threshold to detect a peak. Default is 10h.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ths_min in reg
+  *                      CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+       config_pedo_ths_min.ths_min = val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_CONFIG_PEDO_THS_MIN,
+                              (uint8_t*)&config_pedo_ths_min, 1);
+        if(ret == 0){
+          ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+        }
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  Minimum threshold to detect a peak. Default is 10h.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ths_min in reg  CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+    ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+    if(ret == 0){
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_CONFIG_PEDO_THS_MIN,
+                             (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+        *val =  config_pedo_ths_min.ths_min;
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  pedo_full_scale:   Pedometer data range.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_fs in
+  *                            reg CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pedo_fs_t val)
+{
+  lsm6dsl_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+    if(ret == 0){
+       config_pedo_ths_min.pedo_fs = (uint8_t) val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_CONFIG_PEDO_THS_MIN,
+                              (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer data range.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pedo_fs in
+  *                            reg CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pedo_fs_t *val)
+{
+  lsm6dsl_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+    if(ret == 0){
+      switch (config_pedo_ths_min.pedo_fs) {
+         case LSM6DSL_PEDO_AT_2g:
+          *val = LSM6DSL_PEDO_AT_2g;
+          break;
+        case LSM6DSL_PEDO_AT_4g:
+          *val = LSM6DSL_PEDO_AT_4g;
+          break;
+        default:
+          *val = LSM6DSL_PEDO_FS_ND;
+          break;
+      }
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_step in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_debounce_steps_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      pedo_deb_reg.deb_step = val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_PEDO_DEB_REG,
+                              (uint8_t*)&pedo_deb_reg, 1);
+        if(ret == 0){
+          ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+        }
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_step in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_debounce_steps_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+      if(ret == 0){
+        *val = pedo_deb_reg.deb_step;
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+
+  return ret;
+}
+
+/**
+  * @brief  Debounce time. If the time between two consecutive steps is
+  *         greater than  DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_time in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_timeout_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      pedo_deb_reg.deb_time = val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_PEDO_DEB_REG,
+                              (uint8_t*)&pedo_deb_reg, 1);
+      if(ret == 0){
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Debounce time. If the time between two consecutive steps is
+  *         greater than  DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_time in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_timeout_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      *val = pedo_deb_reg.deb_time;
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_steps_period_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_STEP_COUNT_DELTA, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_pedo_steps_period_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_STEP_COUNT_DELTA, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_significant_motion
+  * @brief       This section groups all the functions that manage the
+  *              significant motion detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable significant motion detection function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sign_motion_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_motion_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.sign_motion_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable significant motion detection function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sign_motion_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_motion_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.sign_motion_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Significant motion threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that store significant motion threshold.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_motion_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SM_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Significant motion threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that store significant motion threshold.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_motion_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SM_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_tilt_detection
+  * @brief       This section groups all the functions that manage the tilt
+  *              event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.tilt_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.tilt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_wrist_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.wrist_tilt_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_wrist_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.wrist_tilt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt latency register (r/w).
+  *         Absolute wrist tilt latency parameters.
+  *         1 LSB = 40 ms. Default value: 0Fh (600 ms).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tilt_latency_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_A_WRIST_TILT_LAT, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt latency register (r/w).
+  *         Absolute wrist tilt latency parameters.
+  *         1 LSB = 40 ms. Default value: 0Fh (600 ms).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tilt_latency_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_A_WRIST_TILT_LAT, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt threshold register(r/w).
+  *         Absolute wrist tilt threshold parameters.
+  *         1 LSB = 15.625 mg.Default value: 20h (500 mg).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tilt_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_A_WRIST_TILT_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt threshold register(r/w).
+  *         Absolute wrist tilt threshold parameters.
+  *         1 LSB = 15.625 mg.Default value: 20h (500 mg).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tilt_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_A_WRIST_TILT_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt mask register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers A_WRIST_TILT_MASK
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tilt_src_set(lsm6dsl_ctx_t *ctx,
+                             lsm6dsl_a_wrist_tilt_mask_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_A_WRIST_TILT_MASK,
+                           (uint8_t*) val, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt mask register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers A_WRIST_TILT_MASK
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_tilt_src_get(lsm6dsl_ctx_t *ctx,
+                             lsm6dsl_a_wrist_tilt_mask_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_A_WRIST_TILT_MASK,
+                           (uint8_t*) val, 1);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_ magnetometer_sensor
+  * @brief       This section groups all the functions that manage additional
+  *              magnetometer sensor.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable soft-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of soft_en in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_soft_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.soft_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable soft-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of soft_en in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_soft_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.soft_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable hard-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of iron_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_hard_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_master_config_t master_config;
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.iron_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+    if(ret == 0){
+      ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+      if(ret == 0){
+        if (val != 0x00U) {
+          ctrl10_c.func_en = val;
+        }
+        ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL10_C,
+                                (uint8_t*)&ctrl10_c, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable hard-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of iron_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_hard_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.iron_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Soft iron 3x3 matrix. Value are expressed in sign-module format.
+  *         (Es. SVVVVVVVb where S is the sign 0/+1/- and V is the value).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_soft_iron_mat_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MAG_SI_XX, buff, 9);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft iron 3x3 matrix. Value are expressed in sign-module format.
+  *         (Es. SVVVVVVVb where S is the sign 0/+1/- and V is the value).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_soft_iron_mat_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MAG_SI_XX, buff, 9);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w). The value is
+  *         expressed as a 16-bit word in two’s complement.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MAG_OFFX_L, buff, 6);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register(r/w).
+  *         The value is expressed as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_mag_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_MAG_OFFX_L, buff, 6);
+    if(ret == 0){
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSL_Sensor_hub
+  * @brief       This section groups all the functions that manage the sensor
+  *              hub functionality.
+  * @{
+  *
+  */
+
+  /**
+  * @brief  Enable function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values func_en
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_func_en_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.func_en = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame with the step of 500 ms and
+  *         full range of 5s. Unsigned 8-bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tph in reg SENSOR_SYNC_TIME_FRAME
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_sync_sens_frame_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_sensor_sync_time_frame_t sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_SENSOR_SYNC_TIME_FRAME,
+                         (uint8_t*)&sensor_sync_time_frame, 1);
+  if(ret == 0){
+     sensor_sync_time_frame.tph = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SENSOR_SYNC_TIME_FRAME,
+                            (uint8_t*)&sensor_sync_time_frame, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame with the step of 500 ms and
+  *         full range of 5s. Unsigned 8-bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tph in reg  SENSOR_SYNC_TIME_FRAME
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_sync_sens_frame_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_sensor_sync_time_frame_t sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_SENSOR_SYNC_TIME_FRAME,
+                         (uint8_t*)&sensor_sync_time_frame, 1);
+  *val =  sensor_sync_time_frame.tph;
+
+  return ret;
+}
+
+/**
+  * @brief  Resolution ratio of error code for sensor synchronization.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rr in reg  SENSOR_SYNC_RES_RATIO
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_sync_sens_ratio_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t val)
+{
+  lsm6dsl_sensor_sync_res_ratio_t sensor_sync_res_ratio;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_SENSOR_SYNC_RES_RATIO,
+                              (uint8_t*)&sensor_sync_res_ratio, 1);
+  if(ret == 0){
+    sensor_sync_res_ratio.rr = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SENSOR_SYNC_RES_RATIO,
+                            (uint8_t*)&sensor_sync_res_ratio, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resolution ratio of error code for sensor synchronization.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rr in reg  SENSOR_SYNC_RES_RATIO
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_sync_sens_ratio_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t *val)
+{
+  lsm6dsl_sensor_sync_res_ratio_t sensor_sync_res_ratio;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_SENSOR_SYNC_RES_RATIO,
+                         (uint8_t*)&sensor_sync_res_ratio, 1);
+
+  switch ( sensor_sync_res_ratio.rr) {
+    case LSM6DSL_RES_RATIO_2_11:
+      *val = LSM6DSL_RES_RATIO_2_11;
+      break;
+    case LSM6DSL_RES_RATIO_2_12:
+      *val = LSM6DSL_RES_RATIO_2_12;
+      break;
+    case LSM6DSL_RES_RATIO_2_13:
+      *val = LSM6DSL_RES_RATIO_2_13;
+      break;
+    case LSM6DSL_RES_RATIO_2_14:
+      *val = LSM6DSL_RES_RATIO_2_14;
+      break;
+    default:
+      *val = LSM6DSL_RES_RATIO_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_master_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.master_on = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_master_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.master_on;
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_pass_through_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pass_through_mode = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_pass_through_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.pass_through_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable/disable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pull_up_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pull_up_en = (uint8_t) val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable/disable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pull_up_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t *val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  switch (master_config.pull_up_en) {
+    case LSM6DSL_EXT_PULL_UP:
+      *val = LSM6DSL_EXT_PULL_UP;
+      break;
+    case LSM6DSL_INTERNAL_PULL_UP:
+      *val = LSM6DSL_INTERNAL_PULL_UP;
+      break;
+    default:
+      *val = LSM6DSL_SH_PIN_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_syncro_mode_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_start_config_t val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.start_config = (uint8_t)val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_syncro_mode_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_start_config_t *val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  switch (master_config.start_config) {
+    case LSM6DSL_XL_GY_DRDY:
+      *val = LSM6DSL_XL_GY_DRDY;
+      break;
+    case LSM6DSL_EXT_ON_INT2_PIN:
+      *val = LSM6DSL_EXT_ON_INT2_PIN;
+      break;
+    default:
+      *val = LSM6DSL_SH_SYNCRO_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Manage the Master DRDY signal on INT1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_on_int1 in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_drdy_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.drdy_on_int1 = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Manage the Master DRDY signal on INT1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_on_int1 in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_drdy_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.drdy_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from SENSORHUB1_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_read_data_raw_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_emb_sh_read_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_SENSORHUB1_REG,
+                         (uint8_t*)&(val->sh_byte_1), 12);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SENSORHUB13_REG,
+                           (uint8_t*)&(val->sh_byte_13), 6);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master command code used for stamping for sensor sync.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_cmd_code in
+  *                reg MASTER_CMD_CODE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_cmd_sens_sync_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_master_cmd_code_t master_cmd_code;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CMD_CODE,
+                         (uint8_t*)&master_cmd_code, 1);
+  if(ret == 0){
+    master_cmd_code.master_cmd_code = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_MASTER_CMD_CODE,
+                            (uint8_t*)&master_cmd_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master command code used for stamping for sensor sync.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_cmd_code in
+  *                reg MASTER_CMD_CODE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_cmd_sens_sync_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_master_cmd_code_t master_cmd_code;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_MASTER_CMD_CODE,
+                         (uint8_t*)&master_cmd_code, 1);
+  *val = master_cmd_code.master_cmd_code;
+
+  return ret;
+}
+
+/**
+  * @brief  Error code used for sensor synchronization.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of error_code in
+  *                reg SENS_SYNC_SPI_ERROR_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_spi_sync_error_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsl_sens_sync_spi_error_code_t sens_sync_spi_error_code;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_SENS_SYNC_SPI_ERROR_CODE,
+                         (uint8_t*)&sens_sync_spi_error_code, 1);
+  if(ret == 0){
+     sens_sync_spi_error_code.error_code = val;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SENS_SYNC_SPI_ERROR_CODE,
+                            (uint8_t*)&sens_sync_spi_error_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Error code used for sensor synchronization.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of error_code in
+  *                reg SENS_SYNC_SPI_ERROR_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_spi_sync_error_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsl_sens_sync_spi_error_code_t sens_sync_spi_error_code;
+  int32_t ret;
+
+  ret = lsm6dsl_read_reg(ctx, LSM6DSL_SENS_SYNC_SPI_ERROR_CODE,
+                         (uint8_t*)&sens_sync_spi_error_code, 1);
+  *val =  sens_sync_spi_error_code.error_code;
+
+  return ret;
+}
+
+/**
+  * @brief   Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of aux_sens_on in reg SLAVE0_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_num_of_dev_connected_set(lsm6dsl_ctx_t *ctx,
+                                            lsm6dsl_aux_sens_on_t val)
+{
+  lsm6dsl_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      slave0_config.aux_sens_on = (uint8_t) val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE0_CONFIG,
+                              (uint8_t*)&slave0_config, 1);
+      if(ret == 0){
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of aux_sens_on in reg SLAVE0_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_num_of_dev_connected_get(lsm6dsl_ctx_t *ctx,
+                                            lsm6dsl_aux_sens_on_t *val)
+{
+  lsm6dsl_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE0_CONFIG, 
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      switch (slave0_config.aux_sens_on) {
+        case LSM6DSL_SLV_0:
+          *val = LSM6DSL_SLV_0;
+          break;
+        case LSM6DSL_SLV_0_1:
+          *val = LSM6DSL_SLV_0_1;
+          break;
+        case LSM6DSL_SLV_0_1_2:
+          *val = LSM6DSL_SLV_0_1_2;
+          break;
+        case LSM6DSL_SLV_0_1_2_3:
+          *val = LSM6DSL_SLV_0_1_2_3;
+          break;
+        default:
+          *val = LSM6DSL_SLV_EN_ND;
+          break;
+      }
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_data;   8 bit data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_cfg_write(lsm6dsl_ctx_t *ctx, lsm6dsl_sh_cfg_write_t *val)
+{
+  lsm6dsl_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv0_add;
+    slv0_add.rw_0 = 0;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+    if(ret == 0){
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV0_SUBADD,
+                              &(val->slv0_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsl_write_reg(ctx, LSM6DSL_DATAWRITE_SRC_MODE_SUB_SLV0,
+                                &(val->slv0_data), 1);
+        if(ret == 0){
+          ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slv0_cfg_read(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_sh_cfg_read_t *val)
+{
+  lsm6dsl_slave0_config_t slave0_config;
+  lsm6dsl_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv_add;
+    slv0_add.rw_0 = 1;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+    if(ret == 0){
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV0_SUBADD,
+                              &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE0_CONFIG,
+                               (uint8_t*)&slave0_config, 1);
+        slave0_config.slave0_numop = val->slv_len;
+        if(ret == 0){
+          ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE0_CONFIG,
+                                  (uint8_t*)&slave0_config, 1);
+          if(ret == 0){
+            ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 1 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slv1_cfg_read(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_sh_cfg_read_t *val)
+{
+  lsm6dsl_slave1_config_t slave1_config;
+  lsm6dsl_slv1_add_t slv1_add;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    slv1_add.slave1_add  = val->slv_add;
+    slv1_add.r_1 = 1;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV1_ADD, (uint8_t*)&slv1_add, 1);
+    if(ret == 0){
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV1_SUBADD,
+                                   &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE1_CONFIG,
+                               (uint8_t*)&slave1_config, 1);
+        slave1_config.slave1_numop = val->slv_len;
+        if(ret == 0){
+          ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE1_CONFIG,
+                                  (uint8_t*)&slave1_config, 1);
+          if(ret == 0){
+            ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 2 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slv2_cfg_read(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_sh_cfg_read_t *val)
+{
+  lsm6dsl_slv2_add_t slv2_add;
+  lsm6dsl_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    slv2_add.slave2_add  = val->slv_add;
+    slv2_add.r_2 = 1;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV2_ADD, (uint8_t*)&slv2_add, 1);
+    if(ret == 0){
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV2_SUBADD,
+                              &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE2_CONFIG,
+                               (uint8_t*)&slave2_config, 1);
+        if(ret == 0){
+          slave2_config.slave2_numop = val->slv_len;
+          ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE2_CONFIG,
+                                  (uint8_t*)&slave2_config, 1);
+          if(ret == 0){
+            ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 3 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slv3_cfg_read(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_sh_cfg_read_t *val)
+{
+  lsm6dsl_slave3_config_t slave3_config;
+  lsm6dsl_slv3_add_t slv3_add;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    slv3_add.slave3_add  = val->slv_add;
+    slv3_add.r_3 = 1;
+    ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV3_ADD, (uint8_t*)&slv3_add, 1);
+    if(ret == 0){
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLV3_SUBADD,
+                              (uint8_t*)&(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE3_CONFIG,
+                               (uint8_t*)&slave3_config, 1);
+        if(ret == 0){
+          slave3_config.slave3_numop = val->slv_len;
+          ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE3_CONFIG,
+                                  (uint8_t*)&slave3_config, 1);
+          if(ret == 0){
+            ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 0 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave0_rate in reg SLAVE0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slave_0_dec_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave0_rate_t val)
+{
+  lsm6dsl_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      slave0_config.slave0_rate = (uint8_t) val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE0_CONFIG,
+                              (uint8_t*)&slave0_config, 1);
+      if(ret == 0){
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 0 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave0_rate in reg SLAVE0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slave_0_dec_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave0_rate_t *val)
+{
+  lsm6dsl_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE0_CONFIG, 
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      switch (slave0_config.slave0_rate) {
+        case LSM6DSL_SL0_NO_DEC:
+          *val = LSM6DSL_SL0_NO_DEC;
+          break;
+        case LSM6DSL_SL0_DEC_2:
+          *val = LSM6DSL_SL0_DEC_2;
+          break;
+        case LSM6DSL_SL0_DEC_4:
+          *val = LSM6DSL_SL0_DEC_4;
+          break;
+        case LSM6DSL_SL0_DEC_8:
+          *val = LSM6DSL_SL0_DEC_8;
+          break;
+        default:
+          *val = LSM6DSL_SL0_DEC_ND;
+          break;
+      }
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.
+  *         This is effective if the Aux_sens_on[1:0] field in
+  *         SLAVE0_CONFIG(04h) is set to a value other than 00.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of write_once in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_write_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_write_once_t val)
+{
+  lsm6dsl_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE1_CONFIG,
+                           (uint8_t*)&slave1_config, 1);
+    slave1_config.write_once = (uint8_t) val;
+    if(ret == 0){
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE1_CONFIG,
+                              (uint8_t*)&slave1_config, 1);
+      if(ret == 0){
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.
+  *         This is effective if the Aux_sens_on[1:0] field in
+  *         SLAVE0_CONFIG(04h) is set to a value other than 00.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of write_once in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_write_mode_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_write_once_t *val)
+{
+  lsm6dsl_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE1_CONFIG, 
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      switch (slave1_config.write_once) {
+        case LSM6DSL_EACH_SH_CYCLE:
+          *val = LSM6DSL_EACH_SH_CYCLE;
+          break;
+        case LSM6DSL_ONLY_FIRST_CYCLE:
+          *val = LSM6DSL_ONLY_FIRST_CYCLE;
+          break;
+        default:
+          *val = LSM6DSL_SH_WR_MODE_ND;
+          break;
+      }
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 1 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave1_rate in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slave_1_dec_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave1_rate_t val)
+{
+  lsm6dsl_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE1_CONFIG, 
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      slave1_config.slave1_rate = (uint8_t) val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE1_CONFIG, 
+                              (uint8_t*)&slave1_config, 1);
+      if(ret == 0){
+          ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 1 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slave_1_dec_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave1_rate_t *val)
+{
+  lsm6dsl_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE1_CONFIG, 
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      switch (slave1_config.slave1_rate) {
+        case LSM6DSL_SL1_NO_DEC:
+          *val = LSM6DSL_SL1_NO_DEC;
+          break;
+        case LSM6DSL_SL1_DEC_2:
+          *val = LSM6DSL_SL1_DEC_2;
+          break;
+        case LSM6DSL_SL1_DEC_4:
+          *val = LSM6DSL_SL1_DEC_4;
+          break;
+        case LSM6DSL_SL1_DEC_8:
+          *val = LSM6DSL_SL1_DEC_8;
+          break;
+        default:
+          *val = LSM6DSL_SL1_DEC_ND;
+          break;
+      }
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 2 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave2_rate in reg SLAVE2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slave_2_dec_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave2_rate_t val)
+{
+  lsm6dsl_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE2_CONFIG, 
+                           (uint8_t*)&slave2_config, 1);
+    if(ret == 0){
+      slave2_config.slave2_rate =(uint8_t) val;
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE2_CONFIG, 
+                              (uint8_t*)&slave2_config, 1);
+      if(ret == 0){
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 2 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave2_rate in reg SLAVE2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slave_2_dec_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave2_rate_t *val)
+{
+  lsm6dsl_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE2_CONFIG, 
+                           (uint8_t*)&slave2_config, 1);
+    if(ret == 0){
+      switch (slave2_config.slave2_rate) {
+        case LSM6DSL_SL2_NO_DEC:
+          *val = LSM6DSL_SL2_NO_DEC;
+          break;
+        case LSM6DSL_SL2_DEC_2:
+          *val = LSM6DSL_SL2_DEC_2;
+          break;
+        case LSM6DSL_SL2_DEC_4:
+          *val = LSM6DSL_SL2_DEC_4;
+          break;
+        case LSM6DSL_SL2_DEC_8:
+          *val = LSM6DSL_SL2_DEC_8;
+          break;
+        default:
+          *val = LSM6DSL_SL2_DEC_ND;
+          break;
+      }
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 3 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave3_rate in reg SLAVE3_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slave_3_dec_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave3_rate_t val)
+{
+  lsm6dsl_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE3_CONFIG, 
+                           (uint8_t*)&slave3_config, 1);
+    slave3_config.slave3_rate = (uint8_t)val;
+    if(ret == 0){
+      ret = lsm6dsl_write_reg(ctx, LSM6DSL_SLAVE3_CONFIG, 
+                              (uint8_t*)&slave3_config, 1);
+      if(ret == 0){
+        ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 3 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave3_rate in reg SLAVE3_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsl_sh_slave_3_dec_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave3_rate_t *val)
+{
+  lsm6dsl_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsl_read_reg(ctx, LSM6DSL_SLAVE3_CONFIG, 
+                           (uint8_t*)&slave3_config, 1);
+    if(ret == 0){
+      switch (slave3_config.slave3_rate) {
+        case LSM6DSL_SL3_NO_DEC:
+          *val = LSM6DSL_SL3_NO_DEC;
+          break;
+        case LSM6DSL_SL3_DEC_2:
+          *val = LSM6DSL_SL3_DEC_2;
+          break;
+        case LSM6DSL_SL3_DEC_4:
+          *val = LSM6DSL_SL3_DEC_4;
+          break;
+        case LSM6DSL_SL3_DEC_8:
+          *val = LSM6DSL_SL3_DEC_8;
+          break;
+        default:
+          *val = LSM6DSL_SL3_DEC_ND;
+          break;
+      }
+      ret = lsm6dsl_mem_bank_set(ctx, LSM6DSL_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsl_STdC/driver/lsm6dsl_reg.h
+++ b/sensor/stmemsc/lsm6dsl_STdC/driver/lsm6dsl_reg.h
@@ -1,0 +1,1921 @@
+/*
+ ******************************************************************************
+ * @file    lsm6dsl_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm6dsl_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DSL_DRIVER_H
+#define LSM6DSL_DRIVER_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM6DSL
+  * @{
+  *
+  */
+
+/** @defgroup LSM6DSL_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LSM9DS1_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lsm6dsl_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lsm6dsl_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lsm6dsl_write_ptr  write_reg;
+  lsm6dsl_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lsm6dsl_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DSL_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define LSM6DSL_I2C_ADD_L     0xD5U
+#define LSM6DSL_I2C_ADD_H     0xD7U
+
+/** Device Identification (Who am I) **/
+#define LSM6DSL_ID            0x6AU
+
+/**
+  * @}
+  *
+  */
+
+#define LSM6DSL_FUNC_CFG_ACCESS              0x01U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t func_cfg_en              : 3;  /* func_cfg_en + func_cfg_en_b */
+} lsm6dsl_func_cfg_access_t;
+
+#define LSM6DSL_SENSOR_SYNC_TIME_FRAME       0x04U
+typedef struct {
+  uint8_t tph                      : 4;
+  uint8_t not_used_01              : 4;
+} lsm6dsl_sensor_sync_time_frame_t;
+
+#define LSM6DSL_SENSOR_SYNC_RES_RATIO        0x05U
+typedef struct {
+  uint8_t rr                       : 2;
+  uint8_t not_used_01              : 6;
+} lsm6dsl_sensor_sync_res_ratio_t;
+
+#define LSM6DSL_FIFO_CTRL1                   0x06U
+typedef struct {
+  uint8_t fth                      : 8;  /* + FIFO_CTRL2(fth) */
+} lsm6dsl_fifo_ctrl1_t;
+
+#define LSM6DSL_FIFO_CTRL2                   0x07U
+typedef struct {
+  uint8_t fth                      : 3;  /* + FIFO_CTRL1(fth) */
+  uint8_t fifo_temp_en             : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t  timer_pedo_fifo_drdy    : 1;
+  uint8_t timer_pedo_fifo_en       : 1;
+} lsm6dsl_fifo_ctrl2_t;
+
+#define LSM6DSL_FIFO_CTRL3                   0x08U
+typedef struct {
+  uint8_t dec_fifo_xl              : 3;
+  uint8_t dec_fifo_gyro            : 3;
+  uint8_t not_used_01              : 2;
+} lsm6dsl_fifo_ctrl3_t;
+
+#define LSM6DSL_FIFO_CTRL4                   0x09U
+typedef struct {
+  uint8_t dec_ds3_fifo             : 3;
+  uint8_t dec_ds4_fifo             : 3;
+  uint8_t only_high_data           : 1;
+  uint8_t stop_on_fth              : 1;
+} lsm6dsl_fifo_ctrl4_t;
+
+#define LSM6DSL_FIFO_CTRL5                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t odr_fifo                 : 4;
+  uint8_t not_used_01              : 1;
+} lsm6dsl_fifo_ctrl5_t;
+
+#define LSM6DSL_DRDY_PULSE_CFG_G             0x0BU
+typedef struct {
+  uint8_t int2_wrist_tilt          : 1;
+  uint8_t not_used_01              : 6;
+  uint8_t drdy_pulsed              : 1;
+} lsm6dsl_drdy_pulse_cfg_g_t;
+
+#define LSM6DSL_INT1_CTRL                    0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_full_flag           : 1;
+  uint8_t int1_sign_mot            : 1;
+  uint8_t int1_step_detector       : 1;
+} lsm6dsl_int1_ctrl_t;
+
+#define LSM6DSL_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_full_flag           : 1;
+  uint8_t int2_step_count_ov       : 1;
+  uint8_t int2_step_delta          : 1;
+} lsm6dsl_int2_ctrl_t;
+
+#define LSM6DSL_WHO_AM_I                     0x0FU
+#define LSM6DSL_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t bw0_xl                   : 1;
+  uint8_t lpf1_bw_sel              : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} lsm6dsl_ctrl1_xl_t;
+
+#define LSM6DSL_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t fs_g                     : 3;  /* fs_g + fs_125 */
+  uint8_t odr_g                    : 4;
+} lsm6dsl_ctrl2_g_t;
+
+#define LSM6DSL_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t ble                      : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} lsm6dsl_ctrl3_c_t;
+
+#define LSM6DSL_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t den_drdy_int1            : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep                    : 1;
+  uint8_t den_xl_en                : 1;
+} lsm6dsl_ctrl4_c_t;
+
+#define LSM6DSL_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t den_lh                   : 1;
+  uint8_t rounding                 : 3;
+} lsm6dsl_ctrl5_c_t;
+
+#define LSM6DSL_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t ftype                    : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t usr_off_w                : 1;
+  uint8_t xl_hm_mode               : 1;
+  uint8_t den_mode                 : 3;  /* trig_en + lvl_en + lvl2_en */
+} lsm6dsl_ctrl6_c_t;
+
+#define LSM6DSL_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t rounding_status          : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t g_hm_mode                : 1;
+} lsm6dsl_ctrl7_g_t;
+
+#define LSM6DSL_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t input_composite          : 1;
+  uint8_t hp_ref_mode              : 1;
+  uint8_t hpcf_xl                  : 2;
+  uint8_t lpf2_xl_en               : 1;
+} lsm6dsl_ctrl8_xl_t;
+
+#define LSM6DSL_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t soft_en                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t den_xl_g                 : 1;
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} lsm6dsl_ctrl9_xl_t;
+
+#define LSM6DSL_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t sign_motion_en           : 1;
+  uint8_t pedo_rst_step            : 1;
+  uint8_t func_en                  : 1;
+  uint8_t tilt_en                  : 1;
+  uint8_t pedo_en                  : 1;
+  uint8_t timer_en                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t wrist_tilt_en            : 1;
+} lsm6dsl_ctrl10_c_t;
+
+#define LSM6DSL_MASTER_CONFIG                0x1AU
+typedef struct {
+  uint8_t master_on                : 1;
+  uint8_t iron_en                  : 1;
+  uint8_t pass_through_mode        : 1;
+  uint8_t pull_up_en               : 1;
+  uint8_t start_config             : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t  data_valid_sel_fifo     : 1;
+  uint8_t drdy_on_int1             : 1;
+} lsm6dsl_master_config_t;
+
+#define LSM6DSL_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state_ia           : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t not_used_01              : 2;
+} lsm6dsl_wake_up_src_t;
+
+#define LSM6DSL_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsl_tap_src_t;
+
+#define LSM6DSL_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} lsm6dsl_d6d_src_t;
+
+#define LSM6DSL_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dsl_status_reg_t;
+
+#define LSM6DSL_OUT_TEMP_L                   0x20U
+#define LSM6DSL_OUT_TEMP_H                   0x21U
+#define LSM6DSL_OUTX_L_G                     0x22U
+#define LSM6DSL_OUTX_H_G                     0x23U
+#define LSM6DSL_OUTY_L_G                     0x24U
+#define LSM6DSL_OUTY_H_G                     0x25U
+#define LSM6DSL_OUTZ_L_G                     0x26U
+#define LSM6DSL_OUTZ_H_G                     0x27U
+#define LSM6DSL_OUTX_L_XL                    0x28U
+#define LSM6DSL_OUTX_H_XL                    0x29U
+#define LSM6DSL_OUTY_L_XL                    0x2AU
+#define LSM6DSL_OUTY_H_XL                    0x2BU
+#define LSM6DSL_OUTZ_L_XL                    0x2CU
+#define LSM6DSL_OUTZ_H_XL                    0x2DU
+#define LSM6DSL_SENSORHUB1_REG               0x2EU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub1_reg_t;
+
+#define LSM6DSL_SENSORHUB2_REG               0x2FU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub2_reg_t;
+
+#define LSM6DSL_SENSORHUB3_REG               0x30U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub3_reg_t;
+
+#define LSM6DSL_SENSORHUB4_REG               0x31U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub4_reg_t;
+
+#define LSM6DSL_SENSORHUB5_REG               0x32U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub5_reg_t;
+
+#define LSM6DSL_SENSORHUB6_REG               0x33U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub6_reg_t;
+
+#define LSM6DSL_SENSORHUB7_REG               0x34U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub7_reg_t;
+
+#define LSM6DSL_SENSORHUB8_REG               0x35U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub8_reg_t;
+
+#define LSM6DSL_SENSORHUB9_REG               0x36U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub9_reg_t;
+
+#define LSM6DSL_SENSORHUB10_REG              0x37U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub10_reg_t;
+
+#define LSM6DSL_SENSORHUB11_REG              0x38U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub11_reg_t;
+
+#define LSM6DSL_SENSORHUB12_REG              0x39U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub12_reg_t;
+
+#define LSM6DSL_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;  /* + FIFO_STATUS2(diff_fifo) */
+} lsm6dsl_fifo_status1_t;
+
+#define LSM6DSL_FIFO_STATUS2                 0x3BU
+typedef struct {
+  uint8_t diff_fifo                : 3;  /* + FIFO_STATUS1(diff_fifo) */
+  uint8_t not_used_01              : 1;
+  uint8_t fifo_empty               : 1;
+  uint8_t fifo_full_smart          : 1;
+  uint8_t over_run                 : 1;
+  uint8_t waterm                   : 1;
+} lsm6dsl_fifo_status2_t;
+
+#define LSM6DSL_FIFO_STATUS3                 0x3CU
+typedef struct {
+  uint8_t fifo_pattern             : 8;  /* + FIFO_STATUS4(fifo_pattern) */
+} lsm6dsl_fifo_status3_t;
+
+#define LSM6DSL_FIFO_STATUS4                 0x3DU
+typedef struct {
+  uint8_t fifo_pattern             : 2;  /* + FIFO_STATUS3(fifo_pattern) */
+  uint8_t not_used_01              : 6;
+} lsm6dsl_fifo_status4_t;
+
+#define LSM6DSL_FIFO_DATA_OUT_L              0x3EU
+#define LSM6DSL_FIFO_DATA_OUT_H              0x3FU
+#define LSM6DSL_TIMESTAMP0_REG               0x40U
+#define LSM6DSL_TIMESTAMP1_REG               0x41U
+#define LSM6DSL_TIMESTAMP2_REG               0x42U
+#define LSM6DSL_STEP_TIMESTAMP_L             0x49U
+#define LSM6DSL_STEP_TIMESTAMP_H             0x4AU
+#define LSM6DSL_STEP_COUNTER_L               0x4BU
+#define LSM6DSL_STEP_COUNTER_H               0x4CU
+
+#define LSM6DSL_SENSORHUB13_REG              0x4DU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub13_reg_t;
+
+#define LSM6DSL_SENSORHUB14_REG              0x4EU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub14_reg_t;
+
+#define LSM6DSL_SENSORHUB15_REG              0x4FU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub15_reg_t;
+
+#define LSM6DSL_SENSORHUB16_REG              0x50U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub16_reg_t;
+
+#define LSM6DSL_SENSORHUB17_REG              0x51U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub17_reg_t;
+
+#define LSM6DSL_SENSORHUB18_REG              0x52U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsl_sensorhub18_reg_t;
+
+#define LSM6DSL_FUNC_SRC1                    0x53U
+typedef struct {
+  uint8_t sensorhub_end_op         : 1;
+  uint8_t si_end_op                : 1;
+  uint8_t hi_fail                  : 1;
+  uint8_t step_overflow            : 1;
+  uint8_t step_detected            : 1;
+  uint8_t tilt_ia                  : 1;
+  uint8_t sign_motion_ia           : 1;
+  uint8_t  step_count_delta_ia     : 1;
+} lsm6dsl_func_src1_t;
+
+#define LSM6DSL_FUNC_SRC2                    0x54U
+typedef struct {
+  uint8_t wrist_tilt_ia            : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t slave0_nack              : 1;
+  uint8_t slave1_nack              : 1;
+  uint8_t slave2_nack              : 1;
+  uint8_t slave3_nack              : 1;
+  uint8_t not_used_02              : 1;
+} lsm6dsl_func_src2_t;
+
+#define LSM6DSL_WRIST_TILT_IA                0x55U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t wrist_tilt_ia_zneg       : 1;
+  uint8_t wrist_tilt_ia_zpos       : 1;
+  uint8_t wrist_tilt_ia_yneg       : 1;
+  uint8_t wrist_tilt_ia_ypos       : 1;
+  uint8_t wrist_tilt_ia_xneg       : 1;
+  uint8_t wrist_tilt_ia_xpos       : 1;
+} lsm6dsl_wrist_tilt_ia_t;
+
+#define LSM6DSL_TAP_CFG                      0x58U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t tap_z_en                 : 1;
+  uint8_t tap_y_en                 : 1;
+  uint8_t tap_x_en                 : 1;
+  uint8_t slope_fds                : 1;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} lsm6dsl_tap_cfg_t;
+
+#define LSM6DSL_TAP_THS_6D                   0x59U
+typedef struct {
+  uint8_t tap_ths                  : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} lsm6dsl_tap_ths_6d_t;
+
+#define LSM6DSL_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} lsm6dsl_int_dur2_t;
+
+#define LSM6DSL_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t not_used_01              : 1;
+  uint8_t single_double_tap        : 1;
+} lsm6dsl_wake_up_ths_t;
+
+#define LSM6DSL_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t timer_hr                 : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} lsm6dsl_wake_up_dur_t;
+
+#define LSM6DSL_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} lsm6dsl_free_fall_t;
+
+#define LSM6DSL_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t int1_timer               : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_inact_state         : 1;
+} lsm6dsl_md1_cfg_t;
+
+#define LSM6DSL_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_iron                : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_inact_state         : 1;
+} lsm6dsl_md2_cfg_t;
+
+#define LSM6DSL_MASTER_CMD_CODE              0x60U
+typedef struct {
+  uint8_t master_cmd_code          : 8;
+} lsm6dsl_master_cmd_code_t;
+
+#define LSM6DSL_SENS_SYNC_SPI_ERROR_CODE     0x61U
+typedef struct {
+  uint8_t error_code               : 8;
+} lsm6dsl_sens_sync_spi_error_code_t;
+
+#define LSM6DSL_OUT_MAG_RAW_X_L              0x66U
+#define LSM6DSL_OUT_MAG_RAW_X_H              0x67U
+#define LSM6DSL_OUT_MAG_RAW_Y_L              0x68U
+#define LSM6DSL_OUT_MAG_RAW_Y_H              0x69U
+#define LSM6DSL_OUT_MAG_RAW_Z_L              0x6AU
+#define LSM6DSL_OUT_MAG_RAW_Z_H              0x6BU
+#define LSM6DSL_X_OFS_USR                    0x73U
+#define LSM6DSL_Y_OFS_USR                    0x74U
+#define LSM6DSL_Z_OFS_USR                    0x75U
+#define LSM6DSL_SLV0_ADD                     0x02U
+typedef struct {
+  uint8_t rw_0                     : 1;
+  uint8_t slave0_add               : 7;
+} lsm6dsl_slv0_add_t;
+
+#define LSM6DSL_SLV0_SUBADD                  0x03U
+typedef struct {
+  uint8_t slave0_reg               : 8;
+} lsm6dsl_slv0_subadd_t;
+
+#define LSM6DSL_SLAVE0_CONFIG                0x04U
+typedef struct {
+  uint8_t slave0_numop             : 3;
+  uint8_t src_mode                 : 1;
+  uint8_t aux_sens_on              : 2;
+  uint8_t slave0_rate              : 2;
+} lsm6dsl_slave0_config_t;
+
+#define LSM6DSL_SLV1_ADD                     0x05U
+typedef struct {
+  uint8_t r_1                      : 1;
+  uint8_t slave1_add               : 7;
+} lsm6dsl_slv1_add_t;
+
+#define LSM6DSL_SLV1_SUBADD                  0x06U
+typedef struct {
+  uint8_t slave1_reg               : 8;
+} lsm6dsl_slv1_subadd_t;
+
+#define LSM6DSL_SLAVE1_CONFIG                0x07U
+typedef struct {
+  uint8_t slave1_numop             : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t write_once               : 1;
+  uint8_t slave1_rate              : 2;
+} lsm6dsl_slave1_config_t;
+
+#define LSM6DSL_SLV2_ADD                     0x08U
+typedef struct {
+  uint8_t r_2                      : 1;
+  uint8_t slave2_add               : 7;
+} lsm6dsl_slv2_add_t;
+
+#define LSM6DSL_SLV2_SUBADD                  0x09U
+typedef struct {
+  uint8_t slave2_reg               : 8;
+} lsm6dsl_slv2_subadd_t;
+
+#define LSM6DSL_SLAVE2_CONFIG                0x0AU
+typedef struct {
+  uint8_t slave2_numop             : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t slave2_rate              : 2;
+} lsm6dsl_slave2_config_t;
+
+#define LSM6DSL_SLV3_ADD                     0x0BU
+typedef struct {
+  uint8_t r_3                      : 1;
+  uint8_t slave3_add               : 7;
+} lsm6dsl_slv3_add_t;
+
+#define LSM6DSL_SLV3_SUBADD                  0x0CU
+typedef struct {
+  uint8_t slave3_reg               : 8;
+} lsm6dsl_slv3_subadd_t;
+
+#define LSM6DSL_SLAVE3_CONFIG                0x0DU
+typedef struct {
+  uint8_t slave3_numop             : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t slave3_rate              : 2;
+} lsm6dsl_slave3_config_t;
+
+#define LSM6DSL_DATAWRITE_SRC_MODE_SUB_SLV0  0x0EU
+typedef struct {
+  uint8_t slave_dataw              : 8;
+} lsm6dsl_datawrite_src_mode_sub_slv0_t;
+
+#define LSM6DSL_CONFIG_PEDO_THS_MIN          0x0FU
+typedef struct {
+  uint8_t ths_min                  : 5;
+  uint8_t not_used_01              : 2;
+  uint8_t pedo_fs                  : 1;
+} lsm6dsl_config_pedo_ths_min_t;
+
+#define LSM6DSL_SM_THS                       0x13U
+#define LSM6DSL_PEDO_DEB_REG                 0x14U
+typedef struct {
+  uint8_t deb_step      : 3;
+  uint8_t deb_time      : 5;
+} lsm6dsl_pedo_deb_reg_t;
+
+#define LSM6DSL_STEP_COUNT_DELTA             0x15U
+#define LSM6DSL_MAG_SI_XX                    0x24U
+#define LSM6DSL_MAG_SI_XY                    0x25U
+#define LSM6DSL_MAG_SI_XZ                    0x26U
+#define LSM6DSL_MAG_SI_YX                    0x27U
+#define LSM6DSL_MAG_SI_YY                    0x28U
+#define LSM6DSL_MAG_SI_YZ                    0x29U
+#define LSM6DSL_MAG_SI_ZX                    0x2AU
+#define LSM6DSL_MAG_SI_ZY                    0x2BU
+#define LSM6DSL_MAG_SI_ZZ                    0x2CU
+#define LSM6DSL_MAG_OFFX_L                   0x2DU
+#define LSM6DSL_MAG_OFFX_H                   0x2EU
+#define LSM6DSL_MAG_OFFY_L                   0x2FU
+#define LSM6DSL_MAG_OFFY_H                   0x30U
+#define LSM6DSL_MAG_OFFZ_L                   0x31U
+#define LSM6DSL_MAG_OFFZ_H                   0x32U
+#define LSM6DSL_A_WRIST_TILT_LAT             0x50U
+#define LSM6DSL_A_WRIST_TILT_THS             0x54U
+#define LSM6DSL_A_WRIST_TILT_MASK            0x59U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t  wrist_tilt_mask_zneg    : 1;
+  uint8_t  wrist_tilt_mask_zpos    : 1;
+  uint8_t  wrist_tilt_mask_yneg    : 1;
+  uint8_t  wrist_tilt_mask_ypos    : 1;
+  uint8_t  wrist_tilt_mask_xneg    : 1;
+  uint8_t  wrist_tilt_mask_xpos    : 1;
+} lsm6dsl_a_wrist_tilt_mask_t;
+
+/**
+  * @defgroup LSM6DSL_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lsm6dsl_func_cfg_access_t                  func_cfg_access;
+  lsm6dsl_sensor_sync_time_frame_t           sensor_sync_time_frame;
+  lsm6dsl_sensor_sync_res_ratio_t            sensor_sync_res_ratio;
+  lsm6dsl_fifo_ctrl1_t                       fifo_ctrl1;
+  lsm6dsl_fifo_ctrl2_t                       fifo_ctrl2;
+  lsm6dsl_fifo_ctrl3_t                       fifo_ctrl3;
+  lsm6dsl_fifo_ctrl4_t                       fifo_ctrl4;
+  lsm6dsl_fifo_ctrl5_t                       fifo_ctrl5;
+  lsm6dsl_drdy_pulse_cfg_g_t                 drdy_pulse_cfg_g;
+  lsm6dsl_int1_ctrl_t                        int1_ctrl;
+  lsm6dsl_int2_ctrl_t                        int2_ctrl;
+  lsm6dsl_ctrl1_xl_t                         ctrl1_xl;
+  lsm6dsl_ctrl2_g_t                          ctrl2_g;
+  lsm6dsl_ctrl3_c_t                          ctrl3_c;
+  lsm6dsl_ctrl4_c_t                          ctrl4_c;
+  lsm6dsl_ctrl5_c_t                          ctrl5_c;
+  lsm6dsl_ctrl6_c_t                          ctrl6_c;
+  lsm6dsl_ctrl7_g_t                          ctrl7_g;
+  lsm6dsl_ctrl8_xl_t                         ctrl8_xl;
+  lsm6dsl_ctrl9_xl_t                         ctrl9_xl;
+  lsm6dsl_ctrl10_c_t                         ctrl10_c;
+  lsm6dsl_master_config_t                    master_config;
+  lsm6dsl_wake_up_src_t                      wake_up_src;
+  lsm6dsl_tap_src_t                          tap_src;
+  lsm6dsl_d6d_src_t                          d6d_src;
+  lsm6dsl_status_reg_t                       status_reg;
+  lsm6dsl_sensorhub1_reg_t                   sensorhub1_reg;
+  lsm6dsl_sensorhub2_reg_t                   sensorhub2_reg;
+  lsm6dsl_sensorhub3_reg_t                   sensorhub3_reg;
+  lsm6dsl_sensorhub4_reg_t                   sensorhub4_reg;
+  lsm6dsl_sensorhub5_reg_t                   sensorhub5_reg;
+  lsm6dsl_sensorhub6_reg_t                   sensorhub6_reg;
+  lsm6dsl_sensorhub7_reg_t                   sensorhub7_reg;
+  lsm6dsl_sensorhub8_reg_t                   sensorhub8_reg;
+  lsm6dsl_sensorhub9_reg_t                   sensorhub9_reg;
+  lsm6dsl_sensorhub10_reg_t                  sensorhub10_reg;
+  lsm6dsl_sensorhub11_reg_t                  sensorhub11_reg;
+  lsm6dsl_sensorhub12_reg_t                  sensorhub12_reg;
+  lsm6dsl_fifo_status1_t                     fifo_status1;
+  lsm6dsl_fifo_status2_t                     fifo_status2;
+  lsm6dsl_fifo_status3_t                     fifo_status3;
+  lsm6dsl_fifo_status4_t                     fifo_status4;
+  lsm6dsl_sensorhub13_reg_t                  sensorhub13_reg;
+  lsm6dsl_sensorhub14_reg_t                  sensorhub14_reg;
+  lsm6dsl_sensorhub15_reg_t                  sensorhub15_reg;
+  lsm6dsl_sensorhub16_reg_t                  sensorhub16_reg;
+  lsm6dsl_sensorhub17_reg_t                  sensorhub17_reg;
+  lsm6dsl_sensorhub18_reg_t                  sensorhub18_reg;
+  lsm6dsl_func_src1_t                        func_src1;
+  lsm6dsl_func_src2_t                        func_src2;
+  lsm6dsl_wrist_tilt_ia_t                    wrist_tilt_ia;
+  lsm6dsl_tap_cfg_t                          tap_cfg;
+  lsm6dsl_tap_ths_6d_t                       tap_ths_6d;
+  lsm6dsl_int_dur2_t                         int_dur2;
+  lsm6dsl_wake_up_ths_t                      wake_up_ths;
+  lsm6dsl_wake_up_dur_t                      wake_up_dur;
+  lsm6dsl_free_fall_t                        free_fall;
+  lsm6dsl_md1_cfg_t                          md1_cfg;
+  lsm6dsl_md2_cfg_t                          md2_cfg;
+  lsm6dsl_master_cmd_code_t                  master_cmd_code;
+  lsm6dsl_sens_sync_spi_error_code_t         sens_sync_spi_error_code;
+  lsm6dsl_slv0_add_t                         slv0_add;
+  lsm6dsl_slv0_subadd_t                      slv0_subadd;
+  lsm6dsl_slave0_config_t                    slave0_config;
+  lsm6dsl_slv1_add_t                         slv1_add;
+  lsm6dsl_slv1_subadd_t                      slv1_subadd;
+  lsm6dsl_slave1_config_t                    slave1_config;
+  lsm6dsl_slv2_add_t                         slv2_add;
+  lsm6dsl_slv2_subadd_t                      slv2_subadd;
+  lsm6dsl_slave2_config_t                    slave2_config;
+  lsm6dsl_slv3_add_t                         slv3_add;
+  lsm6dsl_slv3_subadd_t                      slv3_subadd;
+  lsm6dsl_slave3_config_t                    slave3_config;
+  lsm6dsl_datawrite_src_mode_sub_slv0_t      datawrite_src_mode_sub_slv0;
+  lsm6dsl_config_pedo_ths_min_t              config_pedo_ths_min;
+  lsm6dsl_pedo_deb_reg_t                     pedo_deb_reg;
+  lsm6dsl_a_wrist_tilt_mask_t                a_wrist_tilt_mask;
+  bitwise_t                                  bitwise;
+  uint8_t                                    byte;
+} lsm6dsl_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm6dsl_read_reg(lsm6dsl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lsm6dsl_write_reg(lsm6dsl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lsm6dsl_from_fs2g_to_mg(int16_t lsb);
+extern float_t lsm6dsl_from_fs4g_to_mg(int16_t lsb);
+extern float_t lsm6dsl_from_fs8g_to_mg(int16_t lsb);
+extern float_t lsm6dsl_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t lsm6dsl_from_fs125dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsl_from_fs250dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsl_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsl_from_fs1000dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsl_from_fs2000dps_to_mdps(int16_t lsb);
+
+extern float_t lsm6dsl_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  LSM6DSL_2g       = 0,
+  LSM6DSL_16g      = 1,
+  LSM6DSL_4g       = 2,
+  LSM6DSL_8g       = 3,
+  LSM6DSL_XL_FS_ND = 4,  /* ERROR CODE */
+} lsm6dsl_fs_xl_t;
+int32_t lsm6dsl_xl_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t val);
+int32_t lsm6dsl_xl_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t *val);
+
+typedef enum {
+  LSM6DSL_XL_ODR_OFF      =  0,
+  LSM6DSL_XL_ODR_12Hz5    =  1,
+  LSM6DSL_XL_ODR_26Hz     =  2,
+  LSM6DSL_XL_ODR_52Hz     =  3,
+  LSM6DSL_XL_ODR_104Hz    =  4,
+  LSM6DSL_XL_ODR_208Hz    =  5,
+  LSM6DSL_XL_ODR_416Hz    =  6,
+  LSM6DSL_XL_ODR_833Hz    =  7,
+  LSM6DSL_XL_ODR_1k66Hz   =  8,
+  LSM6DSL_XL_ODR_3k33Hz   =  9,
+  LSM6DSL_XL_ODR_6k66Hz   = 10,
+  LSM6DSL_XL_ODR_1Hz6     = 11,
+  LSM6DSL_XL_ODR_ND       = 12,  /* ERROR CODE */
+} lsm6dsl_odr_xl_t;
+int32_t lsm6dsl_xl_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t val);
+int32_t lsm6dsl_xl_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t *val);
+
+typedef enum {
+  LSM6DSL_250dps     = 0,
+  LSM6DSL_125dps     = 1,
+  LSM6DSL_500dps     = 2,
+  LSM6DSL_1000dps    = 4,
+  LSM6DSL_2000dps    = 6,
+  LSM6DSL_GY_FS_ND   = 7,    /* ERROR CODE */
+} lsm6dsl_fs_g_t;
+int32_t lsm6dsl_gy_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t val);
+int32_t lsm6dsl_gy_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t *val);
+
+typedef enum {
+  LSM6DSL_GY_ODR_OFF    =  0,
+  LSM6DSL_GY_ODR_12Hz5  =  1,
+  LSM6DSL_GY_ODR_26Hz   =  2,
+  LSM6DSL_GY_ODR_52Hz   =  3,
+  LSM6DSL_GY_ODR_104Hz  =  4,
+  LSM6DSL_GY_ODR_208Hz  =  5,
+  LSM6DSL_GY_ODR_416Hz  =  6,
+  LSM6DSL_GY_ODR_833Hz  =  7,
+  LSM6DSL_GY_ODR_1k66Hz =  8,
+  LSM6DSL_GY_ODR_3k33Hz =  9,
+  LSM6DSL_GY_ODR_6k66Hz = 10,
+  LSM6DSL_GY_ODR_ND     = 11,    /* ERROR CODE */
+} lsm6dsl_odr_g_t;
+int32_t lsm6dsl_gy_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t val);
+int32_t lsm6dsl_gy_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t *val);
+
+int32_t lsm6dsl_block_data_update_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_block_data_update_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_LSb_1mg   = 0,
+  LSM6DSL_LSb_16mg  = 1,
+  LSM6DSL_WEIGHT_ND = 2,
+} lsm6dsl_usr_off_w_t;
+int32_t lsm6dsl_xl_offset_weight_set(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_usr_off_w_t val);
+int32_t lsm6dsl_xl_offset_weight_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_usr_off_w_t *val);
+
+typedef enum {
+  LSM6DSL_XL_HIGH_PERFORMANCE  = 0,
+  LSM6DSL_XL_NORMAL            = 1,
+  LSM6DSL_XL_PW_MODE_ND        = 2,    /* ERROR CODE */
+} lsm6dsl_xl_hm_mode_t;
+int32_t lsm6dsl_xl_power_mode_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_xl_hm_mode_t val);
+int32_t lsm6dsl_xl_power_mode_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_xl_hm_mode_t *val);
+
+typedef enum {
+  LSM6DSL_STAT_RND_DISABLE  = 0,
+  LSM6DSL_STAT_RND_ENABLE   = 1,
+  LSM6DSL_STAT_RND_ND       = 2,    /* ERROR CODE */
+} lsm6dsl_rounding_status_t;
+int32_t lsm6dsl_rounding_on_status_set(lsm6dsl_ctx_t *ctx,
+                                       lsm6dsl_rounding_status_t val);
+int32_t lsm6dsl_rounding_on_status_get(lsm6dsl_ctx_t *ctx,
+                                       lsm6dsl_rounding_status_t *val);
+
+typedef enum {
+  LSM6DSL_GY_HIGH_PERFORMANCE  = 0,
+  LSM6DSL_GY_NORMAL            = 1,
+  LSM6DSL_GY_PW_MODE_ND        = 2,    /* ERROR CODE */
+} lsm6dsl_g_hm_mode_t;
+int32_t lsm6dsl_gy_power_mode_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_g_hm_mode_t val);
+int32_t lsm6dsl_gy_power_mode_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_g_hm_mode_t *val);
+
+typedef struct {
+  lsm6dsl_wake_up_src_t        wake_up_src;
+  lsm6dsl_tap_src_t            tap_src;
+  lsm6dsl_d6d_src_t            d6d_src;
+  lsm6dsl_status_reg_t         status_reg;
+  lsm6dsl_func_src1_t          func_src1;
+  lsm6dsl_func_src2_t          func_src2;
+  lsm6dsl_wrist_tilt_ia_t      wrist_tilt_ia;
+  lsm6dsl_a_wrist_tilt_mask_t  a_wrist_tilt_mask;
+} lsm6dsl_all_sources_t;
+int32_t lsm6dsl_all_sources_get(lsm6dsl_ctx_t *ctx,
+                                lsm6dsl_all_sources_t *val);
+
+int32_t lsm6dsl_status_reg_get(lsm6dsl_ctx_t *ctx, lsm6dsl_status_reg_t *val);
+
+int32_t lsm6dsl_xl_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_gy_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_temp_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_xl_usr_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_xl_usr_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_timestamp_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_timestamp_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_LSB_6ms4    = 0,
+  LSM6DSL_LSB_25us    = 1,
+  LSM6DSL_TS_RES_ND   = 2,    /* ERROR CODE */
+} lsm6dsl_timer_hr_t;
+int32_t lsm6dsl_timestamp_res_set(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t val);
+int32_t lsm6dsl_timestamp_res_get(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t *val);
+
+typedef enum {
+  LSM6DSL_ROUND_DISABLE            = 0,
+  LSM6DSL_ROUND_XL                 = 1,
+  LSM6DSL_ROUND_GY                 = 2,
+  LSM6DSL_ROUND_GY_XL              = 3,
+  LSM6DSL_ROUND_SH1_TO_SH6         = 4,
+  LSM6DSL_ROUND_XL_SH1_TO_SH6      = 5,
+  LSM6DSL_ROUND_GY_XL_SH1_TO_SH12  = 6,
+  LSM6DSL_ROUND_GY_XL_SH1_TO_SH6   = 7,
+  LSM6DSL_ROUND_OUT_ND             = 8,    /* ERROR CODE */
+} lsm6dsl_rounding_t;
+int32_t lsm6dsl_rounding_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t val);
+int32_t lsm6dsl_rounding_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t *val);
+
+int32_t lsm6dsl_temperature_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_angular_rate_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_acceleration_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsl_mag_calibrated_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsl_fifo_raw_data_get(lsm6dsl_ctx_t *ctx, uint8_t *buffer,
+                                  uint8_t len);
+
+typedef enum {
+  LSM6DSL_USER_BANK   = 0,
+  LSM6DSL_BANK_A      = 4,
+  LSM6DSL_BANK_B      = 5,
+  LSM6DSL_BANK_ND     = 6,    /* ERROR CODE */
+} lsm6dsl_func_cfg_en_t;
+int32_t lsm6dsl_mem_bank_set(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t val);
+int32_t lsm6dsl_mem_bank_get(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t *val);
+
+typedef enum {
+  LSM6DSL_DRDY_LATCHED    = 0,
+  LSM6DSL_DRDY_PULSED     = 1,
+  LSM6DSL_DRDY_ND         = 2,  /* ERROR CODE */
+} lsm6dsl_drdy_pulsed_g_t;
+int32_t lsm6dsl_data_ready_mode_set(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_drdy_pulsed_g_t val);
+int32_t lsm6dsl_data_ready_mode_get(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_drdy_pulsed_g_t *val);
+
+int32_t lsm6dsl_device_id_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_LSB_AT_LOW_ADD  = 0,
+  LSM6DSL_MSB_AT_LOW_ADD  = 1,
+  LSM6DSL_DATA_FMT_ND     = 2,    /* ERROR CODE */
+} lsm6dsl_ble_t;
+int32_t lsm6dsl_data_format_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t val);
+int32_t lsm6dsl_data_format_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t *val);
+
+int32_t lsm6dsl_auto_increment_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_auto_increment_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_boot_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_boot_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_XL_ST_DISABLE    = 0,
+  LSM6DSL_XL_ST_POSITIVE   = 1,
+  LSM6DSL_XL_ST_NEGATIVE   = 2,
+  LSM6DSL_XL_ST_ND         = 3,    /* ERROR CODE */
+} lsm6dsl_st_xl_t;
+int32_t lsm6dsl_xl_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t val);
+int32_t lsm6dsl_xl_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t *val);
+
+typedef enum {
+  LSM6DSL_GY_ST_DISABLE    = 0,
+  LSM6DSL_GY_ST_POSITIVE   = 1,
+  LSM6DSL_GY_ST_NEGATIVE   = 3,
+  LSM6DSL_GY_ST_ND         = 4,    /* ERROR CODE */
+} lsm6dsl_st_g_t;
+int32_t lsm6dsl_gy_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t val);
+int32_t lsm6dsl_gy_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t *val);
+
+int32_t lsm6dsl_filter_settling_mask_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_filter_settling_mask_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_USE_SLOPE    = 0,
+  LSM6DSL_USE_HPF      = 1,
+  LSM6DSL_HP_PATH_ND   = 2,    /* ERROR CODE */
+} lsm6dsl_slope_fds_t;
+int32_t lsm6dsl_xl_hp_path_internal_set(lsm6dsl_ctx_t *ctx,
+                                        lsm6dsl_slope_fds_t val);
+int32_t lsm6dsl_xl_hp_path_internal_get(lsm6dsl_ctx_t *ctx,
+                                        lsm6dsl_slope_fds_t *val);
+
+typedef enum {
+  LSM6DSL_XL_ANA_BW_1k5Hz = 0,
+  LSM6DSL_XL_ANA_BW_400Hz = 1,
+  LSM6DSL_XL_ANA_BW_ND    = 2,    /* ERROR CODE */
+} lsm6dsl_bw0_xl_t;
+int32_t lsm6dsl_xl_filter_analog_set(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_bw0_xl_t val);
+int32_t lsm6dsl_xl_filter_analog_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_bw0_xl_t *val);
+
+typedef enum {
+  LSM6DSL_XL_LP1_ODR_DIV_2 = 0,
+  LSM6DSL_XL_LP1_ODR_DIV_4 = 1,
+  LSM6DSL_XL_LP1_NA        = 2,  /* ERROR CODE */
+} lsm6dsl_lpf1_bw_sel_t;
+int32_t lsm6dsl_xl_lp1_bandwidth_set(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_lpf1_bw_sel_t val);
+int32_t lsm6dsl_xl_lp1_bandwidth_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_lpf1_bw_sel_t *val);
+
+typedef enum {
+  LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_50     = 0x00,
+  LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_100    = 0x01,
+  LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_9      = 0x02,
+  LSM6DSL_XL_LOW_LAT_LP_ODR_DIV_400    = 0x03,
+  LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_50   = 0x10,
+  LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_100  = 0x11,
+  LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_9    = 0x12,
+  LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_400  = 0x13,
+  LSM6DSL_XL_LP_NA                     = 0x20, /* ERROR CODE */
+} lsm6dsl_input_composite_t;
+int32_t lsm6dsl_xl_lp2_bandwidth_set(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_input_composite_t val);
+int32_t lsm6dsl_xl_lp2_bandwidth_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_input_composite_t *val);
+
+int32_t lsm6dsl_xl_reference_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_xl_reference_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_XL_HP_ODR_DIV_4      = 0x00, /* Slope filter */
+  LSM6DSL_XL_HP_ODR_DIV_100    = 0x01,
+  LSM6DSL_XL_HP_ODR_DIV_9      = 0x02,
+  LSM6DSL_XL_HP_ODR_DIV_400    = 0x03,
+  LSM6DSL_XL_HP_NA             = 0x10, /* ERROR CODE */
+} lsm6dsl_hpcf_xl_t;
+int32_t lsm6dsl_xl_hp_bandwidth_set(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_hpcf_xl_t val);
+int32_t lsm6dsl_xl_hp_bandwidth_get(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_hpcf_xl_t *val);
+
+typedef enum {
+  LSM6DSL_LP2_ONLY                    = 0x00,
+
+  LSM6DSL_HP_16mHz_LP2                = 0x80,
+  LSM6DSL_HP_65mHz_LP2                = 0x90,
+  LSM6DSL_HP_260mHz_LP2               = 0xA0,
+  LSM6DSL_HP_1Hz04_LP2                = 0xB0,
+
+  LSM6DSL_HP_DISABLE_LP1_LIGHT        = 0x0A,
+  LSM6DSL_HP_DISABLE_LP1_NORMAL       = 0x09,
+  LSM6DSL_HP_DISABLE_LP_STRONG        = 0x08,
+  LSM6DSL_HP_DISABLE_LP1_AGGRESSIVE   = 0x0B,
+
+  LSM6DSL_HP_16mHz_LP1_LIGHT          = 0x8A,
+  LSM6DSL_HP_65mHz_LP1_NORMAL         = 0x99,
+  LSM6DSL_HP_260mHz_LP1_STRONG        = 0xA8,
+  LSM6DSL_HP_1Hz04_LP1_AGGRESSIVE     = 0xBB,
+
+  LSM6DSL_HP_GY_BAND_NA               = 0xFF,    /* ERROR CODE */
+} lsm6dsl_lpf1_sel_g_t;
+int32_t lsm6dsl_gy_band_pass_set(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_lpf1_sel_g_t val);
+int32_t lsm6dsl_gy_band_pass_get(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_lpf1_sel_g_t *val);
+
+typedef enum {
+  LSM6DSL_SPI_4_WIRE  = 0,
+  LSM6DSL_SPI_3_WIRE  = 1,
+  LSM6DSL_SPI_MODE_ND = 2,    /* ERROR CODE */
+} lsm6dsl_sim_t;
+int32_t lsm6dsl_spi_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t val);
+int32_t lsm6dsl_spi_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t *val);
+
+typedef enum {
+  LSM6DSL_I2C_ENABLE   = 0,
+  LSM6DSL_I2C_DISABLE  = 1,
+  LSM6DSL_I2C_MODE_ND  = 2,    /* ERROR CODE */
+} lsm6dsl_i2c_disable_t;
+int32_t lsm6dsl_i2c_interface_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_i2c_disable_t val);
+int32_t lsm6dsl_i2c_interface_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_i2c_disable_t *val);
+
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_full_flag           : 1;
+  uint8_t int1_sign_mot            : 1;
+  uint8_t int1_step_detector       : 1;
+  uint8_t int1_timer               : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_inact_state         : 1;
+  uint8_t den_drdy_int1            : 1;
+  uint8_t drdy_on_int1             : 1;
+} lsm6dsl_int1_route_t;
+int32_t lsm6dsl_pin_int1_route_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_int1_route_t val);
+int32_t lsm6dsl_pin_int1_route_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_int1_route_t *val);
+
+typedef struct{
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_full_flag           : 1;
+  uint8_t int2_step_count_ov       : 1;
+  uint8_t int2_step_delta          : 1;
+  uint8_t int2_iron                : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_inact_state         : 1;
+  uint8_t int2_wrist_tilt          : 1;
+} lsm6dsl_int2_route_t;
+int32_t lsm6dsl_pin_int2_route_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_int2_route_t val);
+int32_t lsm6dsl_pin_int2_route_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_int2_route_t *val);
+
+typedef enum {
+  LSM6DSL_PUSH_PULL   = 0,
+  LSM6DSL_OPEN_DRAIN  = 1,
+  LSM6DSL_PIN_MODE_ND = 2,    /* ERROR CODE */
+} lsm6dsl_pp_od_t;
+int32_t lsm6dsl_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t val);
+int32_t lsm6dsl_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t *val);
+
+typedef enum {
+  LSM6DSL_ACTIVE_HIGH   = 0,
+  LSM6DSL_ACTIVE_LOW    = 1,
+  LSM6DSL_POLARITY_ND   = 2,    /* ERROR CODE */
+} lsm6dsl_h_lactive_t;
+int32_t lsm6dsl_pin_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t val);
+int32_t lsm6dsl_pin_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t *val);
+
+int32_t lsm6dsl_all_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_all_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_INT_PULSED   = 0,
+  LSM6DSL_INT_LATCHED  = 1,
+  LSM6DSL_INT_MODE     = 2,    /* ERROR CODE */
+} lsm6dsl_lir_t;
+int32_t lsm6dsl_int_notification_set(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t val);
+int32_t lsm6dsl_int_notification_get(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t *val);
+
+int32_t lsm6dsl_wkup_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_wkup_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_wkup_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_wkup_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_gy_sleep_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_gy_sleep_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_PROPERTY_DISABLE          = 0,
+  LSM6DSL_XL_12Hz5_GY_NOT_AFFECTED  = 1,
+  LSM6DSL_XL_12Hz5_GY_SLEEP         = 2,
+  LSM6DSL_XL_12Hz5_GY_PD            = 3,
+  LSM6DSL_ACT_MODE_ND               = 4,    /* ERROR CODE */
+} lsm6dsl_inact_en_t;
+int32_t lsm6dsl_act_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t val);
+int32_t lsm6dsl_act_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t *val);
+
+int32_t lsm6dsl_act_sleep_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_act_sleep_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_tap_src_get(lsm6dsl_ctx_t *ctx, lsm6dsl_tap_src_t *val);
+
+int32_t lsm6dsl_tap_detection_on_z_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_detection_on_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_tap_detection_on_y_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_detection_on_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_tap_detection_on_x_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_detection_on_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_tap_threshold_x_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_threshold_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_tap_shock_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_shock_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_tap_quiet_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_quiet_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_tap_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_ONLY_SINGLE          = 0,
+  LSM6DSL_BOTH_SINGLE_DOUBLE   = 1,
+  LSM6DSL_TAP_MODE_ND          = 2,    /* ERROR CODE */
+} lsm6dsl_single_double_tap_t;
+int32_t lsm6dsl_tap_mode_set(lsm6dsl_ctx_t *ctx,
+                             lsm6dsl_single_double_tap_t val);
+int32_t lsm6dsl_tap_mode_get(lsm6dsl_ctx_t *ctx,
+                             lsm6dsl_single_double_tap_t *val);
+
+typedef enum {
+  LSM6DSL_ODR_DIV_2_FEED      = 0,
+  LSM6DSL_LPF2_FEED           = 1,
+  LSM6DSL_6D_FEED_ND          = 2,    /* ERROR CODE */
+} lsm6dsl_low_pass_on_6d_t;
+int32_t lsm6dsl_6d_feed_data_set(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_low_pass_on_6d_t val);
+int32_t lsm6dsl_6d_feed_data_get(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_low_pass_on_6d_t *val);
+
+typedef enum {
+  LSM6DSL_DEG_80      = 0,
+  LSM6DSL_DEG_70      = 1,
+  LSM6DSL_DEG_60      = 2,
+  LSM6DSL_DEG_50      = 3,
+  LSM6DSL_6D_TH_ND    = 4,    /* ERROR CODE */
+} lsm6dsl_sixd_ths_t;
+int32_t lsm6dsl_6d_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t val);
+int32_t lsm6dsl_6d_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t *val);
+
+int32_t lsm6dsl_4d_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_4d_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_ff_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_ff_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_FF_TSH_156mg = 0,
+  LSM6DSL_FF_TSH_219mg = 1,
+  LSM6DSL_FF_TSH_250mg = 2,
+  LSM6DSL_FF_TSH_312mg = 3,
+  LSM6DSL_FF_TSH_344mg = 4,
+  LSM6DSL_FF_TSH_406mg = 5,
+  LSM6DSL_FF_TSH_469mg = 6,
+  LSM6DSL_FF_TSH_500mg = 7,
+  LSM6DSL_FF_TSH_ND    = 8,    /* ERROR CODE */
+} lsm6dsl_ff_ths_t;
+int32_t lsm6dsl_ff_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t val);
+int32_t lsm6dsl_ff_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t *val);
+
+int32_t lsm6dsl_fifo_watermark_set(lsm6dsl_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsl_fifo_watermark_get(lsm6dsl_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsl_fifo_data_level_get(lsm6dsl_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsl_fifo_wtm_flag_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_fifo_pattern_get(lsm6dsl_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsl_fifo_temp_batch_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_fifo_temp_batch_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_TRG_XL_GY_DRDY     = 0,
+  LSM6DSL_TRG_STEP_DETECT    = 1,
+  LSM6DSL_TRG_SH_DRDY        = 2,
+  LSM6DSL_TRG_SH_ND          = 3,    /* ERROR CODE */
+} lsm6dsl_trigger_fifo_t;
+int32_t lsm6dsl_fifo_write_trigger_set(lsm6dsl_ctx_t *ctx,
+                                       lsm6dsl_trigger_fifo_t val);
+int32_t lsm6dsl_fifo_write_trigger_get(lsm6dsl_ctx_t *ctx,
+                                       lsm6dsl_trigger_fifo_t *val);
+
+int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_set(lsm6dsl_ctx_t *ctx,
+                                                  uint8_t val);
+int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_get(lsm6dsl_ctx_t *ctx,
+                                                  uint8_t *val);
+
+typedef enum {
+  LSM6DSL_FIFO_XL_DISABLE  = 0,
+  LSM6DSL_FIFO_XL_NO_DEC   = 1,
+  LSM6DSL_FIFO_XL_DEC_2    = 2,
+  LSM6DSL_FIFO_XL_DEC_3    = 3,
+  LSM6DSL_FIFO_XL_DEC_4    = 4,
+  LSM6DSL_FIFO_XL_DEC_8    = 5,
+  LSM6DSL_FIFO_XL_DEC_16   = 6,
+  LSM6DSL_FIFO_XL_DEC_32   = 7,
+  LSM6DSL_FIFO_XL_DEC_ND   = 8,    /* ERROR CODE */
+} lsm6dsl_dec_fifo_xl_t;
+int32_t lsm6dsl_fifo_xl_batch_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_dec_fifo_xl_t val);
+int32_t lsm6dsl_fifo_xl_batch_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_dec_fifo_xl_t *val);
+
+typedef enum {
+  LSM6DSL_FIFO_GY_DISABLE = 0,
+  LSM6DSL_FIFO_GY_NO_DEC  = 1,
+  LSM6DSL_FIFO_GY_DEC_2   = 2,
+  LSM6DSL_FIFO_GY_DEC_3   = 3,
+  LSM6DSL_FIFO_GY_DEC_4   = 4,
+  LSM6DSL_FIFO_GY_DEC_8   = 5,
+  LSM6DSL_FIFO_GY_DEC_16  = 6,
+  LSM6DSL_FIFO_GY_DEC_32  = 7,
+  LSM6DSL_FIFO_GY_DEC_ND  = 8,    /* ERROR CODE */
+} lsm6dsl_dec_fifo_gyro_t;
+int32_t lsm6dsl_fifo_gy_batch_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_dec_fifo_gyro_t val);
+int32_t lsm6dsl_fifo_gy_batch_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_dec_fifo_gyro_t *val);
+
+typedef enum {
+  LSM6DSL_FIFO_DS3_DISABLE   = 0,
+  LSM6DSL_FIFO_DS3_NO_DEC    = 1,
+  LSM6DSL_FIFO_DS3_DEC_2     = 2,
+  LSM6DSL_FIFO_DS3_DEC_3     = 3,
+  LSM6DSL_FIFO_DS3_DEC_4     = 4,
+  LSM6DSL_FIFO_DS3_DEC_8     = 5,
+  LSM6DSL_FIFO_DS3_DEC_16    = 6,
+  LSM6DSL_FIFO_DS3_DEC_32    = 7,
+  LSM6DSL_FIFO_DS3_DEC_ND    = 8,    /* ERROR CODE */
+} lsm6dsl_dec_ds3_fifo_t;
+int32_t lsm6dsl_fifo_dataset_3_batch_set(lsm6dsl_ctx_t *ctx,
+                                         lsm6dsl_dec_ds3_fifo_t val);
+int32_t lsm6dsl_fifo_dataset_3_batch_get(lsm6dsl_ctx_t *ctx,
+                                         lsm6dsl_dec_ds3_fifo_t *val);
+
+typedef enum {
+  LSM6DSL_FIFO_DS4_DISABLE  = 0,
+  LSM6DSL_FIFO_DS4_NO_DEC   = 1,
+  LSM6DSL_FIFO_DS4_DEC_2    = 2,
+  LSM6DSL_FIFO_DS4_DEC_3    = 3,
+  LSM6DSL_FIFO_DS4_DEC_4    = 4,
+  LSM6DSL_FIFO_DS4_DEC_8    = 5,
+  LSM6DSL_FIFO_DS4_DEC_16   = 6,
+  LSM6DSL_FIFO_DS4_DEC_32   = 7,
+  LSM6DSL_FIFO_DS4_DEC_ND   = 8,    /* ERROR CODE */
+} lsm6dsl_dec_ds4_fifo_t;
+int32_t lsm6dsl_fifo_dataset_4_batch_set(lsm6dsl_ctx_t *ctx,
+                                         lsm6dsl_dec_ds4_fifo_t val);
+int32_t lsm6dsl_fifo_dataset_4_batch_get(lsm6dsl_ctx_t *ctx,
+                                         lsm6dsl_dec_ds4_fifo_t *val);
+
+int32_t lsm6dsl_fifo_xl_gy_8bit_format_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_fifo_xl_gy_8bit_format_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_fifo_stop_on_wtm_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_fifo_stop_on_wtm_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_BYPASS_MODE           = 0,
+  LSM6DSL_FIFO_MODE             = 1,
+  LSM6DSL_STREAM_TO_FIFO_MODE   = 3,
+  LSM6DSL_BYPASS_TO_STREAM_MODE = 4,
+  LSM6DSL_STREAM_MODE           = 6,
+  LSM6DSL_FIFO_MODE_ND          = 8,    /* ERROR CODE */
+} lsm6dsl_fifo_mode_t;
+int32_t lsm6dsl_fifo_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t val);
+int32_t lsm6dsl_fifo_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t *val);
+
+typedef enum {
+  LSM6DSL_FIFO_DISABLE   =  0,
+  LSM6DSL_FIFO_12Hz5     =  1,
+  LSM6DSL_FIFO_26Hz      =  2,
+  LSM6DSL_FIFO_52Hz      =  3,
+  LSM6DSL_FIFO_104Hz     =  4,
+  LSM6DSL_FIFO_208Hz     =  5,
+  LSM6DSL_FIFO_416Hz     =  6,
+  LSM6DSL_FIFO_833Hz     =  7,
+  LSM6DSL_FIFO_1k66Hz    =  8,
+  LSM6DSL_FIFO_3k33Hz    =  9,
+  LSM6DSL_FIFO_6k66Hz    = 10,
+  LSM6DSL_FIFO_RATE_ND   = 11,    /* ERROR CODE */
+} lsm6dsl_odr_fifo_t;
+int32_t lsm6dsl_fifo_data_rate_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_odr_fifo_t val);
+int32_t lsm6dsl_fifo_data_rate_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_odr_fifo_t *val);
+
+typedef enum {
+  LSM6DSL_DEN_ACT_LOW    = 0,
+  LSM6DSL_DEN_ACT_HIGH   = 1,
+  LSM6DSL_DEN_POL_ND     = 2,    /* ERROR CODE */
+} lsm6dsl_den_lh_t;
+int32_t lsm6dsl_den_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t val);
+int32_t lsm6dsl_den_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t *val);
+
+typedef enum {
+  LSM6DSL_DEN_DISABLE    = 0,
+  LSM6DSL_LEVEL_FIFO     = 6,
+  LSM6DSL_LEVEL_LETCHED  = 3,
+  LSM6DSL_LEVEL_TRIGGER  = 2,
+  LSM6DSL_EDGE_TRIGGER   = 4,
+  LSM6DSL_DEN_MODE_ND    = 5,    /* ERROR CODE */
+} lsm6dsl_den_mode_t;
+int32_t lsm6dsl_den_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t val);
+int32_t lsm6dsl_den_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t *val);
+
+typedef enum {
+  LSM6DSL_STAMP_IN_GY_DATA     = 0,
+  LSM6DSL_STAMP_IN_XL_DATA     = 1,
+  LSM6DSL_STAMP_IN_GY_XL_DATA  = 2,
+  LSM6DSL_DEN_STAMP_ND         = 3,    /* ERROR CODE */
+} lsm6dsl_den_xl_en_t;
+int32_t lsm6dsl_den_enable_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t val);
+int32_t lsm6dsl_den_enable_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t *val);
+
+int32_t lsm6dsl_den_mark_axis_z_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_den_mark_axis_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_den_mark_axis_y_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_den_mark_axis_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_den_mark_axis_x_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_den_mark_axis_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_pedo_step_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_step_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_pedo_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_pedo_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_PEDO_AT_2g = 0,
+  LSM6DSL_PEDO_AT_4g = 1,
+  LSM6DSL_PEDO_FS_ND = 2,    /* ERROR CODE */
+} lsm6dsl_pedo_fs_t;
+int32_t lsm6dsl_pedo_full_scale_set(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_pedo_fs_t val);
+int32_t lsm6dsl_pedo_full_scale_get(lsm6dsl_ctx_t *ctx,
+                                    lsm6dsl_pedo_fs_t *val);
+
+int32_t lsm6dsl_pedo_debounce_steps_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_debounce_steps_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_pedo_timeout_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_timeout_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_pedo_steps_period_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_pedo_steps_period_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsl_motion_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_motion_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_motion_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_motion_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsl_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_wrist_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_wrist_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_tilt_latency_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_tilt_latency_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsl_tilt_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_tilt_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsl_tilt_src_set(lsm6dsl_ctx_t *ctx,
+                             lsm6dsl_a_wrist_tilt_mask_t *val);
+int32_t lsm6dsl_tilt_src_get(lsm6dsl_ctx_t *ctx,
+                             lsm6dsl_a_wrist_tilt_mask_t *val);
+
+int32_t lsm6dsl_mag_soft_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_mag_soft_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_mag_hard_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_mag_hard_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_mag_soft_iron_mat_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_mag_soft_iron_mat_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsl_mag_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_mag_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsl_func_en_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+
+int32_t lsm6dsl_sh_sync_sens_frame_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_sync_sens_frame_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_RES_RATIO_2_11  = 0,
+  LSM6DSL_RES_RATIO_2_12  = 1,
+  LSM6DSL_RES_RATIO_2_13  = 2,
+  LSM6DSL_RES_RATIO_2_14  = 3,
+  LSM6DSL_RES_RATIO_ND    = 4,    /* ERROR CODE */
+} lsm6dsl_rr_t;
+int32_t lsm6dsl_sh_sync_sens_ratio_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t val);
+int32_t lsm6dsl_sh_sync_sens_ratio_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t *val);
+
+int32_t lsm6dsl_sh_master_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_master_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_sh_pass_through_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_pass_through_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_EXT_PULL_UP       = 0,
+  LSM6DSL_INTERNAL_PULL_UP  = 1,
+  LSM6DSL_SH_PIN_MODE       = 2,    /* ERROR CODE */
+} lsm6dsl_pull_up_en_t;
+int32_t lsm6dsl_sh_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t val);
+int32_t lsm6dsl_sh_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t *val);
+
+typedef enum {
+  LSM6DSL_XL_GY_DRDY        = 0,
+  LSM6DSL_EXT_ON_INT2_PIN   = 1,
+  LSM6DSL_SH_SYNCRO_ND      = 2,    /* ERROR CODE */
+} lsm6dsl_start_config_t;
+int32_t lsm6dsl_sh_syncro_mode_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_start_config_t val);
+int32_t lsm6dsl_sh_syncro_mode_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_start_config_t *val);
+
+int32_t lsm6dsl_sh_drdy_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_drdy_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+    lsm6dsl_sensorhub1_reg_t   sh_byte_1;
+    lsm6dsl_sensorhub2_reg_t   sh_byte_2;
+    lsm6dsl_sensorhub3_reg_t   sh_byte_3;
+    lsm6dsl_sensorhub4_reg_t   sh_byte_4;
+    lsm6dsl_sensorhub5_reg_t   sh_byte_5;
+    lsm6dsl_sensorhub6_reg_t   sh_byte_6;
+    lsm6dsl_sensorhub7_reg_t   sh_byte_7;
+    lsm6dsl_sensorhub8_reg_t   sh_byte_8;
+    lsm6dsl_sensorhub9_reg_t   sh_byte_9;
+    lsm6dsl_sensorhub10_reg_t  sh_byte_10;
+    lsm6dsl_sensorhub11_reg_t  sh_byte_11;
+    lsm6dsl_sensorhub12_reg_t  sh_byte_12;
+    lsm6dsl_sensorhub13_reg_t  sh_byte_13;
+    lsm6dsl_sensorhub14_reg_t  sh_byte_14;
+    lsm6dsl_sensorhub15_reg_t  sh_byte_15;
+    lsm6dsl_sensorhub16_reg_t  sh_byte_16;
+    lsm6dsl_sensorhub17_reg_t  sh_byte_17;
+    lsm6dsl_sensorhub18_reg_t  sh_byte_18;
+} lsm6dsl_emb_sh_read_t;
+int32_t lsm6dsl_sh_read_data_raw_get(lsm6dsl_ctx_t *ctx,
+                                     lsm6dsl_emb_sh_read_t *val);
+
+int32_t lsm6dsl_sh_cmd_sens_sync_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_cmd_sens_sync_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsl_sh_spi_sync_error_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_spi_sync_error_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSL_SLV_0        = 0,
+  LSM6DSL_SLV_0_1      = 1,
+  LSM6DSL_SLV_0_1_2    = 2,
+  LSM6DSL_SLV_0_1_2_3  = 3,
+  LSM6DSL_SLV_EN_ND    = 4,    /* ERROR CODE */
+} lsm6dsl_aux_sens_on_t;
+int32_t lsm6dsl_sh_num_of_dev_connected_set(lsm6dsl_ctx_t *ctx,
+                                            lsm6dsl_aux_sens_on_t val);
+int32_t lsm6dsl_sh_num_of_dev_connected_get(lsm6dsl_ctx_t *ctx,
+                                            lsm6dsl_aux_sens_on_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} lsm6dsl_sh_cfg_write_t;
+int32_t lsm6dsl_sh_cfg_write(lsm6dsl_ctx_t *ctx, lsm6dsl_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} lsm6dsl_sh_cfg_read_t;
+int32_t lsm6dsl_sh_slv0_cfg_read(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_sh_cfg_read_t *val);
+int32_t lsm6dsl_sh_slv1_cfg_read(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_sh_cfg_read_t *val);
+int32_t lsm6dsl_sh_slv2_cfg_read(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_sh_cfg_read_t *val);
+int32_t lsm6dsl_sh_slv3_cfg_read(lsm6dsl_ctx_t *ctx,
+                                 lsm6dsl_sh_cfg_read_t *val);
+
+typedef enum {
+  LSM6DSL_SL0_NO_DEC   = 0,
+  LSM6DSL_SL0_DEC_2    = 1,
+  LSM6DSL_SL0_DEC_4    = 2,
+  LSM6DSL_SL0_DEC_8    = 3,
+  LSM6DSL_SL0_DEC_ND   = 4,    /* ERROR CODE */
+} lsm6dsl_slave0_rate_t;
+int32_t lsm6dsl_sh_slave_0_dec_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave0_rate_t val);
+int32_t lsm6dsl_sh_slave_0_dec_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave0_rate_t *val);
+
+typedef enum {
+  LSM6DSL_EACH_SH_CYCLE     = 0,
+  LSM6DSL_ONLY_FIRST_CYCLE  = 1,
+  LSM6DSL_SH_WR_MODE_ND     = 2,    /* ERROR CODE */
+} lsm6dsl_write_once_t;
+int32_t lsm6dsl_sh_write_mode_set(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_write_once_t val);
+int32_t lsm6dsl_sh_write_mode_get(lsm6dsl_ctx_t *ctx,
+                                  lsm6dsl_write_once_t *val);
+
+typedef enum {
+  LSM6DSL_SL1_NO_DEC   = 0,
+  LSM6DSL_SL1_DEC_2    = 1,
+  LSM6DSL_SL1_DEC_4    = 2,
+  LSM6DSL_SL1_DEC_8    = 3,
+  LSM6DSL_SL1_DEC_ND   = 4,    /* ERROR CODE */
+} lsm6dsl_slave1_rate_t;
+int32_t lsm6dsl_sh_slave_1_dec_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave1_rate_t val);
+int32_t lsm6dsl_sh_slave_1_dec_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave1_rate_t *val);
+
+typedef enum {
+  LSM6DSL_SL2_NO_DEC  = 0,
+  LSM6DSL_SL2_DEC_2   = 1,
+  LSM6DSL_SL2_DEC_4   = 2,
+  LSM6DSL_SL2_DEC_8   = 3,
+  LSM6DSL_SL2_DEC_ND  = 4,    /* ERROR CODE */
+} lsm6dsl_slave2_rate_t;
+int32_t lsm6dsl_sh_slave_2_dec_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave2_rate_t val);
+int32_t lsm6dsl_sh_slave_2_dec_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave2_rate_t *val);
+
+typedef enum {
+  LSM6DSL_SL3_NO_DEC  = 0,
+  LSM6DSL_SL3_DEC_2   = 1,
+  LSM6DSL_SL3_DEC_4   = 2,
+  LSM6DSL_SL3_DEC_8   = 3,
+  LSM6DSL_SL3_DEC_ND  = 4,    /* ERROR CODE */
+} lsm6dsl_slave3_rate_t;
+int32_t lsm6dsl_sh_slave_3_dec_set(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave3_rate_t val);
+int32_t lsm6dsl_sh_slave_3_dec_get(lsm6dsl_ctx_t *ctx,
+                                   lsm6dsl_slave3_rate_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSM6DSL_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsm_STdC/driver/lsm6dsm_reg.c
+++ b/sensor/stmemsc/lsm6dsm_STdC/driver/lsm6dsm_reg.c
@@ -1,0 +1,7812 @@
+/*
+ ******************************************************************************
+ * @file    lsm6dsm_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LSM6DSM driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+#include "lsm6dsm_reg.h"
+
+/**
+  * @defgroup    LSM6DSM
+  * @brief       This file provides a set of functions needed to drive the
+  *              lsm6dsm enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_interfaces_functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsm_read_reg(lsm6dsm_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsm_write_reg(lsm6dsm_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lsm6dsm_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t lsm6dsm_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t lsm6dsm_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t lsm6dsm_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t lsm6dsm_from_fs125dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 4.375f);
+}
+
+float_t lsm6dsm_from_fs250dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 8.750f);
+}
+
+float_t lsm6dsm_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 17.50f);
+}
+
+float_t lsm6dsm_from_fs1000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 35.0f);
+}
+
+float_t lsm6dsm_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t lsm6dsm_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+
+/**
+  * @defgroup    LSM6DSM_data_generation
+  * @brief       This section groups all the functions concerning data
+  *              generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t *val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.fs_xl) {
+    case LSM6DSM_2g:
+      *val = LSM6DSM_2g;
+      break;
+    case LSM6DSM_16g:
+      *val = LSM6DSM_16g;
+      break;
+    case LSM6DSM_4g:
+      *val = LSM6DSM_4g;
+      break;
+    case LSM6DSM_8g:
+      *val = LSM6DSM_8g;
+      break;
+    default:
+      *val = LSM6DSM_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.odr_xl = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t *val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.odr_xl) {
+    case LSM6DSM_XL_ODR_OFF:
+      *val = LSM6DSM_XL_ODR_OFF;
+      break;
+    case LSM6DSM_XL_ODR_12Hz5:
+      *val = LSM6DSM_XL_ODR_12Hz5;
+      break;
+    case LSM6DSM_XL_ODR_26Hz:
+      *val = LSM6DSM_XL_ODR_26Hz;
+      break;
+    case LSM6DSM_XL_ODR_52Hz:
+      *val = LSM6DSM_XL_ODR_52Hz;
+      break;
+    case LSM6DSM_XL_ODR_104Hz:
+      *val = LSM6DSM_XL_ODR_104Hz;
+      break;
+    case LSM6DSM_XL_ODR_208Hz:
+      *val = LSM6DSM_XL_ODR_208Hz;
+      break;
+    case LSM6DSM_XL_ODR_416Hz:
+      *val = LSM6DSM_XL_ODR_416Hz;
+      break;
+    case LSM6DSM_XL_ODR_833Hz:
+      *val = LSM6DSM_XL_ODR_833Hz;
+      break;
+    case LSM6DSM_XL_ODR_1k66Hz:
+      *val = LSM6DSM_XL_ODR_1k66Hz;
+      break;
+    case LSM6DSM_XL_ODR_3k33Hz:
+      *val = LSM6DSM_XL_ODR_3k33Hz;
+      break;
+    case LSM6DSM_XL_ODR_6k66Hz:
+      *val = LSM6DSM_XL_ODR_6k66Hz;
+      break;
+    case LSM6DSM_XL_ODR_1Hz6:
+      *val = LSM6DSM_XL_ODR_1Hz6;
+      break;
+    default:
+      *val = LSM6DSM_XL_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope chain full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t val)
+{
+  lsm6dsm_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.fs_g = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t *val)
+{
+  lsm6dsm_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.fs_g) {
+    case LSM6DSM_250dps:
+      *val = LSM6DSM_250dps;
+      break;
+    case LSM6DSM_125dps:
+      *val = LSM6DSM_125dps;
+      break;
+    case LSM6DSM_500dps:
+      *val = LSM6DSM_500dps;
+      break;
+    case LSM6DSM_1000dps:
+      *val = LSM6DSM_1000dps;
+      break;
+    case LSM6DSM_2000dps:
+      *val = LSM6DSM_2000dps;
+      break;
+    default:
+      *val = LSM6DSM_250dps;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t val)
+{
+  lsm6dsm_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.odr_g = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t *val)
+{
+  lsm6dsm_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.odr_g) {
+    case LSM6DSM_GY_ODR_OFF:
+      *val = LSM6DSM_GY_ODR_OFF;
+      break;
+    case LSM6DSM_GY_ODR_12Hz5:
+      *val = LSM6DSM_GY_ODR_12Hz5;
+      break;
+    case LSM6DSM_GY_ODR_26Hz:
+      *val = LSM6DSM_GY_ODR_26Hz;
+      break;
+    case LSM6DSM_GY_ODR_52Hz:
+      *val = LSM6DSM_GY_ODR_52Hz;
+      break;
+    case LSM6DSM_GY_ODR_104Hz:
+      *val = LSM6DSM_GY_ODR_104Hz;
+      break;
+    case LSM6DSM_GY_ODR_208Hz:
+      *val = LSM6DSM_GY_ODR_208Hz;
+      break;
+    case LSM6DSM_GY_ODR_416Hz:
+      *val = LSM6DSM_GY_ODR_416Hz;
+      break;
+    case LSM6DSM_GY_ODR_833Hz:
+      *val = LSM6DSM_GY_ODR_833Hz;
+      break;
+    case LSM6DSM_GY_ODR_1k66Hz:
+      *val = LSM6DSM_GY_ODR_1k66Hz;
+      break;
+    case LSM6DSM_GY_ODR_3k33Hz:
+      *val = LSM6DSM_GY_ODR_3k33Hz;
+      break;
+    case LSM6DSM_GY_ODR_6k66Hz:
+      *val = LSM6DSM_GY_ODR_6k66Hz;
+      break;
+    default:
+      *val = LSM6DSM_GY_ODR_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_block_data_update_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_block_data_update_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers
+  *         X_OFS_USR(73h), Y_OFS_USR(74h), Z_OFS_USR(75h).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_offset_weight_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_usr_off_w_t val)
+{
+  lsm6dsm_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.usr_off_w = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers
+  *         X_OFS_USR(73h), Y_OFS_USR(74h), Z_OFS_USR(75h).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_offset_weight_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_usr_off_w_t *val)
+{
+  lsm6dsm_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.usr_off_w) {
+    case LSM6DSM_LSb_1mg:
+      *val = LSM6DSM_LSb_1mg;
+      break;
+    case LSM6DSM_LSb_16mg:
+      *val = LSM6DSM_LSb_16mg;
+      break;
+    default:
+      *val = LSM6DSM_LSb_1mg;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode for accelerometer[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_power_mode_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_xl_hm_mode_t val)
+{
+  lsm6dsm_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.xl_hm_mode = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode for accelerometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_power_mode_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_xl_hm_mode_t *val)
+{
+  lsm6dsm_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.xl_hm_mode) {
+    case LSM6DSM_XL_HIGH_PERFORMANCE:
+      *val = LSM6DSM_XL_HIGH_PERFORMANCE;
+      break;
+    case LSM6DSM_XL_NORMAL:
+      *val = LSM6DSM_XL_NORMAL;
+      break;
+    default:
+      *val = LSM6DSM_XL_HIGH_PERFORMANCE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Source register rounding function on WAKE_UP_SRC (1Bh),
+  *         TAP_SRC (1Ch), D6D_SRC (1Dh), STATUS_REG (1Eh) and
+  *         FUNC_SRC1 (53h) registers in the primary interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rounding_status in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_rounding_on_status_set(lsm6dsm_ctx_t *ctx,
+                                       lsm6dsm_rounding_status_t val)
+{
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.rounding_status = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Source register rounding function on WAKE_UP_SRC (1Bh),
+  *         TAP_SRC (1Ch), D6D_SRC (1Dh), STATUS_REG (1Eh) and
+  *         FUNC_SRC1 (53h) registers in the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rounding_status in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_rounding_on_status_get(lsm6dsm_ctx_t *ctx,
+                                       lsm6dsm_rounding_status_t *val)
+{
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.rounding_status) {
+    case LSM6DSM_STAT_RND_DISABLE:
+      *val = LSM6DSM_STAT_RND_DISABLE;
+      break;
+    case LSM6DSM_STAT_RND_ENABLE:
+      *val = LSM6DSM_STAT_RND_ENABLE;
+      break;
+    default:
+      *val = LSM6DSM_STAT_RND_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode disable for gyroscope.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_power_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_g_hm_mode_t val)
+{
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.g_hm_mode = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode disable for gyroscope.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_power_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_g_hm_mode_t *val)
+{
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.g_hm_mode) {
+    case LSM6DSM_GY_HIGH_PERFORMANCE:
+      *val = LSM6DSM_GY_HIGH_PERFORMANCE;
+      break;
+    case LSM6DSM_GY_NORMAL:
+      *val = LSM6DSM_GY_NORMAL;
+      break;
+    default:
+      *val = LSM6DSM_GY_HIGH_PERFORMANCE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    WAKE_UP_SRC, TAP_SRC, D6D_SRC, STATUS_REG,
+  *                FUNC_SRC1, FUNC_SRC2, WRIST_TILT_IA, A_WRIST_TILT_Mask
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_all_sources_get(lsm6dsm_ctx_t *ctx,
+                                lsm6dsm_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_SRC,
+                         (uint8_t*)&(val->wake_up_src), 1);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_SRC,
+                           (uint8_t*)&(val->tap_src), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_D6D_SRC,
+                           (uint8_t*)&(val->d6d_src), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_REG,
+                           (uint8_t*)&(val->status_reg), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_FUNC_SRC1,
+                           (uint8_t*)&(val->func_src1), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_FUNC_SRC2,
+                           (uint8_t*)&(val->func_src2), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_WRIST_TILT_IA,
+                           (uint8_t*)&(val->wrist_tilt_ia), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_B);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_A_WRIST_TILT_MASK,
+                           (uint8_t*)&(val->a_wrist_tilt_mask), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+  }
+
+  return ret;
+}
+/**
+  * @brief  The STATUS_REG register is read by the primary interface[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_status_reg_get(lsm6dsm_ctx_t *ctx, lsm6dsm_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of gda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_temp_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C.
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_usr_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsm_write_reg(ctx, LSM6DSM_X_OFS_USR, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer axis user offset correction xpressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C.
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_usr_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_X_OFS_USR, buff, 3);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_Timestamp
+  * @brief       This section groups all the functions that manage the
+  *              timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable timestamp count. The count is saved in TIMESTAMP0_REG (40h),
+  *         TIMESTAMP1_REG (41h) and TIMESTAMP2_REG (42h).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_timestamp_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.timer_en = val;
+    if ( val != 0x00U) {
+      ctrl10_c.func_en = val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable timestamp count. The count is saved in TIMESTAMP0_REG (40h),
+  *         TIMESTAMP1_REG (41h) and TIMESTAMP2_REG (42h).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_timestamp_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.timer_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp register resolution setting.
+  *         Configuration of this bit affects
+  *         TIMESTAMP0_REG(40h), TIMESTAMP1_REG(41h),
+  *         TIMESTAMP2_REG(42h), STEP_TIMESTAMP_L(49h),
+  *         STEP_TIMESTAMP_H(4Ah) and
+  *         STEP_COUNT_DELTA(15h) registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_hr in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_timestamp_res_set(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t val)
+{
+  lsm6dsm_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.timer_hr = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Timestamp register resolution setting.
+  *         Configuration of this bit affects
+  *         TIMESTAMP0_REG(40h), TIMESTAMP1_REG(41h),
+  *         TIMESTAMP2_REG(42h), STEP_TIMESTAMP_L(49h),
+  *         STEP_TIMESTAMP_H(4Ah) and
+  *         STEP_COUNT_DELTA(15h) registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of timer_hr in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_timestamp_res_get(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t *val)
+{
+  lsm6dsm_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  switch (wake_up_dur.timer_hr) {
+    case LSM6DSM_LSB_6ms4:
+      *val = LSM6DSM_LSB_6ms4;
+      break;
+    case LSM6DSM_LSB_25us:
+      *val = LSM6DSM_LSB_25us;
+      break;
+    default:
+      *val = LSM6DSM_LSB_6ms4;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_Dataoutput
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read from output registers
+  *         through the primary interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_rounding_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t val)
+{
+  lsm6dsm_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Circular burst-mode (rounding) read from output registers
+  *         through the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_rounding_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t *val)
+{
+  lsm6dsm_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.rounding) {
+    case LSM6DSM_ROUND_DISABLE:
+      *val = LSM6DSM_ROUND_DISABLE;
+      break;
+    case LSM6DSM_ROUND_XL:
+      *val = LSM6DSM_ROUND_XL;
+      break;
+    case LSM6DSM_ROUND_GY:
+      *val = LSM6DSM_ROUND_GY;
+      break;
+    case LSM6DSM_ROUND_GY_XL:
+      *val = LSM6DSM_ROUND_GY_XL;
+      break;
+    case LSM6DSM_ROUND_SH1_TO_SH6:
+      *val = LSM6DSM_ROUND_SH1_TO_SH6;
+      break;
+    case LSM6DSM_ROUND_XL_SH1_TO_SH6:
+      *val = LSM6DSM_ROUND_XL_SH1_TO_SH6;
+      break;
+    case LSM6DSM_ROUND_GY_XL_SH1_TO_SH12:
+      *val = LSM6DSM_ROUND_GY_XL_SH1_TO_SH12;
+      break;
+    case LSM6DSM_ROUND_GY_XL_SH1_TO_SH6:
+      *val = LSM6DSM_ROUND_GY_XL_SH1_TO_SH6;
+      break;
+    default:
+      *val = LSM6DSM_ROUND_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r). L and H registers together
+  *         express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_temperature_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_angular_rate_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_acceleration_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_OUTX_L_XL, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer raw data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_calibrated_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_OUT_MAG_RAW_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Read data in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buffer Data buffer to store FIFO data.
+  * @param  len    Number of data to read from FIFO.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_raw_data_get(lsm6dsm_ctx_t *ctx, uint8_t *buffer,
+                                  uint8_t len)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_DATA_OUT_L, buffer, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub
+  *         configuration registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mem_bank_set(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t val)
+{
+  lsm6dsm_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  if(ret == 0){
+    func_cfg_access.func_cfg_en = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FUNC_CFG_ACCESS,
+                            (uint8_t*)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mem_bank_get(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t *val)
+{
+  lsm6dsm_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  switch (func_cfg_access.func_cfg_en) {
+    case LSM6DSM_USER_BANK:
+      *val = LSM6DSM_USER_BANK;
+      break;
+    case LSM6DSM_BANK_B:
+      *val = LSM6DSM_BANK_B;
+      break;
+    default:
+      *val = LSM6DSM_USER_BANK;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_pulsed in reg DRDY_PULSE_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_data_ready_mode_set(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_drdy_pulsed_g_t val)
+{
+  lsm6dsm_drdy_pulse_cfg_t drdy_pulse_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_DRDY_PULSE_CFG,
+                         (uint8_t*)&drdy_pulse_cfg, 1);
+  if(ret == 0){
+    drdy_pulse_cfg.drdy_pulsed = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_DRDY_PULSE_CFG,
+                            (uint8_t*)&drdy_pulse_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of drdy_pulsed in reg DRDY_PULSE_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_data_ready_mode_get(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_drdy_pulsed_g_t *val)
+{
+  lsm6dsm_drdy_pulse_cfg_t drdy_pulse_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_DRDY_PULSE_CFG,
+                         (uint8_t*)&drdy_pulse_cfg, 1);
+  switch (drdy_pulse_cfg.drdy_pulsed) {
+    case LSM6DSM_DRDY_LATCHED:
+      *val = LSM6DSM_DRDY_LATCHED;
+      break;
+    case LSM6DSM_DRDY_PULSED:
+      *val = LSM6DSM_DRDY_PULSED;
+      break;
+    default:
+      *val = LSM6DSM_DRDY_LATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_device_id_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ble in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_data_format_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.ble = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ble in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_data_format_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t *val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.ble) {
+    case LSM6DSM_LSB_AT_LOW_ADD:
+      *val = LSM6DSM_LSB_AT_LOW_ADD;
+      break;
+    case LSM6DSM_MSB_AT_LOW_ADD:
+      *val = LSM6DSM_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LSM6DSM_LSB_AT_LOW_ADD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_auto_increment_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_auto_increment_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_boot_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_boot_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t val)
+{
+  lsm6dsm_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t *val)
+{
+  lsm6dsm_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.st_xl) {
+    case LSM6DSM_XL_ST_DISABLE:
+      *val = LSM6DSM_XL_ST_DISABLE;
+      break;
+    case LSM6DSM_XL_ST_POSITIVE:
+      *val = LSM6DSM_XL_ST_POSITIVE;
+      break;
+    case LSM6DSM_XL_ST_NEGATIVE:
+      *val = LSM6DSM_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSM_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t val)
+{
+  lsm6dsm_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_g = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t *val)
+{
+  lsm6dsm_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.st_g) {
+    case LSM6DSM_GY_ST_DISABLE:
+      *val = LSM6DSM_GY_ST_DISABLE;
+      break;
+    case LSM6DSM_GY_ST_POSITIVE:
+      *val = LSM6DSM_GY_ST_POSITIVE;
+      break;
+    case LSM6DSM_GY_ST_NEGATIVE:
+      *val = LSM6DSM_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSM_GY_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact both accelerometer and gyro.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_filter_settling_mask_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_filter_settling_mask_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slope_fds in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_hp_path_internal_set(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_slope_fds_t val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.slope_fds = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slope_fds in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_hp_path_internal_get(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_slope_fds_t *val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.slope_fds) {
+    case LSM6DSM_USE_SLOPE:
+      *val = LSM6DSM_USE_SLOPE;
+      break;
+    case LSM6DSM_USE_HPF:
+      *val = LSM6DSM_USE_HPF;
+      break;
+    default:
+      *val = LSM6DSM_USE_SLOPE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_accelerometer_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer in every mode.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer analog chain bandwidth selection (only for
+  *         accelerometer ODR ≥ 1.67 kHz).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bw0_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_filter_analog_set(lsm6dsm_ctx_t *ctx, lsm6dsm_bw0_xl_t val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.bw0_xl = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer analog chain bandwidth selection (only for
+  *         accelerometer ODR ≥ 1.67 kHz).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of bw0_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_filter_analog_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_bw0_xl_t *val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.bw0_xl) {
+    case LSM6DSM_XL_ANA_BW_1k5Hz:
+      *val = LSM6DSM_XL_ANA_BW_1k5Hz;
+      break;
+    case LSM6DSM_XL_ANA_BW_400Hz:
+      *val = LSM6DSM_XL_ANA_BW_400Hz;
+      break;
+    default:
+      *val = LSM6DSM_XL_ANA_BW_1k5Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_accelerometer_filters_mode:1,2,3
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer mode 1, 2, 3
+  *              (accelerometer on aux interface disable).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection LPF2 is
+  *         not used.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_lpf1_bw_sel_t val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf1_bw_sel = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+    if(ret == 0){
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+      if(ret == 0){
+        ctrl8_xl.lpf2_xl_en = 0;
+        ctrl8_xl.hp_slope_xl_en = 0;
+        ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection LPF2
+  *         is not used.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_lpf1_bw_sel_t *val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if ((ctrl8_xl.lpf2_xl_en != 0x00U) ||
+        (ctrl8_xl.hp_slope_xl_en != 0x00U)){
+      *val = LSM6DSM_XL_LP1_NA;
+    }
+    else{
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+      switch ( ctrl1_xl.lpf1_bw_sel) {
+        case LSM6DSM_XL_LP1_ODR_DIV_2:
+          *val = LSM6DSM_XL_LP1_ODR_DIV_2;
+          break;
+        case LSM6DSM_XL_LP1_ODR_DIV_4:
+          *val = LSM6DSM_XL_LP1_ODR_DIV_4;
+          break;
+        default:
+          *val = LSM6DSM_XL_LP1_ODR_DIV_2;
+          break;
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 on outputs[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of input_composite in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_lp2_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_input_composite_t val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.input_composite = ( (uint8_t) val & 0x10U ) >> 4;
+    ctrl8_xl.hpcf_xl = (uint8_t) val & 0x03U;
+    ctrl8_xl.lpf2_xl_en = 1;
+    ctrl8_xl.hp_slope_xl_en = 0;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 on outputs[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of input_composite in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_lp2_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_input_composite_t *val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if ((ctrl8_xl.lpf2_xl_en == 0x00U) ||
+        (ctrl8_xl.hp_slope_xl_en != 0x00U)){
+      *val = LSM6DSM_XL_LP_NA;
+    }
+    else{
+      switch ((ctrl8_xl.input_composite << 4) + ctrl8_xl.hpcf_xl) {
+        case LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_50:
+          *val = LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_50;
+          break;
+        case LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_100:
+          *val = LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_100;
+          break;
+        case LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_9:
+          *val = LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_9;
+          break;
+        case LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_400:
+          *val = LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_400;
+          break;
+        case LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_50:
+          *val = LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_50;
+          break;
+        case LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_100:
+          *val = LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_100;
+          break;
+        case LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_9:
+          *val = LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_9;
+          break;
+        case LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_400:
+          *val = LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_400;
+          break;
+        default:
+          *val = LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_50;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hp_ref_mode in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_reference_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.hp_ref_mode = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hp_ref_mode in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_reference_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.hp_ref_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  High pass/Slope on outputs.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hpcf_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_hp_bandwidth_set(lsm6dsm_ctx_t *ctx, lsm6dsm_hpcf_xl_t val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.input_composite = 0;
+    ctrl8_xl.hpcf_xl = (uint8_t)val & 0x03U;
+    ctrl8_xl.hp_slope_xl_en = 1;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass/Slope on outputs.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of hpcf_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_hp_bandwidth_get(lsm6dsm_ctx_t *ctx, lsm6dsm_hpcf_xl_t *val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if (ctrl8_xl.hp_slope_xl_en == 0x00U){
+    *val = LSM6DSM_XL_HP_NA;
+  }
+  switch (ctrl8_xl.hpcf_xl) {
+    case LSM6DSM_XL_HP_ODR_DIV_4:
+      *val = LSM6DSM_XL_HP_ODR_DIV_4;
+      break;
+    case LSM6DSM_XL_HP_ODR_DIV_100:
+      *val = LSM6DSM_XL_HP_ODR_DIV_100;
+      break;
+    case LSM6DSM_XL_HP_ODR_DIV_9:
+      *val = LSM6DSM_XL_HP_ODR_DIV_9;
+      break;
+    case LSM6DSM_XL_HP_ODR_DIV_400:
+      *val = LSM6DSM_XL_HP_ODR_DIV_400;
+      break;
+    default:
+      *val = LSM6DSM_XL_HP_ODR_DIV_4;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_accelerometer_filters_mode:4
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer when mode 4
+  *              (accelerometer on aux interface enable).
+  * @{
+  *
+  */
+
+/**
+  * @brief   Accelerometer digital LPF (LPF1) bandwidth selection.
+  *          Only for mode 4.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_ui_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_ui_lpf1_bw_sel_t val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf1_bw_sel = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  if(ret == 0){
+    ctrl8_xl.hp_slope_xl_en = 0x00U;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer digital LPF (LPF1) bandwidth selection.
+  *          Only for mode 4.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+*/
+int32_t lsm6dsm_xl_ui_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_ui_lpf1_bw_sel_t *val)
+{
+  lsm6dsm_ctrl1_xl_t ctrl1_xl;
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if (ctrl8_xl.hp_slope_xl_en != PROPERTY_DISABLE){
+      *val = LSM6DSM_XL_UI_LP1_NA;
+    }
+    else{
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+      switch (ctrl1_xl.lpf1_bw_sel) {
+        case LSM6DSM_XL_UI_LP1_ODR_DIV_2:
+          *val = LSM6DSM_XL_UI_LP1_ODR_DIV_2;
+          break;
+        case LSM6DSM_XL_UI_LP1_ODR_DIV_4:
+          *val = LSM6DSM_XL_UI_LP1_ODR_DIV_4;
+          break;
+        default:
+          *val = LSM6DSM_XL_UI_LP1_ODR_DIV_2;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Slope filter on outputs.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+*/
+int32_t lsm6dsm_xl_ui_slope_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.hp_slope_xl_en = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slope filter on outputs.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+*/
+int32_t lsm6dsm_xl_ui_slope_get(lsm6dsm_ctx_t *ctx,  uint8_t *val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.hp_slope_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  accelerometer auxiliary low pass bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of filter_xl_conf_ois in reg CTRL3_OIS
+  *
+  * Cut off feq [ODR_UI = 0 / ODR UI ≥ 1600 Hz]
+  * LIGHT      636   Hz  2.96°
+  * NORMAL     295   Hz  5.12°
+  * STRONG     140   Hz  9.39°
+  * AGGRESSIVE  68.2 Hz 17.6°
+  *
+  * Cut off feq [ODR UI ≤ 800 Hz ]
+  * LIGHT      329   Hz  5.08°
+  * NORMAL     222   Hz  7.23°
+  * STRONG     128   Hz 11.5°
+  * AGGRESSIVE  66.5 Hz 19.7°
+  *
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_aux_lp_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_filter_xl_conf_ois_t val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.filter_xl_conf_ois = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  accelerometer auxiliary low pass bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of filter_xl_conf_ois in reg CTRL3_OIS
+  *
+  * Cut off feq [ODR_UI = 0 / ODR UI ≥ 1600 Hz]
+  * LIGHT      636   Hz  2.96°
+  * NORMAL     295   Hz  5.12°
+  * STRONG     140   Hz  9.39°
+  * AGGRESSIVE  68.2 Hz 17.6°
+  *
+  * Cut off feq [ODR UI ≤ 800 Hz ]
+  * LIGHT      329   Hz  5.08°
+  * NORMAL     222   Hz  7.23°
+  * STRONG     128   Hz 11.5°
+  * AGGRESSIVE  66.5 Hz 19.7°
+  *
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_xl_aux_lp_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_filter_xl_conf_ois_t *val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  switch (ctrl3_ois.filter_xl_conf_ois) {
+    case LSM6DSM_AUX_LP_LIGHT:
+      *val = LSM6DSM_AUX_LP_LIGHT;
+      break;
+    case LSM6DSM_AUX_LP_NORMAL:
+      *val = LSM6DSM_AUX_LP_NORMAL;
+      break;
+    case LSM6DSM_AUX_LP_STRONG:
+      *val = LSM6DSM_AUX_LP_STRONG;
+      break;
+    case LSM6DSM_AUX_LP_AGGRESSIVE:
+      *val = LSM6DSM_AUX_LP_AGGRESSIVE;
+      break;
+    default:
+      *val = LSM6DSM_AUX_LP_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_gyroscope_filters_mode:1,2
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact gyroscope mode 1, 2
+  *              (gyroscope on aux interface disable).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Gyroscope low pass path bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope filtering chain configuration.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_band_pass_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lpf1_sel_g_t val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  lsm6dsm_ctrl6_c_t ctrl6_c;
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hpm_g  =  ( (uint8_t)val & 0x30U ) >> 4;
+    ctrl7_g.hp_en_g = ( (uint8_t)val & 0x80U ) >> 7;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+    if(ret == 0){
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+      if(ret == 0){
+        ctrl6_c.ftype = (uint8_t)val & 0x03U;
+        ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+        if(ret == 0){
+          ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C,
+                                 (uint8_t*)&ctrl4_c, 1);
+          if(ret == 0){
+            ctrl4_c.lpf1_sel_g = ( (uint8_t)val & 0x08U ) >> 3;
+            ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL4_C,
+                                    (uint8_t*)&ctrl4_c, 1);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass path bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope filtering chain
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_band_pass_get(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_lpf1_sel_g_t *val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  lsm6dsm_ctrl6_c_t ctrl6_c;
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+    if(ret == 0){
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+      switch ( ( ctrl7_g.hp_en_g << 7 ) + ( ctrl7_g.hpm_g << 4 ) +
+               ( ctrl4_c.lpf1_sel_g << 3) + ctrl6_c.ftype ) {
+        case LSM6DSM_HP_16mHz_LP2:
+          *val = LSM6DSM_HP_16mHz_LP2;
+          break;
+        case LSM6DSM_HP_65mHz_LP2:
+          *val = LSM6DSM_HP_65mHz_LP2;
+          break;
+        case LSM6DSM_HP_260mHz_LP2:
+          *val = LSM6DSM_HP_260mHz_LP2;
+          break;
+        case LSM6DSM_HP_1Hz04_LP2:
+          *val = LSM6DSM_HP_1Hz04_LP2;
+          break;
+        case LSM6DSM_HP_DISABLE_LP1_LIGHT:
+          *val = LSM6DSM_HP_DISABLE_LP1_LIGHT;
+          break;
+        case LSM6DSM_HP_DISABLE_LP1_NORMAL:
+          *val = LSM6DSM_HP_DISABLE_LP1_NORMAL;
+          break;
+        case LSM6DSM_HP_DISABLE_LP_STRONG:
+          *val = LSM6DSM_HP_DISABLE_LP_STRONG;
+          break;
+        case LSM6DSM_HP_DISABLE_LP1_AGGRESSIVE:
+          *val = LSM6DSM_HP_DISABLE_LP1_AGGRESSIVE;
+          break;
+        case LSM6DSM_HP_16mHz_LP1_LIGHT:
+          *val = LSM6DSM_HP_16mHz_LP1_LIGHT;
+          break;
+        case LSM6DSM_HP_65mHz_LP1_NORMAL:
+          *val = LSM6DSM_HP_65mHz_LP1_NORMAL;
+          break;
+        case LSM6DSM_HP_260mHz_LP1_STRONG:
+          *val = LSM6DSM_HP_260mHz_LP1_STRONG;
+          break;
+        case LSM6DSM_HP_1Hz04_LP1_AGGRESSIVE:
+          *val = LSM6DSM_HP_1Hz04_LP1_AGGRESSIVE;
+          break;
+        default:
+          *val = LSM6DSM_HP_65mHz_LP2;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_gyroscope_filters_mode:3,4
+  * @brief   This section group all the functions concerning the filters
+  *          configuration that impact gyroscope when mode 3, 4
+  *          (gyroscope on aux interface enable).
+  * @{
+  *
+  */
+
+/**
+  * @brief  HPF is available on gyroscope's OIS chain only if HP_EN_G
+  *         in CTRL7_G (16h) is set to '0'.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope ui filtering chain configuration in Mode: 3, 4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_ui_high_pass_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hp_en_g = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF is available on gyroscope's OIS chain only if HP_EN_G
+  *         in CTRL7_G (16h) is set to '0'.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope ui filtering chain configuration in Mode: 3, 4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_ui_high_pass_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  *val = ctrl7_g.hp_en_g;
+
+  return ret;
+}
+
+
+/**
+  * @brief  HPF is available on gyroscope's OIS chain only if HP_EN_G
+  *         in CTRL7_G (16h) is set to '0'.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope aux (ois) filtering chain configuration in
+  *                Mode: 3, 4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_aux_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_hp_en_ois_t val)
+{
+  lsm6dsm_ctrl7_g_t ctrl7_g;
+  lsm6dsm_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hp_en_g = 0x00U;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  }
+  if(ret == 0){
+    ctrl2_ois.ftype_ois = (uint8_t)val & 0x03U;
+    ctrl2_ois.hp_en_ois = ( (uint8_t)val & 0x80U ) >> 7;
+    ctrl2_ois.hpm_ois = ( (uint8_t)val & 0x30U ) >> 4;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF is available on gyroscope's OIS chain only if HP_EN_G
+  *         in CTRL7_G (16h) is set to '0'.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope aux (ois) filtering chain configuration in
+  *                Mode: 3, 4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_aux_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_hp_en_ois_t *val)
+{
+  lsm6dsm_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+
+
+  switch ( ( ( ctrl2_ois.hp_en_ois << 7 ) + ( ctrl2_ois.hpm_ois << 4 )
+           + ctrl2_ois.ftype_ois) ) {
+    case LSM6DSM_HP_DISABLE_LP_173Hz:
+      *val = LSM6DSM_HP_DISABLE_LP_173Hz;
+      break;
+    case LSM6DSM_HP_DISABLE_LP_237Hz:
+      *val = LSM6DSM_HP_DISABLE_LP_237Hz;
+      break;
+    case LSM6DSM_HP_DISABLE_LP_351Hz:
+      *val = LSM6DSM_HP_DISABLE_LP_351Hz;
+      break;
+    case LSM6DSM_HP_DISABLE_LP_937Hz:
+      *val = LSM6DSM_HP_DISABLE_LP_937Hz;
+      break;
+    case LSM6DSM_HP_16mHz_LP_173Hz:
+      *val = LSM6DSM_HP_16mHz_LP_173Hz;
+      break;
+    case LSM6DSM_HP_65mHz_LP_237Hz:
+      *val = LSM6DSM_HP_65mHz_LP_237Hz;
+      break;
+    case LSM6DSM_HP_260mHz_LP_351Hz:
+      *val = LSM6DSM_HP_260mHz_LP_351Hz;
+      break;
+    case LSM6DSM_HP_1Hz04_LP_937Hz:
+      *val = LSM6DSM_HP_1Hz04_LP_937Hz;
+      break;
+    default:
+      *val = LSM6DSM_HP_DISABLE_LP_173Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_Auxiliary_interface
+  * @brief       This section groups all the functions concerning
+  *              auxiliary interface.
+  * @{
+  *
+  */
+
+/**
+  * @brief  The STATUS_SPIAux register is read by the auxiliary SPI.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    registers STATUS_SPIAUX.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_status_reg_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_status_spiaux_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_SPIAUX, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  AUX accelerometer data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of xlda in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_SPIAUX, (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  AUX gyroscope data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of gda in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_SPIAUX, (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.gda;
+
+  return ret;
+}
+
+/**
+  * @brief   High when the gyroscope output is in the settling phase.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of gyro_settling in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_gy_flag_settling_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_SPIAUX, (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.gyro_settling;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of lvl2_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_den_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lvl_ois_t val)
+{
+  lsm6dsm_int_ois_t int_ois;
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.lvl2_ois = (uint8_t)val & 0x01U;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_INT_OIS, (uint8_t*)&int_ois, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+    ctrl1_ois.lvl1_ois = ((uint8_t)val & 0x02U) >> 1;
+  }
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lvl2_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_den_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_lvl_ois_t *val)
+{
+  lsm6dsm_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_OIS, (uint8_t*)&int_ois, 1);
+  switch ( int_ois.lvl2_ois ) {
+    case LSM6DSM_AUX_DEN_DISABLE:
+      *val = LSM6DSM_AUX_DEN_DISABLE;
+      break;
+    case LSM6DSM_AUX_DEN_LEVEL_LATCH:
+      *val = LSM6DSM_AUX_DEN_LEVEL_LATCH;
+      break;
+    case LSM6DSM_AUX_DEN_LEVEL_TRIG:
+      *val = LSM6DSM_AUX_DEN_LEVEL_TRIG;
+      break;
+    default:
+      *val = LSM6DSM_AUX_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin. This setting
+  *         has priority over all other INT2 settings.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of int2_drdy_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_drdy_on_int2_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.int2_drdy_ois = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_INT_OIS, (uint8_t*)&int_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin. This setting
+  *         has priority over all other INT2 settings.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of int2_drdy_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_drdy_on_int2_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_OIS, (uint8_t*)&int_ois, 1);
+  *val = int_ois.int2_drdy_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro
+  *         in Mode 3 and Mode 4 (mode4_en = 1) and
+  *         accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are
+  *         available through the SPI2 in registers
+  *         OUTX_L_G(22h) through OUTZ_H_G(27h) and
+  *         STATUS_REG(1Eh) / STATUS_SPIAux, and LPF1 is
+  *         dedicated to this chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of ois_en_spi2 in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t val)
+{
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.ois_en_spi2 = (uint8_t)val & 0x01U;
+    ctrl1_ois.mode4_en = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro
+  *         in Mode 3 and Mode 4 (mode4_en = 1) and
+  *         accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs
+  *         are available through the SPI2 in registers
+  *         OUTX_L_G(22h) through OUTZ_H_G(27h) and
+  *         STATUS_REG(1Eh) / STATUS_SPIAux, and LPF1 is
+  *         dedicated to this chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ois_en_spi2 in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t *val)
+{
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  switch ( (ctrl1_ois.mode4_en << 1) + ctrl1_ois.ois_en_spi2 ) {
+    case LSM6DSM_AUX_DISABLE:
+      *val = LSM6DSM_AUX_DISABLE;
+      break;
+    case LSM6DSM_MODE_3_GY:
+      *val = LSM6DSM_MODE_3_GY;
+      break;
+    case LSM6DSM_MODE_4_GY_XL:
+      *val = LSM6DSM_MODE_4_GY_XL;
+      break;
+    default:
+      *val = LSM6DSM_AUX_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of fs_g_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_gy_full_scale_set(lsm6dsm_ctx_t *ctx,
+                                      lsm6dsm_fs_g_ois_t val)
+{
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.fs_g_ois = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_g_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_gy_full_scale_get(lsm6dsm_ctx_t *ctx,
+                                      lsm6dsm_fs_g_ois_t *val)
+{
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  switch ( ctrl1_ois.fs_g_ois ) {
+    case LSM6DSM_250dps_AUX:
+      *val = LSM6DSM_250dps_AUX;
+      break;
+    case LSM6DSM_125dps_AUX:
+      *val = LSM6DSM_125dps_AUX;
+      break;
+    case LSM6DSM_500dps_AUX:
+      *val = LSM6DSM_500dps_AUX;
+      break;
+    case LSM6DSM_1000dps_AUX:
+      *val = LSM6DSM_1000dps_AUX;
+      break;
+    case LSM6DSM_2000dps_AUX:
+      *val = LSM6DSM_2000dps_AUX;
+      break;
+    default:
+      *val = LSM6DSM_250dps_AUX;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of sim_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t val)
+{
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.sim_ois = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t *val)
+{
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  switch ( ctrl1_ois.sim_ois ) {
+    case LSM6DSM_AUX_SPI_4_WIRE:
+      *val = LSM6DSM_AUX_SPI_4_WIRE;
+      break;
+    case LSM6DSM_AUX_SPI_3_WIRE:
+      *val = LSM6DSM_AUX_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSM_AUX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection on aux interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of ble_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_data_format_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_ois_t val)
+{
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.ble_ois = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection on aux interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ble_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_data_format_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_ois_t *val)
+{
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  switch ( ctrl1_ois.ble_ois ) {
+    case LSM6DSM_AUX_LSB_AT_LOW_ADD:
+      *val = LSM6DSM_AUX_LSB_AT_LOW_ADD;
+      break;
+    case LSM6DSM_AUX_MSB_AT_LOW_ADD:
+      *val = LSM6DSM_AUX_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LSM6DSM_AUX_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp.
+  *         Enable: All OIS chain outputs = 8000h
+  *         during self-test; Disable: OIS chain
+  *         self-test outputs dependent from the aux
+  *         gyro full scale selected.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of st_ois_clampdis in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_gy_clamp_set(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_st_ois_clampdis_t val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.st_ois_clampdis = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp.
+  *         Enable: All OIS chain outputs = 8000h
+  *         during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full
+  *         scale selected.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_ois_clampdis in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_gy_clamp_get(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_st_ois_clampdis_t *val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  switch ( ctrl3_ois.st_ois_clampdis ) {
+    case LSM6DSM_ENABLE_CLAMP:
+      *val = LSM6DSM_ENABLE_CLAMP;
+      break;
+    case LSM6DSM_DISABLE_CLAMP:
+      *val = LSM6DSM_DISABLE_CLAMP;
+      break;
+    default:
+      *val = LSM6DSM_ENABLE_CLAMP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of st_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_gy_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_ois_t val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.st_ois = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_gy_self_test_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_st_ois_t *val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  switch ( ctrl3_ois.st_ois ) {
+    case LSM6DSM_AUX_GY_DISABLE:
+      *val = LSM6DSM_AUX_GY_DISABLE;
+      break;
+    case LSM6DSM_AUX_GY_POS:
+      *val = LSM6DSM_AUX_GY_POS;
+      break;
+    case LSM6DSM_AUX_GY_NEG:
+      *val = LSM6DSM_AUX_GY_NEG;
+      break;
+    default:
+      *val = LSM6DSM_AUX_GY_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of fs_xl_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_xl_full_scale_set(lsm6dsm_ctx_t *ctx,
+                                      lsm6dsm_fs_xl_ois_t val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.fs_xl_ois = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_xl_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_xl_full_scale_get(lsm6dsm_ctx_t *ctx,
+                                      lsm6dsm_fs_xl_ois_t *val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  switch ( ctrl3_ois.fs_xl_ois ) {
+    case LSM6DSM_AUX_2g:
+      *val = LSM6DSM_AUX_2g;
+      break;
+    case LSM6DSM_AUX_16g:
+      *val = LSM6DSM_AUX_16g;
+      break;
+    case LSM6DSM_AUX_4g:
+      *val = LSM6DSM_AUX_4g;
+      break;
+    case LSM6DSM_AUX_8g:
+      *val = LSM6DSM_AUX_8g;
+      break;
+    default:
+      *val = LSM6DSM_AUX_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    change the values of den_lh_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_den_polarity_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_den_lh_ois_t val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.den_lh_ois = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_lh_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_aux_den_polarity_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_den_lh_ois_t *val)
+{
+  lsm6dsm_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  switch ( ctrl3_ois.den_lh_ois ) {
+    case LSM6DSM_AUX_DEN_ACTIVE_LOW:
+      *val = LSM6DSM_AUX_DEN_ACTIVE_LOW;
+      break;
+    case LSM6DSM_AUX_DEN_ACTIVE_HIGH:
+      *val = LSM6DSM_AUX_DEN_ACTIVE_HIGH;
+      break;
+    default:
+      *val = LSM6DSM_AUX_DEN_ACTIVE_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM main serial_interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t *val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.sim) {
+    case LSM6DSM_SPI_4_WIRE:
+      *val = LSM6DSM_SPI_4_WIRE;
+      break;
+    case LSM6DSM_SPI_3_WIRE:
+      *val = LSM6DSM_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSM_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_i2c_interface_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_i2c_disable_t val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_i2c_interface_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_i2c_disable_t *val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  switch (ctrl4_c.i2c_disable) {
+    case LSM6DSM_I2C_ENABLE:
+      *val = LSM6DSM_I2C_ENABLE;
+      break;
+    case LSM6DSM_I2C_DISABLE:
+      *val = LSM6DSM_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM6DSM_I2C_ENABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_interrupt_pins
+  * @brief       This section groups all the functions that manage
+  *              interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select the signal that need to route on int1 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    configure INT1_CTRL, MD1_CFG, CTRL4_C(den_drdy_int1),
+  *                MASTER_CONFIG(drdy_on_int1)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pin_int1_route_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_int1_route_t val)
+{
+  lsm6dsm_master_config_t master_config;
+  lsm6dsm_int1_ctrl_t int1_ctrl;
+  lsm6dsm_md1_cfg_t md1_cfg;
+  lsm6dsm_md2_cfg_t md2_cfg;
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_drdy_xl        = val.int1_drdy_xl;
+    int1_ctrl.int1_drdy_g         = val.int1_drdy_g;
+    int1_ctrl.int1_boot           = val.int1_boot;
+    int1_ctrl.int1_fth            = val.int1_fth;
+    int1_ctrl.int1_fifo_ovr       = val.int1_fifo_ovr;
+    int1_ctrl.int1_full_flag      = val.int1_full_flag;
+    int1_ctrl.int1_sign_mot       = val.int1_sign_mot;
+    int1_ctrl.int1_step_detector  = val.int1_step_detector;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+        md1_cfg.int1_timer           = val.int1_timer;
+        md1_cfg.int1_tilt            = val.int1_tilt;
+        md1_cfg.int1_6d              = val.int1_6d;
+        md1_cfg.int1_double_tap      = val.int1_double_tap;
+        md1_cfg.int1_ff              = val.int1_ff;
+        md1_cfg.int1_wu              = val.int1_wu;
+        md1_cfg.int1_single_tap      = val.int1_single_tap;
+        md1_cfg.int1_inact_state     = val.int1_inact_state;
+        ret = lsm6dsm_write_reg(ctx, LSM6DSM_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ctrl4_c.den_drdy_int1 = val.den_drdy_int1;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+     master_config.drdy_on_int1   = val.den_drdy_int1;
+     ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+    if ((val.int1_6d != 0x00U) ||
+        (val.int1_ff != 0x00U) ||
+        (val.int1_wu != 0x00U) ||
+        (val.int1_single_tap != 0x00U) ||
+        (val.int1_double_tap != 0x00U) ||
+        (val.int1_inact_state != 0x00U)||
+        (md2_cfg.int2_6d != 0x00U) ||
+        (md2_cfg.int2_ff != 0x00U) ||
+        (md2_cfg.int2_wu != 0x00U) ||
+        (md2_cfg.int2_single_tap != 0x00U) ||
+        (md2_cfg.int2_double_tap != 0x00U) ||
+        (md2_cfg.int2_inact_state!= 0x00U) ){
+      tap_cfg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    read INT1_CTRL, MD1_CFG, CTRL4_C(den_drdy_int1),
+  *                MASTER_CONFIG(drdy_on_int1)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pin_int1_route_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_int1_route_t *val)
+{
+  lsm6dsm_master_config_t master_config;
+  lsm6dsm_int1_ctrl_t int1_ctrl;
+  lsm6dsm_md1_cfg_t md1_cfg;
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    val->int1_drdy_xl       = int1_ctrl.int1_drdy_xl;
+    val->int1_drdy_g        = int1_ctrl.int1_drdy_g;
+    val->int1_boot          = int1_ctrl.int1_boot;
+    val->int1_fth           = int1_ctrl.int1_fth;
+    val->int1_fifo_ovr      = int1_ctrl.int1_fifo_ovr;
+    val->int1_full_flag     = int1_ctrl.int1_full_flag;
+    val->int1_sign_mot      = int1_ctrl.int1_sign_mot;
+    val->int1_step_detector = int1_ctrl.int1_step_detector ;
+
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+    if(ret == 0){
+    val->int1_timer       = md1_cfg.int1_timer;
+    val->int1_tilt        = md1_cfg.int1_tilt;
+    val->int1_6d          = md1_cfg.int1_6d;
+    val->int1_double_tap  = md1_cfg.int1_double_tap;
+    val->int1_ff          = md1_cfg.int1_ff;
+    val->int1_wu          = md1_cfg.int1_wu;
+    val->int1_single_tap  = md1_cfg.int1_single_tap;
+    val->int1_inact_state = md1_cfg.int1_inact_state;
+
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      if(ret == 0){
+        val->den_drdy_int1 = ctrl4_c.den_drdy_int1;
+        ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                               (uint8_t*)&master_config, 1);
+        val->den_drdy_int1 = master_config.drdy_on_int1;
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    INT2_CTRL, DRDY_PULSE_CFG(int2_wrist_tilt), MD2_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pin_int2_route_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_int2_route_t val)
+{
+  lsm6dsm_int2_ctrl_t int2_ctrl;
+  lsm6dsm_md1_cfg_t md1_cfg;
+  lsm6dsm_md2_cfg_t md2_cfg;
+  lsm6dsm_drdy_pulse_cfg_t drdy_pulse_cfg;
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_drdy_xl        = val.int2_drdy_xl;
+    int2_ctrl.int2_drdy_g         = val.int2_drdy_g;
+    int2_ctrl.int2_drdy_temp      = val.int2_drdy_temp;
+    int2_ctrl.int2_fth            = val.int2_fth;
+    int2_ctrl.int2_fifo_ovr       = val.int2_fifo_ovr;
+    int2_ctrl.int2_full_flag      = val.int2_full_flag;
+    int2_ctrl.int2_step_count_ov  = val.int2_step_count_ov;
+    int2_ctrl.int2_step_delta     = val.int2_step_delta;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+    md2_cfg.int2_iron              = val.int2_iron;
+    md2_cfg.int2_tilt              = val.int2_tilt;
+    md2_cfg.int2_6d                = val.int2_6d;
+    md2_cfg.int2_double_tap        = val.int2_double_tap;
+    md2_cfg.int2_ff                = val.int2_ff;
+    md2_cfg.int2_wu                = val.int2_wu;
+    md2_cfg.int2_single_tap        = val.int2_single_tap;
+    md2_cfg.int2_inact_state       = val.int2_inact_state;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_DRDY_PULSE_CFG,
+                           (uint8_t*)&drdy_pulse_cfg, 1);
+  }
+  if(ret == 0){
+    drdy_pulse_cfg.int2_wrist_tilt = val.int2_wrist_tilt;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_DRDY_PULSE_CFG,
+                            (uint8_t*)&drdy_pulse_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+    if ((md1_cfg.int1_6d != 0x00U) ||
+        (md1_cfg.int1_ff != 0x00U) ||
+        (md1_cfg.int1_wu != 0x00U) ||
+        (md1_cfg.int1_single_tap != 0x00U) ||
+        (md1_cfg.int1_double_tap != 0x00U) ||
+        (md1_cfg.int1_inact_state != 0x00U) ||
+        (val.int2_6d != 0x00U) ||
+        (val.int2_ff != 0x00U) ||
+        (val.int2_wu != 0x00U) ||
+        (val.int2_single_tap != 0x00U) ||
+        (val.int2_double_tap != 0x00U) ||
+        (val.int2_inact_state!= 0x00U) ){
+      tap_cfg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    INT2_CTRL, DRDY_PULSE_CFG(int2_wrist_tilt), MD2_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pin_int2_route_get(lsm6dsm_ctx_t *ctx,
+lsm6dsm_int2_route_t *val)
+{
+  lsm6dsm_int2_ctrl_t int2_ctrl;
+  lsm6dsm_md2_cfg_t md2_cfg;
+  lsm6dsm_drdy_pulse_cfg_t drdy_pulse_cfg;
+
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    val->int2_drdy_xl         = int2_ctrl.int2_drdy_xl;
+    val->int2_drdy_g          = int2_ctrl.int2_drdy_g;
+    val->int2_drdy_temp       = int2_ctrl.int2_drdy_temp;
+    val->int2_fth             = int2_ctrl.int2_fth;
+    val->int2_fifo_ovr        = int2_ctrl.int2_fifo_ovr;
+    val->int2_full_flag       = int2_ctrl.int2_full_flag;
+    val->int2_step_count_ov   = int2_ctrl.int2_step_count_ov;
+    val->int2_step_delta      = int2_ctrl.int2_step_delta;
+
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+    if(ret == 0){
+      val->int2_iron           = md2_cfg.int2_iron;
+      val->int2_tilt           = md2_cfg.int2_tilt;
+      val->int2_6d             = md2_cfg.int2_6d;
+      val->int2_double_tap     = md2_cfg.int2_double_tap;
+      val->int2_ff             = md2_cfg.int2_ff;
+      val->int2_wu             = md2_cfg.int2_wu;
+      val->int2_single_tap     = md2_cfg.int2_single_tap;
+      val->int2_inact_state    = md2_cfg.int2_inact_state;
+
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_DRDY_PULSE_CFG,
+                             (uint8_t*)&drdy_pulse_cfg, 1);
+      val->int2_wrist_tilt = drdy_pulse_cfg.int2_wrist_tilt;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t *val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.pp_od) {
+    case LSM6DSM_PUSH_PULL:
+      *val = LSM6DSM_PUSH_PULL;
+      break;
+    case LSM6DSM_OPEN_DRAIN:
+      *val = LSM6DSM_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM6DSM_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pin_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pin_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t *val)
+{
+  lsm6dsm_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.h_lactive) {
+    case LSM6DSM_ACTIVE_HIGH:
+      *val = LSM6DSM_ACTIVE_HIGH;
+      break;
+    case LSM6DSM_ACTIVE_LOW:
+      *val = LSM6DSM_ACTIVE_LOW;
+      break;
+    default:
+      *val = LSM6DSM_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_all_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1 = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_all_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lir in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_int_notification_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.lir = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lir in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_int_notification_get(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t *val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.lir) {
+    case LSM6DSM_INT_PULSED:
+      *val = LSM6DSM_INT_PULSED;
+      break;
+    case LSM6DSM_INT_LATCHED:
+      *val = LSM6DSM_INT_LATCHED;
+      break;
+    default:
+      *val = LSM6DSM_INT_PULSED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_Wake_Up_event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_wkup_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_wkup_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_wkup_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_wkup_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_Activity/Inactivity_detection
+  * @brief       This section groups all the functions concerning
+  *              activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_sleep_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.sleep = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_gy_sleep_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.sleep;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of inact_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_act_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.inact_en = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of inact_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_act_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t *val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.inact_en) {
+    case LSM6DSM_PROPERTY_DISABLE:
+      *val = LSM6DSM_PROPERTY_DISABLE;
+      break;
+    case LSM6DSM_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = LSM6DSM_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case LSM6DSM_XL_12Hz5_GY_SLEEP:
+      *val = LSM6DSM_XL_12Hz5_GY_SLEEP;
+      break;
+    case LSM6DSM_XL_12Hz5_GY_PD:
+      *val = LSM6DSM_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = LSM6DSM_PROPERTY_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.1 LSb = 512 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_act_sleep_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_WAKE_UP_DUR,
+          (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode. 1 LSb = 512 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_act_sleep_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_tap_generator
+  * @brief       This section groups all the functions that manage the
+  *              tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read the tap / double tap source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from TAP_SRC
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_src_get(lsm6dsm_ctx_t *ctx, lsm6dsm_tap_src_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG
+  *
+  */
+int32_t lsm6dsm_tap_detection_on_z_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_z_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_detection_on_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_detection_on_y_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_y_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_detection_on_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_detection_on_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_x_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_detection_on_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_threshold_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.tap_ths = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_threshold_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.tap_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event.
+  *         The default value of these bits is 00b which corresponds to
+  *         4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_shock_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.shock = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event.
+  *         The default value of these bits is 00b which corresponds to
+  *         4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_shock_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_quiet_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.quiet = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_quiet_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,1LSB corresponds
+  *         to 32*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.dur = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,1LSB corresponds
+  *         to 32*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of
+  *                                      single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_mode_set(lsm6dsm_ctx_t *ctx,
+                             lsm6dsm_single_double_tap_t val)
+{
+  lsm6dsm_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.single_double_tap = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of single_double_tap
+  *                                      in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tap_mode_get(lsm6dsm_ctx_t *ctx,
+                             lsm6dsm_single_double_tap_t *val)
+{
+  lsm6dsm_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  switch (wake_up_ths.single_double_tap) {
+    case LSM6DSM_ONLY_SINGLE:
+      *val = LSM6DSM_ONLY_SINGLE;
+      break;
+    case LSM6DSM_BOTH_SINGLE_DOUBLE:
+      *val = LSM6DSM_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LSM6DSM_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_ Six_position_detection(6D/4D)
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  LPF2 feed 6D function selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of low_pass_on_6d in
+  *                                   reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_6d_feed_data_set(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_low_pass_on_6d_t val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.low_pass_on_6d = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 feed 6D function selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_6d_feed_data_get(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_low_pass_on_6d_t *val)
+{
+  lsm6dsm_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  switch (ctrl8_xl.low_pass_on_6d) {
+    case LSM6DSM_ODR_DIV_2_FEED:
+      *val = LSM6DSM_ODR_DIV_2_FEED;
+      break;
+    case LSM6DSM_LPF2_FEED:
+      *val = LSM6DSM_LPF2_FEED;
+      break;
+    default:
+      *val = LSM6DSM_ODR_DIV_2_FEED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_6d_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t val)
+{
+  lsm6dsm_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.sixd_ths = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_6d_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t *val)
+{
+  lsm6dsm_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  switch (tap_ths_6d.sixd_ths) {
+    case LSM6DSM_DEG_80:
+      *val = LSM6DSM_DEG_80;
+      break;
+    case LSM6DSM_DEG_70:
+      *val = LSM6DSM_DEG_70;
+      break;
+    case LSM6DSM_DEG_60:
+      *val = LSM6DSM_DEG_60;
+      break;
+    case LSM6DSM_DEG_50:
+      *val = LSM6DSM_DEG_50;
+      break;
+    default:
+      *val = LSM6DSM_DEG_80;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_4d_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.d4d_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_4d_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_free_fall
+  * @brief       This section group all the functions concerning the free
+  *              fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief Free-fall duration event. 1LSb = 1 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_ff_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_wake_up_dur_t wake_up_dur;
+  lsm6dsm_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_dur = (val & 0x1FU);
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FREE_FALL, (uint8_t*)&free_fall, 1);
+    if(ret == 0){
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_DUR,
+                             (uint8_t*)&wake_up_dur, 1);
+      if(ret == 0){
+        wake_up_dur.ff_dur = (val & 0x20U) >> 5;
+        ret = lsm6dsm_write_reg(ctx, LSM6DSM_WAKE_UP_DUR,
+                                (uint8_t*)&wake_up_dur, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event. 1LSb = 1 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_ff_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_wake_up_dur_t wake_up_dur;
+  lsm6dsm_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_ff_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t val)
+{
+  lsm6dsm_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_ff_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t *val)
+{
+  lsm6dsm_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FREE_FALL, (uint8_t*)&free_fall, 1);
+  switch (free_fall.ff_ths) {
+    case LSM6DSM_FF_TSH_156mg:
+      *val = LSM6DSM_FF_TSH_156mg;
+      break;
+    case LSM6DSM_FF_TSH_219mg:
+      *val = LSM6DSM_FF_TSH_219mg;
+      break;
+    case LSM6DSM_FF_TSH_250mg:
+      *val = LSM6DSM_FF_TSH_250mg;
+      break;
+    case LSM6DSM_FF_TSH_312mg:
+      *val = LSM6DSM_FF_TSH_312mg;
+      break;
+    case LSM6DSM_FF_TSH_344mg:
+      *val = LSM6DSM_FF_TSH_344mg;
+      break;
+    case LSM6DSM_FF_TSH_406mg:
+      *val = LSM6DSM_FF_TSH_406mg;
+      break;
+    case LSM6DSM_FF_TSH_469mg:
+      *val = LSM6DSM_FF_TSH_469mg;
+      break;
+    case LSM6DSM_FF_TSH_500mg:
+      *val = LSM6DSM_FF_TSH_500mg;
+      break;
+    default:
+      *val = LSM6DSM_FF_TSH_156mg;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_fifo
+  * @brief       This section group all the functions concerning the
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_watermark_set(lsm6dsm_ctx_t *ctx, uint16_t val)
+{
+  lsm6dsm_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl1.fth = (uint8_t) (0x00FFU & val);
+    fifo_ctrl2.fth = (uint8_t) (( 0x0700U & val ) >> 8);
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+    if(ret == 0){
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_watermark_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsm_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  }
+  *val = ((uint16_t)fifo_ctrl2.fth << 8) + (uint16_t)fifo_ctrl1.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of diff_fifo in reg  FIFO_STATUS1 and
+  *                FIFO_STATUS2(diff_fifo), it is recommended to set the
+  *                BDU bit.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_data_level_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsm_fifo_status1_t fifo_status1;
+  lsm6dsm_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_STATUS1,
+                         (uint8_t*)&fifo_status1, 1);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+    *val = ( (uint16_t) fifo_status2.diff_fifo << 8) +
+             (uint16_t) fifo_status1.diff_fifo;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of watermark in reg  FIFO_STATUS2 and
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_wtm_flag_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_STATUS2, (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.waterm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO pattern.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of fifo_pattern in reg  FIFO_STATUS3 and
+  *                FIFO_STATUS4, it is recommended to set the BDU bit
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_pattern_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsm_fifo_status3_t fifo_status3;
+  lsm6dsm_fifo_status4_t fifo_status4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_STATUS3,
+                         (uint8_t*)&fifo_status3, 1);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_STATUS4,
+                           (uint8_t*)&fifo_status4, 1);
+    *val = ( (uint16_t)fifo_status4.fifo_pattern << 8) +
+             fifo_status3.fifo_pattern;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_temp_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_temp_batch_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.fifo_temp_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_temp_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_temp_batch_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.fifo_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger signal for FIFO write operation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    act on FIFO_CTRL2(timer_pedo_fifo_drdy)
+  *                and MASTER_CONFIG(data_valid_sel_fifo)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_write_trigger_set(lsm6dsm_ctx_t *ctx,
+                                       lsm6dsm_trigger_fifo_t val)
+{
+  lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.timer_pedo_fifo_drdy = (uint8_t)val & 0x01U;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+    if(ret == 0){
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+      if(ret == 0){
+        master_config.data_valid_sel_fifo = (((uint8_t)val & 0x02U) >> 1);
+        ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                                (uint8_t*)&master_config, 1);
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger signal for FIFO write operation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    act on FIFO_CTRL2(timer_pedo_fifo_drdy)
+  *                and MASTER_CONFIG(data_valid_sel_fifo)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_write_trigger_get(lsm6dsm_ctx_t *ctx,
+                                       lsm6dsm_trigger_fifo_t *val)
+{
+  lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+
+    switch ( ( fifo_ctrl2.timer_pedo_fifo_drdy << 1 ) +
+             fifo_ctrl2. timer_pedo_fifo_drdy ) {
+      case LSM6DSM_TRG_XL_GY_DRDY:
+        *val = LSM6DSM_TRG_XL_GY_DRDY;
+        break;
+      case LSM6DSM_TRG_STEP_DETECT:
+        *val = LSM6DSM_TRG_STEP_DETECT;
+        break;
+      case LSM6DSM_TRG_SH_DRDY:
+        *val = LSM6DSM_TRG_SH_DRDY;
+        break;
+      default:
+        *val = LSM6DSM_TRG_XL_GY_DRDY;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enable pedometer step counter and timestamp as 4th
+  *          FIFO data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_pedo_fifo_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_set(lsm6dsm_ctx_t *ctx,
+                                                  uint8_t val)
+{
+  lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.timer_pedo_fifo_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer step counter and timestamp as 4th
+  *         FIFO data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_pedo_fifo_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_get(lsm6dsm_ctx_t *ctx,
+                                                  uint8_t *val)
+{
+  lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.timer_pedo_fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO) for
+  *         accelerometer data.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_fifo_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_xl_batch_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_dec_fifo_xl_t val)
+{
+  lsm6dsm_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_xl = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL3,
+                            (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO) for
+  *         accelerometer data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_fifo_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_xl_batch_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_dec_fifo_xl_t *val)
+{
+  lsm6dsm_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  switch (fifo_ctrl3.dec_fifo_xl) {
+    case LSM6DSM_FIFO_XL_DISABLE:
+      *val = LSM6DSM_FIFO_XL_DISABLE;
+      break;
+    case LSM6DSM_FIFO_XL_NO_DEC:
+      *val = LSM6DSM_FIFO_XL_NO_DEC;
+      break;
+    case LSM6DSM_FIFO_XL_DEC_2:
+      *val = LSM6DSM_FIFO_XL_DEC_2;
+      break;
+    case LSM6DSM_FIFO_XL_DEC_3:
+      *val = LSM6DSM_FIFO_XL_DEC_3;
+      break;
+    case LSM6DSM_FIFO_XL_DEC_4:
+      *val = LSM6DSM_FIFO_XL_DEC_4;
+      break;
+    case LSM6DSM_FIFO_XL_DEC_8:
+      *val = LSM6DSM_FIFO_XL_DEC_8;
+      break;
+    case LSM6DSM_FIFO_XL_DEC_16:
+      *val = LSM6DSM_FIFO_XL_DEC_16;
+      break;
+    case LSM6DSM_FIFO_XL_DEC_32:
+      *val = LSM6DSM_FIFO_XL_DEC_32;
+      break;
+    default:
+      *val = LSM6DSM_FIFO_XL_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_fifo_gyro in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_gy_batch_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_dec_fifo_gyro_t val)
+{
+  lsm6dsm_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_gyro = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_fifo_gyro in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_gy_batch_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_dec_fifo_gyro_t *val)
+{
+  lsm6dsm_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  switch (fifo_ctrl3.dec_fifo_gyro) {
+    case LSM6DSM_FIFO_GY_DISABLE:
+      *val = LSM6DSM_FIFO_GY_DISABLE;
+      break;
+    case LSM6DSM_FIFO_GY_NO_DEC:
+      *val = LSM6DSM_FIFO_GY_NO_DEC;
+      break;
+    case LSM6DSM_FIFO_GY_DEC_2:
+      *val = LSM6DSM_FIFO_GY_DEC_2;
+      break;
+    case LSM6DSM_FIFO_GY_DEC_3:
+      *val = LSM6DSM_FIFO_GY_DEC_3;
+      break;
+    case LSM6DSM_FIFO_GY_DEC_4:
+      *val = LSM6DSM_FIFO_GY_DEC_4;
+      break;
+    case LSM6DSM_FIFO_GY_DEC_8:
+      *val = LSM6DSM_FIFO_GY_DEC_8;
+      break;
+    case LSM6DSM_FIFO_GY_DEC_16:
+      *val = LSM6DSM_FIFO_GY_DEC_16;
+      break;
+    case LSM6DSM_FIFO_GY_DEC_32:
+      *val = LSM6DSM_FIFO_GY_DEC_32;
+      break;
+    default:
+      *val = LSM6DSM_FIFO_GY_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_ds3_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_dataset_3_batch_set(lsm6dsm_ctx_t *ctx,
+                                         lsm6dsm_dec_ds3_fifo_t val)
+{
+  lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds3_fifo = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_ds3_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_dataset_3_batch_get(lsm6dsm_ctx_t *ctx,
+                                         lsm6dsm_dec_ds3_fifo_t *val)
+{
+  lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  switch (fifo_ctrl4.dec_ds3_fifo) {
+    case LSM6DSM_FIFO_DS3_DISABLE:
+      *val = LSM6DSM_FIFO_DS3_DISABLE;
+      break;
+    case LSM6DSM_FIFO_DS3_NO_DEC:
+      *val = LSM6DSM_FIFO_DS3_NO_DEC;
+      break;
+    case LSM6DSM_FIFO_DS3_DEC_2:
+      *val = LSM6DSM_FIFO_DS3_DEC_2;
+      break;
+    case LSM6DSM_FIFO_DS3_DEC_3:
+      *val = LSM6DSM_FIFO_DS3_DEC_3;
+      break;
+    case LSM6DSM_FIFO_DS3_DEC_4:
+      *val = LSM6DSM_FIFO_DS3_DEC_4;
+      break;
+    case LSM6DSM_FIFO_DS3_DEC_8:
+      *val = LSM6DSM_FIFO_DS3_DEC_8;
+      break;
+    case LSM6DSM_FIFO_DS3_DEC_16:
+      *val = LSM6DSM_FIFO_DS3_DEC_16;
+      break;
+    case LSM6DSM_FIFO_DS3_DEC_32:
+      *val = LSM6DSM_FIFO_DS3_DEC_32;
+      break;
+    default:
+      *val = LSM6DSM_FIFO_DS3_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for fourth data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_ds4_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_dataset_4_batch_set(lsm6dsm_ctx_t *ctx,
+                                         lsm6dsm_dec_ds4_fifo_t val)
+{
+  lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds4_fifo = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO) for
+  *          fourth data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_ds4_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_dataset_4_batch_get(lsm6dsm_ctx_t *ctx,
+                                         lsm6dsm_dec_ds4_fifo_t *val)
+{
+  lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  switch (fifo_ctrl4.dec_ds4_fifo) {
+    case LSM6DSM_FIFO_DS4_DISABLE:
+      *val = LSM6DSM_FIFO_DS4_DISABLE;
+      break;
+    case LSM6DSM_FIFO_DS4_NO_DEC:
+      *val = LSM6DSM_FIFO_DS4_NO_DEC;
+      break;
+    case LSM6DSM_FIFO_DS4_DEC_2:
+      *val = LSM6DSM_FIFO_DS4_DEC_2;
+      break;
+    case LSM6DSM_FIFO_DS4_DEC_3:
+      *val = LSM6DSM_FIFO_DS4_DEC_3;
+      break;
+    case LSM6DSM_FIFO_DS4_DEC_4:
+      *val = LSM6DSM_FIFO_DS4_DEC_4;
+      break;
+    case LSM6DSM_FIFO_DS4_DEC_8:
+      *val = LSM6DSM_FIFO_DS4_DEC_8;
+      break;
+    case LSM6DSM_FIFO_DS4_DEC_16:
+      *val = LSM6DSM_FIFO_DS4_DEC_16;
+      break;
+    case LSM6DSM_FIFO_DS4_DEC_32:
+      *val = LSM6DSM_FIFO_DS4_DEC_32;
+      break;
+    default:
+      *val = LSM6DSM_FIFO_DS4_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   8-bit data storage in FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of only_high_data in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_xl_gy_8bit_format_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.only_high_data = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  8-bit data storage in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of only_high_data in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_xl_gy_8bit_format_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.only_high_data;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_stop_on_wtm_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.stop_on_fth = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_stop_on_wtm_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_mode in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t val)
+{
+  lsm6dsm_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.fifo_mode = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fifo_mode in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t *val)
+{
+  lsm6dsm_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  switch (fifo_ctrl5.fifo_mode) {
+    case LSM6DSM_BYPASS_MODE:
+      *val = LSM6DSM_BYPASS_MODE;
+      break;
+    case LSM6DSM_FIFO_MODE:
+      *val = LSM6DSM_FIFO_MODE;
+      break;
+    case LSM6DSM_STREAM_TO_FIFO_MODE:
+      *val = LSM6DSM_STREAM_TO_FIFO_MODE;
+      break;
+    case LSM6DSM_BYPASS_TO_STREAM_MODE:
+      *val = LSM6DSM_BYPASS_TO_STREAM_MODE;
+      break;
+    case LSM6DSM_STREAM_MODE:
+      *val = LSM6DSM_STREAM_MODE;
+      break;
+    default:
+      *val = LSM6DSM_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO ODR selection, setting FIFO_MODE also.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_fifo in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_fifo_t val)
+{
+  lsm6dsm_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.odr_fifo = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO ODR selection, setting FIFO_MODE also.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_fifo in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_fifo_t *val)
+{
+  lsm6dsm_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  switch (fifo_ctrl5.odr_fifo) {
+    case LSM6DSM_FIFO_DISABLE:
+      *val = LSM6DSM_FIFO_DISABLE;
+      break;
+    case LSM6DSM_FIFO_12Hz5:
+      *val = LSM6DSM_FIFO_12Hz5;
+      break;
+    case LSM6DSM_FIFO_26Hz:
+      *val = LSM6DSM_FIFO_26Hz;
+      break;
+    case LSM6DSM_FIFO_52Hz:
+      *val = LSM6DSM_FIFO_52Hz;
+      break;
+    case LSM6DSM_FIFO_104Hz:
+      *val = LSM6DSM_FIFO_104Hz;
+      break;
+    case LSM6DSM_FIFO_208Hz:
+      *val = LSM6DSM_FIFO_208Hz;
+      break;
+    case LSM6DSM_FIFO_416Hz:
+      *val = LSM6DSM_FIFO_416Hz;
+      break;
+    case LSM6DSM_FIFO_833Hz:
+      *val = LSM6DSM_FIFO_833Hz;
+      break;
+    case LSM6DSM_FIFO_1k66Hz:
+      *val = LSM6DSM_FIFO_1k66Hz;
+      break;
+    case LSM6DSM_FIFO_3k33Hz:
+      *val = LSM6DSM_FIFO_3k33Hz;
+      break;
+    case LSM6DSM_FIFO_6k66Hz:
+      *val = LSM6DSM_FIFO_6k66Hz;
+      break;
+    default:
+      *val = LSM6DSM_FIFO_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_DEN_functionality
+  * @brief       This section groups all the functions concerning DEN
+  *              functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_lh in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+ int32_t lsm6dsm_den_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t val)
+{
+  lsm6dsm_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.den_lh = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_lh in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t *val)
+{
+  lsm6dsm_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.den_lh) {
+    case LSM6DSM_DEN_ACT_LOW:
+      *val = LSM6DSM_DEN_ACT_LOW;
+      break;
+    case LSM6DSM_DEN_ACT_HIGH:
+      *val = LSM6DSM_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = LSM6DSM_DEN_ACT_LOW;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t val)
+{
+  lsm6dsm_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.den_mode = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t *val)
+{
+  lsm6dsm_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.den_mode) {
+    case LSM6DSM_DEN_DISABLE:
+      *val = LSM6DSM_DEN_DISABLE;
+      break;
+    case LSM6DSM_LEVEL_LETCHED:
+      *val = LSM6DSM_LEVEL_LETCHED;
+      break;
+    case LSM6DSM_LEVEL_TRIGGER:
+      *val = LSM6DSM_LEVEL_TRIGGER;
+      break;
+    case LSM6DSM_EDGE_TRIGGER:
+      *val = LSM6DSM_EDGE_TRIGGER;
+      break;
+    default:
+      *val = LSM6DSM_DEN_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Extend DEN functionality to accelerometer sensor.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_xl_g in reg CTRL9_XL
+  *                             and den_xl_en in CTRL4_C.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_enable_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_xl_g = (uint8_t)val & 0x01U;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+    if(ret == 0){
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      if(ret == 0){
+        ctrl4_c.den_xl_en = (uint8_t)val & 0x02U;
+        ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Extend DEN functionality to accelerometer sensor. [get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_xl_g in reg CTRL9_XL
+  *                             and den_xl_en in CTRL4_C.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_enable_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t *val)
+{
+  lsm6dsm_ctrl4_c_t ctrl4_c;
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+    switch ( ( ctrl4_c.den_xl_en << 1) + ctrl9_xl.den_xl_g ) {
+      case LSM6DSM_STAMP_IN_GY_DATA:
+        *val = LSM6DSM_STAMP_IN_GY_DATA;
+        break;
+      case LSM6DSM_STAMP_IN_XL_DATA:
+        *val = LSM6DSM_STAMP_IN_XL_DATA;
+        break;
+      case LSM6DSM_STAMP_IN_GY_XL_DATA:
+        *val = LSM6DSM_STAMP_IN_GY_XL_DATA;
+        break;
+      default:
+        *val = LSM6DSM_STAMP_IN_GY_DATA;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_mark_axis_z_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_z = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_mark_axis_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_mark_axis_y_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_y = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_mark_axis_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_mark_axis_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_x = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_den_mark_axis_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_Pedometer
+  * @brief       This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Reset pedometer step counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_rst_step in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_step_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.pedo_rst_step = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset pedometer step counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_rst_step in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_step_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.pedo_rst_step;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer algorithm.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.pedo_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  pedo_sens:   Enable pedometer algorithm.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.pedo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Minimum threshold to detect a peak. Default is 10h.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ths_min in reg
+  *                      CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+       config_pedo_ths_min.ths_min = val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_CONFIG_PEDO_THS_MIN,
+                              (uint8_t*)&config_pedo_ths_min, 1);
+        if(ret == 0){
+          ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+        }
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  Minimum threshold to detect a peak. Default is 10h.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ths_min in reg  CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+    ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+    if(ret == 0){
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_CONFIG_PEDO_THS_MIN,
+                             (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+        *val =  config_pedo_ths_min.ths_min;
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  pedo_full_scale:   Pedometer data range.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_fs in
+  *                            reg CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pedo_fs_t val)
+{
+  lsm6dsm_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+    if(ret == 0){
+       config_pedo_ths_min.pedo_fs = (uint8_t) val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_CONFIG_PEDO_THS_MIN,
+                              (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer data range.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pedo_fs in
+  *                            reg CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pedo_fs_t *val)
+{
+  lsm6dsm_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+    if(ret == 0){
+      switch (config_pedo_ths_min.pedo_fs) {
+         case LSM6DSM_PEDO_AT_2g:
+          *val = LSM6DSM_PEDO_AT_2g;
+          break;
+        case LSM6DSM_PEDO_AT_4g:
+          *val = LSM6DSM_PEDO_AT_4g;
+          break;
+        default:
+          *val = LSM6DSM_PEDO_AT_2g;
+          break;
+      }
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_step in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_debounce_steps_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      pedo_deb_reg.deb_step = val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_PEDO_DEB_REG,
+                              (uint8_t*)&pedo_deb_reg, 1);
+        if(ret == 0){
+          ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+        }
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_step in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_debounce_steps_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+      if(ret == 0){
+        *val = pedo_deb_reg.deb_step;
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+
+  return ret;
+}
+
+/**
+  * @brief  Debounce time. If the time between two consecutive steps is
+  *         greater than  DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_time in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_timeout_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      pedo_deb_reg.deb_time = val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_PEDO_DEB_REG,
+                              (uint8_t*)&pedo_deb_reg, 1);
+      if(ret == 0){
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Debounce time. If the time between two consecutive steps is
+  *         greater than  DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_time in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_timeout_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      *val = pedo_deb_reg.deb_time;
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_steps_period_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_STEP_COUNT_DELTA, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_pedo_steps_period_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_STEP_COUNT_DELTA, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_significant_motion
+  * @brief       This section groups all the functions that manage the
+  *              significant motion detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable significant motion detection function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sign_motion_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_motion_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.sign_motion_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable significant motion detection function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sign_motion_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_motion_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.sign_motion_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Significant motion threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that store significant motion threshold.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_motion_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SM_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Significant motion threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that store significant motion threshold.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_motion_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SM_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_tilt_detection
+  * @brief       This section groups all the functions that manage the tilt
+  *              event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.tilt_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.tilt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_wrist_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.wrist_tilt_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_wrist_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.wrist_tilt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt latency register (r/w).
+  *         Absolute wrist tilt latency parameters.
+  *         1 LSB = 40 ms. Default value: 0Fh (600 ms).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tilt_latency_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_A_WRIST_TILT_LAT, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt latency register (r/w).
+  *         Absolute wrist tilt latency parameters.
+  *         1 LSB = 40 ms. Default value: 0Fh (600 ms).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tilt_latency_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_A_WRIST_TILT_LAT, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt threshold register(r/w).
+  *         Absolute wrist tilt threshold parameters.
+  *         1 LSB = 15.625 mg.Default value: 20h (500 mg).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tilt_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_A_WRIST_TILT_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt threshold register(r/w).
+  *         Absolute wrist tilt threshold parameters.
+  *         1 LSB = 15.625 mg.Default value: 20h (500 mg).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tilt_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_A_WRIST_TILT_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt mask register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers A_WRIST_TILT_MASK
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tilt_src_set(lsm6dsm_ctx_t *ctx,
+                             lsm6dsm_a_wrist_tilt_mask_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_A_WRIST_TILT_MASK,
+                           (uint8_t*) val, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt mask register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers A_WRIST_TILT_MASK
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_tilt_src_get(lsm6dsm_ctx_t *ctx,
+                             lsm6dsm_a_wrist_tilt_mask_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_B);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_A_WRIST_TILT_MASK,
+                           (uint8_t*) val, 1);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_ magnetometer_sensor
+  * @brief       This section groups all the functions that manage additional
+  *              magnetometer sensor.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable soft-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of soft_en in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_soft_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.soft_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable soft-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of soft_en in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_soft_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.soft_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable hard-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of iron_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_hard_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_master_config_t master_config;
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.iron_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+    if(ret == 0){
+      ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+      if(ret == 0){
+        if (val != 0x00U) {
+          ctrl10_c.func_en = val;
+        }
+        ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL10_C,
+                                (uint8_t*)&ctrl10_c, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable hard-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of iron_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_hard_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.iron_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Soft iron 3x3 matrix. Value are expressed in sign-module format.
+  *         (Es. SVVVVVVVb where S is the sign 0/+1/- and V is the value).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_soft_iron_mat_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MAG_SI_XX, buff, 9);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft iron 3x3 matrix. Value are expressed in sign-module format.
+  *         (Es. SVVVVVVVb where S is the sign 0/+1/- and V is the value).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_soft_iron_mat_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MAG_SI_XX, buff, 9);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w). The value is
+  *         expressed as a 16-bit word in two’s complement.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MAG_OFFX_L, buff, 6);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register(r/w).
+  *         The value is expressed as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_mag_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_MAG_OFFX_L, buff, 6);
+    if(ret == 0){
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSM_Sensor_hub
+  * @brief       This section groups all the functions that manage the sensor
+  *              hub functionality.
+  * @{
+  *
+  */
+
+  /**
+  * @brief  Enable function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values func_en
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_func_en_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.func_en = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame with the step of 500 ms and
+  *         full range of 5s. Unsigned 8-bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tph in reg SENSOR_SYNC_TIME_FRAME
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_sync_sens_frame_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_sensor_sync_time_frame_t sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_SENSOR_SYNC_TIME_FRAME,
+                         (uint8_t*)&sensor_sync_time_frame, 1);
+  if(ret == 0){
+     sensor_sync_time_frame.tph = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SENSOR_SYNC_TIME_FRAME,
+                            (uint8_t*)&sensor_sync_time_frame, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame with the step of 500 ms and
+  *         full range of 5s. Unsigned 8-bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tph in reg  SENSOR_SYNC_TIME_FRAME
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_sync_sens_frame_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_sensor_sync_time_frame_t sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_SENSOR_SYNC_TIME_FRAME,
+                         (uint8_t*)&sensor_sync_time_frame, 1);
+  *val =  sensor_sync_time_frame.tph;
+
+  return ret;
+}
+
+/**
+  * @brief  Resolution ratio of error code for sensor synchronization.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rr in reg  SENSOR_SYNC_RES_RATIO
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_sync_sens_ratio_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t val)
+{
+  lsm6dsm_sensor_sync_res_ratio_t sensor_sync_res_ratio;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_SENSOR_SYNC_RES_RATIO,
+                              (uint8_t*)&sensor_sync_res_ratio, 1);
+  if(ret == 0){
+    sensor_sync_res_ratio.rr = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SENSOR_SYNC_RES_RATIO,
+                            (uint8_t*)&sensor_sync_res_ratio, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resolution ratio of error code for sensor synchronization.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rr in reg  SENSOR_SYNC_RES_RATIO
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_sync_sens_ratio_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t *val)
+{
+  lsm6dsm_sensor_sync_res_ratio_t sensor_sync_res_ratio;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_SENSOR_SYNC_RES_RATIO,
+                         (uint8_t*)&sensor_sync_res_ratio, 1);
+
+  switch ( sensor_sync_res_ratio.rr) {
+    case LSM6DSM_RES_RATIO_2_11:
+      *val = LSM6DSM_RES_RATIO_2_11;
+      break;
+    case LSM6DSM_RES_RATIO_2_12:
+      *val = LSM6DSM_RES_RATIO_2_12;
+      break;
+    case LSM6DSM_RES_RATIO_2_13:
+      *val = LSM6DSM_RES_RATIO_2_13;
+      break;
+    case LSM6DSM_RES_RATIO_2_14:
+      *val = LSM6DSM_RES_RATIO_2_14;
+      break;
+    default:
+      *val = LSM6DSM_RES_RATIO_2_11;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_master_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.master_on = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_master_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.master_on;
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_pass_through_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pass_through_mode = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_pass_through_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.pass_through_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable/disable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pull_up_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pull_up_en = (uint8_t) val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable/disable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pull_up_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t *val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  switch (master_config.pull_up_en) {
+    case LSM6DSM_EXT_PULL_UP:
+      *val = LSM6DSM_EXT_PULL_UP;
+      break;
+    case LSM6DSM_INTERNAL_PULL_UP:
+      *val = LSM6DSM_INTERNAL_PULL_UP;
+      break;
+    default:
+      *val = LSM6DSM_SH_PIN_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_syncro_mode_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_start_config_t val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.start_config = (uint8_t)val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_syncro_mode_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_start_config_t *val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  switch (master_config.start_config) {
+    case LSM6DSM_XL_GY_DRDY:
+      *val = LSM6DSM_XL_GY_DRDY;
+      break;
+    case LSM6DSM_EXT_ON_INT2_PIN:
+      *val = LSM6DSM_EXT_ON_INT2_PIN;
+      break;
+    default:
+      *val = LSM6DSM_XL_GY_DRDY;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Manage the Master DRDY signal on INT1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_on_int1 in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_drdy_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.drdy_on_int1 = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Manage the Master DRDY signal on INT1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_on_int1 in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_drdy_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.drdy_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from SENSORHUB1_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_read_data_raw_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_emb_sh_read_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_SENSORHUB1_REG,
+                         (uint8_t*)&(val->sh_byte_1), 12);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SENSORHUB13_REG,
+                           (uint8_t*)&(val->sh_byte_13), 6);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master command code used for stamping for sensor sync.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_cmd_code in
+  *                reg MASTER_CMD_CODE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_cmd_sens_sync_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_master_cmd_code_t master_cmd_code;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CMD_CODE,
+                         (uint8_t*)&master_cmd_code, 1);
+  if(ret == 0){
+    master_cmd_code.master_cmd_code = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_MASTER_CMD_CODE,
+                            (uint8_t*)&master_cmd_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master command code used for stamping for sensor sync.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_cmd_code in
+  *                reg MASTER_CMD_CODE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_cmd_sens_sync_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_master_cmd_code_t master_cmd_code;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_MASTER_CMD_CODE,
+                         (uint8_t*)&master_cmd_code, 1);
+  *val = master_cmd_code.master_cmd_code;
+
+  return ret;
+}
+
+/**
+  * @brief  Error code used for sensor synchronization.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of error_code in
+  *                reg SENS_SYNC_SPI_ERROR_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_spi_sync_error_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsm_sens_sync_spi_error_code_t sens_sync_spi_error_code;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_SENS_SYNC_SPI_ERROR_CODE,
+                         (uint8_t*)&sens_sync_spi_error_code, 1);
+  if(ret == 0){
+     sens_sync_spi_error_code.error_code = val;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SENS_SYNC_SPI_ERROR_CODE,
+                            (uint8_t*)&sens_sync_spi_error_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Error code used for sensor synchronization.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of error_code in
+  *                reg SENS_SYNC_SPI_ERROR_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_spi_sync_error_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_sens_sync_spi_error_code_t sens_sync_spi_error_code;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_SENS_SYNC_SPI_ERROR_CODE,
+                         (uint8_t*)&sens_sync_spi_error_code, 1);
+  *val =  sens_sync_spi_error_code.error_code;
+
+  return ret;
+}
+
+/**
+  * @brief   Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of aux_sens_on in reg SLAVE0_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_num_of_dev_connected_set(lsm6dsm_ctx_t *ctx,
+                                            lsm6dsm_aux_sens_on_t val)
+{
+  lsm6dsm_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      slave0_config.aux_sens_on = (uint8_t) val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE0_CONFIG,
+                              (uint8_t*)&slave0_config, 1);
+      if(ret == 0){
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of aux_sens_on in reg SLAVE0_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_num_of_dev_connected_get(lsm6dsm_ctx_t *ctx,
+                                            lsm6dsm_aux_sens_on_t *val)
+{
+  lsm6dsm_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      switch (slave0_config.aux_sens_on) {
+        case LSM6DSM_SLV_0:
+          *val = LSM6DSM_SLV_0;
+          break;
+        case LSM6DSM_SLV_0_1:
+          *val = LSM6DSM_SLV_0_1;
+          break;
+        case LSM6DSM_SLV_0_1_2:
+          *val = LSM6DSM_SLV_0_1_2;
+          break;
+        case LSM6DSM_SLV_0_1_2_3:
+          *val = LSM6DSM_SLV_0_1_2_3;
+          break;
+        default:
+          *val = LSM6DSM_SLV_0;
+          break;
+      }
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_data;   8 bit data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_cfg_write(lsm6dsm_ctx_t *ctx, lsm6dsm_sh_cfg_write_t *val)
+{
+  lsm6dsm_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv0_add;
+    slv0_add.rw_0 = 0;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+    if(ret == 0){
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV0_SUBADD,
+                              &(val->slv0_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsm_write_reg(ctx, LSM6DSM_DATAWRITE_SRC_MODE_SUB_SLV0,
+                                &(val->slv0_data), 1);
+        if(ret == 0){
+          ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slv0_cfg_read(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_sh_cfg_read_t *val)
+{
+  lsm6dsm_slave0_config_t slave0_config;
+  lsm6dsm_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv_add;
+    slv0_add.rw_0 = 1;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+    if(ret == 0){
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV0_SUBADD,
+                              &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE0_CONFIG,
+                               (uint8_t*)&slave0_config, 1);
+        slave0_config.slave0_numop = val->slv_len;
+        if(ret == 0){
+          ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE0_CONFIG,
+                                  (uint8_t*)&slave0_config, 1);
+          if(ret == 0){
+            ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 1 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slv1_cfg_read(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_sh_cfg_read_t *val)
+{
+  lsm6dsm_slave1_config_t slave1_config;
+  lsm6dsm_slv1_add_t slv1_add;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    slv1_add.slave1_add  = val->slv_add;
+    slv1_add.r_1 = 1;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV1_ADD, (uint8_t*)&slv1_add, 1);
+    if(ret == 0){
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV1_SUBADD,
+                                   &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE1_CONFIG,
+                               (uint8_t*)&slave1_config, 1);
+        slave1_config.slave1_numop = val->slv_len;
+        if(ret == 0){
+          ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE1_CONFIG,
+                                  (uint8_t*)&slave1_config, 1);
+          if(ret == 0){
+            ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 2 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slv2_cfg_read(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_sh_cfg_read_t *val)
+{
+  lsm6dsm_slv2_add_t slv2_add;
+  lsm6dsm_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    slv2_add.slave2_add  = val->slv_add;
+    slv2_add.r_2 = 1;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV2_ADD, (uint8_t*)&slv2_add, 1);
+    if(ret == 0){
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV2_SUBADD,
+                              &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE2_CONFIG,
+                               (uint8_t*)&slave2_config, 1);
+        if(ret == 0){
+          slave2_config.slave2_numop = val->slv_len;
+          ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE2_CONFIG,
+                                  (uint8_t*)&slave2_config, 1);
+          if(ret == 0){
+            ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 3 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slv3_cfg_read(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_sh_cfg_read_t *val)
+{
+  lsm6dsm_slave3_config_t slave3_config;
+  lsm6dsm_slv3_add_t slv3_add;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    slv3_add.slave3_add  = val->slv_add;
+    slv3_add.r_3 = 1;
+    ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV3_ADD, (uint8_t*)&slv3_add, 1);
+    if(ret == 0){
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLV3_SUBADD,
+                              (uint8_t*)&(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE3_CONFIG,
+                               (uint8_t*)&slave3_config, 1);
+        if(ret == 0){
+          slave3_config.slave3_numop = val->slv_len;
+          ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE3_CONFIG,
+                                  (uint8_t*)&slave3_config, 1);
+          if(ret == 0){
+            ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 0 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave0_rate in reg SLAVE0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slave_0_dec_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave0_rate_t val)
+{
+  lsm6dsm_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      slave0_config.slave0_rate = (uint8_t) val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE0_CONFIG,
+                              (uint8_t*)&slave0_config, 1);
+      if(ret == 0){
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 0 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave0_rate in reg SLAVE0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slave_0_dec_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave0_rate_t *val)
+{
+  lsm6dsm_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      switch (slave0_config.slave0_rate) {
+        case LSM6DSM_SL0_NO_DEC:
+          *val = LSM6DSM_SL0_NO_DEC;
+          break;
+        case LSM6DSM_SL0_DEC_2:
+          *val = LSM6DSM_SL0_DEC_2;
+          break;
+        case LSM6DSM_SL0_DEC_4:
+          *val = LSM6DSM_SL0_DEC_4;
+          break;
+        case LSM6DSM_SL0_DEC_8:
+          *val = LSM6DSM_SL0_DEC_8;
+          break;
+        default:
+          *val = LSM6DSM_SL0_NO_DEC;
+          break;
+      }
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.
+  *         This is effective if the Aux_sens_on[1:0] field in
+  *         SLAVE0_CONFIG(04h) is set to a value other than 00.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of write_once in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_write_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_write_once_t val)
+{
+  lsm6dsm_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE1_CONFIG,
+                           (uint8_t*)&slave1_config, 1);
+    slave1_config.write_once = (uint8_t) val;
+    if(ret == 0){
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE1_CONFIG,
+                              (uint8_t*)&slave1_config, 1);
+      if(ret == 0){
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.
+  *         This is effective if the Aux_sens_on[1:0] field in
+  *         SLAVE0_CONFIG(04h) is set to a value other than 00.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of write_once in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_write_mode_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_write_once_t *val)
+{
+  lsm6dsm_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE1_CONFIG,
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      switch (slave1_config.write_once) {
+        case LSM6DSM_EACH_SH_CYCLE:
+          *val = LSM6DSM_EACH_SH_CYCLE;
+          break;
+        case LSM6DSM_ONLY_FIRST_CYCLE:
+          *val = LSM6DSM_ONLY_FIRST_CYCLE;
+          break;
+        default:
+          *val = LSM6DSM_EACH_SH_CYCLE;
+          break;
+      }
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 1 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave1_rate in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slave_1_dec_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave1_rate_t val)
+{
+  lsm6dsm_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE1_CONFIG,
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      slave1_config.slave1_rate = (uint8_t) val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE1_CONFIG,
+                              (uint8_t*)&slave1_config, 1);
+      if(ret == 0){
+          ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 1 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slave_1_dec_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave1_rate_t *val)
+{
+  lsm6dsm_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE1_CONFIG,
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      switch (slave1_config.slave1_rate) {
+        case LSM6DSM_SL1_NO_DEC:
+          *val = LSM6DSM_SL1_NO_DEC;
+          break;
+        case LSM6DSM_SL1_DEC_2:
+          *val = LSM6DSM_SL1_DEC_2;
+          break;
+        case LSM6DSM_SL1_DEC_4:
+          *val = LSM6DSM_SL1_DEC_4;
+          break;
+        case LSM6DSM_SL1_DEC_8:
+          *val = LSM6DSM_SL1_DEC_8;
+          break;
+        default:
+          *val = LSM6DSM_SL1_NO_DEC;
+          break;
+      }
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 2 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave2_rate in reg SLAVE2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slave_2_dec_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave2_rate_t val)
+{
+  lsm6dsm_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE2_CONFIG,
+                           (uint8_t*)&slave2_config, 1);
+    if(ret == 0){
+      slave2_config.slave2_rate =(uint8_t) val;
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE2_CONFIG,
+                              (uint8_t*)&slave2_config, 1);
+      if(ret == 0){
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 2 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave2_rate in reg SLAVE2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slave_2_dec_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave2_rate_t *val)
+{
+  lsm6dsm_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE2_CONFIG,
+                           (uint8_t*)&slave2_config, 1);
+    if(ret == 0){
+      switch (slave2_config.slave2_rate) {
+        case LSM6DSM_SL2_NO_DEC:
+          *val = LSM6DSM_SL2_NO_DEC;
+          break;
+        case LSM6DSM_SL2_DEC_2:
+          *val = LSM6DSM_SL2_DEC_2;
+          break;
+        case LSM6DSM_SL2_DEC_4:
+          *val = LSM6DSM_SL2_DEC_4;
+          break;
+        case LSM6DSM_SL2_DEC_8:
+          *val = LSM6DSM_SL2_DEC_8;
+          break;
+        default:
+          *val = LSM6DSM_SL2_NO_DEC;
+          break;
+      }
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 3 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave3_rate in reg SLAVE3_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slave_3_dec_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave3_rate_t val)
+{
+  lsm6dsm_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE3_CONFIG,
+                           (uint8_t*)&slave3_config, 1);
+    slave3_config.slave3_rate = (uint8_t)val;
+    if(ret == 0){
+      ret = lsm6dsm_write_reg(ctx, LSM6DSM_SLAVE3_CONFIG,
+                              (uint8_t*)&slave3_config, 1);
+      if(ret == 0){
+        ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 3 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave3_rate in reg SLAVE3_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_sh_slave_3_dec_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave3_rate_t *val)
+{
+  lsm6dsm_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_BANK_A);
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_SLAVE3_CONFIG,
+                           (uint8_t*)&slave3_config, 1);
+    if(ret == 0){
+      switch (slave3_config.slave3_rate) {
+        case LSM6DSM_SL3_NO_DEC:
+          *val = LSM6DSM_SL3_NO_DEC;
+          break;
+        case LSM6DSM_SL3_DEC_2:
+          *val = LSM6DSM_SL3_DEC_2;
+          break;
+        case LSM6DSM_SL3_DEC_4:
+          *val = LSM6DSM_SL3_DEC_4;
+          break;
+        case LSM6DSM_SL3_DEC_8:
+          *val = LSM6DSM_SL3_DEC_8;
+          break;
+        default:
+          *val = LSM6DSM_SL3_NO_DEC;
+          break;
+      }
+      ret = lsm6dsm_mem_bank_set(ctx, LSM6DSM_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsm_STdC/driver/lsm6dsm_reg.h
+++ b/sensor/stmemsc/lsm6dsm_STdC/driver/lsm6dsm_reg.h
@@ -1,0 +1,2070 @@
+/*
+ ******************************************************************************
+ * @file    lsm6dsm_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm6dsm_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DSM_DRIVER_H
+#define LSM6DSM_DRIVER_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM6DSM
+  * @{
+  *
+  */
+
+/** @defgroup LSM6DSM_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LSM9DS1_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lsm6dsm_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lsm6dsm_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lsm6dsm_write_ptr  write_reg;
+  lsm6dsm_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lsm6dsm_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DSM_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define LSM6DSM_I2C_ADD_L     0xD5U
+#define LSM6DSM_I2C_ADD_H     0xD7U
+
+/** Device Identification (Who am I) **/
+#define LSM6DSM_ID            0x6AU
+
+/**
+  * @}
+  *
+  */
+
+#define LSM6DSM_FUNC_CFG_ACCESS              0x01U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t func_cfg_en              : 3;  /* func_cfg_en + func_cfg_en_b */
+} lsm6dsm_func_cfg_access_t;
+
+#define LSM6DSM_SENSOR_SYNC_TIME_FRAME       0x04U
+typedef struct {
+  uint8_t tph                      : 4;
+  uint8_t not_used_01              : 4;
+} lsm6dsm_sensor_sync_time_frame_t;
+
+#define LSM6DSM_SENSOR_SYNC_RES_RATIO        0x05U
+typedef struct {
+  uint8_t rr                       : 2;
+  uint8_t not_used_01              : 6;
+} lsm6dsm_sensor_sync_res_ratio_t;
+
+#define LSM6DSM_FIFO_CTRL1                   0x06U
+typedef struct {
+  uint8_t fth                      : 8;  /* + FIFO_CTRL2(fth) */
+} lsm6dsm_fifo_ctrl1_t;
+
+#define LSM6DSM_FIFO_CTRL2                   0x07U
+typedef struct {
+  uint8_t fth                      : 3;  /* + FIFO_CTRL1(fth) */
+  uint8_t fifo_temp_en             : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t  timer_pedo_fifo_drdy    : 1;
+  uint8_t timer_pedo_fifo_en       : 1;
+} lsm6dsm_fifo_ctrl2_t;
+
+#define LSM6DSM_FIFO_CTRL3                   0x08U
+typedef struct {
+  uint8_t dec_fifo_xl              : 3;
+  uint8_t dec_fifo_gyro            : 3;
+  uint8_t not_used_01              : 2;
+} lsm6dsm_fifo_ctrl3_t;
+
+#define LSM6DSM_FIFO_CTRL4                   0x09U
+typedef struct {
+  uint8_t dec_ds3_fifo             : 3;
+  uint8_t dec_ds4_fifo             : 3;
+  uint8_t only_high_data           : 1;
+  uint8_t stop_on_fth              : 1;
+} lsm6dsm_fifo_ctrl4_t;
+
+#define LSM6DSM_FIFO_CTRL5                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t odr_fifo                 : 4;
+  uint8_t not_used_01              : 1;
+} lsm6dsm_fifo_ctrl5_t;
+
+#define LSM6DSM_DRDY_PULSE_CFG               0x0BU
+typedef struct {
+  uint8_t int2_wrist_tilt          : 1;
+  uint8_t not_used_01              : 6;
+  uint8_t drdy_pulsed              : 1;
+} lsm6dsm_drdy_pulse_cfg_t;
+
+#define LSM6DSM_INT1_CTRL                    0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_full_flag           : 1;
+  uint8_t int1_sign_mot            : 1;
+  uint8_t int1_step_detector       : 1;
+} lsm6dsm_int1_ctrl_t;
+
+#define LSM6DSM_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_full_flag           : 1;
+  uint8_t int2_step_count_ov       : 1;
+  uint8_t int2_step_delta          : 1;
+} lsm6dsm_int2_ctrl_t;
+
+#define LSM6DSM_WHO_AM_I                     0x0FU
+#define LSM6DSM_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t bw0_xl                   : 1;
+  uint8_t lpf1_bw_sel              : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} lsm6dsm_ctrl1_xl_t;
+
+#define LSM6DSM_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t fs_g                     : 3;  /* fs_g + fs_125 */
+  uint8_t odr_g                    : 4;
+} lsm6dsm_ctrl2_g_t;
+
+#define LSM6DSM_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t ble                      : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} lsm6dsm_ctrl3_c_t;
+
+#define LSM6DSM_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t den_drdy_int1            : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep                    : 1;
+  uint8_t den_xl_en                : 1;
+} lsm6dsm_ctrl4_c_t;
+
+#define LSM6DSM_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t den_lh                   : 1;
+  uint8_t rounding                 : 3;
+} lsm6dsm_ctrl5_c_t;
+
+#define LSM6DSM_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t ftype                    : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t usr_off_w                : 1;
+  uint8_t xl_hm_mode               : 1;
+  uint8_t den_mode                 : 3;  /* trig_en + lvl_en + lvl2_en */
+} lsm6dsm_ctrl6_c_t;
+
+#define LSM6DSM_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t rounding_status          : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t g_hm_mode                : 1;
+} lsm6dsm_ctrl7_g_t;
+
+#define LSM6DSM_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t input_composite          : 1;
+  uint8_t hp_ref_mode              : 1;
+  uint8_t hpcf_xl                  : 2;
+  uint8_t lpf2_xl_en               : 1;
+} lsm6dsm_ctrl8_xl_t;
+
+#define LSM6DSM_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t soft_en                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t den_xl_g                 : 1;
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} lsm6dsm_ctrl9_xl_t;
+
+#define LSM6DSM_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t sign_motion_en           : 1;
+  uint8_t pedo_rst_step            : 1;
+  uint8_t func_en                  : 1;
+  uint8_t tilt_en                  : 1;
+  uint8_t pedo_en                  : 1;
+  uint8_t timer_en                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t wrist_tilt_en            : 1;
+} lsm6dsm_ctrl10_c_t;
+
+#define LSM6DSM_MASTER_CONFIG                0x1AU
+typedef struct {
+  uint8_t master_on                : 1;
+  uint8_t iron_en                  : 1;
+  uint8_t pass_through_mode        : 1;
+  uint8_t pull_up_en               : 1;
+  uint8_t start_config             : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t  data_valid_sel_fifo     : 1;
+  uint8_t drdy_on_int1             : 1;
+} lsm6dsm_master_config_t;
+
+#define LSM6DSM_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state_ia           : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t not_used_01              : 2;
+} lsm6dsm_wake_up_src_t;
+
+#define LSM6DSM_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsm_tap_src_t;
+
+#define LSM6DSM_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} lsm6dsm_d6d_src_t;
+
+#define LSM6DSM_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dsm_status_reg_t;
+
+#define LSM6DSM_STATUS_SPIAUX                0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t gyro_settling            : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dsm_status_spiaux_t;
+
+#define LSM6DSM_OUT_TEMP_L                   0x20U
+#define LSM6DSM_OUT_TEMP_H                   0x21U
+#define LSM6DSM_OUTX_L_G                     0x22U
+#define LSM6DSM_OUTX_H_G                     0x23U
+#define LSM6DSM_OUTY_L_G                     0x24U
+#define LSM6DSM_OUTY_H_G                     0x25U
+#define LSM6DSM_OUTZ_L_G                     0x26U
+#define LSM6DSM_OUTZ_H_G                     0x27U
+#define LSM6DSM_OUTX_L_XL                    0x28U
+#define LSM6DSM_OUTX_H_XL                    0x29U
+#define LSM6DSM_OUTY_L_XL                    0x2AU
+#define LSM6DSM_OUTY_H_XL                    0x2BU
+#define LSM6DSM_OUTZ_L_XL                    0x2CU
+#define LSM6DSM_OUTZ_H_XL                    0x2DU
+#define LSM6DSM_SENSORHUB1_REG               0x2EU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub1_reg_t;
+
+#define LSM6DSM_SENSORHUB2_REG               0x2FU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub2_reg_t;
+
+#define LSM6DSM_SENSORHUB3_REG               0x30U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub3_reg_t;
+
+#define LSM6DSM_SENSORHUB4_REG               0x31U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub4_reg_t;
+
+#define LSM6DSM_SENSORHUB5_REG               0x32U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub5_reg_t;
+
+#define LSM6DSM_SENSORHUB6_REG               0x33U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub6_reg_t;
+
+#define LSM6DSM_SENSORHUB7_REG               0x34U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub7_reg_t;
+
+#define LSM6DSM_SENSORHUB8_REG               0x35U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub8_reg_t;
+
+#define LSM6DSM_SENSORHUB9_REG               0x36U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub9_reg_t;
+
+#define LSM6DSM_SENSORHUB10_REG              0x37U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub10_reg_t;
+
+#define LSM6DSM_SENSORHUB11_REG              0x38U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub11_reg_t;
+
+#define LSM6DSM_SENSORHUB12_REG              0x39U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub12_reg_t;
+
+#define LSM6DSM_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;  /* + FIFO_STATUS2(diff_fifo) */
+} lsm6dsm_fifo_status1_t;
+
+#define LSM6DSM_FIFO_STATUS2                 0x3BU
+typedef struct {
+  uint8_t diff_fifo                : 3;  /* + FIFO_STATUS1(diff_fifo) */
+  uint8_t not_used_01              : 1;
+  uint8_t fifo_empty               : 1;
+  uint8_t fifo_full_smart          : 1;
+  uint8_t over_run                 : 1;
+  uint8_t waterm                   : 1;
+} lsm6dsm_fifo_status2_t;
+
+#define LSM6DSM_FIFO_STATUS3                 0x3CU
+typedef struct {
+  uint8_t fifo_pattern             : 8;  /* + FIFO_STATUS4(fifo_pattern) */
+} lsm6dsm_fifo_status3_t;
+
+#define LSM6DSM_FIFO_STATUS4                 0x3DU
+typedef struct {
+  uint8_t fifo_pattern             : 2;  /* + FIFO_STATUS3(fifo_pattern) */
+  uint8_t not_used_01              : 6;
+} lsm6dsm_fifo_status4_t;
+
+#define LSM6DSM_FIFO_DATA_OUT_L              0x3EU
+#define LSM6DSM_FIFO_DATA_OUT_H              0x3FU
+#define LSM6DSM_TIMESTAMP0_REG               0x40U
+#define LSM6DSM_TIMESTAMP1_REG               0x41U
+#define LSM6DSM_TIMESTAMP2_REG               0x42U
+#define LSM6DSM_STEP_TIMESTAMP_L             0x49U
+#define LSM6DSM_STEP_TIMESTAMP_H             0x4AU
+#define LSM6DSM_STEP_COUNTER_L               0x4BU
+#define LSM6DSM_STEP_COUNTER_H               0x4CU
+
+#define LSM6DSM_SENSORHUB13_REG              0x4DU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub13_reg_t;
+
+#define LSM6DSM_SENSORHUB14_REG              0x4EU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub14_reg_t;
+
+#define LSM6DSM_SENSORHUB15_REG              0x4FU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub15_reg_t;
+
+#define LSM6DSM_SENSORHUB16_REG              0x50U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub16_reg_t;
+
+#define LSM6DSM_SENSORHUB17_REG              0x51U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub17_reg_t;
+
+#define LSM6DSM_SENSORHUB18_REG              0x52U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6dsm_sensorhub18_reg_t;
+
+#define LSM6DSM_FUNC_SRC1                    0x53U
+typedef struct {
+  uint8_t sensorhub_end_op         : 1;
+  uint8_t si_end_op                : 1;
+  uint8_t hi_fail                  : 1;
+  uint8_t step_overflow            : 1;
+  uint8_t step_detected            : 1;
+  uint8_t tilt_ia                  : 1;
+  uint8_t sign_motion_ia           : 1;
+  uint8_t  step_count_delta_ia     : 1;
+} lsm6dsm_func_src1_t;
+
+#define LSM6DSM_FUNC_SRC2                    0x54U
+typedef struct {
+  uint8_t wrist_tilt_ia            : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t slave0_nack              : 1;
+  uint8_t slave1_nack              : 1;
+  uint8_t slave2_nack              : 1;
+  uint8_t slave3_nack              : 1;
+  uint8_t not_used_02              : 1;
+} lsm6dsm_func_src2_t;
+
+#define LSM6DSM_WRIST_TILT_IA                0x55U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t wrist_tilt_ia_zneg       : 1;
+  uint8_t wrist_tilt_ia_zpos       : 1;
+  uint8_t wrist_tilt_ia_yneg       : 1;
+  uint8_t wrist_tilt_ia_ypos       : 1;
+  uint8_t wrist_tilt_ia_xneg       : 1;
+  uint8_t wrist_tilt_ia_xpos       : 1;
+} lsm6dsm_wrist_tilt_ia_t;
+
+#define LSM6DSM_TAP_CFG                      0x58U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t tap_z_en                 : 1;
+  uint8_t tap_y_en                 : 1;
+  uint8_t tap_x_en                 : 1;
+  uint8_t slope_fds                : 1;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} lsm6dsm_tap_cfg_t;
+
+#define LSM6DSM_TAP_THS_6D                   0x59U
+typedef struct {
+  uint8_t tap_ths                  : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} lsm6dsm_tap_ths_6d_t;
+
+#define LSM6DSM_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} lsm6dsm_int_dur2_t;
+
+#define LSM6DSM_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t not_used_01              : 1;
+  uint8_t single_double_tap        : 1;
+} lsm6dsm_wake_up_ths_t;
+
+#define LSM6DSM_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t timer_hr                 : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} lsm6dsm_wake_up_dur_t;
+
+#define LSM6DSM_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} lsm6dsm_free_fall_t;
+
+#define LSM6DSM_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t int1_timer               : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_inact_state         : 1;
+} lsm6dsm_md1_cfg_t;
+
+#define LSM6DSM_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_iron                : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_inact_state         : 1;
+} lsm6dsm_md2_cfg_t;
+
+#define LSM6DSM_MASTER_CMD_CODE              0x60U
+typedef struct {
+  uint8_t master_cmd_code          : 8;
+} lsm6dsm_master_cmd_code_t;
+
+#define LSM6DSM_SENS_SYNC_SPI_ERROR_CODE     0x61U
+typedef struct {
+  uint8_t error_code               : 8;
+} lsm6dsm_sens_sync_spi_error_code_t;
+
+#define LSM6DSM_OUT_MAG_RAW_X_L              0x66U
+#define LSM6DSM_OUT_MAG_RAW_X_H              0x67U
+#define LSM6DSM_OUT_MAG_RAW_Y_L              0x68U
+#define LSM6DSM_OUT_MAG_RAW_Y_H              0x69U
+#define LSM6DSM_OUT_MAG_RAW_Z_L              0x6AU
+#define LSM6DSM_OUT_MAG_RAW_Z_H              0x6BU
+#define LSM6DSM_INT_OIS                      0x6FU
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t lvl2_ois                 : 1;
+  uint8_t int2_drdy_ois            : 1;
+} lsm6dsm_int_ois_t;
+
+#define LSM6DSM_CTRL1_OIS                    0x70U
+typedef struct {
+  uint8_t ois_en_spi2              : 1;
+  uint8_t fs_g_ois                 : 3;  /* fs_g_ois + fs_125_ois */
+  uint8_t mode4_en                 : 1;
+  uint8_t sim_ois                  : 1;
+  uint8_t lvl1_ois                 : 1;
+  uint8_t ble_ois                  : 1;
+} lsm6dsm_ctrl1_ois_t;
+
+#define LSM6DSM_CTRL2_OIS                    0x71U
+typedef struct {
+  uint8_t hp_en_ois                : 1;
+  uint8_t ftype_ois                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_ois                  : 2;
+  uint8_t not_used_02              : 2;
+} lsm6dsm_ctrl2_ois_t;
+
+#define LSM6DSM_CTRL3_OIS                    0x72U
+typedef struct {
+  uint8_t st_ois_clampdis          : 1;
+  uint8_t st_ois                   : 2;
+  uint8_t filter_xl_conf_ois       : 2;
+  uint8_t fs_xl_ois                : 2;
+  uint8_t den_lh_ois               : 1;
+} lsm6dsm_ctrl3_ois_t;
+
+#define LSM6DSM_X_OFS_USR                    0x73U
+#define LSM6DSM_Y_OFS_USR                    0x74U
+#define LSM6DSM_Z_OFS_USR                    0x75U
+#define LSM6DSM_SLV0_ADD                     0x02U
+typedef struct {
+  uint8_t rw_0                     : 1;
+  uint8_t slave0_add               : 7;
+} lsm6dsm_slv0_add_t;
+
+#define LSM6DSM_SLV0_SUBADD                  0x03U
+typedef struct {
+  uint8_t slave0_reg               : 8;
+} lsm6dsm_slv0_subadd_t;
+
+#define LSM6DSM_SLAVE0_CONFIG                0x04U
+typedef struct {
+  uint8_t slave0_numop             : 3;
+  uint8_t src_mode                 : 1;
+  uint8_t aux_sens_on              : 2;
+  uint8_t slave0_rate              : 2;
+} lsm6dsm_slave0_config_t;
+
+#define LSM6DSM_SLV1_ADD                     0x05U
+typedef struct {
+  uint8_t r_1                      : 1;
+  uint8_t slave1_add               : 7;
+} lsm6dsm_slv1_add_t;
+
+#define LSM6DSM_SLV1_SUBADD                  0x06U
+typedef struct {
+  uint8_t slave1_reg               : 8;
+} lsm6dsm_slv1_subadd_t;
+
+#define LSM6DSM_SLAVE1_CONFIG                0x07U
+typedef struct {
+  uint8_t slave1_numop             : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t write_once               : 1;
+  uint8_t slave1_rate              : 2;
+} lsm6dsm_slave1_config_t;
+
+#define LSM6DSM_SLV2_ADD                     0x08U
+typedef struct {
+  uint8_t r_2                      : 1;
+  uint8_t slave2_add               : 7;
+} lsm6dsm_slv2_add_t;
+
+#define LSM6DSM_SLV2_SUBADD                  0x09U
+typedef struct {
+  uint8_t slave2_reg               : 8;
+} lsm6dsm_slv2_subadd_t;
+
+#define LSM6DSM_SLAVE2_CONFIG                0x0AU
+typedef struct {
+  uint8_t slave2_numop             : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t slave2_rate              : 2;
+} lsm6dsm_slave2_config_t;
+
+#define LSM6DSM_SLV3_ADD                     0x0BU
+typedef struct {
+  uint8_t r_3                      : 1;
+  uint8_t slave3_add               : 7;
+} lsm6dsm_slv3_add_t;
+
+#define LSM6DSM_SLV3_SUBADD                  0x0CU
+typedef struct {
+  uint8_t slave3_reg               : 8;
+} lsm6dsm_slv3_subadd_t;
+
+#define LSM6DSM_SLAVE3_CONFIG                0x0DU
+typedef struct {
+  uint8_t slave3_numop             : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t slave3_rate              : 2;
+} lsm6dsm_slave3_config_t;
+
+#define LSM6DSM_DATAWRITE_SRC_MODE_SUB_SLV0  0x0EU
+typedef struct {
+  uint8_t slave_dataw              : 8;
+} lsm6dsm_datawrite_src_mode_sub_slv0_t;
+
+#define LSM6DSM_CONFIG_PEDO_THS_MIN          0x0FU
+typedef struct {
+  uint8_t ths_min                  : 5;
+  uint8_t not_used_01              : 2;
+  uint8_t pedo_fs                  : 1;
+} lsm6dsm_config_pedo_ths_min_t;
+
+#define LSM6DSM_SM_THS                       0x13U
+#define LSM6DSM_PEDO_DEB_REG                 0x14U
+typedef struct {
+  uint8_t deb_step      : 3;
+  uint8_t deb_time      : 5;
+} lsm6dsm_pedo_deb_reg_t;
+
+#define LSM6DSM_STEP_COUNT_DELTA             0x15U
+#define LSM6DSM_MAG_SI_XX                    0x24U
+#define LSM6DSM_MAG_SI_XY                    0x25U
+#define LSM6DSM_MAG_SI_XZ                    0x26U
+#define LSM6DSM_MAG_SI_YX                    0x27U
+#define LSM6DSM_MAG_SI_YY                    0x28U
+#define LSM6DSM_MAG_SI_YZ                    0x29U
+#define LSM6DSM_MAG_SI_ZX                    0x2AU
+#define LSM6DSM_MAG_SI_ZY                    0x2BU
+#define LSM6DSM_MAG_SI_ZZ                    0x2CU
+#define LSM6DSM_MAG_OFFX_L                   0x2DU
+#define LSM6DSM_MAG_OFFX_H                   0x2EU
+#define LSM6DSM_MAG_OFFY_L                   0x2FU
+#define LSM6DSM_MAG_OFFY_H                   0x30U
+#define LSM6DSM_MAG_OFFZ_L                   0x31U
+#define LSM6DSM_MAG_OFFZ_H                   0x32U
+#define LSM6DSM_A_WRIST_TILT_LAT             0x50U
+#define LSM6DSM_A_WRIST_TILT_THS             0x54U
+#define LSM6DSM_A_WRIST_TILT_MASK            0x59U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t  wrist_tilt_mask_zneg    : 1;
+  uint8_t  wrist_tilt_mask_zpos    : 1;
+  uint8_t  wrist_tilt_mask_yneg    : 1;
+  uint8_t  wrist_tilt_mask_ypos    : 1;
+  uint8_t  wrist_tilt_mask_xneg    : 1;
+  uint8_t  wrist_tilt_mask_xpos    : 1;
+} lsm6dsm_a_wrist_tilt_mask_t;
+
+/**
+  * @defgroup LSM6DSM_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lsm6dsm_func_cfg_access_t                  func_cfg_access;
+  lsm6dsm_sensor_sync_time_frame_t           sensor_sync_time_frame;
+  lsm6dsm_sensor_sync_res_ratio_t            sensor_sync_res_ratio;
+  lsm6dsm_fifo_ctrl1_t                       fifo_ctrl1;
+  lsm6dsm_fifo_ctrl2_t                       fifo_ctrl2;
+  lsm6dsm_fifo_ctrl3_t                       fifo_ctrl3;
+  lsm6dsm_fifo_ctrl4_t                       fifo_ctrl4;
+  lsm6dsm_fifo_ctrl5_t                       fifo_ctrl5;
+  lsm6dsm_drdy_pulse_cfg_t                   drdy_pulse_cfg;
+  lsm6dsm_int1_ctrl_t                        int1_ctrl;
+  lsm6dsm_int2_ctrl_t                        int2_ctrl;
+  lsm6dsm_ctrl1_xl_t                         ctrl1_xl;
+  lsm6dsm_ctrl2_g_t                          ctrl2_g;
+  lsm6dsm_ctrl3_c_t                          ctrl3_c;
+  lsm6dsm_ctrl4_c_t                          ctrl4_c;
+  lsm6dsm_ctrl5_c_t                          ctrl5_c;
+  lsm6dsm_ctrl6_c_t                          ctrl6_c;
+  lsm6dsm_ctrl7_g_t                          ctrl7_g;
+  lsm6dsm_ctrl8_xl_t                         ctrl8_xl;
+  lsm6dsm_ctrl9_xl_t                         ctrl9_xl;
+  lsm6dsm_ctrl10_c_t                         ctrl10_c;
+  lsm6dsm_master_config_t                    master_config;
+  lsm6dsm_wake_up_src_t                      wake_up_src;
+  lsm6dsm_tap_src_t                          tap_src;
+  lsm6dsm_d6d_src_t                          d6d_src;
+  lsm6dsm_status_reg_t                       status_reg;
+  lsm6dsm_status_spiaux_t                    status_spiaux;
+  lsm6dsm_sensorhub1_reg_t                   sensorhub1_reg;
+  lsm6dsm_sensorhub2_reg_t                   sensorhub2_reg;
+  lsm6dsm_sensorhub3_reg_t                   sensorhub3_reg;
+  lsm6dsm_sensorhub4_reg_t                   sensorhub4_reg;
+  lsm6dsm_sensorhub5_reg_t                   sensorhub5_reg;
+  lsm6dsm_sensorhub6_reg_t                   sensorhub6_reg;
+  lsm6dsm_sensorhub7_reg_t                   sensorhub7_reg;
+  lsm6dsm_sensorhub8_reg_t                   sensorhub8_reg;
+  lsm6dsm_sensorhub9_reg_t                   sensorhub9_reg;
+  lsm6dsm_sensorhub10_reg_t                  sensorhub10_reg;
+  lsm6dsm_sensorhub11_reg_t                  sensorhub11_reg;
+  lsm6dsm_sensorhub12_reg_t                  sensorhub12_reg;
+  lsm6dsm_fifo_status1_t                     fifo_status1;
+  lsm6dsm_fifo_status2_t                     fifo_status2;
+  lsm6dsm_fifo_status3_t                     fifo_status3;
+  lsm6dsm_fifo_status4_t                     fifo_status4;
+  lsm6dsm_sensorhub13_reg_t                  sensorhub13_reg;
+  lsm6dsm_sensorhub14_reg_t                  sensorhub14_reg;
+  lsm6dsm_sensorhub15_reg_t                  sensorhub15_reg;
+  lsm6dsm_sensorhub16_reg_t                  sensorhub16_reg;
+  lsm6dsm_sensorhub17_reg_t                  sensorhub17_reg;
+  lsm6dsm_sensorhub18_reg_t                  sensorhub18_reg;
+  lsm6dsm_func_src1_t                        func_src1;
+  lsm6dsm_func_src2_t                        func_src2;
+  lsm6dsm_wrist_tilt_ia_t                    wrist_tilt_ia;
+  lsm6dsm_tap_cfg_t                          tap_cfg;
+  lsm6dsm_tap_ths_6d_t                       tap_ths_6d;
+  lsm6dsm_int_dur2_t                         int_dur2;
+  lsm6dsm_wake_up_ths_t                      wake_up_ths;
+  lsm6dsm_wake_up_dur_t                      wake_up_dur;
+  lsm6dsm_free_fall_t                        free_fall;
+  lsm6dsm_md1_cfg_t                          md1_cfg;
+  lsm6dsm_md2_cfg_t                          md2_cfg;
+  lsm6dsm_master_cmd_code_t                  master_cmd_code;
+  lsm6dsm_sens_sync_spi_error_code_t         sens_sync_spi_error_code;
+  lsm6dsm_int_ois_t                          int_ois;
+  lsm6dsm_ctrl1_ois_t                        ctrl1_ois;
+  lsm6dsm_ctrl2_ois_t                        ctrl2_ois;
+  lsm6dsm_ctrl3_ois_t                        ctrl3_ois;
+  lsm6dsm_slv0_add_t                         slv0_add;
+  lsm6dsm_slv0_subadd_t                      slv0_subadd;
+  lsm6dsm_slave0_config_t                    slave0_config;
+  lsm6dsm_slv1_add_t                         slv1_add;
+  lsm6dsm_slv1_subadd_t                      slv1_subadd;
+  lsm6dsm_slave1_config_t                    slave1_config;
+  lsm6dsm_slv2_add_t                         slv2_add;
+  lsm6dsm_slv2_subadd_t                      slv2_subadd;
+  lsm6dsm_slave2_config_t                    slave2_config;
+  lsm6dsm_slv3_add_t                         slv3_add;
+  lsm6dsm_slv3_subadd_t                      slv3_subadd;
+  lsm6dsm_slave3_config_t                    slave3_config;
+  lsm6dsm_datawrite_src_mode_sub_slv0_t      datawrite_src_mode_sub_slv0;
+  lsm6dsm_config_pedo_ths_min_t              config_pedo_ths_min;
+  lsm6dsm_pedo_deb_reg_t                     pedo_deb_reg;
+  lsm6dsm_a_wrist_tilt_mask_t                a_wrist_tilt_mask;
+  bitwise_t                                  bitwise;
+  uint8_t                                    byte;
+} lsm6dsm_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm6dsm_read_reg(lsm6dsm_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lsm6dsm_write_reg(lsm6dsm_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lsm6dsm_from_fs2g_to_mg(int16_t lsb);
+extern float_t lsm6dsm_from_fs4g_to_mg(int16_t lsb);
+extern float_t lsm6dsm_from_fs8g_to_mg(int16_t lsb);
+extern float_t lsm6dsm_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t lsm6dsm_from_fs125dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsm_from_fs250dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsm_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsm_from_fs1000dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsm_from_fs2000dps_to_mdps(int16_t lsb);
+
+extern float_t lsm6dsm_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  LSM6DSM_2g       = 0,
+  LSM6DSM_16g      = 1,
+  LSM6DSM_4g       = 2,
+  LSM6DSM_8g       = 3,
+} lsm6dsm_fs_xl_t;
+int32_t lsm6dsm_xl_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t val);
+int32_t lsm6dsm_xl_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t *val);
+
+typedef enum {
+  LSM6DSM_XL_ODR_OFF      =  0,
+  LSM6DSM_XL_ODR_12Hz5    =  1,
+  LSM6DSM_XL_ODR_26Hz     =  2,
+  LSM6DSM_XL_ODR_52Hz     =  3,
+  LSM6DSM_XL_ODR_104Hz    =  4,
+  LSM6DSM_XL_ODR_208Hz    =  5,
+  LSM6DSM_XL_ODR_416Hz    =  6,
+  LSM6DSM_XL_ODR_833Hz    =  7,
+  LSM6DSM_XL_ODR_1k66Hz   =  8,
+  LSM6DSM_XL_ODR_3k33Hz   =  9,
+  LSM6DSM_XL_ODR_6k66Hz   = 10,
+  LSM6DSM_XL_ODR_1Hz6     = 11,
+} lsm6dsm_odr_xl_t;
+int32_t lsm6dsm_xl_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t val);
+int32_t lsm6dsm_xl_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t *val);
+
+typedef enum {
+  LSM6DSM_250dps     = 0,
+  LSM6DSM_125dps     = 1,
+  LSM6DSM_500dps     = 2,
+  LSM6DSM_1000dps    = 4,
+  LSM6DSM_2000dps    = 6,
+} lsm6dsm_fs_g_t;
+int32_t lsm6dsm_gy_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t val);
+int32_t lsm6dsm_gy_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t *val);
+
+typedef enum {
+  LSM6DSM_GY_ODR_OFF    =  0,
+  LSM6DSM_GY_ODR_12Hz5  =  1,
+  LSM6DSM_GY_ODR_26Hz   =  2,
+  LSM6DSM_GY_ODR_52Hz   =  3,
+  LSM6DSM_GY_ODR_104Hz  =  4,
+  LSM6DSM_GY_ODR_208Hz  =  5,
+  LSM6DSM_GY_ODR_416Hz  =  6,
+  LSM6DSM_GY_ODR_833Hz  =  7,
+  LSM6DSM_GY_ODR_1k66Hz =  8,
+  LSM6DSM_GY_ODR_3k33Hz =  9,
+  LSM6DSM_GY_ODR_6k66Hz = 10,
+} lsm6dsm_odr_g_t;
+int32_t lsm6dsm_gy_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t val);
+int32_t lsm6dsm_gy_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t *val);
+
+int32_t lsm6dsm_block_data_update_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_block_data_update_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_LSb_1mg   = 0,
+  LSM6DSM_LSb_16mg  = 1,
+} lsm6dsm_usr_off_w_t;
+int32_t lsm6dsm_xl_offset_weight_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_usr_off_w_t val);
+int32_t lsm6dsm_xl_offset_weight_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_usr_off_w_t *val);
+
+typedef enum {
+  LSM6DSM_XL_HIGH_PERFORMANCE  = 0,
+  LSM6DSM_XL_NORMAL            = 1,
+} lsm6dsm_xl_hm_mode_t;
+int32_t lsm6dsm_xl_power_mode_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_xl_hm_mode_t val);
+int32_t lsm6dsm_xl_power_mode_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_xl_hm_mode_t *val);
+
+typedef enum {
+  LSM6DSM_STAT_RND_DISABLE  = 0,
+  LSM6DSM_STAT_RND_ENABLE   = 1,
+} lsm6dsm_rounding_status_t;
+int32_t lsm6dsm_rounding_on_status_set(lsm6dsm_ctx_t *ctx,
+                                       lsm6dsm_rounding_status_t val);
+int32_t lsm6dsm_rounding_on_status_get(lsm6dsm_ctx_t *ctx,
+                                       lsm6dsm_rounding_status_t *val);
+
+typedef enum {
+  LSM6DSM_GY_HIGH_PERFORMANCE  = 0,
+  LSM6DSM_GY_NORMAL            = 1,
+} lsm6dsm_g_hm_mode_t;
+int32_t lsm6dsm_gy_power_mode_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_g_hm_mode_t val);
+int32_t lsm6dsm_gy_power_mode_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_g_hm_mode_t *val);
+
+typedef struct {
+  lsm6dsm_wake_up_src_t        wake_up_src;
+  lsm6dsm_tap_src_t            tap_src;
+  lsm6dsm_d6d_src_t            d6d_src;
+  lsm6dsm_status_reg_t         status_reg;
+  lsm6dsm_func_src1_t          func_src1;
+  lsm6dsm_func_src2_t          func_src2;
+  lsm6dsm_wrist_tilt_ia_t      wrist_tilt_ia;
+  lsm6dsm_a_wrist_tilt_mask_t  a_wrist_tilt_mask;
+} lsm6dsm_all_sources_t;
+int32_t lsm6dsm_all_sources_get(lsm6dsm_ctx_t *ctx,
+                                lsm6dsm_all_sources_t *val);
+
+int32_t lsm6dsm_status_reg_get(lsm6dsm_ctx_t *ctx, lsm6dsm_status_reg_t *val);
+
+int32_t lsm6dsm_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_temp_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_xl_usr_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_xl_usr_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_timestamp_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_timestamp_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_LSB_6ms4    = 0,
+  LSM6DSM_LSB_25us    = 1,
+} lsm6dsm_timer_hr_t;
+int32_t lsm6dsm_timestamp_res_set(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t val);
+int32_t lsm6dsm_timestamp_res_get(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t *val);
+
+typedef enum {
+  LSM6DSM_ROUND_DISABLE            = 0,
+  LSM6DSM_ROUND_XL                 = 1,
+  LSM6DSM_ROUND_GY                 = 2,
+  LSM6DSM_ROUND_GY_XL              = 3,
+  LSM6DSM_ROUND_SH1_TO_SH6         = 4,
+  LSM6DSM_ROUND_XL_SH1_TO_SH6      = 5,
+  LSM6DSM_ROUND_GY_XL_SH1_TO_SH12  = 6,
+  LSM6DSM_ROUND_GY_XL_SH1_TO_SH6   = 7,
+} lsm6dsm_rounding_t;
+int32_t lsm6dsm_rounding_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t val);
+int32_t lsm6dsm_rounding_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t *val);
+
+int32_t lsm6dsm_temperature_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_angular_rate_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_acceleration_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsm_mag_calibrated_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsm_fifo_raw_data_get(lsm6dsm_ctx_t *ctx, uint8_t *buffer,
+                                  uint8_t len);
+
+typedef enum {
+  LSM6DSM_USER_BANK   = 0,
+  LSM6DSM_BANK_A      = 4,
+  LSM6DSM_BANK_B      = 5,
+} lsm6dsm_func_cfg_en_t;
+int32_t lsm6dsm_mem_bank_set(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t val);
+int32_t lsm6dsm_mem_bank_get(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t *val);
+
+typedef enum {
+  LSM6DSM_DRDY_LATCHED    = 0,
+  LSM6DSM_DRDY_PULSED     = 1,
+} lsm6dsm_drdy_pulsed_g_t;
+int32_t lsm6dsm_data_ready_mode_set(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_drdy_pulsed_g_t val);
+int32_t lsm6dsm_data_ready_mode_get(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_drdy_pulsed_g_t *val);
+
+int32_t lsm6dsm_device_id_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_LSB_AT_LOW_ADD  = 0,
+  LSM6DSM_MSB_AT_LOW_ADD  = 1,
+} lsm6dsm_ble_t;
+int32_t lsm6dsm_data_format_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t val);
+int32_t lsm6dsm_data_format_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t *val);
+
+int32_t lsm6dsm_auto_increment_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_auto_increment_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_boot_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_boot_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_XL_ST_DISABLE    = 0,
+  LSM6DSM_XL_ST_POSITIVE   = 1,
+  LSM6DSM_XL_ST_NEGATIVE   = 2,
+} lsm6dsm_st_xl_t;
+int32_t lsm6dsm_xl_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t val);
+int32_t lsm6dsm_xl_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t *val);
+
+typedef enum {
+  LSM6DSM_GY_ST_DISABLE    = 0,
+  LSM6DSM_GY_ST_POSITIVE   = 1,
+  LSM6DSM_GY_ST_NEGATIVE   = 3,
+} lsm6dsm_st_g_t;
+int32_t lsm6dsm_gy_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t val);
+int32_t lsm6dsm_gy_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t *val);
+
+int32_t lsm6dsm_filter_settling_mask_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_filter_settling_mask_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_USE_SLOPE    = 0,
+  LSM6DSM_USE_HPF      = 1,
+} lsm6dsm_slope_fds_t;
+int32_t lsm6dsm_xl_hp_path_internal_set(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_slope_fds_t val);
+int32_t lsm6dsm_xl_hp_path_internal_get(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_slope_fds_t *val);
+
+typedef enum {
+  LSM6DSM_XL_ANA_BW_1k5Hz = 0,
+  LSM6DSM_XL_ANA_BW_400Hz = 1,
+} lsm6dsm_bw0_xl_t;
+int32_t lsm6dsm_xl_filter_analog_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_bw0_xl_t val);
+int32_t lsm6dsm_xl_filter_analog_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_bw0_xl_t *val);
+
+typedef enum {
+  LSM6DSM_XL_LP1_ODR_DIV_2 = 0,
+  LSM6DSM_XL_LP1_ODR_DIV_4 = 1,
+  LSM6DSM_XL_LP1_NA        = 2,  /* ERROR CODE */
+} lsm6dsm_lpf1_bw_sel_t;
+int32_t lsm6dsm_xl_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_lpf1_bw_sel_t val);
+int32_t lsm6dsm_xl_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_lpf1_bw_sel_t *val);
+
+typedef enum {
+  LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_50     = 0x00,
+  LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_100    = 0x01,
+  LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_9      = 0x02,
+  LSM6DSM_XL_LOW_LAT_LP_ODR_DIV_400    = 0x03,
+  LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_50   = 0x10,
+  LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_100  = 0x11,
+  LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_9    = 0x12,
+  LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_400  = 0x13,
+  LSM6DSM_XL_LP_NA                     = 0x20, /* ERROR CODE */
+} lsm6dsm_input_composite_t;
+int32_t lsm6dsm_xl_lp2_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_input_composite_t val);
+int32_t lsm6dsm_xl_lp2_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_input_composite_t *val);
+
+int32_t lsm6dsm_xl_reference_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_xl_reference_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_XL_HP_ODR_DIV_4      = 0x00, /* Slope filter */
+  LSM6DSM_XL_HP_ODR_DIV_100    = 0x01,
+  LSM6DSM_XL_HP_ODR_DIV_9      = 0x02,
+  LSM6DSM_XL_HP_ODR_DIV_400    = 0x03,
+  LSM6DSM_XL_HP_NA             = 0x10, /* ERROR CODE */
+} lsm6dsm_hpcf_xl_t;
+int32_t lsm6dsm_xl_hp_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_hpcf_xl_t val);
+int32_t lsm6dsm_xl_hp_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_hpcf_xl_t *val);
+
+typedef enum {
+  LSM6DSM_XL_UI_LP1_ODR_DIV_2 = 0,
+  LSM6DSM_XL_UI_LP1_ODR_DIV_4 = 1,
+  LSM6DSM_XL_UI_LP1_NA        = 2,
+} lsm6dsm_ui_lpf1_bw_sel_t;
+int32_t lsm6dsm_xl_ui_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_ui_lpf1_bw_sel_t val);
+int32_t lsm6dsm_xl_ui_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_ui_lpf1_bw_sel_t *val);
+
+int32_t lsm6dsm_xl_ui_slope_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_xl_ui_slope_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_AUX_LP_LIGHT          = 2,
+  LSM6DSM_AUX_LP_NORMAL         = 3,
+  LSM6DSM_AUX_LP_STRONG         = 0,
+  LSM6DSM_AUX_LP_AGGRESSIVE     = 1,
+} lsm6dsm_filter_xl_conf_ois_t;
+int32_t lsm6dsm_xl_aux_lp_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_filter_xl_conf_ois_t val);
+int32_t lsm6dsm_xl_aux_lp_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                        lsm6dsm_filter_xl_conf_ois_t *val);
+
+typedef enum {
+  LSM6DSM_LP2_ONLY                    = 0x00,
+
+  LSM6DSM_HP_16mHz_LP2                = 0x80,
+  LSM6DSM_HP_65mHz_LP2                = 0x90,
+  LSM6DSM_HP_260mHz_LP2               = 0xA0,
+  LSM6DSM_HP_1Hz04_LP2                = 0xB0,
+
+  LSM6DSM_HP_DISABLE_LP1_LIGHT        = 0x0A,
+  LSM6DSM_HP_DISABLE_LP1_NORMAL       = 0x09,
+  LSM6DSM_HP_DISABLE_LP_STRONG        = 0x08,
+  LSM6DSM_HP_DISABLE_LP1_AGGRESSIVE   = 0x0B,
+
+  LSM6DSM_HP_16mHz_LP1_LIGHT          = 0x8A,
+  LSM6DSM_HP_65mHz_LP1_NORMAL         = 0x99,
+  LSM6DSM_HP_260mHz_LP1_STRONG        = 0xA8,
+  LSM6DSM_HP_1Hz04_LP1_AGGRESSIVE     = 0xBB,
+} lsm6dsm_lpf1_sel_g_t;
+int32_t lsm6dsm_gy_band_pass_set(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_lpf1_sel_g_t val);
+int32_t lsm6dsm_gy_band_pass_get(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_lpf1_sel_g_t *val);
+
+int32_t lsm6dsm_gy_ui_high_pass_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_gy_ui_high_pass_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_HP_DISABLE_LP_173Hz        = 0x02,
+  LSM6DSM_HP_DISABLE_LP_237Hz        = 0x01,
+  LSM6DSM_HP_DISABLE_LP_351Hz        = 0x00,
+  LSM6DSM_HP_DISABLE_LP_937Hz        = 0x03,
+
+  LSM6DSM_HP_16mHz_LP_173Hz          = 0x82,
+  LSM6DSM_HP_65mHz_LP_237Hz          = 0x91,
+  LSM6DSM_HP_260mHz_LP_351Hz         = 0xA0,
+  LSM6DSM_HP_1Hz04_LP_937Hz          = 0xB3,
+} lsm6dsm_hp_en_ois_t;
+int32_t lsm6dsm_gy_aux_bandwidth_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_hp_en_ois_t val);
+int32_t lsm6dsm_gy_aux_bandwidth_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_hp_en_ois_t *val);
+
+int32_t lsm6dsm_aux_status_reg_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_status_spiaux_t *val);
+
+int32_t lsm6dsm_aux_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_aux_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_aux_gy_flag_settling_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_AUX_DEN_DISABLE         = 0,
+  LSM6DSM_AUX_DEN_LEVEL_LATCH     = 3,
+  LSM6DSM_AUX_DEN_LEVEL_TRIG      = 2,
+} lsm6dsm_lvl_ois_t;
+int32_t lsm6dsm_aux_den_mode_set(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_lvl_ois_t val);
+int32_t lsm6dsm_aux_den_mode_get(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_lvl_ois_t *val);
+
+int32_t lsm6dsm_aux_drdy_on_int2_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_aux_drdy_on_int2_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_AUX_DISABLE   = 0,
+  LSM6DSM_MODE_3_GY     = 1,
+  LSM6DSM_MODE_4_GY_XL  = 3,
+} lsm6dsm_ois_en_spi2_t;
+int32_t lsm6dsm_aux_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t val);
+int32_t lsm6dsm_aux_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t *val);
+
+typedef enum {
+  LSM6DSM_250dps_AUX   = 0,
+  LSM6DSM_125dps_AUX   = 1,
+  LSM6DSM_500dps_AUX   = 2,
+  LSM6DSM_1000dps_AUX  = 4,
+  LSM6DSM_2000dps_AUX  = 6,
+} lsm6dsm_fs_g_ois_t;
+int32_t lsm6dsm_aux_gy_full_scale_set(lsm6dsm_ctx_t *ctx,
+                                      lsm6dsm_fs_g_ois_t val);
+int32_t lsm6dsm_aux_gy_full_scale_get(lsm6dsm_ctx_t *ctx,
+                                      lsm6dsm_fs_g_ois_t *val);
+
+typedef enum {
+  LSM6DSM_AUX_SPI_4_WIRE = 0,
+  LSM6DSM_AUX_SPI_3_WIRE = 1,
+} lsm6dsm_sim_ois_t;
+int32_t lsm6dsm_aux_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t val);
+int32_t lsm6dsm_aux_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t *val);
+
+typedef enum {
+  LSM6DSM_AUX_LSB_AT_LOW_ADD = 0,
+  LSM6DSM_AUX_MSB_AT_LOW_ADD = 1,
+} lsm6dsm_ble_ois_t;
+int32_t lsm6dsm_aux_data_format_set(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_ble_ois_t val);
+int32_t lsm6dsm_aux_data_format_get(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_ble_ois_t *val);
+
+typedef enum {
+  LSM6DSM_ENABLE_CLAMP    = 0,
+  LSM6DSM_DISABLE_CLAMP   = 1,
+} lsm6dsm_st_ois_clampdis_t;
+int32_t lsm6dsm_aux_gy_clamp_set(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_st_ois_clampdis_t val);
+int32_t lsm6dsm_aux_gy_clamp_get(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_st_ois_clampdis_t *val);
+
+typedef enum {
+  LSM6DSM_AUX_GY_DISABLE  = 0,
+  LSM6DSM_AUX_GY_POS      = 1,
+  LSM6DSM_AUX_GY_NEG      = 3,
+} lsm6dsm_st_ois_t;
+int32_t lsm6dsm_aux_gy_self_test_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_st_ois_t val);
+int32_t lsm6dsm_aux_gy_self_test_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_st_ois_t *val);
+
+typedef enum {
+  LSM6DSM_AUX_2g   = 0,
+  LSM6DSM_AUX_16g  = 1,
+  LSM6DSM_AUX_4g   = 2,
+  LSM6DSM_AUX_8g   = 3,
+} lsm6dsm_fs_xl_ois_t;
+int32_t lsm6dsm_aux_xl_full_scale_set(lsm6dsm_ctx_t *ctx,
+                                      lsm6dsm_fs_xl_ois_t val);
+int32_t lsm6dsm_aux_xl_full_scale_get(lsm6dsm_ctx_t *ctx,
+                                      lsm6dsm_fs_xl_ois_t *val);
+
+typedef enum {
+  LSM6DSM_AUX_DEN_ACTIVE_LOW   = 0,
+  LSM6DSM_AUX_DEN_ACTIVE_HIGH  = 1,
+} lsm6dsm_den_lh_ois_t;
+int32_t lsm6dsm_aux_den_polarity_set(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_den_lh_ois_t val);
+int32_t lsm6dsm_aux_den_polarity_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_den_lh_ois_t *val);
+
+typedef enum {
+  LSM6DSM_SPI_4_WIRE  = 0,
+  LSM6DSM_SPI_3_WIRE  = 1,
+} lsm6dsm_sim_t;
+int32_t lsm6dsm_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t val);
+int32_t lsm6dsm_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t *val);
+
+typedef enum {
+  LSM6DSM_I2C_ENABLE   = 0,
+  LSM6DSM_I2C_DISABLE  = 1,
+} lsm6dsm_i2c_disable_t;
+int32_t lsm6dsm_i2c_interface_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_i2c_disable_t val);
+int32_t lsm6dsm_i2c_interface_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_i2c_disable_t *val);
+
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_full_flag           : 1;
+  uint8_t int1_sign_mot            : 1;
+  uint8_t int1_step_detector       : 1;
+  uint8_t int1_timer               : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_inact_state         : 1;
+  uint8_t den_drdy_int1            : 1;
+  uint8_t drdy_on_int1             : 1;
+} lsm6dsm_int1_route_t;
+int32_t lsm6dsm_pin_int1_route_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_int1_route_t val);
+int32_t lsm6dsm_pin_int1_route_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_int1_route_t *val);
+
+typedef struct{
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_full_flag           : 1;
+  uint8_t int2_step_count_ov       : 1;
+  uint8_t int2_step_delta          : 1;
+  uint8_t int2_iron                : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_inact_state         : 1;
+  uint8_t int2_wrist_tilt          : 1;
+} lsm6dsm_int2_route_t;
+int32_t lsm6dsm_pin_int2_route_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_int2_route_t val);
+int32_t lsm6dsm_pin_int2_route_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_int2_route_t *val);
+
+typedef enum {
+  LSM6DSM_PUSH_PULL   = 0,
+  LSM6DSM_OPEN_DRAIN  = 1,
+} lsm6dsm_pp_od_t;
+int32_t lsm6dsm_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t val);
+int32_t lsm6dsm_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t *val);
+
+typedef enum {
+  LSM6DSM_ACTIVE_HIGH   = 0,
+  LSM6DSM_ACTIVE_LOW    = 1,
+} lsm6dsm_h_lactive_t;
+int32_t lsm6dsm_pin_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t val);
+int32_t lsm6dsm_pin_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t *val);
+
+int32_t lsm6dsm_all_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_all_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_INT_PULSED   = 0,
+  LSM6DSM_INT_LATCHED  = 1,
+} lsm6dsm_lir_t;
+int32_t lsm6dsm_int_notification_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t val);
+int32_t lsm6dsm_int_notification_get(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t *val);
+
+int32_t lsm6dsm_wkup_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_wkup_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_wkup_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_wkup_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_gy_sleep_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_gy_sleep_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_PROPERTY_DISABLE          = 0,
+  LSM6DSM_XL_12Hz5_GY_NOT_AFFECTED  = 1,
+  LSM6DSM_XL_12Hz5_GY_SLEEP         = 2,
+  LSM6DSM_XL_12Hz5_GY_PD            = 3,
+} lsm6dsm_inact_en_t;
+int32_t lsm6dsm_act_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t val);
+int32_t lsm6dsm_act_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t *val);
+
+int32_t lsm6dsm_act_sleep_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_act_sleep_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_tap_src_get(lsm6dsm_ctx_t *ctx, lsm6dsm_tap_src_t *val);
+
+int32_t lsm6dsm_tap_detection_on_z_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_detection_on_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_tap_detection_on_y_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_detection_on_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_tap_detection_on_x_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_detection_on_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_tap_threshold_x_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_threshold_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_tap_shock_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_shock_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_tap_quiet_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_quiet_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_tap_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_ONLY_SINGLE          = 0,
+  LSM6DSM_BOTH_SINGLE_DOUBLE   = 1,
+} lsm6dsm_single_double_tap_t;
+int32_t lsm6dsm_tap_mode_set(lsm6dsm_ctx_t *ctx,
+                             lsm6dsm_single_double_tap_t val);
+int32_t lsm6dsm_tap_mode_get(lsm6dsm_ctx_t *ctx,
+                             lsm6dsm_single_double_tap_t *val);
+
+typedef enum {
+  LSM6DSM_ODR_DIV_2_FEED      = 0,
+  LSM6DSM_LPF2_FEED           = 1,
+} lsm6dsm_low_pass_on_6d_t;
+int32_t lsm6dsm_6d_feed_data_set(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_low_pass_on_6d_t val);
+int32_t lsm6dsm_6d_feed_data_get(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_low_pass_on_6d_t *val);
+
+typedef enum {
+  LSM6DSM_DEG_80      = 0,
+  LSM6DSM_DEG_70      = 1,
+  LSM6DSM_DEG_60      = 2,
+  LSM6DSM_DEG_50      = 3,
+} lsm6dsm_sixd_ths_t;
+int32_t lsm6dsm_6d_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t val);
+int32_t lsm6dsm_6d_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t *val);
+
+int32_t lsm6dsm_4d_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_4d_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_ff_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_ff_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_FF_TSH_156mg = 0,
+  LSM6DSM_FF_TSH_219mg = 1,
+  LSM6DSM_FF_TSH_250mg = 2,
+  LSM6DSM_FF_TSH_312mg = 3,
+  LSM6DSM_FF_TSH_344mg = 4,
+  LSM6DSM_FF_TSH_406mg = 5,
+  LSM6DSM_FF_TSH_469mg = 6,
+  LSM6DSM_FF_TSH_500mg = 7,
+} lsm6dsm_ff_ths_t;
+int32_t lsm6dsm_ff_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t val);
+int32_t lsm6dsm_ff_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t *val);
+
+int32_t lsm6dsm_fifo_watermark_set(lsm6dsm_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsm_fifo_watermark_get(lsm6dsm_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsm_fifo_data_level_get(lsm6dsm_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsm_fifo_wtm_flag_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_fifo_pattern_get(lsm6dsm_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsm_fifo_temp_batch_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_fifo_temp_batch_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_TRG_XL_GY_DRDY     = 0,
+  LSM6DSM_TRG_STEP_DETECT    = 1,
+  LSM6DSM_TRG_SH_DRDY        = 2,
+} lsm6dsm_trigger_fifo_t;
+int32_t lsm6dsm_fifo_write_trigger_set(lsm6dsm_ctx_t *ctx,
+                                       lsm6dsm_trigger_fifo_t val);
+int32_t lsm6dsm_fifo_write_trigger_get(lsm6dsm_ctx_t *ctx,
+                                       lsm6dsm_trigger_fifo_t *val);
+
+int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_set(lsm6dsm_ctx_t *ctx,
+                                                  uint8_t val);
+int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_get(lsm6dsm_ctx_t *ctx,
+                                                  uint8_t *val);
+
+typedef enum {
+  LSM6DSM_FIFO_XL_DISABLE  = 0,
+  LSM6DSM_FIFO_XL_NO_DEC   = 1,
+  LSM6DSM_FIFO_XL_DEC_2    = 2,
+  LSM6DSM_FIFO_XL_DEC_3    = 3,
+  LSM6DSM_FIFO_XL_DEC_4    = 4,
+  LSM6DSM_FIFO_XL_DEC_8    = 5,
+  LSM6DSM_FIFO_XL_DEC_16   = 6,
+  LSM6DSM_FIFO_XL_DEC_32   = 7,
+} lsm6dsm_dec_fifo_xl_t;
+int32_t lsm6dsm_fifo_xl_batch_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_dec_fifo_xl_t val);
+int32_t lsm6dsm_fifo_xl_batch_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_dec_fifo_xl_t *val);
+
+typedef enum {
+  LSM6DSM_FIFO_GY_DISABLE = 0,
+  LSM6DSM_FIFO_GY_NO_DEC  = 1,
+  LSM6DSM_FIFO_GY_DEC_2   = 2,
+  LSM6DSM_FIFO_GY_DEC_3   = 3,
+  LSM6DSM_FIFO_GY_DEC_4   = 4,
+  LSM6DSM_FIFO_GY_DEC_8   = 5,
+  LSM6DSM_FIFO_GY_DEC_16  = 6,
+  LSM6DSM_FIFO_GY_DEC_32  = 7,
+} lsm6dsm_dec_fifo_gyro_t;
+int32_t lsm6dsm_fifo_gy_batch_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_dec_fifo_gyro_t val);
+int32_t lsm6dsm_fifo_gy_batch_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_dec_fifo_gyro_t *val);
+
+typedef enum {
+  LSM6DSM_FIFO_DS3_DISABLE   = 0,
+  LSM6DSM_FIFO_DS3_NO_DEC    = 1,
+  LSM6DSM_FIFO_DS3_DEC_2     = 2,
+  LSM6DSM_FIFO_DS3_DEC_3     = 3,
+  LSM6DSM_FIFO_DS3_DEC_4     = 4,
+  LSM6DSM_FIFO_DS3_DEC_8     = 5,
+  LSM6DSM_FIFO_DS3_DEC_16    = 6,
+  LSM6DSM_FIFO_DS3_DEC_32    = 7,
+} lsm6dsm_dec_ds3_fifo_t;
+int32_t lsm6dsm_fifo_dataset_3_batch_set(lsm6dsm_ctx_t *ctx,
+                                         lsm6dsm_dec_ds3_fifo_t val);
+int32_t lsm6dsm_fifo_dataset_3_batch_get(lsm6dsm_ctx_t *ctx,
+                                         lsm6dsm_dec_ds3_fifo_t *val);
+
+typedef enum {
+  LSM6DSM_FIFO_DS4_DISABLE  = 0,
+  LSM6DSM_FIFO_DS4_NO_DEC   = 1,
+  LSM6DSM_FIFO_DS4_DEC_2    = 2,
+  LSM6DSM_FIFO_DS4_DEC_3    = 3,
+  LSM6DSM_FIFO_DS4_DEC_4    = 4,
+  LSM6DSM_FIFO_DS4_DEC_8    = 5,
+  LSM6DSM_FIFO_DS4_DEC_16   = 6,
+  LSM6DSM_FIFO_DS4_DEC_32   = 7,
+} lsm6dsm_dec_ds4_fifo_t;
+int32_t lsm6dsm_fifo_dataset_4_batch_set(lsm6dsm_ctx_t *ctx,
+                                         lsm6dsm_dec_ds4_fifo_t val);
+int32_t lsm6dsm_fifo_dataset_4_batch_get(lsm6dsm_ctx_t *ctx,
+                                         lsm6dsm_dec_ds4_fifo_t *val);
+
+int32_t lsm6dsm_fifo_xl_gy_8bit_format_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_fifo_xl_gy_8bit_format_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_fifo_stop_on_wtm_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_fifo_stop_on_wtm_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_BYPASS_MODE           = 0,
+  LSM6DSM_FIFO_MODE             = 1,
+  LSM6DSM_STREAM_TO_FIFO_MODE   = 3,
+  LSM6DSM_BYPASS_TO_STREAM_MODE = 4,
+  LSM6DSM_STREAM_MODE           = 6,
+} lsm6dsm_fifo_mode_t;
+int32_t lsm6dsm_fifo_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t val);
+int32_t lsm6dsm_fifo_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t *val);
+
+typedef enum {
+  LSM6DSM_FIFO_DISABLE   =  0,
+  LSM6DSM_FIFO_12Hz5     =  1,
+  LSM6DSM_FIFO_26Hz      =  2,
+  LSM6DSM_FIFO_52Hz      =  3,
+  LSM6DSM_FIFO_104Hz     =  4,
+  LSM6DSM_FIFO_208Hz     =  5,
+  LSM6DSM_FIFO_416Hz     =  6,
+  LSM6DSM_FIFO_833Hz     =  7,
+  LSM6DSM_FIFO_1k66Hz    =  8,
+  LSM6DSM_FIFO_3k33Hz    =  9,
+  LSM6DSM_FIFO_6k66Hz    = 10,
+} lsm6dsm_odr_fifo_t;
+int32_t lsm6dsm_fifo_data_rate_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_odr_fifo_t val);
+int32_t lsm6dsm_fifo_data_rate_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_odr_fifo_t *val);
+
+typedef enum {
+  LSM6DSM_DEN_ACT_LOW    = 0,
+  LSM6DSM_DEN_ACT_HIGH   = 1,
+} lsm6dsm_den_lh_t;
+int32_t lsm6dsm_den_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t val);
+int32_t lsm6dsm_den_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t *val);
+
+typedef enum {
+  LSM6DSM_DEN_DISABLE    = 0,
+  LSM6DSM_LEVEL_FIFO     = 6,
+  LSM6DSM_LEVEL_LETCHED  = 3,
+  LSM6DSM_LEVEL_TRIGGER  = 2,
+  LSM6DSM_EDGE_TRIGGER   = 4,
+} lsm6dsm_den_mode_t;
+int32_t lsm6dsm_den_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t val);
+int32_t lsm6dsm_den_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t *val);
+
+typedef enum {
+  LSM6DSM_STAMP_IN_GY_DATA     = 0,
+  LSM6DSM_STAMP_IN_XL_DATA     = 1,
+  LSM6DSM_STAMP_IN_GY_XL_DATA  = 2,
+} lsm6dsm_den_xl_en_t;
+int32_t lsm6dsm_den_enable_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t val);
+int32_t lsm6dsm_den_enable_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t *val);
+
+int32_t lsm6dsm_den_mark_axis_z_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_den_mark_axis_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_den_mark_axis_y_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_den_mark_axis_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_den_mark_axis_x_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_den_mark_axis_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_pedo_step_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_step_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_pedo_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_pedo_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_PEDO_AT_2g = 0,
+  LSM6DSM_PEDO_AT_4g = 1,
+} lsm6dsm_pedo_fs_t;
+int32_t lsm6dsm_pedo_full_scale_set(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_pedo_fs_t val);
+int32_t lsm6dsm_pedo_full_scale_get(lsm6dsm_ctx_t *ctx,
+                                    lsm6dsm_pedo_fs_t *val);
+
+int32_t lsm6dsm_pedo_debounce_steps_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_debounce_steps_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_pedo_timeout_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_timeout_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_pedo_steps_period_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_pedo_steps_period_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsm_motion_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_motion_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_motion_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_motion_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsm_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_wrist_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_wrist_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_tilt_latency_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_tilt_latency_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsm_tilt_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_tilt_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsm_tilt_src_set(lsm6dsm_ctx_t *ctx,
+                             lsm6dsm_a_wrist_tilt_mask_t *val);
+int32_t lsm6dsm_tilt_src_get(lsm6dsm_ctx_t *ctx,
+                             lsm6dsm_a_wrist_tilt_mask_t *val);
+
+int32_t lsm6dsm_mag_soft_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_mag_soft_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_mag_hard_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_mag_hard_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_mag_soft_iron_mat_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_mag_soft_iron_mat_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsm_mag_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_mag_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsm_func_en_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+
+int32_t lsm6dsm_sh_sync_sens_frame_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_sync_sens_frame_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_RES_RATIO_2_11  = 0,
+  LSM6DSM_RES_RATIO_2_12  = 1,
+  LSM6DSM_RES_RATIO_2_13  = 2,
+  LSM6DSM_RES_RATIO_2_14  = 3,
+} lsm6dsm_rr_t;
+int32_t lsm6dsm_sh_sync_sens_ratio_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t val);
+int32_t lsm6dsm_sh_sync_sens_ratio_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t *val);
+
+int32_t lsm6dsm_sh_master_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_master_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_sh_pass_through_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_pass_through_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_EXT_PULL_UP       = 0,
+  LSM6DSM_INTERNAL_PULL_UP  = 1,
+  LSM6DSM_SH_PIN_MODE       = 2,
+} lsm6dsm_pull_up_en_t;
+int32_t lsm6dsm_sh_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t val);
+int32_t lsm6dsm_sh_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t *val);
+
+typedef enum {
+  LSM6DSM_XL_GY_DRDY        = 0,
+  LSM6DSM_EXT_ON_INT2_PIN   = 1,
+} lsm6dsm_start_config_t;
+int32_t lsm6dsm_sh_syncro_mode_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_start_config_t val);
+int32_t lsm6dsm_sh_syncro_mode_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_start_config_t *val);
+
+int32_t lsm6dsm_sh_drdy_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_drdy_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+    lsm6dsm_sensorhub1_reg_t   sh_byte_1;
+    lsm6dsm_sensorhub2_reg_t   sh_byte_2;
+    lsm6dsm_sensorhub3_reg_t   sh_byte_3;
+    lsm6dsm_sensorhub4_reg_t   sh_byte_4;
+    lsm6dsm_sensorhub5_reg_t   sh_byte_5;
+    lsm6dsm_sensorhub6_reg_t   sh_byte_6;
+    lsm6dsm_sensorhub7_reg_t   sh_byte_7;
+    lsm6dsm_sensorhub8_reg_t   sh_byte_8;
+    lsm6dsm_sensorhub9_reg_t   sh_byte_9;
+    lsm6dsm_sensorhub10_reg_t  sh_byte_10;
+    lsm6dsm_sensorhub11_reg_t  sh_byte_11;
+    lsm6dsm_sensorhub12_reg_t  sh_byte_12;
+    lsm6dsm_sensorhub13_reg_t  sh_byte_13;
+    lsm6dsm_sensorhub14_reg_t  sh_byte_14;
+    lsm6dsm_sensorhub15_reg_t  sh_byte_15;
+    lsm6dsm_sensorhub16_reg_t  sh_byte_16;
+    lsm6dsm_sensorhub17_reg_t  sh_byte_17;
+    lsm6dsm_sensorhub18_reg_t  sh_byte_18;
+} lsm6dsm_emb_sh_read_t;
+int32_t lsm6dsm_sh_read_data_raw_get(lsm6dsm_ctx_t *ctx,
+                                     lsm6dsm_emb_sh_read_t *val);
+
+int32_t lsm6dsm_sh_cmd_sens_sync_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_cmd_sens_sync_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsm_sh_spi_sync_error_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_spi_sync_error_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSM_NORMAL_MODE_READ  = 0,
+  LSM6DSM_SRC_MODE_READ     = 1,
+} lsm6dsm_src_mode_t;
+int32_t lsm6dsm_sh_cfg_slave_0_rd_mode_set(lsm6dsm_ctx_t *ctx,
+                                           lsm6dsm_src_mode_t val);
+int32_t lsm6dsm_sh_cfg_slave_0_rd_mode_get(lsm6dsm_ctx_t *ctx,
+                                           lsm6dsm_src_mode_t *val);
+
+typedef enum {
+  LSM6DSM_SLV_0        = 0,
+  LSM6DSM_SLV_0_1      = 1,
+  LSM6DSM_SLV_0_1_2    = 2,
+  LSM6DSM_SLV_0_1_2_3  = 3,
+} lsm6dsm_aux_sens_on_t;
+int32_t lsm6dsm_sh_num_of_dev_connected_set(lsm6dsm_ctx_t *ctx,
+                                            lsm6dsm_aux_sens_on_t val);
+int32_t lsm6dsm_sh_num_of_dev_connected_get(lsm6dsm_ctx_t *ctx,
+                                            lsm6dsm_aux_sens_on_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} lsm6dsm_sh_cfg_write_t;
+int32_t lsm6dsm_sh_cfg_write(lsm6dsm_ctx_t *ctx, lsm6dsm_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} lsm6dsm_sh_cfg_read_t;
+int32_t lsm6dsm_sh_slv0_cfg_read(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_sh_cfg_read_t *val);
+int32_t lsm6dsm_sh_slv1_cfg_read(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_sh_cfg_read_t *val);
+int32_t lsm6dsm_sh_slv2_cfg_read(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_sh_cfg_read_t *val);
+int32_t lsm6dsm_sh_slv3_cfg_read(lsm6dsm_ctx_t *ctx,
+                                 lsm6dsm_sh_cfg_read_t *val);
+
+typedef enum {
+  LSM6DSM_SL0_NO_DEC   = 0,
+  LSM6DSM_SL0_DEC_2    = 1,
+  LSM6DSM_SL0_DEC_4    = 2,
+  LSM6DSM_SL0_DEC_8    = 3,
+} lsm6dsm_slave0_rate_t;
+int32_t lsm6dsm_sh_slave_0_dec_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave0_rate_t val);
+int32_t lsm6dsm_sh_slave_0_dec_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave0_rate_t *val);
+
+typedef enum {
+  LSM6DSM_EACH_SH_CYCLE     = 0,
+  LSM6DSM_ONLY_FIRST_CYCLE  = 1,
+} lsm6dsm_write_once_t;
+int32_t lsm6dsm_sh_write_mode_set(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_write_once_t val);
+int32_t lsm6dsm_sh_write_mode_get(lsm6dsm_ctx_t *ctx,
+                                  lsm6dsm_write_once_t *val);
+
+typedef enum {
+  LSM6DSM_SL1_NO_DEC   = 0,
+  LSM6DSM_SL1_DEC_2    = 1,
+  LSM6DSM_SL1_DEC_4    = 2,
+  LSM6DSM_SL1_DEC_8    = 3,
+} lsm6dsm_slave1_rate_t;
+int32_t lsm6dsm_sh_slave_1_dec_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave1_rate_t val);
+int32_t lsm6dsm_sh_slave_1_dec_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave1_rate_t *val);
+
+typedef enum {
+  LSM6DSM_SL2_NO_DEC  = 0,
+  LSM6DSM_SL2_DEC_2   = 1,
+  LSM6DSM_SL2_DEC_4   = 2,
+  LSM6DSM_SL2_DEC_8   = 3,
+} lsm6dsm_slave2_rate_t;
+int32_t lsm6dsm_sh_slave_2_dec_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave2_rate_t val);
+int32_t lsm6dsm_sh_slave_2_dec_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave2_rate_t *val);
+
+typedef enum {
+  LSM6DSM_SL3_NO_DEC  = 0,
+  LSM6DSM_SL3_DEC_2   = 1,
+  LSM6DSM_SL3_DEC_4   = 2,
+  LSM6DSM_SL3_DEC_8   = 3,
+} lsm6dsm_slave3_rate_t;
+int32_t lsm6dsm_sh_slave_3_dec_set(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave3_rate_t val);
+int32_t lsm6dsm_sh_slave_3_dec_get(lsm6dsm_ctx_t *ctx,
+                                   lsm6dsm_slave3_rate_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSM6DSM_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c
+++ b/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c
@@ -1,0 +1,8929 @@
+/*
+  ******************************************************************************
+  * @file    lsm6dso_reg.c
+  * @author  Sensor Solutions Software Team
+  * @brief   LSM6DSO driver file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions
+  * are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright
+  *      notice, this list of conditions and the following disclaimer in the
+  *      documentation and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its
+  *      contributors may be used to endorse or promote products derived from
+  *      this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  * POSSIBILITY OF SUCH DAMAGE.
+  *
+  */
+
+#include "lsm6dso_reg.h"
+
+/**
+  * @defgroup  LSM6DSO
+  * @brief     This file provides a set of functions needed to drive the
+  *            lsm6dso enhanced inertial module.
+  * @{
+  *
+*/
+
+/**
+  * @defgroup  LSM6DSO_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dso_read_reg(lsm6dso_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dso_write_reg(lsm6dso_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+*/
+
+/**
+  * @defgroup  LSM6DSO_Sensitivity
+  * @brief     These functions convert raw-data into engineering units.
+  * @{
+  *
+*/
+float_t lsm6dso_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lsm6dso_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t lsm6dso_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t lsm6dso_from_fs16_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) *0.488f;
+}
+
+float_t lsm6dso_from_fs125_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *4.375f;
+}
+
+float_t lsm6dso_from_fs500_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *17.50f;
+}
+
+float_t lsm6dso_from_fs250_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *8.750f;
+}
+
+float_t lsm6dso_from_fs1000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *35.0f;
+}
+
+float_t lsm6dso_from_fs2000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *70.0f;
+}
+
+float_t lsm6dso_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+float_t lsm6dso_from_lsb_to_nsec(int16_t lsb)
+{
+  return ((float_t)lsb * 25000.0f);
+}
+
+/**
+  * @}
+  *
+*/
+
+/**
+  * @defgroup  LSM6DSO_Data_Generation
+  * @brief     This section groups all the functions concerning
+  *            data generation.
+  *
+*/
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dso_xl_full_scale_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_fs_xl_t val)
+{
+  lsm6dso_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fs_xl = (uint8_t) val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dso_xl_full_scale_get(lsm6dso_ctx_t *ctx, lsm6dso_fs_xl_t *val)
+{
+  lsm6dso_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+  switch (reg.fs_xl) {
+    case LSM6DSO_2g:
+      *val = LSM6DSO_2g;
+      break;
+    case LSM6DSO_16g:
+      *val = LSM6DSO_16g;
+      break;
+    case LSM6DSO_4g:
+      *val = LSM6DSO_4g;
+      break;
+    case LSM6DSO_8g:
+      *val = LSM6DSO_8g;
+      break;
+    default:
+      *val = LSM6DSO_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dso_xl_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_odr_xl_t val)
+{
+  lsm6dso_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odr_xl = (uint8_t) val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dso_xl_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_odr_xl_t *val)
+{
+  lsm6dso_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+
+  switch (reg.odr_xl) {
+    case LSM6DSO_XL_ODR_OFF:
+      *val = LSM6DSO_XL_ODR_OFF;
+      break;
+    case LSM6DSO_XL_ODR_12Hz5:
+      *val = LSM6DSO_XL_ODR_12Hz5;
+      break;
+    case LSM6DSO_XL_ODR_26Hz:
+      *val = LSM6DSO_XL_ODR_26Hz;
+      break;
+    case LSM6DSO_XL_ODR_52Hz:
+      *val = LSM6DSO_XL_ODR_52Hz;
+      break;
+    case LSM6DSO_XL_ODR_104Hz:
+      *val = LSM6DSO_XL_ODR_104Hz;
+      break;
+    case LSM6DSO_XL_ODR_208Hz:
+      *val = LSM6DSO_XL_ODR_208Hz;
+      break;
+    case LSM6DSO_XL_ODR_417Hz:
+      *val = LSM6DSO_XL_ODR_417Hz;
+      break;
+    case LSM6DSO_XL_ODR_833Hz:
+      *val = LSM6DSO_XL_ODR_833Hz;
+      break;
+    case LSM6DSO_XL_ODR_1667Hz:
+      *val = LSM6DSO_XL_ODR_1667Hz;
+      break;
+    case LSM6DSO_XL_ODR_3333Hz:
+      *val = LSM6DSO_XL_ODR_3333Hz;
+      break;
+    case LSM6DSO_XL_ODR_6667Hz:
+      *val = LSM6DSO_XL_ODR_6667Hz;
+      break;
+    case LSM6DSO_XL_ODR_6Hz5:
+      *val = LSM6DSO_XL_ODR_6Hz5;
+      break;
+    default:
+      *val = LSM6DSO_XL_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6dso_gy_full_scale_set(lsm6dso_ctx_t *ctx, lsm6dso_fs_g_t val)
+{
+  lsm6dso_ctrl2_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fs_g = (uint8_t) val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6dso_gy_full_scale_get(lsm6dso_ctx_t *ctx, lsm6dso_fs_g_t *val)
+{
+  lsm6dso_ctrl2_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t*)&reg, 1);
+  switch (reg.fs_g) {
+    case LSM6DSO_250dps:
+      *val = LSM6DSO_250dps;
+      break;
+    case LSM6DSO_125dps:
+      *val = LSM6DSO_125dps;
+      break;
+    case LSM6DSO_500dps:
+      *val = LSM6DSO_500dps;
+      break;
+    case LSM6DSO_1000dps:
+      *val = LSM6DSO_1000dps;
+      break;
+    case LSM6DSO_2000dps:
+      *val = LSM6DSO_2000dps;
+      break;
+    default:
+      *val = LSM6DSO_250dps;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6dso_gy_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_odr_g_t val)
+{
+  lsm6dso_ctrl2_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odr_g = (uint8_t) val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6dso_gy_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_odr_g_t *val)
+{
+  lsm6dso_ctrl2_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_G, (uint8_t*)&reg, 1);
+  switch (reg.odr_g) {
+    case LSM6DSO_GY_ODR_OFF:
+      *val = LSM6DSO_GY_ODR_OFF;
+      break;
+    case LSM6DSO_GY_ODR_12Hz5:
+      *val = LSM6DSO_GY_ODR_12Hz5;
+      break;
+    case LSM6DSO_GY_ODR_26Hz:
+      *val = LSM6DSO_GY_ODR_26Hz;
+      break;
+    case LSM6DSO_GY_ODR_52Hz:
+      *val = LSM6DSO_GY_ODR_52Hz;
+      break;
+    case LSM6DSO_GY_ODR_104Hz:
+      *val = LSM6DSO_GY_ODR_104Hz;
+      break;
+    case LSM6DSO_GY_ODR_208Hz:
+      *val = LSM6DSO_GY_ODR_208Hz;
+      break;
+    case LSM6DSO_GY_ODR_417Hz:
+      *val = LSM6DSO_GY_ODR_417Hz;
+      break;
+    case LSM6DSO_GY_ODR_833Hz:
+      *val = LSM6DSO_GY_ODR_833Hz;
+      break;
+    case LSM6DSO_GY_ODR_1667Hz:
+      *val = LSM6DSO_GY_ODR_1667Hz;
+      break;
+    case LSM6DSO_GY_ODR_3333Hz:
+      *val = LSM6DSO_GY_ODR_3333Hz;
+      break;
+    case LSM6DSO_GY_ODR_6667Hz:
+      *val = LSM6DSO_GY_ODR_6667Hz;
+      break;
+    default:
+      *val = LSM6DSO_GY_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_block_data_update_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_block_data_update_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_w in reg CTRL6_C
+  *
+  */
+int32_t lsm6dso_xl_offset_weight_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_usr_off_w_t val)
+{
+  lsm6dso_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.usr_off_w = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *           Y_OFS_USR (74h), Z_OFS_USR (75h).[get]
+  *
+  * @param    ctx      read / write interface definitions
+  * @param    val      Get the values of usr_off_w in reg CTRL6_C
+  *
+  */
+int32_t lsm6dso_xl_offset_weight_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_usr_off_w_t *val)
+{
+  lsm6dso_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+
+  switch (reg.usr_off_w) {
+    case LSM6DSO_LSb_1mg:
+      *val = LSM6DSO_LSb_1mg;
+      break;
+    case LSM6DSO_LSb_16mg:
+      *val = LSM6DSO_LSb_16mg;
+      break;
+    default:
+      *val = LSM6DSO_LSb_1mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer power mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of xl_hm_mode in
+  *                               reg CTRL6_C
+  *
+  */
+int32_t lsm6dso_xl_power_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_xl_hm_mode_t val)
+{
+  lsm6dso_ctrl5_c_t ctrl5_c;
+  lsm6dso_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*) &ctrl5_c, 1);
+  if (ret == 0) {
+    ctrl5_c.xl_ulp_en = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*) &ctrl5_c, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*) &ctrl6_c, 1);
+  }
+  if (ret == 0) {
+    ctrl6_c.xl_hm_mode = (uint8_t)val & 0x01U;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*) &ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer power mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of xl_hm_mode in reg CTRL6_C
+  *
+  */
+int32_t lsm6dso_xl_power_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_xl_hm_mode_t *val)
+{
+  lsm6dso_ctrl5_c_t ctrl5_c;
+  lsm6dso_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*) &ctrl5_c, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*) &ctrl6_c, 1);
+    switch ( (ctrl5_c.xl_ulp_en << 1) | ctrl6_c.xl_hm_mode) {
+      case LSM6DSO_HIGH_PERFORMANCE_MD:
+        *val = LSM6DSO_HIGH_PERFORMANCE_MD;
+        break;
+      case LSM6DSO_LOW_NORMAL_POWER_MD:
+        *val = LSM6DSO_LOW_NORMAL_POWER_MD;
+        break;
+      case LSM6DSO_ULTRA_LOW_POWER_MD:
+        *val = LSM6DSO_ULTRA_LOW_POWER_MD;
+        break;
+      default:
+        *val = LSM6DSO_HIGH_PERFORMANCE_MD;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode for gyroscope.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of g_hm_mode in reg CTRL7_G
+  *
+  */
+int32_t lsm6dso_gy_power_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_g_hm_mode_t val)
+{
+  lsm6dso_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.g_hm_mode = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode for gyroscope.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of g_hm_mode in reg CTRL7_G
+  *
+  */
+int32_t lsm6dso_gy_power_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_g_hm_mode_t *val)
+{
+  lsm6dso_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  switch (reg.g_hm_mode) {
+    case LSM6DSO_GY_HIGH_PERFORMANCE:
+      *val = LSM6DSO_GY_HIGH_PERFORMANCE;
+      break;
+    case LSM6DSO_GY_NORMAL:
+      *val = LSM6DSO_GY_NORMAL;
+      break;
+    default:
+      *val = LSM6DSO_GY_HIGH_PERFORMANCE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers ALL_INT_SRC; WAKE_UP_SRC;
+  *                              TAP_SRC; D6D_SRC; STATUS_REG;
+  *                              EMB_FUNC_STATUS; FSM_STATUS_A/B
+  *
+  */
+int32_t lsm6dso_all_sources_get(lsm6dso_ctx_t *ctx,
+                                lsm6dso_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_ALL_INT_SRC,
+                         (uint8_t*)&val->all_int_src, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_SRC,
+                           (uint8_t*)&val->wake_up_src, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_SRC,
+                           (uint8_t*)&val->tap_src, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_D6D_SRC,
+                           (uint8_t*)&val->d6d_src, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_REG,
+                           (uint8_t*)&val->status_reg, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS,
+                           (uint8_t*)&val->emb_func_status, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_STATUS_A,
+                           (uint8_t*)&val->fsm_status_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_STATUS_B,
+                           (uint8_t*)&val->fsm_status_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register STATUS_REG
+  *
+  */
+int32_t lsm6dso_status_reg_get(lsm6dso_ctx_t *ctx, lsm6dso_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of xlda in reg STATUS_REG
+  *
+  */
+int32_t lsm6dso_xl_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_status_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of gda in reg STATUS_REG
+  *
+  */
+int32_t lsm6dso_gy_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_status_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tda in reg STATUS_REG
+  *
+  */
+int32_t lsm6dso_temp_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_status_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in
+  *         two’s complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_x_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_x_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_y_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_y_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_z_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_write_reg(ctx, LSM6DSO_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_z_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enables user offset on out.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_out in reg CTRL7_G
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.usr_off_on_out = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User offset on out flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      values of usr_off_on_out in reg CTRL7_G
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  *val = reg.usr_off_on_out;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_Timestamp
+  * @brief     This section groups all the functions that manage the
+  *            timestamp generation.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of timestamp_en in reg CTRL10_C
+  *
+  */
+int32_t lsm6dso_timestamp_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl10_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL10_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.timestamp_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL10_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of timestamp_en in reg CTRL10_C
+  *
+  */
+int32_t lsm6dso_timestamp_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl10_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL10_C, (uint8_t*)&reg, 1);
+  *val = reg.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp first data output register (r).
+  *         The value is expressed as a 32-bit word and the bit
+  *         resolution is 25 μs.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_timestamp_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TIMESTAMP0, buff, 4);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_Data output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Circular burst-mode (rounding) read of the output
+  *         registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of rounding in reg CTRL5_C
+  *
+  */
+int32_t lsm6dso_rounding_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_rounding_t val)
+{
+  lsm6dso_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.rounding = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of rounding in reg CTRL5_C
+  *
+  */
+int32_t lsm6dso_rounding_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_rounding_t *val)
+{
+  lsm6dso_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  switch (reg.rounding) {
+    case LSM6DSO_NO_ROUND:
+      *val = LSM6DSO_NO_ROUND;
+      break;
+    case LSM6DSO_ROUND_XL:
+      *val = LSM6DSO_ROUND_XL;
+      break;
+    case LSM6DSO_ROUND_GY:
+      *val = LSM6DSO_ROUND_GY;
+      break;
+    case LSM6DSO_ROUND_GY_XL:
+      *val = LSM6DSO_ROUND_GY_XL;
+      break;
+    default:
+      *val = LSM6DSO_NO_ROUND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r).
+  *         L and H registers together express a 16-bit word in two’s
+  *         complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_temperature_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit
+  *         word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_angular_rate_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register.
+  *         The value is expressed as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_acceleration_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_OUTX_L_A, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  FIFO data output [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_fifo_out_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_DATA_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Step counter output register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_number_of_steps_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_STEP_COUNTER_L, buff, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  *
+  */
+int32_t lsm6dso_steps_reset(lsm6dso_ctx_t *ctx)
+{
+  lsm6dso_emb_func_src_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_SRC, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.pedo_rst_step = PROPERTY_ENABLE;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_SRC, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_common
+  * @brief   This section groups common usefull functions.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Difference in percentage of the effective ODR(and timestamp rate)
+  *         with respect to the typical.
+  *         Step:  0.15%. 8-bit format, 2's complement.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of freq_fine in reg
+  *                      INTERNAL_FREQ_FINE
+  *
+  */
+int32_t lsm6dso_odr_cal_reg_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_internal_freq_fine_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INTERNAL_FREQ_FINE, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.freq_fine = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INTERNAL_FREQ_FINE,
+                            (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Difference in percentage of the effective ODR(and timestamp rate)
+  *         with respect to the typical.
+  *         Step:  0.15%. 8-bit format, 2's complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  *
+  */
+int32_t lsm6dso_odr_cal_reg_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_internal_freq_fine_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INTERNAL_FREQ_FINE, (uint8_t*)&reg, 1);
+  *val = reg.freq_fine;
+
+  return ret;
+}
+
+
+/**
+  * @brief  Enable access to the embedded functions/sensor
+  *         hub configuration registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reg_access in
+  *                               reg FUNC_CFG_ACCESS
+  *
+  */
+int32_t lsm6dso_mem_bank_set(lsm6dso_ctx_t *ctx, lsm6dso_reg_access_t val)
+{
+  lsm6dso_func_cfg_access_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.reg_access = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor
+  *         hub configuration registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of reg_access in
+  *                               reg FUNC_CFG_ACCESS
+  *
+  */
+int32_t lsm6dso_mem_bank_get(lsm6dso_ctx_t *ctx, lsm6dso_reg_access_t *val)
+{
+  lsm6dso_func_cfg_access_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FUNC_CFG_ACCESS, (uint8_t*)&reg, 1);
+  switch (reg.reg_access) {
+    case LSM6DSO_USER_BANK:
+      *val = LSM6DSO_USER_BANK;
+      break;
+    case LSM6DSO_SENSOR_HUB_BANK:
+      *val = LSM6DSO_SENSOR_HUB_BANK;
+      break;
+    case LSM6DSO_EMBEDDED_FUNC_BANK:
+      *val = LSM6DSO_EMBEDDED_FUNC_BANK;
+      break;
+    default:
+      *val = LSM6DSO_USER_BANK;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write a line(byte) in a page.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t address: page line address
+  * @param  val      value to write
+  *
+  */
+int32_t lsm6dso_ln_pg_write_byte(lsm6dso_ctx_t *ctx, uint16_t address,
+                                 uint8_t *val)
+{
+  lsm6dso_page_rw_t page_rw;
+  lsm6dso_page_sel_t page_sel;
+  lsm6dso_page_address_t page_address;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x02; /* page_write enable */
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+
+  if (ret == 0) {
+    page_sel.page_sel = ((uint8_t)(address >> 8) & 0x0FU);
+    page_sel.not_used_01 = 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_address.page_addr = (uint8_t)address & 0xFFU;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_ADDRESS,
+                            (uint8_t*)&page_address, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_VALUE, val, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x00; /* page_write disable */
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write buffer in a page.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t address: page line address
+  * @param  uint8_t *buf: buffer to write
+  * @param  uint8_t len: buffer len
+  *
+  */
+int32_t lsm6dso_ln_pg_write(lsm6dso_ctx_t *ctx, uint16_t address,
+                            uint8_t *buf, uint8_t len)
+{
+  lsm6dso_page_rw_t page_rw;
+  lsm6dso_page_sel_t page_sel;
+  lsm6dso_page_address_t  page_address;
+  int32_t ret;
+  uint8_t msb, lsb;
+  uint8_t i ;
+
+  msb = ((uint8_t)(address >> 8) & 0x0fU);
+  lsb = (uint8_t)address & 0xFFU;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x02; /* page_write enable*/
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_sel.page_sel = msb;
+    page_sel.not_used_01 = 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_address.page_addr = lsb;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_ADDRESS,
+                            (uint8_t*)&page_address, 1);
+  }
+
+  if (ret == 0) {
+
+    for (i = 0; ( (i < len) && (ret == 0) ); i++)
+    {
+      ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_VALUE, &buf[i], 1);
+
+      /* Check if page wrap */
+      if ( (lsb == 0x00U) && (ret == 0) ) {
+        lsb++;
+        msb++;
+        ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t*)&page_sel, 1);
+        if (ret == 0) {
+          page_sel.page_sel = msb;
+          page_sel.not_used_01 = 1;
+          ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL,
+                                  (uint8_t*)&page_sel, 1);
+        }
+      }
+    }
+    page_sel.page_sel = 0;
+    page_sel.not_used_01 = 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x00; /* page_write disable */
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+
+  if (ret == 0) {
+
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read a line(byte) in a page.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t address: page line address
+  * @param  val      read value
+  *
+  */
+int32_t lsm6dso_ln_pg_read_byte(lsm6dso_ctx_t *ctx, uint16_t address,
+                                uint8_t *val)
+{
+  lsm6dso_page_rw_t page_rw;
+  lsm6dso_page_sel_t page_sel;
+  lsm6dso_page_address_t  page_address;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x01; /* page_read enable*/
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_sel.page_sel = ((uint8_t)(address >> 8) & 0x0FU);
+    page_sel.not_used_01 = 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_address.page_addr = (uint8_t)address & 0x00FFU;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_ADDRESS,
+                            (uint8_t*)&page_address, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_VALUE, val, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x00; /* page_read disable */
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of
+  *                                     dataready_pulsed in
+  *                                     reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dso_data_ready_mode_set(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_dataready_pulsed_t val)
+{
+  lsm6dso_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.dataready_pulsed = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of
+  *                                     dataready_pulsed in
+  *                                     reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dso_data_ready_mode_get(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_dataready_pulsed_t *val)
+{
+  lsm6dso_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  switch (reg.dataready_pulsed) {
+    case LSM6DSO_DRDY_LATCHED:
+      *val = LSM6DSO_DRDY_LATCHED;
+      break;
+    case LSM6DSO_DRDY_PULSED:
+      *val = LSM6DSO_DRDY_PULSED;
+      break;
+    default:
+      *val = LSM6DSO_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Device "Who am I".[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_device_id_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values
+  *         in user registers[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sw_reset in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_reset_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sw_reset = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sw_reset in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_reset_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  *val = reg.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_inc in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_auto_increment_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.if_inc = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_inc in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_auto_increment_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  *val = reg.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_boot_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.boot = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_boot_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st_xl in reg CTRL5_C
+  *
+  */
+int32_t lsm6dso_xl_self_test_set(lsm6dso_ctx_t *ctx, lsm6dso_st_xl_t val)
+{
+  lsm6dso_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.st_xl = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st_xl in reg CTRL5_C
+  *
+  */
+int32_t lsm6dso_xl_self_test_get(lsm6dso_ctx_t *ctx, lsm6dso_st_xl_t *val)
+{
+  lsm6dso_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  switch (reg.st_xl) {
+    case LSM6DSO_XL_ST_DISABLE:
+      *val = LSM6DSO_XL_ST_DISABLE;
+      break;
+    case LSM6DSO_XL_ST_POSITIVE:
+      *val = LSM6DSO_XL_ST_POSITIVE;
+      break;
+    case LSM6DSO_XL_ST_NEGATIVE:
+      *val = LSM6DSO_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSO_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st_g in reg CTRL5_C
+  *
+  */
+int32_t lsm6dso_gy_self_test_set(lsm6dso_ctx_t *ctx, lsm6dso_st_g_t val)
+{
+  lsm6dso_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.st_g = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st_g in reg CTRL5_C
+  *
+  */
+int32_t lsm6dso_gy_self_test_get(lsm6dso_ctx_t *ctx, lsm6dso_st_g_t *val)
+{
+  lsm6dso_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL5_C, (uint8_t*)&reg, 1);
+  switch (reg.st_g) {
+    case LSM6DSO_GY_ST_DISABLE:
+      *val = LSM6DSO_GY_ST_DISABLE;
+      break;
+    case LSM6DSO_GY_ST_POSITIVE:
+      *val = LSM6DSO_GY_ST_POSITIVE;
+      break;
+    case LSM6DSO_GY_ST_NEGATIVE:
+      *val = LSM6DSO_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSO_GY_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_filters
+  * @brief     This section group all the functions concerning the
+  *            filters configuration
+  * @{
+  *
+*/
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf2_xl_en in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dso_xl_filter_lp2_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.lpf2_xl_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf2_xl_en in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dso_xl_filter_lp2_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_XL, (uint8_t*)&reg, 1);
+  *val = reg.lpf2_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0]
+  *         in CTRL6_C (15h).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf1_sel_g in reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_gy_filter_lp1_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.lpf1_sel_g = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0]
+  *         in CTRL6_C (15h).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf1_sel_g in reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_gy_filter_lp1_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  *val = reg.lpf1_sel_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_mask in reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_filter_settling_mask_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.drdy_mask = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_mask in reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_filter_settling_mask_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  *val = reg.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope lp1 bandwidth.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ftype in reg CTRL6_C
+  *
+  */
+int32_t lsm6dso_gy_lp1_bandwidth_set(lsm6dso_ctx_t *ctx, lsm6dso_ftype_t val)
+{
+  lsm6dso_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ftype = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope lp1 bandwidth.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val       Get the values of ftype in reg CTRL6_C
+  *
+  */
+int32_t lsm6dso_gy_lp1_bandwidth_get(lsm6dso_ctx_t *ctx, lsm6dso_ftype_t *val)
+{
+  lsm6dso_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+  switch (reg.ftype) {
+    case LSM6DSO_ULTRA_LIGHT:
+      *val = LSM6DSO_ULTRA_LIGHT;
+      break;
+    case LSM6DSO_VERY_LIGHT:
+      *val = LSM6DSO_VERY_LIGHT;
+      break;
+    case LSM6DSO_LIGHT:
+      *val = LSM6DSO_LIGHT;
+      break;
+    case LSM6DSO_MEDIUM:
+      *val = LSM6DSO_MEDIUM;
+      break;
+    case LSM6DSO_STRONG:
+      *val = LSM6DSO_STRONG;
+      break;
+    case LSM6DSO_VERY_STRONG:
+      *val = LSM6DSO_VERY_STRONG;
+      break;
+    case LSM6DSO_AGGRESSIVE:
+      *val = LSM6DSO_AGGRESSIVE;
+      break;
+    case LSM6DSO_XTREME:
+      *val = LSM6DSO_XTREME;
+      break;
+    default:
+      *val = LSM6DSO_ULTRA_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of low_pass_on_6d in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dso_xl_lp2_on_6d_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.low_pass_on_6d = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of low_pass_on_6d in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dso_xl_lp2_on_6d_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  *val = reg.low_pass_on_6d;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection
+  *         on output.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_slope_xl_en
+  *                                   in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dso_xl_hp_path_on_out_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_hp_slope_xl_en_t val)
+{
+  lsm6dso_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.hp_slope_xl_en = ((uint8_t)val & 0x10U) >> 4;
+    reg.hp_ref_mode_xl = ((uint8_t)val & 0x20U) >> 5;
+    reg.hpcf_xl = (uint8_t)val & 0x07U;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection
+  *         on output.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp_slope_xl_en
+  *                                   in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dso_xl_hp_path_on_out_get(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_hp_slope_xl_en_t *val)
+{
+  lsm6dso_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  switch ((reg.hp_ref_mode_xl << 5) | (reg.hp_slope_xl_en << 4) |
+          reg.hpcf_xl) {
+    case LSM6DSO_HP_PATH_DISABLE_ON_OUT:
+      *val = LSM6DSO_HP_PATH_DISABLE_ON_OUT;
+      break;
+    case LSM6DSO_SLOPE_ODR_DIV_4:
+      *val = LSM6DSO_SLOPE_ODR_DIV_4;
+      break;
+    case LSM6DSO_HP_ODR_DIV_10:
+      *val = LSM6DSO_HP_ODR_DIV_10;
+      break;
+    case LSM6DSO_HP_ODR_DIV_20:
+      *val = LSM6DSO_HP_ODR_DIV_20;
+      break;
+    case LSM6DSO_HP_ODR_DIV_45:
+      *val = LSM6DSO_HP_ODR_DIV_45;
+      break;
+    case LSM6DSO_HP_ODR_DIV_100:
+      *val = LSM6DSO_HP_ODR_DIV_100;
+      break;
+    case LSM6DSO_HP_ODR_DIV_200:
+      *val = LSM6DSO_HP_ODR_DIV_200;
+      break;
+    case LSM6DSO_HP_ODR_DIV_400:
+      *val = LSM6DSO_HP_ODR_DIV_400;
+      break;
+    case LSM6DSO_HP_ODR_DIV_800:
+      *val = LSM6DSO_HP_ODR_DIV_800;
+      break;
+    case LSM6DSO_HP_REF_MD_ODR_DIV_10:
+      *val = LSM6DSO_HP_REF_MD_ODR_DIV_10;
+      break;
+    case LSM6DSO_HP_REF_MD_ODR_DIV_20:
+      *val = LSM6DSO_HP_REF_MD_ODR_DIV_20;
+      break;
+    case LSM6DSO_HP_REF_MD_ODR_DIV_45:
+      *val = LSM6DSO_HP_REF_MD_ODR_DIV_45;
+      break;
+    case LSM6DSO_HP_REF_MD_ODR_DIV_100:
+      *val = LSM6DSO_HP_REF_MD_ODR_DIV_100;
+      break;
+    case LSM6DSO_HP_REF_MD_ODR_DIV_200:
+      *val = LSM6DSO_HP_REF_MD_ODR_DIV_200;
+      break;
+    case LSM6DSO_HP_REF_MD_ODR_DIV_400:
+      *val = LSM6DSO_HP_REF_MD_ODR_DIV_400;
+      break;
+    case LSM6DSO_HP_REF_MD_ODR_DIV_800:
+      *val = LSM6DSO_HP_REF_MD_ODR_DIV_800;
+      break;
+    case LSM6DSO_LP_ODR_DIV_10:
+      *val = LSM6DSO_LP_ODR_DIV_10;
+      break;
+    case LSM6DSO_LP_ODR_DIV_20:
+      *val = LSM6DSO_LP_ODR_DIV_20;
+      break;
+    case LSM6DSO_LP_ODR_DIV_45:
+      *val = LSM6DSO_LP_ODR_DIV_45;
+      break;
+    case LSM6DSO_LP_ODR_DIV_100:
+      *val = LSM6DSO_LP_ODR_DIV_100;
+      break;
+    case LSM6DSO_LP_ODR_DIV_200:
+      *val = LSM6DSO_LP_ODR_DIV_200;
+      break;
+    case LSM6DSO_LP_ODR_DIV_400:
+      *val = LSM6DSO_LP_ODR_DIV_400;
+      break;
+    case LSM6DSO_LP_ODR_DIV_800:
+      *val = LSM6DSO_LP_ODR_DIV_800;
+      break;
+    default:
+      *val = LSM6DSO_HP_PATH_DISABLE_ON_OUT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing this bit.
+  *         Active only during device exit from power-down mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fastsettl_mode_xl in
+  *                  reg CTRL8_XL
+  *
+  */
+int32_t lsm6dso_xl_fast_settling_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fastsettl_mode_xl = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing this bit.
+  *         Active only during device exit from power-down mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fastsettl_mode_xl in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dso_xl_fast_settling_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  *val = reg.fastsettl_mode_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of slope_fds in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_xl_hp_path_internal_set(lsm6dso_ctx_t *ctx,
+                                        lsm6dso_slope_fds_t val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.slope_fds = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of slope_fds in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_xl_hp_path_internal_get(lsm6dso_ctx_t *ctx,
+                                        lsm6dso_slope_fds_t *val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  switch (reg.slope_fds) {
+    case LSM6DSO_USE_SLOPE:
+      *val = LSM6DSO_USE_SLOPE;
+      break;
+    case LSM6DSO_USE_HPF:
+      *val = LSM6DSO_USE_HPF;
+      break;
+    default:
+      *val = LSM6DSO_USE_SLOPE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital high-pass filter. The filter is
+  *         enabled only if the gyro is in HP mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp_en_g and hp_en_g
+  *                            in reg CTRL7_G
+  *
+  */
+int32_t lsm6dso_gy_hp_path_internal_set(lsm6dso_ctx_t *ctx,
+                                        lsm6dso_hpm_g_t val)
+{
+  lsm6dso_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.hp_en_g = ((uint8_t)val & 0x80U) >> 7;
+    reg.hpm_g = (uint8_t)val & 0x03U;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital high-pass filter. The filter is
+  *         enabled only if the gyro is in HP mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp_en_g and hp_en_g
+  *                            in reg CTRL7_G
+  *
+  */
+int32_t lsm6dso_gy_hp_path_internal_get(lsm6dso_ctx_t *ctx,
+                                        lsm6dso_hpm_g_t *val)
+{
+  lsm6dso_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  switch ((reg.hp_en_g << 7) + reg.hpm_g) {
+    case LSM6DSO_HP_FILTER_NONE:
+      *val = LSM6DSO_HP_FILTER_NONE;
+      break;
+    case LSM6DSO_HP_FILTER_16mHz:
+      *val = LSM6DSO_HP_FILTER_16mHz;
+      break;
+    case LSM6DSO_HP_FILTER_65mHz:
+      *val = LSM6DSO_HP_FILTER_65mHz;
+      break;
+    case LSM6DSO_HP_FILTER_260mHz:
+      *val = LSM6DSO_HP_FILTER_260mHz;
+      break;
+    case LSM6DSO_HP_FILTER_1Hz04:
+      *val = LSM6DSO_HP_FILTER_1Hz04;
+      break;
+    default:
+      *val = LSM6DSO_HP_FILTER_NONE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_ Auxiliary_interface
+  * @brief     This section groups all the functions concerning
+  *            auxiliary interface.
+  * @{
+  *
+*/
+
+/**
+  * @brief  aOn auxiliary interface connect/disconnect SDO and OCS
+  *         internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ois_pu_dis in
+  *                               reg PIN_CTRL
+  *
+  */
+int32_t lsm6dso_aux_sdo_ocs_mode_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_ois_pu_dis_t val)
+{
+  lsm6dso_pin_ctrl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ois_pu_dis = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  On auxiliary interface connect/disconnect SDO and OCS
+  *         internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ois_pu_dis in reg PIN_CTRL
+  *
+  */
+int32_t lsm6dso_aux_sdo_ocs_mode_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_ois_pu_dis_t *val)
+{
+  lsm6dso_pin_ctrl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t*)&reg, 1);
+  switch (reg.ois_pu_dis) {
+    case LSM6DSO_AUX_PULL_UP_DISC:
+      *val = LSM6DSO_AUX_PULL_UP_DISC;
+      break;
+    case LSM6DSO_AUX_PULL_UP_CONNECT:
+      *val = LSM6DSO_AUX_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LSM6DSO_AUX_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  OIS chain on aux interface power on mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ois_on in reg CTRL7_G
+  *
+  */
+int32_t lsm6dso_aux_pw_on_ctrl_set(lsm6dso_ctx_t *ctx, lsm6dso_ois_on_t val)
+{
+  lsm6dso_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ois_on_en = (uint8_t)val & 0x01U;
+    reg.ois_on = (uint8_t)val & 0x01U;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  aux_pw_on_ctrl: [get]  OIS chain on aux interface power on mode
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ois_on in reg CTRL7_G
+  *
+  */
+int32_t lsm6dso_aux_pw_on_ctrl_get(lsm6dso_ctx_t *ctx, lsm6dso_ois_on_t *val)
+{
+  lsm6dso_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL7_G, (uint8_t*)&reg, 1);
+  switch (reg.ois_on) {
+    case LSM6DSO_AUX_ON:
+      *val = LSM6DSO_AUX_ON;
+      break;
+    case LSM6DSO_AUX_ON_BY_AUX_INTERFACE:
+      *val = LSM6DSO_AUX_ON_BY_AUX_INTERFACE;
+      break;
+    default:
+      *val = LSM6DSO_AUX_ON;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale management between UI chain and
+  *         OIS chain. When XL UI is on, the full scale is the same
+  *         between UI/OIS and is chosen by the UI CTRL registers;
+  *         when XL UI is in PD, the OIS can choose the FS.
+  *         Full scales are independent between the UI/OIS chain
+  *         but both bound to 8 g.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of xl_fs_mode in
+  *                               reg CTRL8_XL
+  *
+  */
+int32_t lsm6dso_aux_xl_fs_mode_set(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_xl_fs_mode_t val)
+{
+  lsm6dso_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.xl_fs_mode = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale management between UI chain and
+  *         OIS chain. When XL UI is on, the full scale is the same
+  *         between UI/OIS and is chosen by the UI CTRL registers;
+  *         when XL UI is in PD, the OIS can choose the FS.
+  *         Full scales are independent between the UI/OIS chain
+  *         but both bound to 8 g.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of xl_fs_mode in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dso_aux_xl_fs_mode_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_xl_fs_mode_t *val)
+{
+  lsm6dso_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL8_XL, (uint8_t*)&reg, 1);
+  switch (reg.xl_fs_mode) {
+    case LSM6DSO_USE_SAME_XL_FS:
+      *val = LSM6DSO_USE_SAME_XL_FS;
+      break;
+    case LSM6DSO_USE_DIFFERENT_XL_FS:
+      *val = LSM6DSO_USE_DIFFERENT_XL_FS;
+      break;
+    default:
+      *val = LSM6DSO_USE_SAME_XL_FS;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_SPIAux register is read by the auxiliary SPI.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  lsm6dso_status_spiaux_t: registers STATUS_SPIAUX
+  *
+  */
+int32_t lsm6dso_aux_status_reg_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_status_spiaux_t *val)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_SPIAUX, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  aux_xl_flag_data_ready: [get]  AUX accelerometer data available
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of xlda in reg STATUS_SPIAUX
+  *
+  */
+int32_t lsm6dso_aux_xl_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_status_spiaux_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_SPIAUX, (uint8_t*)&reg, 1);
+  *val = reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  aux_gy_flag_data_ready: [get]  AUX gyroscope data available.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of gda in reg STATUS_SPIAUX
+  *
+  */
+int32_t lsm6dso_aux_gy_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_status_spiaux_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_SPIAUX, (uint8_t*)&reg, 1);
+  *val = reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  High when the gyroscope output is in the settling phase.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of gyro_settling in reg STATUS_SPIAUX
+  *
+  */
+int32_t lsm6dso_aux_gy_flag_settling_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_status_spiaux_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_SPIAUX, (uint8_t*)&reg, 1);
+  *val = reg.gyro_settling;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer self-test. Effective only if XL OIS
+  *         chain is enabled.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st_xl_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dso_aux_xl_self_test_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_st_xl_ois_t val)
+{
+  lsm6dso_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.st_xl_ois = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer self-test. Effective only if XL OIS
+  *         chain is enabled.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st_xl_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dso_aux_xl_self_test_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_st_xl_ois_t *val)
+{
+  lsm6dso_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  switch (reg.st_xl_ois) {
+    case LSM6DSO_AUX_XL_DISABLE:
+      *val = LSM6DSO_AUX_XL_DISABLE;
+      break;
+    case LSM6DSO_AUX_XL_POS:
+      *val = LSM6DSO_AUX_XL_POS;
+      break;
+    case LSM6DSO_AUX_XL_NEG:
+      *val = LSM6DSO_AUX_XL_NEG;
+      break;
+    default:
+      *val = LSM6DSO_AUX_XL_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_lh_ois in
+  *                  reg INT_OIS
+  *
+  */
+int32_t lsm6dso_aux_den_polarity_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_den_lh_ois_t val)
+{
+  lsm6dso_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_lh_ois = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of den_lh_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dso_aux_den_polarity_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_den_lh_ois_t *val)
+{
+  lsm6dso_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  switch (reg.den_lh_ois) {
+    case LSM6DSO_AUX_DEN_ACTIVE_LOW:
+      *val = LSM6DSO_AUX_DEN_ACTIVE_LOW;
+      break;
+    case LSM6DSO_AUX_DEN_ACTIVE_HIGH:
+      *val = LSM6DSO_AUX_DEN_ACTIVE_HIGH;
+      break;
+    default:
+      *val = LSM6DSO_AUX_DEN_ACTIVE_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lvl2_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dso_aux_den_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_lvl2_ois_t val)
+{
+  lsm6dso_ctrl1_ois_t ctrl1_ois;
+  lsm6dso_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*) &int_ois, 1);
+  if (ret == 0) {
+    int_ois.lvl2_ois = (uint8_t)val & 0x01U;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*) &int_ois, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*) &ctrl1_ois, 1);
+  }
+  if (ret == 0) {
+    ctrl1_ois.lvl1_ois = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*) &ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lvl2_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dso_aux_den_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_lvl2_ois_t *val)
+{
+  lsm6dso_ctrl1_ois_t ctrl1_ois;
+  lsm6dso_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*) &int_ois, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*) &ctrl1_ois, 1);
+    switch ((ctrl1_ois.lvl1_ois << 1) + int_ois.lvl2_ois) {
+      case LSM6DSO_AUX_DEN_DISABLE:
+        *val = LSM6DSO_AUX_DEN_DISABLE;
+        break;
+      case LSM6DSO_AUX_DEN_LEVEL_LATCH:
+        *val = LSM6DSO_AUX_DEN_LEVEL_LATCH;
+        break;
+      case LSM6DSO_AUX_DEN_LEVEL_TRIG:
+        *val = LSM6DSO_AUX_DEN_LEVEL_TRIG;
+        break;
+      default:
+        *val = LSM6DSO_AUX_DEN_DISABLE;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin.
+  *         This setting has priority over all other INT2 settings.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_drdy_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dso_aux_drdy_on_int2_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int2_drdy_ois = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin.
+  *         This setting has priority over all other INT2 settings.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_drdy_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dso_aux_drdy_on_int2_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_OIS, (uint8_t*)&reg, 1);
+  *val = reg.int2_drdy_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro in Mode 3 and Mode 4
+  *         (mode4_en = 1) and accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are available
+  *         through the SPI2 in registers OUTX_L_G (22h) through
+  *         OUTZ_H_G (27h) and STATUS_REG (1Eh) / STATUS_SPIAux, and
+  *         LPF1 is dedicated to this chain.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ois_en_spi2 in
+  *                                reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dso_aux_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_ois_en_spi2_t val)
+{
+  lsm6dso_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ois_en_spi2 = (uint8_t)val & 0x01U;
+    reg.mode4_en = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro in Mode 3 and Mode 4
+  *         (mode4_en = 1) and accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are available
+  *         through the SPI2 in registers OUTX_L_G (22h) through
+  *         OUTZ_H_G (27h) and STATUS_REG (1Eh) / STATUS_SPIAux, and
+  *         LPF1 is dedicated to this chain.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ois_en_spi2 in
+  *                                reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dso_aux_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_ois_en_spi2_t *val)
+{
+  lsm6dso_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch ((reg.mode4_en << 1) | reg.ois_en_spi2) {
+    case LSM6DSO_AUX_DISABLE:
+      *val = LSM6DSO_AUX_DISABLE;
+      break;
+    case LSM6DSO_MODE_3_GY:
+      *val = LSM6DSO_MODE_3_GY;
+      break;
+    case LSM6DSO_MODE_4_GY_XL:
+      *val = LSM6DSO_MODE_4_GY_XL;
+      break;
+    default:
+      *val = LSM6DSO_AUX_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs_g_ois in reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_full_scale_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_fs_g_ois_t val)
+{
+  lsm6dso_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fs_g_ois = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs_g_ois in reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_full_scale_get(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_fs_g_ois_t *val)
+{
+  lsm6dso_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch (reg.fs_g_ois) {
+    case LSM6DSO_250dps_AUX:
+      *val = LSM6DSO_250dps_AUX;
+      break;
+    case LSM6DSO_125dps_AUX:
+      *val = LSM6DSO_125dps_AUX;
+      break;
+    case LSM6DSO_500dps_AUX:
+      *val = LSM6DSO_500dps_AUX;
+      break;
+    case LSM6DSO_1000dps_AUX:
+      *val = LSM6DSO_1000dps_AUX;
+      break;
+    case LSM6DSO_2000dps_AUX:
+      *val = LSM6DSO_2000dps_AUX;
+      break;
+    default:
+      *val = LSM6DSO_250dps_AUX;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim_ois in reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dso_aux_spi_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_sim_ois_t val)
+{
+  lsm6dso_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sim_ois = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim_ois in reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dso_aux_spi_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_sim_ois_t *val)
+{
+  lsm6dso_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch (reg.sim_ois) {
+    case LSM6DSO_AUX_SPI_4_WIRE:
+      *val = LSM6DSO_AUX_SPI_4_WIRE;
+      break;
+    case LSM6DSO_AUX_SPI_3_WIRE:
+      *val = LSM6DSO_AUX_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSO_AUX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope digital LPF1 filter bandwidth.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ftype_ois in
+  *                              reg CTRL2_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_lp1_bandwidth_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_ftype_ois_t val)
+{
+  lsm6dso_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ftype_ois = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL2_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope digital LPF1 filter bandwidth.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ftype_ois in reg CTRL2_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_lp1_bandwidth_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_ftype_ois_t *val)
+{
+  lsm6dso_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_OIS, (uint8_t*)&reg, 1);
+  switch (reg.ftype_ois) {
+    case LSM6DSO_351Hz39:
+      *val = LSM6DSO_351Hz39;
+      break;
+    case LSM6DSO_236Hz63:
+      *val = LSM6DSO_236Hz63;
+      break;
+    case LSM6DSO_172Hz70:
+      *val = LSM6DSO_172Hz70;
+      break;
+    case LSM6DSO_937Hz91:
+      *val = LSM6DSO_937Hz91;
+      break;
+    default:
+      *val = LSM6DSO_351Hz39;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain digital high-pass filter cutoff.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpm_ois in reg CTRL2_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_hp_bandwidth_set(lsm6dso_ctx_t *ctx,
+                                        lsm6dso_hpm_ois_t val)
+{
+  lsm6dso_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.hpm_ois = (uint8_t)val & 0x03U;
+    reg.hp_en_ois = ((uint8_t)val & 0x10U) >> 4;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL2_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain digital high-pass filter cutoff.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hpm_ois in reg CTRL2_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_hp_bandwidth_get(lsm6dso_ctx_t *ctx,
+                                        lsm6dso_hpm_ois_t *val)
+{
+  lsm6dso_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL2_OIS, (uint8_t*)&reg, 1);
+  switch ((reg.hp_en_ois << 4) | reg.hpm_ois) {
+    case LSM6DSO_AUX_HP_DISABLE:
+      *val = LSM6DSO_AUX_HP_DISABLE;
+      break;
+    case LSM6DSO_AUX_HP_Hz016:
+      *val = LSM6DSO_AUX_HP_Hz016;
+      break;
+    case LSM6DSO_AUX_HP_Hz065:
+      *val = LSM6DSO_AUX_HP_Hz065;
+      break;
+    case LSM6DSO_AUX_HP_Hz260:
+      *val = LSM6DSO_AUX_HP_Hz260;
+      break;
+    case LSM6DSO_AUX_HP_1Hz040:
+      *val = LSM6DSO_AUX_HP_1Hz040;
+      break;
+    default:
+      *val = LSM6DSO_AUX_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp.
+  *         Enable: All OIS chain outputs = 8000h
+  *         during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full
+  *         scale selected.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st_ois_clampdis in
+  *                                    reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_clamp_set(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_st_ois_clampdis_t val)
+{
+  lsm6dso_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.st_ois_clampdis = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp.
+  *         Enable: All OIS chain outputs = 8000h
+  *         during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full
+  *         scale selected.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st_ois_clampdis in
+  *                                    reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_clamp_get(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_st_ois_clampdis_t *val)
+{
+  lsm6dso_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch (reg.st_ois_clampdis) {
+    case LSM6DSO_ENABLE_CLAMP:
+      *val = LSM6DSO_ENABLE_CLAMP;
+      break;
+    case LSM6DSO_DISABLE_CLAMP:
+      *val = LSM6DSO_DISABLE_CLAMP;
+      break;
+    default:
+      *val = LSM6DSO_ENABLE_CLAMP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st_ois in reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_self_test_set(lsm6dso_ctx_t *ctx, lsm6dso_st_ois_t val)
+{
+  lsm6dso_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.st_ois = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st_ois in reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dso_aux_gy_self_test_get(lsm6dso_ctx_t *ctx, lsm6dso_st_ois_t *val)
+{
+  lsm6dso_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch (reg.st_ois) {
+    case LSM6DSO_AUX_GY_DISABLE:
+      *val = LSM6DSO_AUX_GY_DISABLE;
+      break;
+    case LSM6DSO_AUX_GY_POS:
+      *val = LSM6DSO_AUX_GY_POS;
+      break;
+    case LSM6DSO_AUX_GY_NEG:
+      *val = LSM6DSO_AUX_GY_NEG;
+      break;
+    default:
+      *val = LSM6DSO_AUX_GY_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of
+  *                                       filter_xl_conf_ois in reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dso_aux_xl_bandwidth_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_filter_xl_conf_ois_t val)
+{
+  lsm6dso_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.filter_xl_conf_ois = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of
+  *                                       filter_xl_conf_ois in reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dso_aux_xl_bandwidth_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_filter_xl_conf_ois_t *val)
+{
+  lsm6dso_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+
+  switch (reg.filter_xl_conf_ois) {
+    case LSM6DSO_289Hz:
+      *val = LSM6DSO_289Hz;
+      break;
+    case LSM6DSO_258Hz:
+      *val = LSM6DSO_258Hz;
+      break;
+    case LSM6DSO_120Hz:
+      *val = LSM6DSO_120Hz;
+      break;
+    case LSM6DSO_65Hz2:
+      *val = LSM6DSO_65Hz2;
+      break;
+    case LSM6DSO_33Hz2:
+      *val = LSM6DSO_33Hz2;
+      break;
+    case LSM6DSO_16Hz6:
+      *val = LSM6DSO_16Hz6;
+      break;
+    case LSM6DSO_8Hz30:
+      *val = LSM6DSO_8Hz30;
+      break;
+    case LSM6DSO_4Hz15:
+      *val = LSM6DSO_4Hz15;
+      break;
+    default:
+      *val = LSM6DSO_289Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs_xl_ois in
+  *                              reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dso_aux_xl_full_scale_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_fs_xl_ois_t val)
+{
+  lsm6dso_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fs_xl_ois = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs_xl_ois in reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dso_aux_xl_full_scale_get(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_fs_xl_ois_t *val)
+{
+  lsm6dso_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch (reg.fs_xl_ois) {
+    case LSM6DSO_AUX_2g:
+      *val = LSM6DSO_AUX_2g;
+      break;
+    case LSM6DSO_AUX_16g:
+      *val = LSM6DSO_AUX_16g;
+      break;
+    case LSM6DSO_AUX_4g:
+      *val = LSM6DSO_AUX_4g;
+      break;
+    case LSM6DSO_AUX_8g:
+      *val = LSM6DSO_AUX_8g;
+      break;
+    default:
+      *val = LSM6DSO_AUX_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_ main_serial_interface
+  * @brief     This section groups all the functions concerning main
+  *            serial interface management (not auxiliary)
+  * @{
+  *
+*/
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sdo_pu_en in
+  *                              reg PIN_CTRL
+  *
+  */
+int32_t lsm6dso_sdo_sa0_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_sdo_pu_en_t val)
+{
+  lsm6dso_pin_ctrl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sdo_pu_en = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sdo_pu_en in reg PIN_CTRL
+  *
+  */
+int32_t lsm6dso_sdo_sa0_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_sdo_pu_en_t *val)
+{
+  lsm6dso_pin_ctrl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_PIN_CTRL, (uint8_t*)&reg, 1);
+  switch (reg.sdo_pu_en) {
+    case LSM6DSO_PULL_UP_DISC:
+      *val = LSM6DSO_PULL_UP_DISC;
+      break;
+    case LSM6DSO_PULL_UP_CONNECT:
+      *val = LSM6DSO_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LSM6DSO_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_spi_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_sim_t val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sim = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_spi_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_sim_t *val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  switch (reg.sim) {
+    case LSM6DSO_SPI_4_WIRE:
+      *val = LSM6DSO_SPI_4_WIRE;
+      break;
+    case LSM6DSO_SPI_3_WIRE:
+      *val = LSM6DSO_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSO_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_disable in
+  *                                reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_i2c_interface_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_i2c_disable_t val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.i2c_disable = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_disable in
+  *                                reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_i2c_interface_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_i2c_disable_t *val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  switch (reg.i2c_disable) {
+    case LSM6DSO_I2C_ENABLE:
+      *val = LSM6DSO_I2C_ENABLE;
+      break;
+    case LSM6DSO_I2C_DISABLE:
+      *val = LSM6DSO_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM6DSO_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol[.set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i3c_disable
+  *                                    in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_i3c_disable_set(lsm6dso_ctx_t *ctx, lsm6dso_i3c_disable_t val)
+{
+  lsm6dso_i3c_bus_avb_t i3c_bus_avb;
+  lsm6dso_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if (ret == 0) {
+    ctrl9_xl.i3c_disable = ((uint8_t)val & 0x80U) >> 7;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB,
+                           (uint8_t*)&i3c_bus_avb, 1);
+  }
+  if (ret == 0) {
+    i3c_bus_avb.i3c_bus_avb_sel = (uint8_t)val & 0x03U;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_I3C_BUS_AVB,
+                            (uint8_t*)&i3c_bus_avb, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i3c_disable in
+  *                                reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_i3c_disable_get(lsm6dso_ctx_t *ctx, lsm6dso_i3c_disable_t *val)
+{
+  lsm6dso_ctrl9_xl_t ctrl9_xl;
+  lsm6dso_i3c_bus_avb_t i3c_bus_avb;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB,
+                           (uint8_t*)&i3c_bus_avb, 1);
+
+    switch ((ctrl9_xl.i3c_disable << 7) | i3c_bus_avb.i3c_bus_avb_sel) {
+      case LSM6DSO_I3C_DISABLE:
+        *val = LSM6DSO_I3C_DISABLE;
+        break;
+      case LSM6DSO_I3C_ENABLE_T_50us:
+        *val = LSM6DSO_I3C_ENABLE_T_50us;
+        break;
+      case LSM6DSO_I3C_ENABLE_T_2us:
+        *val = LSM6DSO_I3C_ENABLE_T_2us;
+        break;
+      case LSM6DSO_I3C_ENABLE_T_1ms:
+        *val = LSM6DSO_I3C_ENABLE_T_1ms;
+        break;
+      case LSM6DSO_I3C_ENABLE_T_25ms:
+        *val = LSM6DSO_I3C_ENABLE_T_25ms;
+        break;
+      default:
+        *val = LSM6DSO_I3C_DISABLE;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_interrupt_pins
+  * @brief     This section groups all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect INT1 internal pull-down.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pd_dis_int1 in reg I3C_BUS_AVB
+  *
+  */
+int32_t lsm6dso_int1_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_int1_pd_en_t val)
+{
+  lsm6dso_i3c_bus_avb_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.pd_dis_int1 = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect INT1 internal pull-down.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pd_dis_int1 in reg I3C_BUS_AVB
+  *
+  */
+int32_t lsm6dso_int1_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_int1_pd_en_t *val)
+{
+  lsm6dso_i3c_bus_avb_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_I3C_BUS_AVB, (uint8_t*)&reg, 1);
+  switch (reg.pd_dis_int1) {
+    case LSM6DSO_PULL_DOWN_DISC:
+      *val = LSM6DSO_PULL_DOWN_DISC;
+      break;
+    case LSM6DSO_PULL_DOWN_CONNECT:
+      *val = LSM6DSO_PULL_DOWN_CONNECT;
+      break;
+    default:
+      *val = LSM6DSO_PULL_DOWN_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      struct of registers: INT1_CTRL,
+  *                  MD1_CFG, EMB_FUNC_INT1, FSM_INT1_A,
+  *                  FSM_INT1_B
+  *
+  */
+int32_t lsm6dso_pin_int1_route_set(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_pin_int1_route_t *val)
+{
+  lsm6dso_pin_int2_route_t pin_int2_route;
+  lsm6dso_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INT1,
+                            (uint8_t*)&val->emb_func_int1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT1_A,
+                            (uint8_t*)&val->fsm_int1_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT1_B,
+                            (uint8_t*)&val->fsm_int1_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  if (ret == 0) {
+    if ( ( val->emb_func_int1.int1_fsm_lc
+         | val->emb_func_int1.int1_sig_mot
+         | val->emb_func_int1.int1_step_detector
+         | val->emb_func_int1.int1_tilt
+         | val->fsm_int1_a.int1_fsm1
+         | val->fsm_int1_a.int1_fsm2
+         | val->fsm_int1_a.int1_fsm3
+         | val->fsm_int1_a.int1_fsm4
+         | val->fsm_int1_a.int1_fsm5
+         | val->fsm_int1_a.int1_fsm6
+         | val->fsm_int1_a.int1_fsm7
+         | val->fsm_int1_a.int1_fsm8
+         | val->fsm_int1_b.int1_fsm9
+         | val->fsm_int1_b.int1_fsm10
+         | val->fsm_int1_b.int1_fsm11
+         | val->fsm_int1_b.int1_fsm12
+         | val->fsm_int1_b.int1_fsm13
+         | val->fsm_int1_b.int1_fsm14
+         | val->fsm_int1_b.int1_fsm15
+         | val->fsm_int1_b.int1_fsm16) != PROPERTY_DISABLE){
+      val->md1_cfg.int1_emb_func = PROPERTY_ENABLE;
+    }
+    else{
+      val->md1_cfg.int1_emb_func = PROPERTY_DISABLE;
+    }
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT1_CTRL,
+                            (uint8_t*)&val->int1_ctrl, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MD1_CFG, (uint8_t*)&val->md1_cfg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*) &tap_cfg2, 1);
+  }
+
+  if (ret == 0) {
+    ret = lsm6dso_pin_int2_route_get(ctx, &pin_int2_route);
+  }
+  if (ret == 0) {
+    if ( ( pin_int2_route.int2_ctrl.int2_cnt_bdr
+         | pin_int2_route.int2_ctrl.int2_drdy_g
+         | pin_int2_route.int2_ctrl.int2_drdy_temp
+         | pin_int2_route.int2_ctrl.int2_drdy_xl
+         | pin_int2_route.int2_ctrl.int2_fifo_full
+         | pin_int2_route.int2_ctrl.int2_fifo_ovr
+         | pin_int2_route.int2_ctrl.int2_fifo_th
+         | pin_int2_route.md2_cfg.int2_6d
+         | pin_int2_route.md2_cfg.int2_double_tap
+         | pin_int2_route.md2_cfg.int2_ff
+         | pin_int2_route.md2_cfg.int2_wu
+         | pin_int2_route.md2_cfg.int2_single_tap
+         | pin_int2_route.md2_cfg.int2_sleep_change
+         | val->int1_ctrl.den_drdy_flag
+         | val->int1_ctrl.int1_boot
+         | val->int1_ctrl.int1_cnt_bdr
+         | val->int1_ctrl.int1_drdy_g
+         | val->int1_ctrl.int1_drdy_xl
+         | val->int1_ctrl.int1_fifo_full
+         | val->int1_ctrl.int1_fifo_ovr
+         | val->int1_ctrl.int1_fifo_th
+         | val->md1_cfg.int1_6d
+         | val->md1_cfg.int1_double_tap
+         | val->md1_cfg.int1_ff
+         | val->md1_cfg.int1_wu
+         | val->md1_cfg.int1_single_tap
+         | val->md1_cfg.int1_sleep_change) != PROPERTY_DISABLE) {
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*) &tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      struct of registers: INT1_CTRL, MD1_CFG,
+  *                  EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
+  *
+  */
+int32_t lsm6dso_pin_int1_route_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_pin_int1_route_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INT1,
+                           (uint8_t*)&val->emb_func_int1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_INT1_A,
+                           (uint8_t*)&val->fsm_int1_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_INT1_B,
+                           (uint8_t*)&val->fsm_int1_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_INT1_CTRL,
+                           (uint8_t*)&val->int1_ctrl, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MD1_CFG, (uint8_t*)&val->md1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers INT2_CTRL,  MD2_CFG,
+  *                  EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  *
+  */
+int32_t lsm6dso_pin_int2_route_set(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_pin_int2_route_t *val)
+{
+  lsm6dso_pin_int1_route_t pin_int1_route;
+  lsm6dso_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INT2,
+                            (uint8_t*)&val->emb_func_int2, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT2_A,
+                            (uint8_t*)&val->fsm_int2_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_INT2_B,
+                            (uint8_t*)&val->fsm_int2_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  if (ret == 0) {
+    if (( val->emb_func_int2.int2_fsm_lc
+        | val->emb_func_int2.int2_sig_mot
+        | val->emb_func_int2.int2_step_detector
+        | val->emb_func_int2.int2_tilt
+        | val->fsm_int2_a.int2_fsm1
+        | val->fsm_int2_a.int2_fsm2
+        | val->fsm_int2_a.int2_fsm3
+        | val->fsm_int2_a.int2_fsm4
+        | val->fsm_int2_a.int2_fsm5
+        | val->fsm_int2_a.int2_fsm6
+        | val->fsm_int2_a.int2_fsm7
+        | val->fsm_int2_a.int2_fsm8
+        | val->fsm_int2_b.int2_fsm9
+        | val->fsm_int2_b.int2_fsm10
+        | val->fsm_int2_b.int2_fsm11
+        | val->fsm_int2_b.int2_fsm12
+        | val->fsm_int2_b.int2_fsm13
+        | val->fsm_int2_b.int2_fsm14
+        | val->fsm_int2_b.int2_fsm15
+        | val->fsm_int2_b.int2_fsm16 )!= PROPERTY_DISABLE ){
+      val->md2_cfg.int2_emb_func = PROPERTY_ENABLE;
+    }
+    else{
+      val->md2_cfg.int2_emb_func = PROPERTY_DISABLE;
+    }
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT2_CTRL,
+                            (uint8_t*)&val->int2_ctrl, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t*)&val->md2_cfg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*) &tap_cfg2, 1);
+  }
+
+  if (ret == 0) {
+    ret = lsm6dso_pin_int1_route_get(ctx, &pin_int1_route);
+  }
+
+  if (ret == 0) {
+    if ( ( val->int2_ctrl.int2_cnt_bdr
+         | val->int2_ctrl.int2_drdy_g
+         | val->int2_ctrl.int2_drdy_temp
+         | val->int2_ctrl.int2_drdy_xl
+         | val->int2_ctrl.int2_fifo_full
+         | val->int2_ctrl.int2_fifo_ovr
+         | val->int2_ctrl.int2_fifo_th
+         | val->md2_cfg.int2_6d
+         | val->md2_cfg.int2_double_tap
+         | val->md2_cfg.int2_ff
+         | val->md2_cfg.int2_wu
+         | val->md2_cfg.int2_single_tap
+         | val->md2_cfg.int2_sleep_change
+         | pin_int1_route.int1_ctrl.den_drdy_flag
+         | pin_int1_route.int1_ctrl.int1_boot
+         | pin_int1_route.int1_ctrl.int1_cnt_bdr
+         | pin_int1_route.int1_ctrl.int1_drdy_g
+         | pin_int1_route.int1_ctrl.int1_drdy_xl
+         | pin_int1_route.int1_ctrl.int1_fifo_full
+         | pin_int1_route.int1_ctrl.int1_fifo_ovr
+         | pin_int1_route.int1_ctrl.int1_fifo_th
+         | pin_int1_route.md1_cfg.int1_6d
+         | pin_int1_route.md1_cfg.int1_double_tap
+         | pin_int1_route.md1_cfg.int1_ff
+         | pin_int1_route.md1_cfg.int1_wu
+         | pin_int1_route.md1_cfg.int1_single_tap
+         | pin_int1_route.md1_cfg.int1_sleep_change ) != PROPERTY_DISABLE) {
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*) &tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers INT2_CTRL,  MD2_CFG,
+  *                  EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  *
+  */
+int32_t lsm6dso_pin_int2_route_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_pin_int2_route_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INT2,
+                           (uint8_t*)&val->emb_func_int2, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_INT2_A,
+                           (uint8_t*)&val->fsm_int2_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_INT2_B,
+                           (uint8_t*)&val->fsm_int2_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_INT2_CTRL,
+                           (uint8_t*)&val->int2_ctrl, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MD2_CFG, (uint8_t*)&val->md2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pp_od in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_pin_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_pp_od_t val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.pp_od = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pp_od in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_pin_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_pp_od_t *val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+
+  switch (reg.pp_od) {
+    case LSM6DSO_PUSH_PULL:
+      *val = LSM6DSO_PUSH_PULL;
+      break;
+    case LSM6DSO_OPEN_DRAIN:
+      *val = LSM6DSO_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM6DSO_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of h_lactive in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_pin_polarity_set(lsm6dso_ctx_t *ctx, lsm6dso_h_lactive_t val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.h_lactive = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of h_lactive in reg CTRL3_C
+  *
+  */
+int32_t lsm6dso_pin_polarity_get(lsm6dso_ctx_t *ctx, lsm6dso_h_lactive_t *val)
+{
+  lsm6dso_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL3_C, (uint8_t*)&reg, 1);
+
+  switch (reg.h_lactive) {
+    case LSM6DSO_ACTIVE_HIGH:
+      *val = LSM6DSO_ACTIVE_HIGH;
+      break;
+    case LSM6DSO_ACTIVE_LOW:
+      *val = LSM6DSO_ACTIVE_LOW;
+      break;
+    default:
+      *val = LSM6DSO_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_all_on_int1_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int2_on_int1 = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_all_on_int1_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  *val = reg.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt notification mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_int_notification_set(lsm6dso_ctx_t *ctx, lsm6dso_lir_t val)
+{
+  lsm6dso_tap_cfg0_t tap_cfg0;
+  lsm6dso_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*) &tap_cfg0, 1);
+  if (ret == 0) {
+    tap_cfg0.lir = (uint8_t)val & 0x01U;
+    tap_cfg0.int_clr_on_read = (uint8_t)val & 0x01U;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*) &tap_cfg0, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.emb_func_lir = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt notification mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_int_notification_get(lsm6dso_ctx_t *ctx, lsm6dso_lir_t *val)
+{
+  lsm6dso_tap_cfg0_t tap_cfg0;
+  lsm6dso_page_rw_t page_rw;
+  int32_t ret;
+
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*) &tap_cfg0, 1);
+  if (ret == 0) {
+
+      ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  if (ret == 0) {
+    switch ((page_rw.emb_func_lir << 1) | tap_cfg0.lir) {
+      case LSM6DSO_ALL_INT_PULSED:
+        *val = LSM6DSO_ALL_INT_PULSED;
+        break;
+      case LSM6DSO_BASE_LATCHED_EMB_PULSED:
+        *val = LSM6DSO_BASE_LATCHED_EMB_PULSED;
+        break;
+      case LSM6DSO_BASE_PULSED_EMB_LATCHED:
+        *val = LSM6DSO_BASE_PULSED_EMB_LATCHED;
+        break;
+      case LSM6DSO_ALL_INT_LATCHED:
+        *val = LSM6DSO_ALL_INT_LATCHED;
+        break;
+      default:
+        *val = LSM6DSO_ALL_INT_PULSED;
+        break;
+    }
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_Wake_Up_event
+  * @brief     This section groups all the functions that manage the Wake Up
+  *            event generation.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[set]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_ths_w in
+  *                                 reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dso_wkup_ths_weight_set(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_wake_ths_w_t val)
+{
+  lsm6dso_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.wake_ths_w = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[get]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of wake_ths_w in
+  *                                 reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dso_wkup_ths_weight_get(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_wake_ths_w_t *val)
+{
+  lsm6dso_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+
+  switch (reg.wake_ths_w) {
+    case LSM6DSO_LSb_FS_DIV_64:
+      *val = LSM6DSO_LSb_FS_DIV_64;
+      break;
+    case LSM6DSO_LSb_FS_DIV_256:
+      *val = LSM6DSO_LSb_FS_DIV_256;
+      break;
+    default:
+      *val = LSM6DSO_LSb_FS_DIV_64;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dso_wkup_threshold_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.wk_ths = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dso_wkup_threshold_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  *val = reg.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.[set]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_wu in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_on_wkup_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.usr_off_on_wu = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.[get]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_wu in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dso_xl_usr_offset_on_wkup_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  *val = reg.usr_off_on_wu;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.[set]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dso_wkup_dur_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.wake_dur = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.[get]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dso_wkup_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  *val = reg.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_ Activity/Inactivity_detection
+  * @brief     This section groups all the functions concerning
+  *            activity/inactivity detection.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_g in reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_gy_sleep_mode_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sleep_g = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_g in reg CTRL4_C
+  *
+  */
+int32_t lsm6dso_gy_sleep_mode_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL4_C, (uint8_t*)&reg, 1);
+  *val = reg.sleep_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of
+  *         sleep change on INT pins
+  *         (only if INT1_SLEEP_CHANGE or
+  *         INT2_SLEEP_CHANGE bits are enabled).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_status_on_int in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_act_pin_notification_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_sleep_status_on_int_t val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sleep_status_on_int = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of
+  *         sleep change on INT pins (only if
+  *         INT1_SLEEP_CHANGE or
+  *         INT2_SLEEP_CHANGE bits are enabled).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sleep_status_on_int in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_act_pin_notification_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_sleep_status_on_int_t *val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  switch (reg.sleep_status_on_int) {
+    case LSM6DSO_DRIVE_SLEEP_CHG_EVENT:
+      *val = LSM6DSO_DRIVE_SLEEP_CHG_EVENT;
+      break;
+    case LSM6DSO_DRIVE_SLEEP_STATUS:
+      *val = LSM6DSO_DRIVE_SLEEP_STATUS;
+      break;
+    default:
+      *val = LSM6DSO_DRIVE_SLEEP_CHG_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of inact_en in reg TAP_CFG2
+  *
+  */
+int32_t lsm6dso_act_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_inact_en_t val)
+{
+  lsm6dso_tap_cfg2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.inact_en = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of inact_en in reg TAP_CFG2
+  *
+  */
+int32_t lsm6dso_act_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_inact_en_t *val)
+{
+  lsm6dso_tap_cfg2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*)&reg, 1);
+  switch (reg.inact_en) {
+    case LSM6DSO_XL_AND_GY_NOT_AFFECTED:
+      *val = LSM6DSO_XL_AND_GY_NOT_AFFECTED;
+      break;
+    case LSM6DSO_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = LSM6DSO_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case LSM6DSO_XL_12Hz5_GY_SLEEP:
+      *val = LSM6DSO_XL_12Hz5_GY_SLEEP;
+      break;
+    case LSM6DSO_XL_12Hz5_GY_PD:
+      *val = LSM6DSO_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = LSM6DSO_XL_AND_GY_NOT_AFFECTED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.[set]
+  *         1 LSb = 512 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dso_act_sleep_dur_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sleep_dur = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.[get]
+  *         1 LSb = 512 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dso_act_sleep_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  *val = reg.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_tap_generator
+  * @brief     This section groups all the functions that manage the
+  *            tap and double tap event generation.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_tap_detection_on_z_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_z_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_tap_detection_on_z_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  *val = reg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_tap_detection_on_y_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_y_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_tap_detection_on_y_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  *val = reg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_tap_detection_on_x_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_x_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dso_tap_detection_on_x_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG0, (uint8_t*)&reg, 1);
+  *val = reg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  X-axis tap recognition threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_x in reg TAP_CFG1
+  *
+  */
+int32_t lsm6dso_tap_threshold_x_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_tap_cfg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_ths_x = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X-axis tap recognition threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_x in reg TAP_CFG1
+  *
+  */
+int32_t lsm6dso_tap_threshold_x_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_tap_cfg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG1, (uint8_t*)&reg, 1);
+  *val = reg.tap_ths_x;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_priority in
+  *                                 reg TAP_CFG1
+  *
+  */
+int32_t lsm6dso_tap_axis_priority_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_tap_priority_t val)
+{
+  lsm6dso_tap_cfg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_priority = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tap_priority in
+  *                                 reg TAP_CFG1
+  *
+  */
+int32_t lsm6dso_tap_axis_priority_get(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_tap_priority_t *val)
+{
+  lsm6dso_tap_cfg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG1, (uint8_t*)&reg, 1);
+  switch (reg.tap_priority) {
+    case LSM6DSO_XYZ:
+      *val = LSM6DSO_XYZ;
+      break;
+    case LSM6DSO_YXZ:
+      *val = LSM6DSO_YXZ;
+      break;
+    case LSM6DSO_XZY:
+      *val = LSM6DSO_XZY;
+      break;
+    case LSM6DSO_ZYX:
+      *val = LSM6DSO_ZYX;
+      break;
+    case LSM6DSO_YZX:
+      *val = LSM6DSO_YZX;
+      break;
+    case LSM6DSO_ZXY:
+      *val = LSM6DSO_ZXY;
+      break;
+    default:
+      *val = LSM6DSO_XYZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y-axis tap recognition threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_y in reg TAP_CFG2
+  *
+  */
+int32_t lsm6dso_tap_threshold_y_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_tap_cfg2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_ths_y = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y-axis tap recognition threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_y in reg TAP_CFG2
+  *
+  */
+int32_t lsm6dso_tap_threshold_y_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_tap_cfg2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_CFG2, (uint8_t*)&reg, 1);
+  *val = reg.tap_ths_y;
+
+  return ret;
+}
+
+/**
+  * @brief  Z-axis recognition threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_z in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dso_tap_threshold_z_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_ths_z = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z-axis recognition threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_z in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dso_tap_threshold_z_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  *val = reg.tap_ths_z;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an
+  *         over threshold signal detection to be recognized
+  *         as a tap event. The default value of these bits
+  *         is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR2
+  *
+  */
+int32_t lsm6dso_tap_shock_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.shock = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an
+  *         over threshold signal detection to be recognized
+  *         as a tap event. The default value of these bits
+  *         is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR2
+  *
+  */
+int32_t lsm6dso_tap_shock_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  *val = reg.shock;
+
+  return ret;
+}
+
+/**
+  * @brief   Quiet time is the time after the first detected
+  *          tap in which there must not be any over threshold
+  *          event.
+  *          The default value of these bits is 00b which
+  *          corresponds to 2*ODR_XL time. If the QUIET[1:0]
+  *          bits are set to a different value,
+  *          1LSB corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR2
+  *
+  */
+int32_t lsm6dso_tap_quiet_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.quiet = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected
+  *         tap in which there must not be any over threshold
+  *         event.
+  *         The default value of these bits is 00b which
+  *         corresponds to 2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR2
+  *
+  */
+int32_t lsm6dso_tap_quiet_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  *val = reg.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled,
+  *         this register expresses the maximum time
+  *         between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,
+  *         1LSB corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of dur in reg INT_DUR2
+  *
+  */
+int32_t lsm6dso_tap_dur_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.dur = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled,
+  *         this register expresses the maximum time
+  *         between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time. If the DUR[3:0]
+  *         bits are set to a different value,
+  *         1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of dur in reg INT_DUR2
+  *
+  */
+int32_t lsm6dso_tap_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_INT_DUR2, (uint8_t*)&reg, 1);
+  *val = reg.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of single_double_tap in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dso_tap_mode_set(lsm6dso_ctx_t *ctx,
+                             lsm6dso_single_double_tap_t val)
+{
+  lsm6dso_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.single_double_tap = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of single_double_tap in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dso_tap_mode_get(lsm6dso_ctx_t *ctx,
+                             lsm6dso_single_double_tap_t *val)
+{
+  lsm6dso_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_THS, (uint8_t*)&reg, 1);
+
+  switch (reg.single_double_tap) {
+    case LSM6DSO_ONLY_SINGLE:
+      *val = LSM6DSO_ONLY_SINGLE;
+      break;
+    case LSM6DSO_BOTH_SINGLE_DOUBLE:
+      *val = LSM6DSO_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LSM6DSO_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_ Six_position_detection(6D/4D)
+  * @brief   This section groups all the functions concerning six position
+  *          detection (6D).
+  * @{
+  *
+*/
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sixd_ths in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dso_6d_threshold_set(lsm6dso_ctx_t *ctx, lsm6dso_sixd_ths_t val)
+{
+  lsm6dso_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sixd_ths = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sixd_ths in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dso_6d_threshold_get(lsm6dso_ctx_t *ctx, lsm6dso_sixd_ths_t *val)
+{
+  lsm6dso_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  switch (reg.sixd_ths) {
+    case LSM6DSO_DEG_80:
+      *val = LSM6DSO_DEG_80;
+      break;
+    case LSM6DSO_DEG_70:
+      *val = LSM6DSO_DEG_70;
+      break;
+    case LSM6DSO_DEG_60:
+      *val = LSM6DSO_DEG_60;
+      break;
+    case LSM6DSO_DEG_50:
+      *val = LSM6DSO_DEG_50;
+      break;
+    default:
+      *val = LSM6DSO_DEG_80;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_en in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dso_4d_mode_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.d4d_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_en in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dso_4d_mode_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_TAP_THS_6D, (uint8_t*)&reg, 1);
+  *val = reg.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_free_fall
+  * @brief   This section group all the functions concerning the free
+  *          fall detection.
+  * @{
+  *
+*/
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lsm6dso_ff_threshold_set(lsm6dso_ctx_t *ctx, lsm6dso_ff_ths_t val)
+{
+  lsm6dso_free_fall_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ff_ths = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lsm6dso_ff_threshold_get(lsm6dso_ctx_t *ctx, lsm6dso_ff_ths_t *val)
+{
+  lsm6dso_free_fall_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t*)&reg, 1);
+  switch (reg.ff_ths) {
+    case LSM6DSO_FF_TSH_156mg:
+      *val = LSM6DSO_FF_TSH_156mg;
+      break;
+    case LSM6DSO_FF_TSH_219mg:
+      *val = LSM6DSO_FF_TSH_219mg;
+      break;
+    case LSM6DSO_FF_TSH_250mg:
+      *val = LSM6DSO_FF_TSH_250mg;
+      break;
+    case LSM6DSO_FF_TSH_312mg:
+      *val = LSM6DSO_FF_TSH_312mg;
+      break;
+    case LSM6DSO_FF_TSH_344mg:
+      *val = LSM6DSO_FF_TSH_344mg;
+      break;
+    case LSM6DSO_FF_TSH_406mg:
+      *val = LSM6DSO_FF_TSH_406mg;
+      break;
+    case LSM6DSO_FF_TSH_469mg:
+      *val = LSM6DSO_FF_TSH_469mg;
+      break;
+    case LSM6DSO_FF_TSH_500mg:
+      *val = LSM6DSO_FF_TSH_500mg;
+      break;
+    default:
+      *val = LSM6DSO_FF_TSH_156mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event.[set]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in reg FREE_FALL
+  *
+  */
+int32_t lsm6dso_ff_dur_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_wake_up_dur_t wake_up_dur;
+  lsm6dso_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  if (ret == 0) {
+    wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
+    free_fall.ff_dur = (uint8_t)val & 0x1FU;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event.[get]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in reg FREE_FALL
+  *
+  */
+int32_t lsm6dso_ff_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_wake_up_dur_t wake_up_dur;
+  lsm6dso_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FREE_FALL, (uint8_t*)&free_fall, 1);
+    *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_fifo
+  * @brief   This section group all the functions concerning the fifo usage
+  * @{
+  *
+*/
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_CTRL1
+  *
+  */
+int32_t lsm6dso_fifo_watermark_set(lsm6dso_ctx_t *ctx, uint16_t val)
+{
+  lsm6dso_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dso_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if (ret == 0) {
+    fifo_ctrl1.wtm = 0x00FFU & (uint8_t)val;
+    fifo_ctrl2.wtm = (uint8_t)(( 0x0100U & val ) >> 8);
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_CTRL1
+  *
+  */
+int32_t lsm6dso_fifo_watermark_get(lsm6dso_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dso_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dso_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+    *val = ((uint16_t)fifo_ctrl2.wtm << 8) + (uint16_t)fifo_ctrl1.wtm;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO compression feature initialization request [set].
+  *
+  * @param  ctx       read / write interface definitions
+  * @param  val       change the values of FIFO_COMPR_INIT in
+  *                   reg EMB_FUNC_INIT_B
+  *
+  */
+int32_t lsm6dso_compression_algo_init_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_emb_func_init_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.fifo_compr_init = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO compression feature initialization request [get].
+  *
+  * @param  ctx    read / write interface definitions
+  * @param  val    change the values of FIFO_COMPR_INIT in
+  *                reg EMB_FUNC_INIT_B
+  *
+  */
+int32_t lsm6dso_compression_algo_init_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_init_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.fifo_compr_init;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable and configure compression algo.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of uncoptr_rate in
+  *                  reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dso_compression_algo_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_uncoptr_rate_t val)
+{
+  lsm6dso_emb_func_en_b_t emb_func_en_b;
+  lsm6dso_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
+                           (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    emb_func_en_b.fifo_compr_en = ((uint8_t)val & 0x04U) >> 2;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
+                            (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  }
+  if (ret == 0) {
+    fifo_ctrl2.fifo_compr_rt_en = ((uint8_t)val & 0x04U) >> 2;
+    fifo_ctrl2.uncoptr_rate = (uint8_t)val & 0x03U;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable and configure compression algo.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of uncoptr_rate in
+  *                  reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dso_compression_algo_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_uncoptr_rate_t *val)
+{
+  lsm6dso_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+
+  switch ((reg.fifo_compr_rt_en<<2) | reg.uncoptr_rate) {
+    case LSM6DSO_CMP_DISABLE:
+      *val = LSM6DSO_CMP_DISABLE;
+      break;
+    case LSM6DSO_CMP_ALWAYS:
+      *val = LSM6DSO_CMP_ALWAYS;
+      break;
+    case LSM6DSO_CMP_8_TO_1:
+      *val = LSM6DSO_CMP_8_TO_1;
+      break;
+    case LSM6DSO_CMP_16_TO_1:
+      *val = LSM6DSO_CMP_16_TO_1;
+      break;
+    case LSM6DSO_CMP_32_TO_1:
+      *val = LSM6DSO_CMP_32_TO_1;
+      break;
+    default:
+      *val = LSM6DSO_CMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odrchg_en in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dso_fifo_virtual_sens_odr_chg_set(lsm6dso_ctx_t *ctx,
+                                              uint8_t val)
+{
+  lsm6dso_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odrchg_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odrchg_en in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dso_fifo_virtual_sens_odr_chg_get(lsm6dso_ctx_t *ctx,
+                                              uint8_t *val)
+{
+  lsm6dso_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  *val = reg.odrchg_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_compr_rt_en in
+  *                  reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dso_compression_algo_real_time_set(lsm6dso_ctx_t *ctx,
+                                               uint8_t val)
+{
+  lsm6dso_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fifo_compr_rt_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enables/Disables compression algorithm runtime. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_compr_rt_en in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dso_compression_algo_real_time_get(lsm6dso_ctx_t *ctx,
+                                               uint8_t *val)
+{
+  lsm6dso_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_compr_rt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at
+  *         threshold level.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of stop_on_wtm in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dso_fifo_stop_on_wtm_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.stop_on_wtm = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at
+  *         threshold level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of stop_on_wtm in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dso_fifo_stop_on_wtm_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  *val = reg.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdr_xl in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6dso_fifo_xl_batch_set(lsm6dso_ctx_t *ctx, lsm6dso_bdr_xl_t val)
+{
+  lsm6dso_fifo_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.bdr_xl = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of bdr_xl in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6dso_fifo_xl_batch_get(lsm6dso_ctx_t *ctx, lsm6dso_bdr_xl_t *val)
+{
+  lsm6dso_fifo_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  switch (reg.bdr_xl) {
+    case LSM6DSO_XL_NOT_BATCHED:
+      *val = LSM6DSO_XL_NOT_BATCHED;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_12Hz5:
+      *val = LSM6DSO_XL_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_26Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_26Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_52Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_52Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_104Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_104Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_208Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_208Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_417Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_417Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_833Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_833Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_1667Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_1667Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_3333Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_3333Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_6667Hz:
+      *val = LSM6DSO_XL_BATCHED_AT_6667Hz;
+      break;
+    case LSM6DSO_XL_BATCHED_AT_6Hz5:
+      *val = LSM6DSO_XL_BATCHED_AT_6Hz5;
+      break;
+    default:
+      *val = LSM6DSO_XL_NOT_BATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdr_gy in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6dso_fifo_gy_batch_set(lsm6dso_ctx_t *ctx, lsm6dso_bdr_gy_t val)
+{
+  lsm6dso_fifo_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.bdr_gy = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of bdr_gy in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6dso_fifo_gy_batch_get(lsm6dso_ctx_t *ctx, lsm6dso_bdr_gy_t *val)
+{
+  lsm6dso_fifo_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  switch (reg.bdr_gy) {
+    case LSM6DSO_GY_NOT_BATCHED:
+      *val = LSM6DSO_GY_NOT_BATCHED;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_12Hz5:
+      *val = LSM6DSO_GY_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_26Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_26Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_52Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_52Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_104Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_104Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_208Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_208Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_417Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_417Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_833Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_833Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_1667Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_1667Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_3333Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_3333Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_6667Hz:
+      *val = LSM6DSO_GY_BATCHED_AT_6667Hz;
+      break;
+    case LSM6DSO_GY_BATCHED_AT_6Hz5:
+      *val = LSM6DSO_GY_BATCHED_AT_6Hz5;
+      break;
+    default:
+      *val = LSM6DSO_GY_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_mode in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dso_fifo_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_fifo_mode_t val)
+{
+  lsm6dso_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fifo_mode = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fifo_mode in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dso_fifo_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_fifo_mode_t *val)
+{
+  lsm6dso_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+
+  switch (reg.fifo_mode) {
+    case LSM6DSO_BYPASS_MODE:
+      *val = LSM6DSO_BYPASS_MODE;
+      break;
+    case LSM6DSO_FIFO_MODE:
+      *val = LSM6DSO_FIFO_MODE;
+      break;
+    case LSM6DSO_STREAM_TO_FIFO_MODE:
+      *val = LSM6DSO_STREAM_TO_FIFO_MODE;
+      break;
+    case LSM6DSO_BYPASS_TO_STREAM_MODE:
+      *val = LSM6DSO_BYPASS_TO_STREAM_MODE;
+      break;
+    case LSM6DSO_STREAM_MODE:
+      *val = LSM6DSO_STREAM_MODE;
+      break;
+    case LSM6DSO_BYPASS_TO_FIFO_MODE:
+      *val = LSM6DSO_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LSM6DSO_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr_t_batch in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dso_fifo_temp_batch_set(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_odr_t_batch_t val)
+{
+  lsm6dso_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odr_t_batch = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr_t_batch in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dso_fifo_temp_batch_get(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_odr_t_batch_t *val)
+{
+  lsm6dso_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+
+  switch (reg.odr_t_batch) {
+    case LSM6DSO_TEMP_NOT_BATCHED:
+      *val = LSM6DSO_TEMP_NOT_BATCHED;
+      break;
+    case LSM6DSO_TEMP_BATCHED_AT_1Hz6:
+      *val = LSM6DSO_TEMP_BATCHED_AT_1Hz6;
+      break;
+    case LSM6DSO_TEMP_BATCHED_AT_12Hz5:
+      *val = LSM6DSO_TEMP_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSO_TEMP_BATCHED_AT_52Hz:
+      *val = LSM6DSO_TEMP_BATCHED_AT_52Hz;
+      break;
+    default:
+      *val = LSM6DSO_TEMP_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr_ts_batch in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dso_fifo_timestamp_decimation_set(lsm6dso_ctx_t *ctx,
+                                              lsm6dso_odr_ts_batch_t val)
+{
+  lsm6dso_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odr_ts_batch = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects decimation for timestamp batching in FIFO.
+  *          Writing rate will be the maximum rate between XL and
+  *          GYRO BDR divided by decimation decoder.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr_ts_batch in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dso_fifo_timestamp_decimation_get(lsm6dso_ctx_t *ctx,
+                                              lsm6dso_odr_ts_batch_t *val)
+{
+  lsm6dso_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  switch (reg.odr_ts_batch) {
+    case LSM6DSO_NO_DECIMATION:
+      *val = LSM6DSO_NO_DECIMATION;
+      break;
+    case LSM6DSO_DEC_1:
+      *val = LSM6DSO_DEC_1;
+      break;
+    case LSM6DSO_DEC_8:
+      *val = LSM6DSO_DEC_8;
+      break;
+    case LSM6DSO_DEC_32:
+      *val = LSM6DSO_DEC_32;
+      break;
+    default:
+      *val = LSM6DSO_NO_DECIMATION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *         between XL and gyro.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of trig_counter_bdr
+  *                  in reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dso_fifo_cnt_event_batch_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_trig_counter_bdr_t val)
+{
+  lsm6dso_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.trig_counter_bdr = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *         between XL and gyro.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of trig_counter_bdr
+  *                                     in reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dso_fifo_cnt_event_batch_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_trig_counter_bdr_t *val)
+{
+  lsm6dso_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  switch (reg.trig_counter_bdr) {
+    case LSM6DSO_XL_BATCH_EVENT:
+      *val = LSM6DSO_XL_BATCH_EVENT;
+      break;
+    case LSM6DSO_GYRO_BATCH_EVENT:
+      *val = LSM6DSO_GYRO_BATCH_EVENT;
+      break;
+    default:
+      *val = LSM6DSO_XL_BATCH_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching vents for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of rst_counter_bdr in
+  *                      reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dso_rst_batch_counter_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.rst_counter_bdr = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of rst_counter_bdr in
+  *                  reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dso_rst_batch_counter_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  *val = reg.rst_counter_bdr;
+
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of cnt_bdr_th in
+  *                  reg COUNTER_BDR_REG2 and COUNTER_BDR_REG1.
+  *
+  */
+int32_t lsm6dso_batch_counter_threshold_set(lsm6dso_ctx_t *ctx, uint16_t val)
+{
+  lsm6dso_counter_bdr_reg1_t counter_bdr_reg1;
+  lsm6dso_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1,
+                         (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0) {
+    counter_bdr_reg2.cnt_bdr_th =  0x00FFU & (uint8_t)val;
+    counter_bdr_reg1.cnt_bdr_th = (uint8_t)(0x0700U & val) >> 8;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG1,
+                            (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_COUNTER_BDR_REG2,
+                            (uint8_t*)&counter_bdr_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of cnt_bdr_th in
+  *                  reg COUNTER_BDR_REG2 and COUNTER_BDR_REG1.
+  *
+  */
+int32_t lsm6dso_batch_counter_threshold_get(lsm6dso_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dso_counter_bdr_reg1_t counter_bdr_reg1;
+  lsm6dso_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG1,
+                         (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_COUNTER_BDR_REG2,
+                           (uint8_t*)&counter_bdr_reg2, 1);
+
+    *val = ((uint16_t)counter_bdr_reg1.cnt_bdr_th << 8)
+    + (uint16_t)counter_bdr_reg2.cnt_bdr_th;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Number of unread sensor data(TAG + 6 bytes) stored in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of diff_fifo in reg FIFO_STATUS1
+  *
+  */
+int32_t lsm6dso_fifo_data_level_get(lsm6dso_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dso_fifo_status1_t fifo_status1;
+  lsm6dso_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS1,
+                         (uint8_t*)&fifo_status1, 1);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+    *val = ((uint16_t)fifo_status2.diff_fifo << 8) +
+            (uint16_t)fifo_status1.diff_fifo;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_STATUS2
+  *
+  */
+int32_t lsm6dso_fifo_status_get(lsm6dso_ctx_t *ctx,
+                                lsm6dso_fifo_status2_t *val)
+{
+  int32_t ret;
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO full status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_full_ia in reg FIFO_STATUS2
+  *
+  */
+int32_t lsm6dso_fifo_full_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_full_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  fifo_over_run_latched in
+  *                  reg FIFO_STATUS2
+  *
+  */
+int32_t lsm6dso_fifo_ovr_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_ovr_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  *
+  */
+int32_t lsm6dso_fifo_wtm_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_STATUS2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_wtm_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  Identifies the sensor in FIFO_DATA_OUT.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tag_sensor in reg FIFO_DATA_OUT_TAG
+  *
+  */
+int32_t lsm6dso_fifo_sensor_tag_get(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_fifo_tag_t *val)
+{
+  lsm6dso_fifo_data_out_tag_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_FIFO_DATA_OUT_TAG, (uint8_t*)&reg, 1);
+  switch (reg.tag_sensor) {
+    case LSM6DSO_GYRO_NC_TAG:
+      *val = LSM6DSO_GYRO_NC_TAG;
+      break;
+    case LSM6DSO_XL_NC_TAG:
+      *val = LSM6DSO_XL_NC_TAG;
+      break;
+    case LSM6DSO_TEMPERATURE_TAG:
+      *val = LSM6DSO_TEMPERATURE_TAG;
+      break;
+    case LSM6DSO_CFG_CHANGE_TAG:
+      *val = LSM6DSO_CFG_CHANGE_TAG;
+      break;
+    case LSM6DSO_XL_NC_T_2_TAG:
+      *val = LSM6DSO_XL_NC_T_2_TAG;
+      break;
+    case LSM6DSO_XL_NC_T_1_TAG:
+      *val = LSM6DSO_XL_NC_T_1_TAG;
+      break;
+    case LSM6DSO_XL_2XC_TAG:
+      *val = LSM6DSO_XL_2XC_TAG;
+      break;
+    case LSM6DSO_XL_3XC_TAG:
+      *val = LSM6DSO_XL_3XC_TAG;
+      break;
+    case LSM6DSO_GYRO_NC_T_2_TAG:
+      *val = LSM6DSO_GYRO_NC_T_2_TAG;
+      break;
+    case LSM6DSO_GYRO_NC_T_1_TAG:
+      *val = LSM6DSO_GYRO_NC_T_1_TAG;
+      break;
+    case LSM6DSO_GYRO_2XC_TAG:
+      *val = LSM6DSO_GYRO_2XC_TAG;
+      break;
+    case LSM6DSO_GYRO_3XC_TAG:
+      *val = LSM6DSO_GYRO_3XC_TAG;
+      break;
+    case LSM6DSO_SENSORHUB_SLAVE0_TAG:
+      *val = LSM6DSO_SENSORHUB_SLAVE0_TAG;
+      break;
+    case LSM6DSO_SENSORHUB_SLAVE1_TAG:
+      *val = LSM6DSO_SENSORHUB_SLAVE1_TAG;
+      break;
+    case LSM6DSO_SENSORHUB_SLAVE2_TAG:
+      *val = LSM6DSO_SENSORHUB_SLAVE2_TAG;
+      break;
+    case LSM6DSO_SENSORHUB_SLAVE3_TAG:
+      *val = LSM6DSO_SENSORHUB_SLAVE3_TAG;
+      break;
+    case LSM6DSO_STEP_CPUNTER_TAG:
+      *val = LSM6DSO_STEP_CPUNTER_TAG;
+      break;
+    case LSM6DSO_GAME_ROTATION_TAG:
+      *val = LSM6DSO_GAME_ROTATION_TAG;
+      break;
+    case LSM6DSO_GEOMAG_ROTATION_TAG:
+      *val = LSM6DSO_GEOMAG_ROTATION_TAG;
+      break;
+    case LSM6DSO_ROTATION_TAG:
+      *val = LSM6DSO_ROTATION_TAG;
+      break;
+    case LSM6DSO_SENSORHUB_NACK_TAG:
+      *val = LSM6DSO_SENSORHUB_NACK_TAG;
+      break;
+    default:
+      *val = LSM6DSO_GYRO_NC_TAG;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  :  Enable FIFO batching of pedometer embedded
+  *            function values.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of gbias_fifo_en in
+  *                  reg LSM6DSO_EMB_FUNC_FIFO_CFG
+  *
+  */
+int32_t lsm6dso_fifo_pedo_batch_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_emb_func_fifo_cfg_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.pedo_fifo_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG,
+                            (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching of pedometer embedded function values.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pedo_fifo_en in
+  *                  reg LSM6DSO_EMB_FUNC_FIFO_CFG
+  *
+  */
+int32_t lsm6dso_fifo_pedo_batch_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_fifo_cfg_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_FIFO_CFG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.pedo_fifo_en;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable FIFO batching data of first slave.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_0_en in
+  *                  reg SLV0_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_batch_slave_0_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_slv0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.batch_ext_sens_0_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of first slave.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_0_en in
+  *                  reg SLV0_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_batch_slave_0_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_slv0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.batch_ext_sens_0_en;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of second slave.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_1_en in
+  *                  reg SLV1_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_batch_slave_1_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_slv1_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.batch_ext_sens_1_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enable FIFO batching data of second slave.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_1_en in
+  *                  reg SLV1_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_batch_slave_1_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_slv1_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t*)&reg, 1);
+    *val = reg.batch_ext_sens_1_en;
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of third slave.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_2_en in
+  *                  reg SLV2_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_batch_slave_2_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_slv2_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV2_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.batch_ext_sens_2_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV2_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of third slave.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_2_en in
+  *                  reg SLV2_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_batch_slave_2_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_slv2_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV2_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.batch_ext_sens_2_en;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enable FIFO batching data of fourth slave.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_3_en
+  *                  in reg SLV3_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_batch_slave_3_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_slv3_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV3_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.batch_ext_sens_3_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV3_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of fourth slave.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_3_en in
+  *                  reg SLV3_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_batch_slave_3_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_slv3_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV3_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.batch_ext_sens_3_en;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_DEN_functionality
+  * @brief     This section groups all the functions concerning
+  *            DEN functionality.
+  * @{
+  *
+*/
+
+/**
+  * @brief  DEN functionality marking mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_mode in reg CTRL6_C
+  *
+  */
+int32_t lsm6dso_den_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_den_mode_t val)
+{
+  lsm6dso_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_mode = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of den_mode in reg CTRL6_C
+  *
+  */
+int32_t lsm6dso_den_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_den_mode_t *val)
+{
+  lsm6dso_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL6_C, (uint8_t*)&reg, 1);
+
+  switch (reg.den_mode) {
+    case LSM6DSO_DEN_DISABLE:
+      *val = LSM6DSO_DEN_DISABLE;
+      break;
+    case LSM6DSO_LEVEL_FIFO:
+      *val = LSM6DSO_LEVEL_FIFO;
+      break;
+    case LSM6DSO_LEVEL_LETCHED:
+      *val = LSM6DSO_LEVEL_LETCHED;
+      break;
+    case LSM6DSO_LEVEL_TRIGGER:
+      *val = LSM6DSO_LEVEL_TRIGGER;
+      break;
+    case LSM6DSO_EDGE_TRIGGER:
+      *val = LSM6DSO_EDGE_TRIGGER;
+      break;
+    default:
+      *val = LSM6DSO_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_lh in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_polarity_set(lsm6dso_ctx_t *ctx, lsm6dso_den_lh_t val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_lh = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of den_lh in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_polarity_get(lsm6dso_ctx_t *ctx, lsm6dso_den_lh_t *val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+
+  switch (reg.den_lh) {
+    case LSM6DSO_DEN_ACT_LOW:
+      *val = LSM6DSO_DEN_ACT_LOW;
+      break;
+    case LSM6DSO_DEN_ACT_HIGH:
+      *val = LSM6DSO_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = LSM6DSO_DEN_ACT_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_xl_g in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_enable_set(lsm6dso_ctx_t *ctx, lsm6dso_den_xl_g_t val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_xl_g = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of den_xl_g in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_enable_get(lsm6dso_ctx_t *ctx, lsm6dso_den_xl_g_t *val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+
+  switch (reg.den_xl_g) {
+    case LSM6DSO_STAMP_IN_GY_DATA:
+      *val = LSM6DSO_STAMP_IN_GY_DATA;
+      break;
+    case LSM6DSO_STAMP_IN_XL_DATA:
+      *val = LSM6DSO_STAMP_IN_XL_DATA;
+      break;
+    case LSM6DSO_STAMP_IN_GY_XL_DATA:
+      *val = LSM6DSO_STAMP_IN_GY_XL_DATA;
+      break;
+    default:
+      *val = LSM6DSO_STAMP_IN_GY_DATA;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_z in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_mark_axis_x_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_z = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_z in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_mark_axis_x_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  *val = reg.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_y in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_mark_axis_y_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_y = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_y in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_mark_axis_y_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  *val = reg.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_x in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_mark_axis_z_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_x = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_x in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dso_den_mark_axis_z_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_read_reg(ctx, LSM6DSO_CTRL9_XL, (uint8_t*)&reg, 1);
+  *val = reg.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_Pedometer
+  * @brief     This section groups all the functions that manage pedometer.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Enable pedometer algorithm.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      turn on and configure pedometer
+  *
+  */
+int32_t lsm6dso_pedo_sens_set(lsm6dso_ctx_t *ctx, lsm6dso_pedo_md_t val)
+{
+  lsm6dso_emb_func_en_a_t emb_func_en_a;
+  lsm6dso_emb_func_en_b_t emb_func_en_b;
+  lsm6dso_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_CMD_REG,
+                                (uint8_t*)&pedo_cmd_reg);
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A,
+                           (uint8_t*)&emb_func_en_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
+                           (uint8_t*)&emb_func_en_b, 1);
+
+    emb_func_en_a.pedo_en = (uint8_t)val & 0x01U;
+    emb_func_en_b.pedo_adv_en = ((uint8_t)val & 0x02U)>>1;
+    pedo_cmd_reg.fp_rejection_en = ((uint8_t)val & 0x10U)>>4;
+    pedo_cmd_reg.ad_det_en = ((uint8_t)val & 0x20U)>>5;
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_A,
+                            (uint8_t*)&emb_func_en_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
+                            (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer algorithm.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      turn on and configure pedometer
+  *
+  */
+int32_t lsm6dso_pedo_sens_get(lsm6dso_ctx_t *ctx, lsm6dso_pedo_md_t *val)
+{
+  lsm6dso_emb_func_en_a_t emb_func_en_a;
+  lsm6dso_emb_func_en_b_t emb_func_en_b;
+  lsm6dso_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_CMD_REG,
+                                (uint8_t*)&pedo_cmd_reg);
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A,
+                           (uint8_t*)&emb_func_en_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B,
+                           (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  switch ( (pedo_cmd_reg.ad_det_en <<5) | (pedo_cmd_reg.fp_rejection_en << 4) |
+           (emb_func_en_b.pedo_adv_en << 1) | emb_func_en_a.pedo_en) {
+    case LSM6DSO_PEDO_DISABLE:
+      *val = LSM6DSO_PEDO_DISABLE;
+      break;
+    case LSM6DSO_PEDO_BASE_MODE:
+      *val = LSM6DSO_PEDO_BASE_MODE;
+      break;
+    case LSM6DSO_PEDO_ADV_MODE:
+      *val = LSM6DSO_PEDO_ADV_MODE;
+      break;
+    case LSM6DSO_FALSE_STEP_REJ:
+      *val = LSM6DSO_FALSE_STEP_REJ;
+      break;
+    case LSM6DSO_FALSE_STEP_REJ_ADV_MODE:
+      *val = LSM6DSO_FALSE_STEP_REJ_ADV_MODE;
+      break;
+    default:
+      *val = LSM6DSO_PEDO_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for step detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of is_step_det in reg EMB_FUNC_STATUS
+  *
+  */
+int32_t lsm6dso_pedo_step_detect_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_status_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.is_step_det;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_pedo_debounce_steps_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_DEB_STEPS_CONF, buff);
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_pedo_debounce_steps_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_DEB_STEPS_CONF, buff);
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_pedo_steps_period_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_H,
+                                   &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Time period register for step detection on delta time (r/w).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_pedo_steps_period_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_SC_DELTAT_H,
+                                  &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Set when user wants to generate interrupt on count overflow
+  *         event/every step.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of carry_count_en in reg PEDO_CMD_REG
+  *
+  */
+int32_t lsm6dso_pedo_int_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_carry_count_en_t val)
+{
+  lsm6dso_pedo_cmd_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_CMD_REG, (uint8_t*)&reg);
+  if (ret == 0) {
+    reg.carry_count_en = (uint8_t)val;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_PEDO_CMD_REG,
+                                   (uint8_t*)&reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Set when user wants to generate interrupt on count overflow
+  *         event/every step.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of carry_count_en in reg PEDO_CMD_REG
+  *
+  */
+int32_t lsm6dso_pedo_int_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_carry_count_en_t *val)
+{
+  lsm6dso_pedo_cmd_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_PEDO_CMD_REG, (uint8_t*)&reg);
+  switch (reg.carry_count_en) {
+    case LSM6DSO_EVERY_STEP:
+      *val = LSM6DSO_EVERY_STEP;
+      break;
+    case LSM6DSO_COUNT_OVERFLOW:
+      *val = LSM6DSO_COUNT_OVERFLOW;
+      break;
+    default:
+      *val = LSM6DSO_EVERY_STEP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_significant_motion
+  * @brief   This section groups all the functions that manage the
+  *          significant motion detection.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Enable significant motion detection function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sign_motion_en in reg EMB_FUNC_EN_A
+  *
+  */
+int32_t lsm6dso_motion_sens_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_emb_func_en_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.sign_motion_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable significant motion detection function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sign_motion_en in reg EMB_FUNC_EN_A
+  *
+  */
+int32_t lsm6dso_motion_sens_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_en_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.sign_motion_en;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt status bit for significant motion detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of is_sigmot in reg EMB_FUNC_STATUS
+  *
+  */
+int32_t lsm6dso_motion_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_status_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.is_sigmot;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_tilt_detection
+  * @brief     This section groups all the functions that manage the tilt
+  *            event detection.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tilt_en in reg EMB_FUNC_EN_A
+  *
+  */
+int32_t lsm6dso_tilt_sens_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_emb_func_en_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.tilt_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tilt_en in reg EMB_FUNC_EN_A
+  *
+  */
+int32_t lsm6dso_tilt_sens_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_en_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.tilt_en;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for tilt detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of is_tilt in reg EMB_FUNC_STATUS
+  *
+  */
+int32_t lsm6dso_tilt_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_status_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.is_tilt;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_ magnetometer_sensor
+  * @brief     This section groups all the functions that manage additional
+  *            magnetometer sensor.
+  * @{
+  *
+*/
+
+/**
+  * @brief  External magnetometer sensitivity value register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_mag_sensitivity_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SENSITIVITY_L,
+                                 &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SENSITIVITY_H,
+                                   &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer sensitivity value register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_mag_sensitivity_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SENSITIVITY_L,
+                                &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SENSITIVITY_H,
+                                  &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_mag_offset_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFX_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFX_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_OFFZ_H, &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_mag_offset_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFX_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFX_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_OFFZ_H, &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft-iron (3x3 symmetric) matrix correction
+  *         register (r/w). The value is expressed as
+  *         half-precision floating-point format:
+  *         SEEEEEFFFFFFFFFF
+  *         S: 1 sign bit;
+  *         E: 5 exponent bits;
+  *         F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_mag_soft_iron_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XX_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XX_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_XZ_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_YY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_YY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_YZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_YZ_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_ZZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_SI_ZZ_H, &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Soft-iron (3x3 symmetric) matrix
+  *         correction register (r/w).
+  *         The value is expressed as half-precision
+  *         floating-point format:
+  *         SEEEEEFFFFFFFFFF
+  *         S: 1 sign bit;
+  *         E: 5 exponent bits;
+  *         F: 10 fraction bits.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_mag_soft_iron_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XX_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XX_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_XZ_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_YY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_YY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_YZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_YZ_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_ZZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_SI_ZZ_H, &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Z-axis coordinates
+  *         rotation (to be aligned to
+  *         accelerometer/gyroscope axes
+  *         orientation).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mag_z_axis in reg MAG_CFG_A
+  *
+  */
+int32_t lsm6dso_mag_z_orient_set(lsm6dso_ctx_t *ctx, lsm6dso_mag_z_axis_t val)
+{
+  lsm6dso_mag_cfg_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t*)&reg);
+  if (ret == 0) {
+    reg.mag_z_axis = (uint8_t) val;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t*)&reg);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Z-axis coordinates
+  *         rotation (to be aligned to
+  *         accelerometer/gyroscope axes
+  *         orientation).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of mag_z_axis in reg MAG_CFG_A
+  *
+  */
+int32_t lsm6dso_mag_z_orient_get(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_mag_z_axis_t *val)
+{
+  lsm6dso_mag_cfg_a_t reg;
+  int32_t ret;
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t*)&reg);
+  switch (reg.mag_z_axis) {
+    case LSM6DSO_Z_EQ_Y:
+      *val = LSM6DSO_Z_EQ_Y;
+      break;
+    case LSM6DSO_Z_EQ_MIN_Y:
+      *val = LSM6DSO_Z_EQ_MIN_Y;
+      break;
+    case LSM6DSO_Z_EQ_X:
+      *val = LSM6DSO_Z_EQ_X;
+      break;
+    case LSM6DSO_Z_EQ_MIN_X:
+      *val = LSM6DSO_Z_EQ_MIN_X;
+      break;
+    case LSM6DSO_Z_EQ_MIN_Z:
+      *val = LSM6DSO_Z_EQ_MIN_Z;
+      break;
+    case LSM6DSO_Z_EQ_Z:
+      *val = LSM6DSO_Z_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSO_Z_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Magnetometer Y-axis coordinates
+  *          rotation (to be aligned to
+  *          accelerometer/gyroscope axes
+  *          orientation).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mag_y_axis in reg MAG_CFG_A
+  *
+  */
+int32_t lsm6dso_mag_y_orient_set(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_mag_y_axis_t val)
+{
+  lsm6dso_mag_cfg_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t*)&reg);
+  if (ret == 0) {
+    reg.mag_y_axis = (uint8_t)val;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_A,(uint8_t*) &reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Y-axis coordinates
+  *         rotation (to be aligned to
+  *         accelerometer/gyroscope axes
+  *         orientation).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of mag_y_axis in reg MAG_CFG_A
+  *
+  */
+int32_t lsm6dso_mag_y_orient_get(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_mag_y_axis_t *val)
+{
+  lsm6dso_mag_cfg_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_A, (uint8_t*)&reg);
+  switch (reg.mag_y_axis) {
+    case LSM6DSO_Y_EQ_Y:
+      *val = LSM6DSO_Y_EQ_Y;
+      break;
+    case LSM6DSO_Y_EQ_MIN_Y:
+      *val = LSM6DSO_Y_EQ_MIN_Y;
+      break;
+    case LSM6DSO_Y_EQ_X:
+      *val = LSM6DSO_Y_EQ_X;
+      break;
+    case LSM6DSO_Y_EQ_MIN_X:
+      *val = LSM6DSO_Y_EQ_MIN_X;
+      break;
+    case LSM6DSO_Y_EQ_MIN_Z:
+      *val = LSM6DSO_Y_EQ_MIN_Z;
+      break;
+    case LSM6DSO_Y_EQ_Z:
+      *val = LSM6DSO_Y_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSO_Y_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer X-axis coordinates
+  *         rotation (to be aligned to
+  *         accelerometer/gyroscope axes
+  *         orientation).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mag_x_axis in reg MAG_CFG_B
+  *
+  */
+int32_t lsm6dso_mag_x_orient_set(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_mag_x_axis_t val)
+{
+  lsm6dso_mag_cfg_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_B, (uint8_t*)&reg);
+  if (ret == 0) {
+    reg.mag_x_axis = (uint8_t)val;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_MAG_CFG_B, (uint8_t*)&reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Magnetometer X-axis coordinates
+  *          rotation (to be aligned to
+  *          accelerometer/gyroscope axes
+  *          orientation).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of mag_x_axis in reg MAG_CFG_B
+  *
+  */
+int32_t lsm6dso_mag_x_orient_get(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_mag_x_axis_t *val)
+{
+  lsm6dso_mag_cfg_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_MAG_CFG_B, (uint8_t*)&reg);
+  switch (reg.mag_x_axis) {
+    case LSM6DSO_X_EQ_Y:
+      *val = LSM6DSO_X_EQ_Y;
+      break;
+    case LSM6DSO_X_EQ_MIN_Y:
+      *val = LSM6DSO_X_EQ_MIN_Y;
+      break;
+    case LSM6DSO_X_EQ_X:
+      *val = LSM6DSO_X_EQ_X;
+      break;
+    case LSM6DSO_X_EQ_MIN_X:
+      *val = LSM6DSO_X_EQ_MIN_X;
+      break;
+    case LSM6DSO_X_EQ_MIN_Z:
+      *val = LSM6DSO_X_EQ_MIN_Z;
+      break;
+    case LSM6DSO_X_EQ_Z:
+      *val = LSM6DSO_X_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSO_X_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_significant_motion
+  * @brief     This section groups all the functions that manage the
+  *            state_machine.
+  * @{
+  *
+*/
+
+/**
+  * @brief   Interrupt status bit for FSM long counter
+  *          timeout interrupt event.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of is_fsm_lc in reg EMB_FUNC_STATUS
+  *
+  */
+int32_t lsm6dso_long_cnt_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_status_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_STATUS, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.is_fsm_lc;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Final State Machine global enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_en in reg EMB_FUNC_EN_B
+  *
+  */
+int32_t lsm6dso_emb_fsm_en_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  lsm6dso_emb_func_en_b_t reg;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.fsm_en = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Final State Machine global enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t *: return the values of fsm_en in reg EMB_FUNC_EN_B
+  *
+  */
+int32_t lsm6dso_emb_fsm_en_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  lsm6dso_emb_func_en_b_t reg;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.fsm_en;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Final State Machine enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  *
+  */
+int32_t lsm6dso_fsm_enable_set(lsm6dso_ctx_t *ctx,
+                               lsm6dso_emb_fsm_enable_t *val)
+{
+  int32_t ret;
+  lsm6dso_emb_func_en_b_t reg;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_ENABLE_A,
+                            (uint8_t*)&val->fsm_enable_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_ENABLE_B,
+                            (uint8_t*)&val->fsm_enable_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    if ( (val->fsm_enable_a.fsm1_en   |
+         val->fsm_enable_a.fsm2_en  |
+         val->fsm_enable_a.fsm3_en  |
+         val->fsm_enable_a.fsm4_en  |
+         val->fsm_enable_a.fsm5_en  |
+         val->fsm_enable_a.fsm6_en  |
+         val->fsm_enable_a.fsm7_en  |
+         val->fsm_enable_a.fsm8_en  |
+         val->fsm_enable_b.fsm9_en  |
+         val->fsm_enable_b.fsm10_en  |
+         val->fsm_enable_b.fsm11_en  |
+         val->fsm_enable_b.fsm12_en  |
+         val->fsm_enable_b.fsm13_en  |
+         val->fsm_enable_b.fsm14_en  |
+         val->fsm_enable_b.fsm15_en  |
+         val->fsm_enable_b.fsm16_en  )
+        != PROPERTY_DISABLE)
+    {
+      reg.fsm_en = PROPERTY_ENABLE;
+    }
+    else
+    {
+      reg.fsm_en = PROPERTY_DISABLE;
+    }
+
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Final State Machine enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  *
+  */
+int32_t lsm6dso_fsm_enable_get(lsm6dso_ctx_t *ctx,
+                               lsm6dso_emb_fsm_enable_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_ENABLE_A, (uint8_t*) val, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_long_cnt_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_L, buff, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_long_cnt_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_L, buff, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Clear FSM long counter value.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_lc_clr in
+  *                  reg FSM_LONG_COUNTER_CLEAR
+  *
+  */
+int32_t lsm6dso_long_clr_set(lsm6dso_ctx_t *ctx, lsm6dso_fsm_lc_clr_t val)
+{
+  lsm6dso_fsm_long_counter_clear_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR,
+    (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg. fsm_lc_clr = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR,
+    (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Clear FSM long counter value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fsm_lc_clr in
+  *                  reg FSM_LONG_COUNTER_CLEAR
+  *
+  */
+int32_t lsm6dso_long_clr_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_lc_clr_t *val)
+{
+  lsm6dso_fsm_long_counter_clear_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_LONG_COUNTER_CLEAR,
+    (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.fsm_lc_clr) {
+      case LSM6DSO_LC_NORMAL:
+        *val = LSM6DSO_LC_NORMAL;
+        break;
+      case LSM6DSO_LC_CLEAR:
+        *val = LSM6DSO_LC_CLEAR;
+        break;
+      case LSM6DSO_LC_CLEAR_DONE:
+        *val = LSM6DSO_LC_CLEAR_DONE;
+        break;
+      default:
+        *val = LSM6DSO_LC_NORMAL;
+        break;
+    }
+  }
+
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM output registers[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      struct of registers from FSM_OUTS1 to FSM_OUTS16
+  *
+  */
+int32_t lsm6dso_fsm_out_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_out_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_FSM_OUTS1, (uint8_t*) &val, 16);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  *
+  */
+int32_t lsm6dso_fsm_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_fsm_odr_t val)
+{
+  lsm6dso_emb_func_odr_cfg_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B,
+                           (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.not_used_01 = 3; /* set default values */
+    reg.not_used_02 = 2; /* set default values */
+    reg.fsm_odr = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B,
+                            (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  *
+  */
+int32_t lsm6dso_fsm_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_odr_t *val)
+{
+  lsm6dso_emb_func_odr_cfg_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_ODR_CFG_B,
+                           (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.fsm_odr) {
+      case LSM6DSO_ODR_FSM_12Hz5:
+        *val = LSM6DSO_ODR_FSM_12Hz5;
+        break;
+      case LSM6DSO_ODR_FSM_26Hz:
+        *val = LSM6DSO_ODR_FSM_26Hz;
+        break;
+      case LSM6DSO_ODR_FSM_52Hz:
+        *val = LSM6DSO_ODR_FSM_52Hz;
+        break;
+      case LSM6DSO_ODR_FSM_104Hz:
+        *val = LSM6DSO_ODR_FSM_104Hz;
+        break;
+      default:
+        *val = LSM6DSO_ODR_FSM_12Hz5;
+        break;
+    }
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_init in reg FSM_INIT
+  *
+  */
+int32_t lsm6dso_fsm_init_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_emb_func_init_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.fsm_init = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_init in reg FSM_INIT
+  *
+  */
+int32_t lsm6dso_fsm_init_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_emb_func_init_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.fsm_init;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value,
+  *         the FSM generates an interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_long_cnt_int_value_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_H,
+                                   &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value,
+  *         the FSM generates an interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_long_cnt_int_value_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_LC_TIMEOUT_H,
+                                  &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_fsm_number_of_programs_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_PROGRAMS, buff);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_fsm_number_of_programs_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_PROGRAMS, buff);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w).
+  *         First available address is 0x033C.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dso_fsm_start_address_set(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_START_ADD_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_write_byte(ctx, LSM6DSO_FSM_START_ADD_H,
+                                   &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w).
+  *         First available address is 0x033C.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dso_fsm_start_address_get(lsm6dso_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_START_ADD_L, buff);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dso_ln_pg_read_byte(ctx, LSM6DSO_FSM_START_ADD_H, buff);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSO_Sensor_hub
+  * @brief     This section groups all the functions that manage the
+  *            sensor hub.
+  * @{
+  *
+*/
+
+/**
+* @brief  Sensor hub output registers.[get]
+*
+* @param  ctx      read / write interface definitions
+* @param  val      union of registers from SENSOR_HUB_1 to SENSOR_HUB_18
+*
+  */
+int32_t lsm6dso_sh_read_data_raw_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_emb_sh_read_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SENSOR_HUB_1, (uint8_t*) val, 18U);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of aux_sens_on in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_slave_connected_set(lsm6dso_ctx_t *ctx,
+                                       lsm6dso_aux_sens_on_t val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.aux_sens_on = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of aux_sens_on in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_slave_connected_get(lsm6dso_ctx_t *ctx,
+                                       lsm6dso_aux_sens_on_t *val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.aux_sens_on) {
+      case LSM6DSO_SLV_0:
+        *val = LSM6DSO_SLV_0;
+        break;
+      case LSM6DSO_SLV_0_1:
+        *val = LSM6DSO_SLV_0_1;
+        break;
+      case LSM6DSO_SLV_0_1_2:
+        *val = LSM6DSO_SLV_0_1_2;
+        break;
+      case LSM6DSO_SLV_0_1_2_3:
+        *val = LSM6DSO_SLV_0_1_2_3;
+        break;
+      default:
+        *val = LSM6DSO_SLV_0;
+        break;
+    }
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of master_on in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_master_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.master_on = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of master_on in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_master_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.master_on;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shub_pu_en in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_pin_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_shub_pu_en_t val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.shub_pu_en = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of shub_pu_en in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_pin_mode_get(lsm6dso_ctx_t *ctx,
+                                lsm6dso_shub_pu_en_t *val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.shub_pu_en) {
+      case LSM6DSO_EXT_PULL_UP:
+        *val = LSM6DSO_EXT_PULL_UP;
+        break;
+      case LSM6DSO_INTERNAL_PULL_UP:
+        *val = LSM6DSO_INTERNAL_PULL_UP;
+        break;
+      default:
+        *val = LSM6DSO_EXT_PULL_UP;
+        break;
+    }
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pass_through_mode in
+  *                  reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_pass_through_set(lsm6dso_ctx_t *ctx, uint8_t val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.pass_through_mode = val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pass_through_mode in
+  *                  reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_pass_through_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.pass_through_mode;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of start_config in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_syncro_mode_set(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_start_config_t val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.start_config = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of start_config in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_syncro_mode_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_start_config_t *val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.start_config) {
+      case LSM6DSO_EXT_ON_INT2_PIN:
+        *val = LSM6DSO_EXT_ON_INT2_PIN;
+        break;
+      case LSM6DSO_XL_GY_DRDY:
+        *val = LSM6DSO_XL_GY_DRDY;
+        break;
+      default:
+        *val = LSM6DSO_EXT_ON_INT2_PIN;
+        break;
+    }
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first
+  *         sensor hub cycle.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of write_once in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_write_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_write_once_t val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.write_once = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of write_once in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_write_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_write_once_t *val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.write_once) {
+      case LSM6DSO_EACH_SH_CYCLE:
+        *val = LSM6DSO_EACH_SH_CYCLE;
+        break;
+      case LSM6DSO_ONLY_FIRST_CYCLE:
+        *val = LSM6DSO_ONLY_FIRST_CYCLE;
+        break;
+      default:
+        *val = LSM6DSO_EACH_SH_CYCLE;
+        break;
+    }
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reset Master logic and output registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  *
+  */
+int32_t lsm6dso_sh_reset_set(lsm6dso_ctx_t *ctx)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.rst_master_regs = PROPERTY_ENABLE;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.rst_master_regs = PROPERTY_DISABLE;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reset Master logic and output registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of rst_master_regs in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_reset_get(lsm6dso_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dso_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.rst_master_regs;
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the master communicates.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shub_odr in reg slv1_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_shub_odr_t val)
+{
+  lsm6dso_slv0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.shub_odr = (uint8_t)val;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the master communicates.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of shub_odr in reg slv1_CONFIG
+  *
+  */
+int32_t lsm6dso_sh_data_rate_get(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_shub_odr_t *val)
+{
+  lsm6dso_slv0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.shub_odr) {
+      case LSM6DSO_SH_ODR_104Hz:
+        *val = LSM6DSO_SH_ODR_104Hz;
+        break;
+      case LSM6DSO_SH_ODR_52Hz:
+        *val = LSM6DSO_SH_ODR_52Hz;
+        break;
+      case LSM6DSO_SH_ODR_26Hz:
+        *val = LSM6DSO_SH_ODR_26Hz;
+        break;
+      case LSM6DSO_SH_ODR_13Hz:
+        *val = LSM6DSO_SH_ODR_13Hz;
+        break;
+      default:
+        *val = LSM6DSO_SH_ODR_104Hz;
+        break;
+    }
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      a structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_data;   8 bit data to write
+  *
+  */
+int32_t lsm6dso_sh_cfg_write(lsm6dso_ctx_t *ctx, lsm6dso_sh_cfg_write_t *val)
+{
+  lsm6dso_slv0_add_t reg;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    reg.slave0 = val->slv0_add;
+    reg.rw_0 = 0;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_ADD, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_SUBADD,
+    &(val->slv0_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_DATAWRITE_SLV0,
+    &(val->slv0_data), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_len;    num of bit to read
+  *
+  */
+int32_t lsm6dso_sh_slv0_cfg_read(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sh_cfg_read_t *val)
+{
+  lsm6dso_slv0_add_t slv0_add;
+  lsm6dso_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    slv0_add.slave0 = val->slv_add;
+    slv0_add.rw_0 = 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_SUBADD,
+    &(val->slv_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV0_CONFIG,
+                           (uint8_t*)&slv0_config, 1);
+  }
+  if (ret == 0) {
+    slv0_config.slave0_numop = val->slv_len;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV0_CONFIG,
+                            (uint8_t*)&slv0_config, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write/read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_len;    num of bit to read
+  *
+  */
+int32_t lsm6dso_sh_slv1_cfg_read(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sh_cfg_read_t *val)
+{
+  lsm6dso_slv1_add_t slv1_add;
+  lsm6dso_slv1_config_t slv1_config;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    slv1_add.slave1_add = val->slv_add;
+    slv1_add.r_1 = 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_ADD, (uint8_t*)&slv1_add, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_SUBADD,
+    &(val->slv_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV1_CONFIG,
+                           (uint8_t*)&slv1_config, 1);
+  }
+  if (ret == 0) {
+    slv1_config.slave1_numop = val->slv_len;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV1_CONFIG,
+                            (uint8_t*)&slv1_config, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write/read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t slv2_add;    8 bit i2c device address
+  *                      - uint8_t slv2_subadd; 8 bit register device address
+  *                      - uint8_t slv2_len;    num of bit to read
+  *
+  */
+int32_t lsm6dso_sh_slv2_cfg_read(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sh_cfg_read_t *val)
+{
+  lsm6dso_slv2_add_t slv2_add;
+  lsm6dso_slv2_config_t slv2_config;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    slv2_add.slave2_add = val->slv_add;
+    slv2_add.r_2 = 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV2_ADD, (uint8_t*)&slv2_add, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV2_SUBADD,
+    &(val->slv_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV2_CONFIG,
+                           (uint8_t*)&slv2_config, 1);
+  }
+  if (ret == 0) {
+    slv2_config.slave2_numop = val->slv_len;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV2_CONFIG,
+                            (uint8_t*)&slv2_config, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief Configure slave 0 for perform a write/read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t slv3_add;    8 bit i2c device address
+  *                      - uint8_t slv3_subadd; 8 bit register device address
+  *                      - uint8_t slv3_len;    num of bit to read
+  *
+  */
+int32_t lsm6dso_sh_slv3_cfg_read(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sh_cfg_read_t *val)
+{
+  lsm6dso_slv3_add_t slv3_add;
+  lsm6dso_slv3_config_t slv3_config;
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    slv3_add.slave3_add = val->slv_add;
+    slv3_add.r_3 = 1;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV3_ADD, (uint8_t*)&slv3_add, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV3_SUBADD,
+    &(val->slv_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_SLV3_CONFIG,
+                           (uint8_t*)&slv3_config, 1);
+  }
+  if (ret == 0) {
+    slv3_config.slave3_numop = val->slv_len;
+    ret = lsm6dso_write_reg(ctx, LSM6DSO_SLV3_CONFIG,
+                            (uint8_t*)&slv3_config, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS_MASTER to
+  *
+  */
+int32_t lsm6dso_sh_status_get(lsm6dso_ctx_t *ctx,
+                              lsm6dso_status_master_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dso_read_reg(ctx, LSM6DSO_STATUS_MASTER, (uint8_t*) val, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dso_mem_bank_set(ctx, LSM6DSO_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.h
+++ b/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.h
@@ -1,0 +1,2699 @@
+/*
+ ******************************************************************************
+ * @file    lsm6dso_reg.h
+ * @author  Sensor Solutions Software Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm6dso_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DSO_DRIVER_H
+#define LSM6DSO_DRIVER_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM6DSO
+  * @{
+  *
+  */
+
+/** @defgroup LSM6DSO_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LSM6DSO_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lsm6dso_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lsm6dso_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lsm6dso_write_ptr  write_reg;
+  lsm6dso_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lsm6dso_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DSO_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define LSM6DSO_I2C_ADD_L                    0xD5
+#define LSM6DSO_I2C_ADD_H                    0xD7
+
+/** Device Identification (Who am I) **/
+#define LSM6DSO_ID                           0x6C
+
+/**
+  * @}
+  *
+  */
+
+#define LSM6DSO_FUNC_CFG_ACCESS              0x01U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t reg_access               : 2; /* shub_reg_access + func_cfg_access */
+} lsm6dso_func_cfg_access_t;
+
+#define LSM6DSO_PIN_CTRL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t sdo_pu_en                : 1;
+  uint8_t ois_pu_dis               : 1;
+} lsm6dso_pin_ctrl_t;
+
+#define LSM6DSO_FIFO_CTRL1                   0x07U
+typedef struct {
+  uint8_t wtm                      : 8;
+} lsm6dso_fifo_ctrl1_t;
+
+#define LSM6DSO_FIFO_CTRL2                   0x08U
+typedef struct {
+  uint8_t wtm                      : 1;
+  uint8_t uncoptr_rate             : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t odrchg_en                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t fifo_compr_rt_en         : 1;
+  uint8_t stop_on_wtm              : 1;
+} lsm6dso_fifo_ctrl2_t;
+
+#define LSM6DSO_FIFO_CTRL3                   0x09U
+typedef struct {
+  uint8_t bdr_xl                   : 4;
+  uint8_t bdr_gy                   : 4;
+} lsm6dso_fifo_ctrl3_t;
+
+#define LSM6DSO_FIFO_CTRL4                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t odr_t_batch              : 2;
+  uint8_t odr_ts_batch             : 2;
+} lsm6dso_fifo_ctrl4_t;
+
+#define LSM6DSO_COUNTER_BDR_REG1             0x0BU
+typedef struct {
+  uint8_t cnt_bdr_th               : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t trig_counter_bdr         : 1;
+  uint8_t rst_counter_bdr          : 1;
+  uint8_t dataready_pulsed         : 1;
+} lsm6dso_counter_bdr_reg1_t;
+
+#define LSM6DSO_COUNTER_BDR_REG2             0x0CU
+typedef struct {
+  uint8_t cnt_bdr_th               : 8;
+} lsm6dso_counter_bdr_reg2_t;
+
+#define LSM6DSO_INT1_CTRL  0x0D
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fifo_th             : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_fifo_full           : 1;
+  uint8_t int1_cnt_bdr             : 1;
+  uint8_t den_drdy_flag            : 1;
+} lsm6dso_int1_ctrl_t;
+
+#define LSM6DSO_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fifo_th             : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_fifo_full           : 1;
+  uint8_t int2_cnt_bdr             : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dso_int2_ctrl_t;
+
+#define LSM6DSO_WHO_AM_I                     0x0FU
+#define LSM6DSO_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf2_xl_en               : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} lsm6dso_ctrl1_xl_t;
+
+#define LSM6DSO_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t fs_g                     : 3; /* fs_125 + fs_g */
+  uint8_t odr_g                    : 4;
+} lsm6dso_ctrl2_g_t;
+
+#define LSM6DSO_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} lsm6dso_ctrl3_c_t;
+
+#define LSM6DSO_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep_g                  : 1;
+  uint8_t not_used_03              : 1;
+} lsm6dso_ctrl4_c_t;
+
+#define LSM6DSO_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t rounding                 : 2;
+  uint8_t xl_ulp_en                : 1;
+} lsm6dso_ctrl5_c_t;
+
+#define LSM6DSO_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t ftype                    : 3;
+  uint8_t usr_off_w                : 1;
+  uint8_t xl_hm_mode               : 1;
+  uint8_t den_mode                 : 3;   /* trig_en + lvl1_en + lvl2_en */
+} lsm6dso_ctrl6_c_t;
+
+#define LSM6DSO_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t ois_on                   : 1;
+  uint8_t usr_off_on_out           : 1;
+  uint8_t ois_on_en                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t g_hm_mode                : 1;
+} lsm6dso_ctrl7_g_t;
+
+#define LSM6DSO_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t xl_fs_mode               : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t fastsettl_mode_xl        : 1;
+  uint8_t hp_ref_mode_xl           : 1;
+  uint8_t hpcf_xl                  : 3;
+} lsm6dso_ctrl8_xl_t;
+
+#define LSM6DSO_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t i3c_disable              : 1;
+  uint8_t den_lh                   : 1;
+  uint8_t den_xl_g                 : 2;   /* den_xl_en + den_xl_g */
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} lsm6dso_ctrl9_xl_t;
+
+#define LSM6DSO_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t timestamp_en             : 1;
+  uint8_t not_used_02              : 2;
+} lsm6dso_ctrl10_c_t;
+
+#define LSM6DSO_ALL_INT_SRC                  0x1AU
+typedef struct {
+  uint8_t ff_ia                    : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t single_tap               : 1;
+  uint8_t double_tap               : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t sleep_change_ia          : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t timestamp_endcount       : 1;
+} lsm6dso_all_int_src_t;
+
+#define LSM6DSO_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state              : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t sleep_change_ia          : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dso_wake_up_src_t;
+
+#define LSM6DSO_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_02              : 1;
+} lsm6dso_tap_src_t;
+
+#define LSM6DSO_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} lsm6dso_d6d_src_t;
+
+#define LSM6DSO_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dso_status_reg_t;
+
+#define LSM6DSO_STATUS_SPIAUX                0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t gyro_settling            : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dso_status_spiaux_t;
+
+#define LSM6DSO_OUT_TEMP_L                   0x20U
+#define LSM6DSO_OUT_TEMP_H                   0x21U
+#define LSM6DSO_OUTX_L_G                     0x22U
+#define LSM6DSO_OUTX_H_G                     0x23U
+#define LSM6DSO_OUTY_L_G                     0x24U
+#define LSM6DSO_OUTY_H_G                     0x25U
+#define LSM6DSO_OUTZ_L_G                     0x26U
+#define LSM6DSO_OUTZ_H_G                     0x27U
+#define LSM6DSO_OUTX_L_A                     0x28U
+#define LSM6DSO_OUTX_H_A                     0x29U
+#define LSM6DSO_OUTY_L_A                     0x2AU
+#define LSM6DSO_OUTY_H_A                     0x2BU
+#define LSM6DSO_OUTZ_L_A                     0x2CU
+#define LSM6DSO_OUTZ_H_A                     0x2DU
+#define LSM6DSO_EMB_FUNC_STATUS_MAINPAGE     0x35U
+typedef struct {
+  uint8_t not_used_01             : 3;
+  uint8_t is_step_det             : 1;
+  uint8_t is_tilt                 : 1;
+  uint8_t is_sigmot               : 1;
+  uint8_t not_used_02             : 1;
+  uint8_t is_fsm_lc               : 1;
+} lsm6dso_emb_func_status_mainpage_t;
+
+#define LSM6DSO_FSM_STATUS_A_MAINPAGE        0x36U
+typedef struct {
+  uint8_t is_fsm1                 : 1;
+  uint8_t is_fsm2                 : 1;
+  uint8_t is_fsm3                 : 1;
+  uint8_t is_fsm4                 : 1;
+  uint8_t is_fsm5                 : 1;
+  uint8_t is_fsm6                 : 1;
+  uint8_t is_fsm7                 : 1;
+  uint8_t is_fsm8                 : 1;
+  } lsm6dso_fsm_status_a_mainpage_t;
+
+#define LSM6DSO_FSM_STATUS_B_MAINPAGE        0x37U
+typedef struct {
+  uint8_t IS_FSM9                 : 1;
+  uint8_t IS_FSM10                : 1;
+  uint8_t IS_FSM11                : 1;
+  uint8_t IS_FSM12                : 1;
+  uint8_t IS_FSM13                : 1;
+  uint8_t IS_FSM14                : 1;
+  uint8_t IS_FSM15                : 1;
+  uint8_t IS_FSM16                : 1;
+} lsm6dso_fsm_status_b_mainpage_t;
+
+#define LSM6DSO_STATUS_MASTER_MAINPAGE       0x39U
+typedef struct {
+  uint8_t sens_hub_endop          : 1;
+  uint8_t not_used_01             : 2;
+  uint8_t slave0_nack             : 1;
+  uint8_t slave1_nack             : 1;
+  uint8_t slave2_nack             : 1;
+  uint8_t slave3_nack             : 1;
+  uint8_t wr_once_done            : 1;
+} lsm6dso_status_master_mainpage_t;
+
+#define LSM6DSO_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;
+} lsm6dso_fifo_status1_t;
+
+#define LSM6DSO_FIFO_STATUS2                 0x3B
+typedef struct {
+  uint8_t diff_fifo                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t over_run_latched         : 1;
+  uint8_t counter_bdr_ia           : 1;
+  uint8_t fifo_full_ia             : 1;
+  uint8_t fifo_ovr_ia              : 1;
+  uint8_t fifo_wtm_ia              : 1;
+} lsm6dso_fifo_status2_t;
+
+#define LSM6DSO_TIMESTAMP0                   0x40U
+#define LSM6DSO_TIMESTAMP1                   0x41U
+#define LSM6DSO_TIMESTAMP2                   0x42U
+#define LSM6DSO_TIMESTAMP3                   0x43U
+#define LSM6DSO_TAP_CFG0                     0x56U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t tap_z_en                 : 1;
+  uint8_t tap_y_en                 : 1;
+  uint8_t tap_x_en                 : 1;
+  uint8_t slope_fds                : 1;
+  uint8_t sleep_status_on_int      : 1;
+  uint8_t int_clr_on_read          : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dso_tap_cfg0_t;
+
+#define LSM6DSO_TAP_CFG1                     0x57U
+typedef struct {
+  uint8_t tap_ths_x                : 5;
+  uint8_t tap_priority             : 3;
+} lsm6dso_tap_cfg1_t;
+
+#define LSM6DSO_TAP_CFG2                     0x58U
+typedef struct {
+  uint8_t tap_ths_y                : 5;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} lsm6dso_tap_cfg2_t;
+
+#define LSM6DSO_TAP_THS_6D                   0x59U
+typedef struct {
+  uint8_t tap_ths_z                : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} lsm6dso_tap_ths_6d_t;
+
+#define LSM6DSO_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} lsm6dso_int_dur2_t;
+
+#define LSM6DSO_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t usr_off_on_wu            : 1;
+  uint8_t single_double_tap        : 1;
+} lsm6dso_wake_up_ths_t;
+
+#define LSM6DSO_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t wake_ths_w               : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} lsm6dso_wake_up_dur_t;
+
+#define LSM6DSO_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} lsm6dso_free_fall_t;
+
+#define LSM6DSO_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t int1_shub                : 1;
+  uint8_t int1_emb_func            : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_sleep_change        : 1;
+} lsm6dso_md1_cfg_t;
+
+#define LSM6DSO_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_timestamp           : 1;
+  uint8_t int2_emb_func            : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_sleep_change        : 1;
+} lsm6dso_md2_cfg_t;
+
+#define LSM6DSO_I3C_BUS_AVB                  0x62U
+typedef struct {
+  uint8_t pd_dis_int1              : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t i3c_bus_avb_sel          : 2;
+  uint8_t not_used_02              : 3;
+} lsm6dso_i3c_bus_avb_t;
+
+#define LSM6DSO_INTERNAL_FREQ_FINE           0x63U
+typedef struct {
+  uint8_t freq_fine                : 8;
+} lsm6dso_internal_freq_fine_t;
+
+#define LSM6DSO_INT_OIS                      0x6FU
+typedef struct {
+  uint8_t st_xl_ois                : 2;
+  uint8_t not_used_01              : 3;
+  uint8_t den_lh_ois               : 1;
+  uint8_t lvl2_ois                 : 1;
+  uint8_t int2_drdy_ois            : 1;
+} lsm6dso_int_ois_t;
+
+#define LSM6DSO_CTRL1_OIS                    0x70U
+typedef struct {
+  uint8_t ois_en_spi2              : 1;
+  uint8_t fs_g_ois                 : 3; /* fs_125_ois + fs[1:0]_g_ois */
+  uint8_t mode4_en                 : 1;
+  uint8_t sim_ois                  : 1;
+  uint8_t lvl1_ois                  : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dso_ctrl1_ois_t;
+
+#define LSM6DSO_CTRL2_OIS                    0x71U
+typedef struct {
+  uint8_t hp_en_ois                : 1;
+  uint8_t ftype_ois                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_ois                  : 2;
+  uint8_t not_used_02              : 2;
+} lsm6dso_ctrl2_ois_t;
+
+#define LSM6DSO_CTRL3_OIS                    0x72U
+typedef struct {
+  uint8_t st_ois_clampdis          : 1;
+  uint8_t st_ois                   : 2;
+  uint8_t filter_xl_conf_ois       : 3;
+  uint8_t fs_xl_ois                : 2;
+} lsm6dso_ctrl3_ois_t;
+
+#define LSM6DSO_X_OFS_USR                    0x73U
+#define LSM6DSO_Y_OFS_USR                    0x74U
+#define LSM6DSO_Z_OFS_USR                    0x75U
+#define LSM6DSO_FIFO_DATA_OUT_TAG            0x78U
+typedef struct {
+  uint8_t tag_parity               : 1;
+  uint8_t tag_cnt                  : 2;
+  uint8_t tag_sensor               : 5;
+} lsm6dso_fifo_data_out_tag_t;
+
+#define LSM6DSO_FIFO_DATA_OUT_X_L            0x79U
+#define LSM6DSO_FIFO_DATA_OUT_X_H            0x7AU
+#define LSM6DSO_FIFO_DATA_OUT_Y_L            0x7BU
+#define LSM6DSO_FIFO_DATA_OUT_Y_H            0x7CU
+#define LSM6DSO_FIFO_DATA_OUT_Z_L            0x7DU
+#define LSM6DSO_FIFO_DATA_OUT_Z_H            0x7EU
+#define LSM6DSO_PAGE_SEL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 4;
+  uint8_t page_sel                 : 4;
+} lsm6dso_page_sel_t;
+
+#define LSM6DSO_EMB_FUNC_EN_A                0x04U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t pedo_en                  : 1;
+  uint8_t tilt_en                  : 1;
+  uint8_t sign_motion_en           : 1;
+  uint8_t not_used_02              : 2;
+} lsm6dso_emb_func_en_a_t;
+
+#define LSM6DSO_EMB_FUNC_EN_B                0x05U
+typedef struct {
+  uint8_t fsm_en                   : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t fifo_compr_en            : 1;
+  uint8_t pedo_adv_en              : 1;
+  uint8_t not_used_02              : 3;
+} lsm6dso_emb_func_en_b_t;
+
+#define LSM6DSO_PAGE_ADDRESS                 0x08U
+typedef struct {
+  uint8_t page_addr                : 8;
+} lsm6dso_page_address_t;
+
+#define LSM6DSO_PAGE_VALUE                   0x09U
+typedef struct {
+  uint8_t page_value               : 8;
+} lsm6dso_page_value_t;
+
+#define LSM6DSO_EMB_FUNC_INT1                0x0AU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t int1_step_detector       : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_sig_mot             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int1_fsm_lc              : 1;
+} lsm6dso_emb_func_int1_t;
+
+#define LSM6DSO_FSM_INT1_A                   0x0BU
+typedef struct {
+  uint8_t int1_fsm1                : 1;
+  uint8_t int1_fsm2                : 1;
+  uint8_t int1_fsm3                : 1;
+  uint8_t int1_fsm4                : 1;
+  uint8_t int1_fsm5                : 1;
+  uint8_t int1_fsm6                : 1;
+  uint8_t int1_fsm7                : 1;
+  uint8_t int1_fsm8                : 1;
+} lsm6dso_fsm_int1_a_t;
+
+#define LSM6DSO_FSM_INT1_B                   0x0CU
+typedef struct {
+  uint8_t int1_fsm9                : 1;
+  uint8_t int1_fsm10               : 1;
+  uint8_t int1_fsm11               : 1;
+  uint8_t int1_fsm12               : 1;
+  uint8_t int1_fsm13               : 1;
+  uint8_t int1_fsm14               : 1;
+  uint8_t int1_fsm15               : 1;
+  uint8_t int1_fsm16               : 1;
+} lsm6dso_fsm_int1_b_t;
+
+#define LSM6DSO_EMB_FUNC_INT2                0x0EU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t int2_step_detector       : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_sig_mot             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_fsm_lc              : 1;
+} lsm6dso_emb_func_int2_t;
+
+#define LSM6DSO_FSM_INT2_A                   0x0FU
+typedef struct {
+  uint8_t int2_fsm1                : 1;
+  uint8_t int2_fsm2                : 1;
+  uint8_t int2_fsm3                : 1;
+  uint8_t int2_fsm4                : 1;
+  uint8_t int2_fsm5                : 1;
+  uint8_t int2_fsm6                : 1;
+  uint8_t int2_fsm7                : 1;
+  uint8_t int2_fsm8                : 1;
+} lsm6dso_fsm_int2_a_t;
+
+#define LSM6DSO_FSM_INT2_B                   0x10U
+typedef struct {
+  uint8_t int2_fsm9                : 1;
+  uint8_t int2_fsm10               : 1;
+  uint8_t int2_fsm11               : 1;
+  uint8_t int2_fsm12               : 1;
+  uint8_t int2_fsm13               : 1;
+  uint8_t int2_fsm14               : 1;
+  uint8_t int2_fsm15               : 1;
+  uint8_t int2_fsm16               : 1;
+} lsm6dso_fsm_int2_b_t;
+
+#define LSM6DSO_EMB_FUNC_STATUS              0x12U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t is_step_det              : 1;
+  uint8_t is_tilt                  : 1;
+  uint8_t is_sigmot                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t is_fsm_lc                : 1;
+} lsm6dso_emb_func_status_t;
+
+#define LSM6DSO_FSM_STATUS_A                 0x13U
+typedef struct {
+  uint8_t is_fsm1                  : 1;
+  uint8_t is_fsm2                  : 1;
+  uint8_t is_fsm3                  : 1;
+  uint8_t is_fsm4                  : 1;
+  uint8_t is_fsm5                  : 1;
+  uint8_t is_fsm6                  : 1;
+  uint8_t is_fsm7                  : 1;
+  uint8_t is_fsm8                  : 1;
+} lsm6dso_fsm_status_a_t;
+
+#define LSM6DSO_FSM_STATUS_B                 0x14U
+typedef struct {
+  uint8_t is_fsm9                  : 1;
+  uint8_t is_fsm10                 : 1;
+  uint8_t is_fsm11                 : 1;
+  uint8_t is_fsm12                 : 1;
+  uint8_t is_fsm13                 : 1;
+  uint8_t is_fsm14                 : 1;
+  uint8_t is_fsm15                 : 1;
+  uint8_t is_fsm16                 : 1;
+} lsm6dso_fsm_status_b_t;
+
+#define LSM6DSO_PAGE_RW                      0x17U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t page_rw                  : 2;  /* page_write + page_read */
+  uint8_t emb_func_lir             : 1;
+} lsm6dso_page_rw_t;
+
+#define LSM6DSO_EMB_FUNC_FIFO_CFG			       0x44U
+typedef struct {
+  uint8_t not_used_00              : 6;
+  uint8_t pedo_fifo_en             : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dso_emb_func_fifo_cfg_t;
+
+#define LSM6DSO_FSM_ENABLE_A                 0x46U
+typedef struct {
+  uint8_t fsm1_en                  : 1;
+  uint8_t fsm2_en                  : 1;
+  uint8_t fsm3_en                  : 1;
+  uint8_t fsm4_en                  : 1;
+  uint8_t fsm5_en                  : 1;
+  uint8_t fsm6_en                  : 1;
+  uint8_t fsm7_en                  : 1;
+  uint8_t fsm8_en                  : 1;
+} lsm6dso_fsm_enable_a_t;
+
+#define LSM6DSO_FSM_ENABLE_B                 0x47U
+typedef struct {
+  uint8_t fsm9_en                  : 1;
+  uint8_t fsm10_en                 : 1;
+  uint8_t fsm11_en                 : 1;
+  uint8_t fsm12_en                 : 1;
+  uint8_t fsm13_en                 : 1;
+  uint8_t fsm14_en                 : 1;
+  uint8_t fsm15_en                 : 1;
+  uint8_t fsm16_en                 : 1;
+} lsm6dso_fsm_enable_b_t;
+
+#define LSM6DSO_FSM_LONG_COUNTER_L           0x48U
+#define LSM6DSO_FSM_LONG_COUNTER_H           0x49U
+#define LSM6DSO_FSM_LONG_COUNTER_CLEAR       0x4AU
+typedef struct {
+  uint8_t fsm_lc_clr               : 2;  /* fsm_lc_cleared + fsm_lc_clear */
+  uint8_t not_used_01              : 6;
+} lsm6dso_fsm_long_counter_clear_t;
+
+#define LSM6DSO_FSM_OUTS1                    0x4CU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs1_t;
+
+#define LSM6DSO_FSM_OUTS2                    0x4DU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs2_t;
+
+#define LSM6DSO_FSM_OUTS3                    0x4EU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs3_t;
+
+#define LSM6DSO_FSM_OUTS4                    0x4FU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs4_t;
+
+#define LSM6DSO_FSM_OUTS5                    0x50U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs5_t;
+
+#define LSM6DSO_FSM_OUTS6                    0x51U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs6_t;
+
+#define LSM6DSO_FSM_OUTS7                    0x52U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs7_t;
+
+#define LSM6DSO_FSM_OUTS8                    0x53U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs8_t;
+
+#define LSM6DSO_FSM_OUTS9                    0x54U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs9_t;
+
+#define LSM6DSO_FSM_OUTS10                   0x55U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs10_t;
+
+#define LSM6DSO_FSM_OUTS11                   0x56U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs11_t;
+
+#define LSM6DSO_FSM_OUTS12                   0x57U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs12_t;
+
+#define LSM6DSO_FSM_OUTS13                   0x58U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs13_t;
+
+#define LSM6DSO_FSM_OUTS14                   0x59U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs14_t;
+
+#define LSM6DSO_FSM_OUTS15                   0x5AU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs15_t;
+
+#define LSM6DSO_FSM_OUTS16                   0x5BU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dso_fsm_outs16_t;
+
+#define LSM6DSO_EMB_FUNC_ODR_CFG_B           0x5FU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t fsm_odr                  : 2;
+  uint8_t not_used_02              : 3;
+} lsm6dso_emb_func_odr_cfg_b_t;
+
+#define LSM6DSO_STEP_COUNTER_L               0x62U
+#define LSM6DSO_STEP_COUNTER_H               0x63U
+#define LSM6DSO_EMB_FUNC_SRC                 0x64U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t stepcounter_bit_set      : 1;
+  uint8_t step_overflow            : 1;
+  uint8_t step_count_delta_ia      : 1;
+  uint8_t step_detected            : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t pedo_rst_step            : 1;
+} lsm6dso_emb_func_src_t;
+
+#define LSM6DSO_EMB_FUNC_INIT_A              0x66U
+typedef struct {
+  uint8_t not_used_01               : 3;
+  uint8_t step_det_init             : 1;
+  uint8_t tilt_init                 : 1;
+  uint8_t sig_mot_init              : 1;
+  uint8_t not_used_02               : 2;
+} lsm6dso_emb_func_init_a_t;
+
+#define LSM6DSO_EMB_FUNC_INIT_B              0x67U
+typedef struct {
+  uint8_t fsm_init                 : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t fifo_compr_init          : 1;
+  uint8_t not_used_02              : 4;
+} lsm6dso_emb_func_init_b_t;
+
+#define LSM6DSO_MAG_SENSITIVITY_L            0xBAU
+#define LSM6DSO_MAG_SENSITIVITY_H            0xBBU
+#define LSM6DSO_MAG_OFFX_L                   0xC0U
+#define LSM6DSO_MAG_OFFX_H                   0xC1U
+#define LSM6DSO_MAG_OFFY_L                   0xC2U
+#define LSM6DSO_MAG_OFFY_H                   0xC3U
+#define LSM6DSO_MAG_OFFZ_L                   0xC4U
+#define LSM6DSO_MAG_OFFZ_H                   0xC5U
+#define LSM6DSO_MAG_SI_XX_L                  0xC6U
+#define LSM6DSO_MAG_SI_XX_H                  0xC7U
+#define LSM6DSO_MAG_SI_XY_L                  0xC8U
+#define LSM6DSO_MAG_SI_XY_H                  0xC9U
+#define LSM6DSO_MAG_SI_XZ_L                  0xCAU
+#define LSM6DSO_MAG_SI_XZ_H                  0xCBU
+#define LSM6DSO_MAG_SI_YY_L                  0xCCU
+#define LSM6DSO_MAG_SI_YY_H                  0xCDU
+#define LSM6DSO_MAG_SI_YZ_L                  0xCEU
+#define LSM6DSO_MAG_SI_YZ_H                  0xCFU
+#define LSM6DSO_MAG_SI_ZZ_L                  0xD0U
+#define LSM6DSO_MAG_SI_ZZ_H                  0xD1U
+#define LSM6DSO_MAG_CFG_A                    0xD4U
+typedef struct {
+  uint8_t mag_z_axis               : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t mag_y_axis               : 3;
+  uint8_t not_used_02              : 1;
+} lsm6dso_mag_cfg_a_t;
+
+#define LSM6DSO_MAG_CFG_B                    0xD5U
+typedef struct {
+  uint8_t mag_x_axis               : 3;
+  uint8_t not_used_01              : 5;
+} lsm6dso_mag_cfg_b_t;
+
+#define LSM6DSO_FSM_LC_TIMEOUT_L             0x17AU
+#define LSM6DSO_FSM_LC_TIMEOUT_H             0x17BU
+#define LSM6DSO_FSM_PROGRAMS                 0x17CU
+#define LSM6DSO_FSM_START_ADD_L              0x17EU
+#define LSM6DSO_FSM_START_ADD_H              0x17FU
+#define LSM6DSO_PEDO_CMD_REG                 0x183U
+typedef struct {
+  uint8_t ad_det_en                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t fp_rejection_en          : 1;
+  uint8_t carry_count_en           : 1;
+  uint8_t not_used_02              : 4;
+} lsm6dso_pedo_cmd_reg_t;
+
+#define LSM6DSO_PEDO_DEB_STEPS_CONF          0x184U
+#define LSM6DSO_PEDO_SC_DELTAT_L             0x1D0U
+#define LSM6DSO_PEDO_SC_DELTAT_H             0x1D1U
+#define LSM6DSO_SENSOR_HUB_1                 0x02U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_1_t;
+
+#define LSM6DSO_SENSOR_HUB_2                 0x03U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_2_t;
+
+#define LSM6DSO_SENSOR_HUB_3                 0x04U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_3_t;
+
+#define LSM6DSO_SENSOR_HUB_4                 0x05U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_4_t;
+
+#define LSM6DSO_SENSOR_HUB_5                 0x06U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_5_t;
+
+#define LSM6DSO_SENSOR_HUB_6                 0x07U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_6_t;
+
+#define LSM6DSO_SENSOR_HUB_7                 0x08U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_7_t;
+
+#define LSM6DSO_SENSOR_HUB_8                 0x09U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_8_t;
+
+#define LSM6DSO_SENSOR_HUB_9                 0x0AU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_9_t;
+
+#define LSM6DSO_SENSOR_HUB_10                0x0BU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_10_t;
+
+#define LSM6DSO_SENSOR_HUB_11                0x0CU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_11_t;
+
+#define LSM6DSO_SENSOR_HUB_12                0x0DU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_12_t;
+
+#define LSM6DSO_SENSOR_HUB_13                0x0EU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_13_t;
+
+#define LSM6DSO_SENSOR_HUB_14                0x0FU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_14_t;
+
+#define LSM6DSO_SENSOR_HUB_15                0x10U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_15_t;
+
+#define LSM6DSO_SENSOR_HUB_16                0x11U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_16_t;
+
+#define LSM6DSO_SENSOR_HUB_17                0x12U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_17_t;
+
+#define LSM6DSO_SENSOR_HUB_18                0x13U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dso_sensor_hub_18_t;
+
+#define LSM6DSO_MASTER_CONFIG                0x14U
+typedef struct {
+  uint8_t aux_sens_on              : 2;
+  uint8_t master_on                : 1;
+  uint8_t shub_pu_en               : 1;
+  uint8_t pass_through_mode        : 1;
+  uint8_t start_config             : 1;
+  uint8_t write_once               : 1;
+  uint8_t rst_master_regs          : 1;
+} lsm6dso_master_config_t;
+
+#define LSM6DSO_SLV0_ADD                     0x15U
+typedef struct {
+  uint8_t rw_0                     : 1;
+  uint8_t slave0                   : 7;
+} lsm6dso_slv0_add_t;
+
+#define LSM6DSO_SLV0_SUBADD                  0x16U
+typedef struct {
+  uint8_t slave0_reg               : 8;
+} lsm6dso_slv0_subadd_t;
+
+#define LSM6DSO_SLV0_CONFIG                  0x17U
+typedef struct {
+  uint8_t slave0_numop             : 3;
+  uint8_t batch_ext_sens_0_en      : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t shub_odr                 : 2;
+} lsm6dso_slv0_config_t;
+
+#define LSM6DSO_SLV1_ADD                     0x18U
+typedef struct {
+  uint8_t r_1                      : 1;
+  uint8_t slave1_add               : 7;
+} lsm6dso_slv1_add_t;
+
+#define LSM6DSO_SLV1_SUBADD                  0x19U
+typedef struct {
+  uint8_t slave1_reg               : 8;
+} lsm6dso_slv1_subadd_t;
+
+#define LSM6DSO_SLV1_CONFIG                  0x1AU
+typedef struct {
+  uint8_t slave1_numop             : 3;
+  uint8_t batch_ext_sens_1_en      : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dso_slv1_config_t;
+
+#define LSM6DSO_SLV2_ADD                     0x1BU
+typedef struct {
+  uint8_t r_2                      : 1;
+  uint8_t slave2_add               : 7;
+} lsm6dso_slv2_add_t;
+
+#define LSM6DSO_SLV2_SUBADD                  0x1CU
+typedef struct {
+  uint8_t slave2_reg               : 8;
+} lsm6dso_slv2_subadd_t;
+
+#define LSM6DSO_SLV2_CONFIG                  0x1DU
+typedef struct {
+  uint8_t slave2_numop             : 3;
+  uint8_t batch_ext_sens_2_en      : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dso_slv2_config_t;
+
+#define LSM6DSO_SLV3_ADD                     0x1EU
+typedef struct {
+  uint8_t r_3                      : 1;
+  uint8_t slave3_add               : 7;
+} lsm6dso_slv3_add_t;
+
+#define LSM6DSO_SLV3_SUBADD                  0x1FU
+typedef struct {
+  uint8_t slave3_reg               : 8;
+} lsm6dso_slv3_subadd_t;
+
+#define LSM6DSO_SLV3_CONFIG                  0x20U
+typedef struct {
+  uint8_t slave3_numop             : 3;
+  uint8_t  batch_ext_sens_3_en     : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dso_slv3_config_t;
+
+#define LSM6DSO_DATAWRITE_SLV0               0x21U
+typedef struct {
+  uint8_t slave0_dataw             : 8;
+} lsm6dso_datawrite_src_mode_sub_slv0_t;
+
+#define LSM6DSO_STATUS_MASTER                0x22U
+typedef struct {
+  uint8_t sens_hub_endop           : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t slave0_nack              : 1;
+  uint8_t slave1_nack              : 1;
+  uint8_t slave2_nack              : 1;
+  uint8_t slave3_nack              : 1;
+  uint8_t wr_once_done             : 1;
+} lsm6dso_status_master_t;
+
+/**
+  * @defgroup LSM6DSO_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lsm6dso_func_cfg_access_t               func_cfg_access;
+  lsm6dso_pin_ctrl_t                      pin_ctrl;
+  lsm6dso_fifo_ctrl1_t                    fifo_ctrl1;
+  lsm6dso_fifo_ctrl2_t                    fifo_ctrl2;
+  lsm6dso_fifo_ctrl3_t                    fifo_ctrl3;
+  lsm6dso_fifo_ctrl4_t                    fifo_ctrl4;
+  lsm6dso_counter_bdr_reg1_t              counter_bdr_reg1;
+  lsm6dso_counter_bdr_reg2_t              counter_bdr_reg2;
+  lsm6dso_int1_ctrl_t                     int1_ctrl;
+  lsm6dso_int2_ctrl_t                     int2_ctrl;
+  lsm6dso_ctrl1_xl_t                      ctrl1_xl;
+  lsm6dso_ctrl2_g_t                       ctrl2_g;
+  lsm6dso_ctrl3_c_t                       ctrl3_c;
+  lsm6dso_ctrl4_c_t                       ctrl4_c;
+  lsm6dso_ctrl5_c_t                       ctrl5_c;
+  lsm6dso_ctrl6_c_t                       ctrl6_c;
+  lsm6dso_ctrl7_g_t                       ctrl7_g;
+  lsm6dso_ctrl8_xl_t                      ctrl8_xl;
+  lsm6dso_ctrl9_xl_t                      ctrl9_xl;
+  lsm6dso_ctrl10_c_t                      ctrl10_c;
+  lsm6dso_all_int_src_t                   all_int_src;
+  lsm6dso_wake_up_src_t                   wake_up_src;
+  lsm6dso_tap_src_t                       tap_src;
+  lsm6dso_d6d_src_t                       d6d_src;
+  lsm6dso_status_reg_t                    status_reg;
+  lsm6dso_status_spiaux_t                 status_spiaux;
+  lsm6dso_fifo_status1_t                  fifo_status1;
+  lsm6dso_fifo_status2_t                  fifo_status2;
+  lsm6dso_tap_cfg0_t                      tap_cfg0;
+  lsm6dso_tap_cfg1_t                      tap_cfg1;
+  lsm6dso_tap_cfg2_t                      tap_cfg2;
+  lsm6dso_tap_ths_6d_t                    tap_ths_6d;
+  lsm6dso_int_dur2_t                      int_dur2;
+  lsm6dso_wake_up_ths_t                   wake_up_ths;
+  lsm6dso_wake_up_dur_t                   wake_up_dur;
+  lsm6dso_free_fall_t                     free_fall;
+  lsm6dso_md1_cfg_t                       md1_cfg;
+  lsm6dso_md2_cfg_t                       md2_cfg;
+  lsm6dso_i3c_bus_avb_t                   i3c_bus_avb;
+  lsm6dso_internal_freq_fine_t            internal_freq_fine;
+  lsm6dso_int_ois_t                       int_ois;
+  lsm6dso_ctrl1_ois_t                     ctrl1_ois;
+  lsm6dso_ctrl2_ois_t                     ctrl2_ois;
+  lsm6dso_ctrl3_ois_t                     ctrl3_ois;
+  lsm6dso_fifo_data_out_tag_t             fifo_data_out_tag;
+  lsm6dso_page_sel_t                      page_sel;
+  lsm6dso_emb_func_en_a_t                 emb_func_en_a;
+  lsm6dso_emb_func_en_b_t                 emb_func_en_b;
+  lsm6dso_page_address_t                  page_address;
+  lsm6dso_page_value_t                    page_value;
+  lsm6dso_emb_func_int1_t                 emb_func_int1;
+  lsm6dso_fsm_int1_a_t                    fsm_int1_a;
+  lsm6dso_fsm_int1_b_t                    fsm_int1_b;
+  lsm6dso_emb_func_int2_t                 emb_func_int2;
+  lsm6dso_fsm_int2_a_t                    fsm_int2_a;
+  lsm6dso_fsm_int2_b_t                    fsm_int2_b;
+  lsm6dso_emb_func_status_t               emb_func_status;
+  lsm6dso_fsm_status_a_t                  fsm_status_a;
+  lsm6dso_fsm_status_b_t                  fsm_status_b;
+  lsm6dso_page_rw_t                       page_rw;
+  lsm6dso_emb_func_fifo_cfg_t	            emb_func_fifo_cfg;
+  lsm6dso_fsm_enable_a_t                  fsm_enable_a;
+  lsm6dso_fsm_enable_b_t                  fsm_enable_b;
+  lsm6dso_fsm_long_counter_clear_t        fsm_long_counter_clear;
+  lsm6dso_fsm_outs1_t                     fsm_outs1;
+  lsm6dso_fsm_outs2_t                     fsm_outs2;
+  lsm6dso_fsm_outs3_t                     fsm_outs3;
+  lsm6dso_fsm_outs4_t                     fsm_outs4;
+  lsm6dso_fsm_outs5_t                     fsm_outs5;
+  lsm6dso_fsm_outs6_t                     fsm_outs6;
+  lsm6dso_fsm_outs7_t                     fsm_outs7;
+  lsm6dso_fsm_outs8_t                     fsm_outs8;
+  lsm6dso_fsm_outs9_t                     fsm_outs9;
+  lsm6dso_fsm_outs10_t                    fsm_outs10;
+  lsm6dso_fsm_outs11_t                    fsm_outs11;
+  lsm6dso_fsm_outs12_t                    fsm_outs12;
+  lsm6dso_fsm_outs13_t                    fsm_outs13;
+  lsm6dso_fsm_outs14_t                    fsm_outs14;
+  lsm6dso_fsm_outs15_t                    fsm_outs15;
+  lsm6dso_fsm_outs16_t                    fsm_outs16;
+  lsm6dso_emb_func_odr_cfg_b_t            emb_func_odr_cfg_b;
+  lsm6dso_emb_func_src_t                  emb_func_src;
+  lsm6dso_emb_func_init_a_t               emb_func_init_a;
+  lsm6dso_emb_func_init_b_t               emb_func_init_b;
+  lsm6dso_mag_cfg_a_t                     mag_cfg_a;
+  lsm6dso_mag_cfg_b_t                     mag_cfg_b;
+  lsm6dso_pedo_cmd_reg_t                  pedo_cmd_reg;
+  lsm6dso_sensor_hub_1_t                  sensor_hub_1;
+  lsm6dso_sensor_hub_2_t                  sensor_hub_2;
+  lsm6dso_sensor_hub_3_t                  sensor_hub_3;
+  lsm6dso_sensor_hub_4_t                  sensor_hub_4;
+  lsm6dso_sensor_hub_5_t                  sensor_hub_5;
+  lsm6dso_sensor_hub_6_t                  sensor_hub_6;
+  lsm6dso_sensor_hub_7_t                  sensor_hub_7;
+  lsm6dso_sensor_hub_8_t                  sensor_hub_8;
+  lsm6dso_sensor_hub_9_t                  sensor_hub_9;
+  lsm6dso_sensor_hub_10_t                 sensor_hub_10;
+  lsm6dso_sensor_hub_11_t                 sensor_hub_11;
+  lsm6dso_sensor_hub_12_t                 sensor_hub_12;
+  lsm6dso_sensor_hub_13_t                 sensor_hub_13;
+  lsm6dso_sensor_hub_14_t                 sensor_hub_14;
+  lsm6dso_sensor_hub_15_t                 sensor_hub_15;
+  lsm6dso_sensor_hub_16_t                 sensor_hub_16;
+  lsm6dso_sensor_hub_17_t                 sensor_hub_17;
+  lsm6dso_sensor_hub_18_t                 sensor_hub_18;
+  lsm6dso_master_config_t                 master_config;
+  lsm6dso_slv0_add_t                      slv0_add;
+  lsm6dso_slv0_subadd_t                   slv0_subadd;
+  lsm6dso_slv0_config_t                   slv0_config;
+  lsm6dso_slv1_add_t                      slv1_add;
+  lsm6dso_slv1_subadd_t                   slv1_subadd;
+  lsm6dso_slv1_config_t                   slv1_config;
+  lsm6dso_slv2_add_t                      slv2_add;
+  lsm6dso_slv2_subadd_t                   slv2_subadd;
+  lsm6dso_slv2_config_t                   slv2_config;
+  lsm6dso_slv3_add_t                      slv3_add;
+  lsm6dso_slv3_subadd_t                   slv3_subadd;
+  lsm6dso_slv3_config_t                   slv3_config;
+  lsm6dso_datawrite_src_mode_sub_slv0_t   datawrite_src_mode_sub_slv0;
+  lsm6dso_status_master_t                 status_master;
+  bitwise_t                               bitwise;
+  uint8_t                                 byte;
+} lsm6dso_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm6dso_read_reg(lsm6dso_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lsm6dso_write_reg(lsm6dso_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lsm6dso_from_fs2_to_mg(int16_t lsb);
+extern float_t lsm6dso_from_fs4_to_mg(int16_t lsb);
+extern float_t lsm6dso_from_fs8_to_mg(int16_t lsb);
+extern float_t lsm6dso_from_fs16_to_mg(int16_t lsb);
+extern float_t lsm6dso_from_fs125_to_mdps(int16_t lsb);
+extern float_t lsm6dso_from_fs500_to_mdps(int16_t lsb);
+extern float_t lsm6dso_from_fs250_to_mdps(int16_t lsb);
+extern float_t lsm6dso_from_fs1000_to_mdps(int16_t lsb);
+extern float_t lsm6dso_from_fs2000_to_mdps(int16_t lsb);
+extern float_t lsm6dso_from_lsb_to_celsius(int16_t lsb);
+extern float_t lsm6dso_from_lsb_to_nsec(int16_t lsb);
+
+typedef enum {
+  LSM6DSO_2g   = 0,
+  LSM6DSO_16g  = 1, /* if XL_FS_MODE = ‘1’ -> LSM6DSO_2g */
+  LSM6DSO_4g   = 2,
+  LSM6DSO_8g   = 3,
+} lsm6dso_fs_xl_t;
+int32_t lsm6dso_xl_full_scale_set(lsm6dso_ctx_t *ctx, lsm6dso_fs_xl_t val);
+int32_t lsm6dso_xl_full_scale_get(lsm6dso_ctx_t *ctx, lsm6dso_fs_xl_t *val);
+
+typedef enum {
+  LSM6DSO_XL_ODR_OFF    = 0,
+  LSM6DSO_XL_ODR_12Hz5  = 1,
+  LSM6DSO_XL_ODR_26Hz   = 2,
+  LSM6DSO_XL_ODR_52Hz   = 3,
+  LSM6DSO_XL_ODR_104Hz  = 4,
+  LSM6DSO_XL_ODR_208Hz  = 5,
+  LSM6DSO_XL_ODR_417Hz  = 6,
+  LSM6DSO_XL_ODR_833Hz  = 7,
+  LSM6DSO_XL_ODR_1667Hz = 8,
+  LSM6DSO_XL_ODR_3333Hz = 9,
+  LSM6DSO_XL_ODR_6667Hz = 10,
+  LSM6DSO_XL_ODR_6Hz5   = 11, /* (low power only) */
+} lsm6dso_odr_xl_t;
+int32_t lsm6dso_xl_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_odr_xl_t val);
+int32_t lsm6dso_xl_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_odr_xl_t *val);
+
+typedef enum {
+  LSM6DSO_250dps   = 0,
+  LSM6DSO_125dps   = 1,
+  LSM6DSO_500dps   = 2,
+  LSM6DSO_1000dps  = 4,
+  LSM6DSO_2000dps  = 6,
+} lsm6dso_fs_g_t;
+int32_t lsm6dso_gy_full_scale_set(lsm6dso_ctx_t *ctx, lsm6dso_fs_g_t val);
+int32_t lsm6dso_gy_full_scale_get(lsm6dso_ctx_t *ctx, lsm6dso_fs_g_t *val);
+
+typedef enum {
+  LSM6DSO_GY_ODR_OFF    = 0,
+  LSM6DSO_GY_ODR_12Hz5  = 1,
+  LSM6DSO_GY_ODR_26Hz   = 2,
+  LSM6DSO_GY_ODR_52Hz   = 3,
+  LSM6DSO_GY_ODR_104Hz  = 4,
+  LSM6DSO_GY_ODR_208Hz  = 5,
+  LSM6DSO_GY_ODR_417Hz  = 6,
+  LSM6DSO_GY_ODR_833Hz  = 7,
+  LSM6DSO_GY_ODR_1667Hz = 8,
+  LSM6DSO_GY_ODR_3333Hz = 9,
+  LSM6DSO_GY_ODR_6667Hz = 10,
+} lsm6dso_odr_g_t;
+int32_t lsm6dso_gy_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_odr_g_t val);
+int32_t lsm6dso_gy_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_odr_g_t *val);
+
+int32_t lsm6dso_block_data_update_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_block_data_update_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_LSb_1mg  = 0,
+  LSM6DSO_LSb_16mg = 1,
+} lsm6dso_usr_off_w_t;
+int32_t lsm6dso_xl_offset_weight_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_usr_off_w_t val);
+int32_t lsm6dso_xl_offset_weight_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_usr_off_w_t *val);
+
+typedef enum {
+  LSM6DSO_HIGH_PERFORMANCE_MD  = 0,
+  LSM6DSO_LOW_NORMAL_POWER_MD  = 1,
+  LSM6DSO_ULTRA_LOW_POWER_MD   = 2,
+} lsm6dso_xl_hm_mode_t;
+int32_t lsm6dso_xl_power_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_xl_hm_mode_t val);
+int32_t lsm6dso_xl_power_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_xl_hm_mode_t *val);
+
+typedef enum {
+  LSM6DSO_GY_HIGH_PERFORMANCE  = 0,
+  LSM6DSO_GY_NORMAL            = 1,
+} lsm6dso_g_hm_mode_t;
+int32_t lsm6dso_gy_power_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_g_hm_mode_t val);
+int32_t lsm6dso_gy_power_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_g_hm_mode_t *val);
+
+typedef struct {
+  lsm6dso_all_int_src_t       all_int_src;
+  lsm6dso_wake_up_src_t       wake_up_src;
+  lsm6dso_tap_src_t           tap_src;
+  lsm6dso_d6d_src_t           d6d_src;
+  lsm6dso_status_reg_t        status_reg;
+  lsm6dso_emb_func_status_t   emb_func_status;
+  lsm6dso_fsm_status_a_t      fsm_status_a;
+  lsm6dso_fsm_status_b_t      fsm_status_b;
+} lsm6dso_all_sources_t;
+int32_t lsm6dso_all_sources_get(lsm6dso_ctx_t *ctx,
+                                lsm6dso_all_sources_t *val);
+
+int32_t lsm6dso_status_reg_get(lsm6dso_ctx_t *ctx,
+                               lsm6dso_status_reg_t *val);
+
+int32_t lsm6dso_xl_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_gy_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_temp_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_xl_usr_offset_x_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_x_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_xl_usr_offset_y_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_y_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_xl_usr_offset_z_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_z_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_xl_usr_offset_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_usr_offset_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_timestamp_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_timestamp_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_timestamp_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSO_NO_ROUND      = 0,
+  LSM6DSO_ROUND_XL      = 1,
+  LSM6DSO_ROUND_GY      = 2,
+  LSM6DSO_ROUND_GY_XL   = 3,
+} lsm6dso_rounding_t;
+int32_t lsm6dso_rounding_mode_set(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_rounding_t val);
+int32_t lsm6dso_rounding_mode_get(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_rounding_t *val);
+
+int32_t lsm6dso_temperature_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_angular_rate_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_acceleration_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_fifo_out_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_number_of_steps_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_steps_reset(lsm6dso_ctx_t *ctx);
+
+int32_t lsm6dso_odr_cal_reg_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_odr_cal_reg_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_USER_BANK           = 0,
+  LSM6DSO_SENSOR_HUB_BANK     = 1,
+  LSM6DSO_EMBEDDED_FUNC_BANK  = 2,
+} lsm6dso_reg_access_t;
+int32_t lsm6dso_mem_bank_set(lsm6dso_ctx_t *ctx, lsm6dso_reg_access_t val);
+int32_t lsm6dso_mem_bank_get(lsm6dso_ctx_t *ctx, lsm6dso_reg_access_t *val);
+
+int32_t lsm6dso_ln_pg_write_byte(lsm6dso_ctx_t *ctx, uint16_t address,
+                                 uint8_t *val);
+int32_t lsm6dso_ln_pg_read_byte(lsm6dso_ctx_t *ctx, uint16_t address,
+                                uint8_t *val);
+int32_t lsm6dso_ln_pg_write(lsm6dso_ctx_t *ctx, uint16_t address,
+                            uint8_t *buf, uint8_t len);
+int32_t lsm6dso_ln_pg_read(lsm6dso_ctx_t *ctx, uint16_t address,
+                           uint8_t *val);
+
+typedef enum {
+  LSM6DSO_DRDY_LATCHED = 0,
+  LSM6DSO_DRDY_PULSED  = 1,
+} lsm6dso_dataready_pulsed_t;
+int32_t lsm6dso_data_ready_mode_set(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_dataready_pulsed_t val);
+int32_t lsm6dso_data_ready_mode_get(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_dataready_pulsed_t *val);
+
+int32_t lsm6dso_device_id_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_reset_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_reset_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_auto_increment_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_auto_increment_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_boot_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_boot_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_XL_ST_DISABLE  = 0,
+  LSM6DSO_XL_ST_POSITIVE = 1,
+  LSM6DSO_XL_ST_NEGATIVE = 2,
+} lsm6dso_st_xl_t;
+int32_t lsm6dso_xl_self_test_set(lsm6dso_ctx_t *ctx, lsm6dso_st_xl_t val);
+int32_t lsm6dso_xl_self_test_get(lsm6dso_ctx_t *ctx, lsm6dso_st_xl_t *val);
+
+typedef enum {
+  LSM6DSO_GY_ST_DISABLE  = 0,
+  LSM6DSO_GY_ST_POSITIVE = 1,
+  LSM6DSO_GY_ST_NEGATIVE = 3,
+} lsm6dso_st_g_t;
+int32_t lsm6dso_gy_self_test_set(lsm6dso_ctx_t *ctx, lsm6dso_st_g_t val);
+int32_t lsm6dso_gy_self_test_get(lsm6dso_ctx_t *ctx, lsm6dso_st_g_t *val);
+
+int32_t lsm6dso_xl_filter_lp2_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_filter_lp2_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_gy_filter_lp1_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_gy_filter_lp1_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_filter_settling_mask_set(lsm6dso_ctx_t *ctx,
+                                         uint8_t val);
+int32_t lsm6dso_filter_settling_mask_get(lsm6dso_ctx_t *ctx,
+                                         uint8_t *val);
+
+typedef enum {
+  LSM6DSO_ULTRA_LIGHT  = 0,
+  LSM6DSO_VERY_LIGHT   = 1,
+  LSM6DSO_LIGHT        = 2,
+  LSM6DSO_MEDIUM       = 3,
+  LSM6DSO_STRONG       = 4, /* not available for data rate > 1k670Hz */
+  LSM6DSO_VERY_STRONG  = 5, /* not available for data rate > 1k670Hz */
+  LSM6DSO_AGGRESSIVE   = 6, /* not available for data rate > 1k670Hz */
+  LSM6DSO_XTREME       = 7, /* not available for data rate > 1k670Hz */
+} lsm6dso_ftype_t;
+int32_t lsm6dso_gy_lp1_bandwidth_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_ftype_t val);
+int32_t lsm6dso_gy_lp1_bandwidth_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_ftype_t *val);
+
+int32_t lsm6dso_xl_lp2_on_6d_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_lp2_on_6d_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_HP_PATH_DISABLE_ON_OUT    = 0x00,
+  LSM6DSO_SLOPE_ODR_DIV_4           = 0x10,
+  LSM6DSO_HP_ODR_DIV_10             = 0x11,
+  LSM6DSO_HP_ODR_DIV_20             = 0x12,
+  LSM6DSO_HP_ODR_DIV_45             = 0x13,
+  LSM6DSO_HP_ODR_DIV_100            = 0x14,
+  LSM6DSO_HP_ODR_DIV_200            = 0x15,
+  LSM6DSO_HP_ODR_DIV_400            = 0x16,
+  LSM6DSO_HP_ODR_DIV_800            = 0x17,
+  LSM6DSO_HP_REF_MD_ODR_DIV_10      = 0x31,
+  LSM6DSO_HP_REF_MD_ODR_DIV_20      = 0x32,
+  LSM6DSO_HP_REF_MD_ODR_DIV_45      = 0x33,
+  LSM6DSO_HP_REF_MD_ODR_DIV_100     = 0x34,
+  LSM6DSO_HP_REF_MD_ODR_DIV_200     = 0x35,
+  LSM6DSO_HP_REF_MD_ODR_DIV_400     = 0x36,
+  LSM6DSO_HP_REF_MD_ODR_DIV_800     = 0x37,
+  LSM6DSO_LP_ODR_DIV_10             = 0x01,
+  LSM6DSO_LP_ODR_DIV_20             = 0x02,
+  LSM6DSO_LP_ODR_DIV_45             = 0x03,
+  LSM6DSO_LP_ODR_DIV_100            = 0x04,
+  LSM6DSO_LP_ODR_DIV_200            = 0x05,
+  LSM6DSO_LP_ODR_DIV_400            = 0x06,
+  LSM6DSO_LP_ODR_DIV_800            = 0x07,
+} lsm6dso_hp_slope_xl_en_t;
+int32_t lsm6dso_xl_hp_path_on_out_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_hp_slope_xl_en_t val);
+int32_t lsm6dso_xl_hp_path_on_out_get(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_hp_slope_xl_en_t *val);
+
+int32_t lsm6dso_xl_fast_settling_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_fast_settling_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_USE_SLOPE = 0,
+  LSM6DSO_USE_HPF   = 1,
+} lsm6dso_slope_fds_t;
+int32_t lsm6dso_xl_hp_path_internal_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_slope_fds_t val);
+int32_t lsm6dso_xl_hp_path_internal_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_slope_fds_t *val);
+
+typedef enum {
+  LSM6DSO_HP_FILTER_NONE     = 0x00,
+  LSM6DSO_HP_FILTER_16mHz    = 0x80,
+  LSM6DSO_HP_FILTER_65mHz    = 0x81,
+  LSM6DSO_HP_FILTER_260mHz   = 0x82,
+  LSM6DSO_HP_FILTER_1Hz04    = 0x83,
+} lsm6dso_hpm_g_t;
+int32_t lsm6dso_gy_hp_path_internal_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_hpm_g_t val);
+int32_t lsm6dso_gy_hp_path_internal_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_hpm_g_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_PULL_UP_DISC       = 0,
+  LSM6DSO_AUX_PULL_UP_CONNECT    = 1,
+} lsm6dso_ois_pu_dis_t;
+int32_t lsm6dso_aux_sdo_ocs_mode_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_ois_pu_dis_t val);
+int32_t lsm6dso_aux_sdo_ocs_mode_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_ois_pu_dis_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_ON                    = 1,
+  LSM6DSO_AUX_ON_BY_AUX_INTERFACE   = 0,
+} lsm6dso_ois_on_t;
+int32_t lsm6dso_aux_pw_on_ctrl_set(lsm6dso_ctx_t *ctx, lsm6dso_ois_on_t val);
+int32_t lsm6dso_aux_pw_on_ctrl_get(lsm6dso_ctx_t *ctx, lsm6dso_ois_on_t *val);
+
+typedef enum {
+  LSM6DSO_USE_SAME_XL_FS        = 0,
+  LSM6DSO_USE_DIFFERENT_XL_FS   = 1,
+} lsm6dso_xl_fs_mode_t;
+int32_t lsm6dso_aux_xl_fs_mode_set(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_xl_fs_mode_t val);
+int32_t lsm6dso_aux_xl_fs_mode_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_xl_fs_mode_t *val);
+
+int32_t lsm6dso_aux_status_reg_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_status_spiaux_t *val);
+
+int32_t lsm6dso_aux_xl_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_aux_gy_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_aux_gy_flag_settling_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_XL_DISABLE = 0,
+  LSM6DSO_AUX_XL_POS     = 1,
+  LSM6DSO_AUX_XL_NEG     = 2,
+} lsm6dso_st_xl_ois_t;
+int32_t lsm6dso_aux_xl_self_test_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_st_xl_ois_t val);
+int32_t lsm6dso_aux_xl_self_test_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_st_xl_ois_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_DEN_ACTIVE_LOW     = 0,
+  LSM6DSO_AUX_DEN_ACTIVE_HIGH    = 1,
+} lsm6dso_den_lh_ois_t;
+int32_t lsm6dso_aux_den_polarity_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_den_lh_ois_t val);
+int32_t lsm6dso_aux_den_polarity_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_den_lh_ois_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_DEN_DISABLE         = 0,
+  LSM6DSO_AUX_DEN_LEVEL_LATCH     = 3,
+  LSM6DSO_AUX_DEN_LEVEL_TRIG      = 2,
+} lsm6dso_lvl2_ois_t;
+int32_t lsm6dso_aux_den_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_lvl2_ois_t val);
+int32_t lsm6dso_aux_den_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_lvl2_ois_t *val);
+
+int32_t lsm6dso_aux_drdy_on_int2_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_aux_drdy_on_int2_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_DISABLE  = 0,
+  LSM6DSO_MODE_3_GY    = 1,
+  LSM6DSO_MODE_4_GY_XL = 3,
+} lsm6dso_ois_en_spi2_t;
+int32_t lsm6dso_aux_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_ois_en_spi2_t val);
+int32_t lsm6dso_aux_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_ois_en_spi2_t *val);
+
+typedef enum {
+  LSM6DSO_250dps_AUX  = 0,
+  LSM6DSO_125dps_AUX  = 1,
+  LSM6DSO_500dps_AUX  = 2,
+  LSM6DSO_1000dps_AUX = 4,
+  LSM6DSO_2000dps_AUX = 6,
+} lsm6dso_fs_g_ois_t;
+int32_t lsm6dso_aux_gy_full_scale_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_fs_g_ois_t val);
+int32_t lsm6dso_aux_gy_full_scale_get(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_fs_g_ois_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_SPI_4_WIRE = 0,
+  LSM6DSO_AUX_SPI_3_WIRE = 1,
+} lsm6dso_sim_ois_t;
+int32_t lsm6dso_aux_spi_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_sim_ois_t val);
+int32_t lsm6dso_aux_spi_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_sim_ois_t *val);
+
+typedef enum {
+  LSM6DSO_351Hz39 = 0,
+  LSM6DSO_236Hz63 = 1,
+  LSM6DSO_172Hz70 = 2,
+  LSM6DSO_937Hz91 = 3,
+} lsm6dso_ftype_ois_t;
+int32_t lsm6dso_aux_gy_lp1_bandwidth_set(lsm6dso_ctx_t *ctx,
+                                          lsm6dso_ftype_ois_t val);
+int32_t lsm6dso_aux_gy_lp1_bandwidth_get(lsm6dso_ctx_t *ctx,
+                                          lsm6dso_ftype_ois_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_HP_DISABLE = 0x00,
+  LSM6DSO_AUX_HP_Hz016   = 0x10,
+  LSM6DSO_AUX_HP_Hz065   = 0x11,
+  LSM6DSO_AUX_HP_Hz260   = 0x12,
+  LSM6DSO_AUX_HP_1Hz040  = 0x13,
+} lsm6dso_hpm_ois_t;
+int32_t lsm6dso_aux_gy_hp_bandwidth_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_hpm_ois_t val);
+int32_t lsm6dso_aux_gy_hp_bandwidth_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_hpm_ois_t *val);
+
+typedef enum {
+  LSM6DSO_ENABLE_CLAMP  = 0,
+  LSM6DSO_DISABLE_CLAMP = 1,
+} lsm6dso_st_ois_clampdis_t;
+int32_t lsm6dso_aux_gy_clamp_set(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_st_ois_clampdis_t val);
+int32_t lsm6dso_aux_gy_clamp_get(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_st_ois_clampdis_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_GY_DISABLE = 0,
+  LSM6DSO_AUX_GY_POS     = 1,
+  LSM6DSO_AUX_GY_NEG     = 3,
+} lsm6dso_st_ois_t;
+int32_t lsm6dso_aux_gy_self_test_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_st_ois_t val);
+int32_t lsm6dso_aux_gy_self_test_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_st_ois_t *val);
+
+typedef enum {
+  LSM6DSO_289Hz = 0,
+  LSM6DSO_258Hz = 1,
+  LSM6DSO_120Hz = 2,
+  LSM6DSO_65Hz2 = 3,
+  LSM6DSO_33Hz2 = 4,
+  LSM6DSO_16Hz6 = 5,
+  LSM6DSO_8Hz30 = 6,
+  LSM6DSO_4Hz15 = 7,
+} lsm6dso_filter_xl_conf_ois_t;
+int32_t lsm6dso_aux_xl_bandwidth_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_filter_xl_conf_ois_t val);
+int32_t lsm6dso_aux_xl_bandwidth_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_filter_xl_conf_ois_t *val);
+
+typedef enum {
+  LSM6DSO_AUX_2g  = 0,
+  LSM6DSO_AUX_16g = 1,
+  LSM6DSO_AUX_4g  = 2,
+  LSM6DSO_AUX_8g  = 3,
+} lsm6dso_fs_xl_ois_t;
+int32_t lsm6dso_aux_xl_full_scale_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_fs_xl_ois_t val);
+int32_t lsm6dso_aux_xl_full_scale_get(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_fs_xl_ois_t *val);
+
+typedef enum {
+  LSM6DSO_PULL_UP_DISC       = 0,
+  LSM6DSO_PULL_UP_CONNECT    = 1,
+} lsm6dso_sdo_pu_en_t;
+int32_t lsm6dso_sdo_sa0_mode_set(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sdo_pu_en_t val);
+int32_t lsm6dso_sdo_sa0_mode_get(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sdo_pu_en_t *val);
+
+typedef enum {
+  LSM6DSO_SPI_4_WIRE = 0,
+  LSM6DSO_SPI_3_WIRE = 1,
+} lsm6dso_sim_t;
+int32_t lsm6dso_spi_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_sim_t val);
+int32_t lsm6dso_spi_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_sim_t *val);
+
+typedef enum {
+  LSM6DSO_I2C_ENABLE  = 0,
+  LSM6DSO_I2C_DISABLE = 1,
+} lsm6dso_i2c_disable_t;
+int32_t lsm6dso_i2c_interface_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_i2c_disable_t val);
+int32_t lsm6dso_i2c_interface_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_i2c_disable_t *val);
+
+typedef enum {
+  LSM6DSO_I3C_DISABLE         = 0x00,
+  LSM6DSO_I3C_ENABLE_T_50us   = 0x80,
+  LSM6DSO_I3C_ENABLE_T_2us    = 0x81,
+  LSM6DSO_I3C_ENABLE_T_1ms    = 0x82,
+  LSM6DSO_I3C_ENABLE_T_25ms   = 0x83,
+} lsm6dso_i3c_disable_t;
+int32_t lsm6dso_i3c_disable_set(lsm6dso_ctx_t *ctx,
+                                lsm6dso_i3c_disable_t val);
+int32_t lsm6dso_i3c_disable_get(lsm6dso_ctx_t *ctx,
+                                lsm6dso_i3c_disable_t *val);
+
+typedef enum {
+  LSM6DSO_PULL_DOWN_DISC       = 0,
+  LSM6DSO_PULL_DOWN_CONNECT    = 1,
+} lsm6dso_int1_pd_en_t;
+int32_t lsm6dso_int1_mode_set(lsm6dso_ctx_t *ctx,
+                              lsm6dso_int1_pd_en_t val);
+int32_t lsm6dso_int1_mode_get(lsm6dso_ctx_t *ctx,
+                              lsm6dso_int1_pd_en_t *val);
+
+typedef struct {
+    lsm6dso_int1_ctrl_t          int1_ctrl;
+    lsm6dso_md1_cfg_t            md1_cfg;
+    lsm6dso_emb_func_int1_t      emb_func_int1;
+    lsm6dso_fsm_int1_a_t         fsm_int1_a;
+    lsm6dso_fsm_int1_b_t         fsm_int1_b;
+} lsm6dso_pin_int1_route_t;
+int32_t lsm6dso_pin_int1_route_set(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_pin_int1_route_t *val);
+int32_t lsm6dso_pin_int1_route_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_pin_int1_route_t *val);
+
+typedef struct {
+  lsm6dso_int2_ctrl_t          int2_ctrl;
+  lsm6dso_md2_cfg_t            md2_cfg;
+  lsm6dso_emb_func_int2_t      emb_func_int2;
+  lsm6dso_fsm_int2_a_t         fsm_int2_a;
+  lsm6dso_fsm_int2_b_t         fsm_int2_b;
+} lsm6dso_pin_int2_route_t;
+int32_t lsm6dso_pin_int2_route_set(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_pin_int2_route_t *val);
+int32_t lsm6dso_pin_int2_route_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_pin_int2_route_t *val);
+
+typedef enum {
+  LSM6DSO_PUSH_PULL   = 0,
+  LSM6DSO_OPEN_DRAIN  = 1,
+} lsm6dso_pp_od_t;
+int32_t lsm6dso_pin_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_pp_od_t val);
+int32_t lsm6dso_pin_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_pp_od_t *val);
+
+typedef enum {
+  LSM6DSO_ACTIVE_HIGH = 0,
+  LSM6DSO_ACTIVE_LOW  = 1,
+} lsm6dso_h_lactive_t;
+int32_t lsm6dso_pin_polarity_set(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_h_lactive_t val);
+int32_t lsm6dso_pin_polarity_get(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_h_lactive_t *val);
+
+int32_t lsm6dso_all_on_int1_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_all_on_int1_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_ALL_INT_PULSED            = 0,
+  LSM6DSO_BASE_LATCHED_EMB_PULSED   = 1,
+  LSM6DSO_BASE_PULSED_EMB_LATCHED   = 2,
+  LSM6DSO_ALL_INT_LATCHED           = 3,
+} lsm6dso_lir_t;
+int32_t lsm6dso_int_notification_set(lsm6dso_ctx_t *ctx, lsm6dso_lir_t val);
+int32_t lsm6dso_int_notification_get(lsm6dso_ctx_t *ctx, lsm6dso_lir_t *val);
+
+typedef enum {
+  LSM6DSO_LSb_FS_DIV_64       = 0,
+  LSM6DSO_LSb_FS_DIV_256      = 1,
+} lsm6dso_wake_ths_w_t;
+int32_t lsm6dso_wkup_ths_weight_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_wake_ths_w_t val);
+int32_t lsm6dso_wkup_ths_weight_get(lsm6dso_ctx_t *ctx,
+                                       lsm6dso_wake_ths_w_t *val);
+
+int32_t lsm6dso_wkup_threshold_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_wkup_threshold_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_xl_usr_offset_on_wkup_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_usr_offset_on_wkup_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_wkup_dur_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_wkup_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_gy_sleep_mode_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_gy_sleep_mode_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_DRIVE_SLEEP_CHG_EVENT = 0,
+  LSM6DSO_DRIVE_SLEEP_STATUS    = 1,
+} lsm6dso_sleep_status_on_int_t;
+int32_t lsm6dso_act_pin_notification_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_sleep_status_on_int_t val);
+int32_t lsm6dso_act_pin_notification_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_sleep_status_on_int_t *val);
+
+typedef enum {
+  LSM6DSO_XL_AND_GY_NOT_AFFECTED      = 0,
+  LSM6DSO_XL_12Hz5_GY_NOT_AFFECTED    = 1,
+  LSM6DSO_XL_12Hz5_GY_SLEEP           = 2,
+  LSM6DSO_XL_12Hz5_GY_PD              = 3,
+} lsm6dso_inact_en_t;
+int32_t lsm6dso_act_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_inact_en_t val);
+int32_t lsm6dso_act_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_inact_en_t *val);
+
+int32_t lsm6dso_act_sleep_dur_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_act_sleep_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tap_detection_on_z_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_detection_on_z_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tap_detection_on_y_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_detection_on_y_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tap_detection_on_x_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_detection_on_x_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tap_threshold_x_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_threshold_x_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_XYZ = 0,
+  LSM6DSO_YXZ = 1,
+  LSM6DSO_XZY = 2,
+  LSM6DSO_ZYX = 3,
+  LSM6DSO_YZX = 5,
+  LSM6DSO_ZXY = 6,
+} lsm6dso_tap_priority_t;
+int32_t lsm6dso_tap_axis_priority_set(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_tap_priority_t val);
+int32_t lsm6dso_tap_axis_priority_get(lsm6dso_ctx_t *ctx,
+                                      lsm6dso_tap_priority_t *val);
+
+int32_t lsm6dso_tap_threshold_y_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_threshold_y_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tap_threshold_z_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_threshold_z_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tap_shock_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_shock_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tap_quiet_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_quiet_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tap_dur_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_ONLY_SINGLE = 0,
+  LSM6DSO_BOTH_SINGLE_DOUBLE = 1,
+} lsm6dso_single_double_tap_t;
+int32_t lsm6dso_tap_mode_set(lsm6dso_ctx_t *ctx,
+                             lsm6dso_single_double_tap_t val);
+int32_t lsm6dso_tap_mode_get(lsm6dso_ctx_t *ctx,
+                             lsm6dso_single_double_tap_t *val);
+
+typedef enum {
+  LSM6DSO_DEG_80  = 0,
+  LSM6DSO_DEG_70  = 1,
+  LSM6DSO_DEG_60  = 2,
+  LSM6DSO_DEG_50  = 3,
+} lsm6dso_sixd_ths_t;
+int32_t lsm6dso_6d_threshold_set(lsm6dso_ctx_t *ctx, lsm6dso_sixd_ths_t val);
+int32_t lsm6dso_6d_threshold_get(lsm6dso_ctx_t *ctx, lsm6dso_sixd_ths_t *val);
+
+int32_t lsm6dso_4d_mode_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_4d_mode_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_FF_TSH_156mg = 0,
+  LSM6DSO_FF_TSH_219mg = 1,
+  LSM6DSO_FF_TSH_250mg = 2,
+  LSM6DSO_FF_TSH_312mg = 3,
+  LSM6DSO_FF_TSH_344mg = 4,
+  LSM6DSO_FF_TSH_406mg = 5,
+  LSM6DSO_FF_TSH_469mg = 6,
+  LSM6DSO_FF_TSH_500mg = 7,
+} lsm6dso_ff_ths_t;
+int32_t lsm6dso_ff_threshold_set(lsm6dso_ctx_t *ctx, lsm6dso_ff_ths_t val);
+int32_t lsm6dso_ff_threshold_get(lsm6dso_ctx_t *ctx, lsm6dso_ff_ths_t *val);
+
+int32_t lsm6dso_ff_dur_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_ff_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_fifo_watermark_set(lsm6dso_ctx_t *ctx, uint16_t val);
+int32_t lsm6dso_fifo_watermark_get(lsm6dso_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dso_compression_algo_init_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_compression_algo_init_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_CMP_DISABLE  = 0x00,
+  LSM6DSO_CMP_ALWAYS   = 0x04,
+  LSM6DSO_CMP_8_TO_1   = 0x05,
+  LSM6DSO_CMP_16_TO_1  = 0x06,
+  LSM6DSO_CMP_32_TO_1  = 0x07,
+} lsm6dso_uncoptr_rate_t;
+int32_t lsm6dso_compression_algo_set(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_uncoptr_rate_t val);
+int32_t lsm6dso_compression_algo_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_uncoptr_rate_t *val);
+
+int32_t lsm6dso_fifo_virtual_sens_odr_chg_set(lsm6dso_ctx_t *ctx,
+                                              uint8_t val);
+int32_t lsm6dso_fifo_virtual_sens_odr_chg_get(lsm6dso_ctx_t *ctx,
+                                              uint8_t *val);
+
+int32_t lsm6dso_compression_algo_real_time_set(lsm6dso_ctx_t *ctx,
+                                               uint8_t val);
+int32_t lsm6dso_compression_algo_real_time_get(lsm6dso_ctx_t *ctx,
+                                               uint8_t *val);
+
+int32_t lsm6dso_fifo_stop_on_wtm_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_fifo_stop_on_wtm_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_XL_NOT_BATCHED     	=  0,
+  LSM6DSO_XL_BATCHED_AT_12Hz5   =  1,
+  LSM6DSO_XL_BATCHED_AT_26Hz    =  2,
+  LSM6DSO_XL_BATCHED_AT_52Hz    =  3,
+  LSM6DSO_XL_BATCHED_AT_104Hz   =  4,
+  LSM6DSO_XL_BATCHED_AT_208Hz   =  5,
+  LSM6DSO_XL_BATCHED_AT_417Hz   =  6,
+  LSM6DSO_XL_BATCHED_AT_833Hz   =  7,
+  LSM6DSO_XL_BATCHED_AT_1667Hz  =  8,
+  LSM6DSO_XL_BATCHED_AT_3333Hz  =  9,
+  LSM6DSO_XL_BATCHED_AT_6667Hz  = 10,
+  LSM6DSO_XL_BATCHED_AT_6Hz5    = 11,
+} lsm6dso_bdr_xl_t;
+int32_t lsm6dso_fifo_xl_batch_set(lsm6dso_ctx_t *ctx, lsm6dso_bdr_xl_t val);
+int32_t lsm6dso_fifo_xl_batch_get(lsm6dso_ctx_t *ctx, lsm6dso_bdr_xl_t *val);
+
+typedef enum {
+  LSM6DSO_GY_NOT_BATCHED         = 0,
+  LSM6DSO_GY_BATCHED_AT_12Hz5    = 1,
+  LSM6DSO_GY_BATCHED_AT_26Hz     = 2,
+  LSM6DSO_GY_BATCHED_AT_52Hz     = 3,
+  LSM6DSO_GY_BATCHED_AT_104Hz    = 4,
+  LSM6DSO_GY_BATCHED_AT_208Hz    = 5,
+  LSM6DSO_GY_BATCHED_AT_417Hz    = 6,
+  LSM6DSO_GY_BATCHED_AT_833Hz    = 7,
+  LSM6DSO_GY_BATCHED_AT_1667Hz   = 8,
+  LSM6DSO_GY_BATCHED_AT_3333Hz   = 9,
+  LSM6DSO_GY_BATCHED_AT_6667Hz   = 10,
+  LSM6DSO_GY_BATCHED_AT_6Hz5     = 11,
+} lsm6dso_bdr_gy_t;
+int32_t lsm6dso_fifo_gy_batch_set(lsm6dso_ctx_t *ctx, lsm6dso_bdr_gy_t val);
+int32_t lsm6dso_fifo_gy_batch_get(lsm6dso_ctx_t *ctx, lsm6dso_bdr_gy_t *val);
+
+typedef enum {
+  LSM6DSO_BYPASS_MODE             = 0,
+  LSM6DSO_FIFO_MODE               = 1,
+  LSM6DSO_STREAM_TO_FIFO_MODE     = 3,
+  LSM6DSO_BYPASS_TO_STREAM_MODE   = 4,
+  LSM6DSO_STREAM_MODE             = 6,
+  LSM6DSO_BYPASS_TO_FIFO_MODE     = 7,
+} lsm6dso_fifo_mode_t;
+int32_t lsm6dso_fifo_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_fifo_mode_t val);
+int32_t lsm6dso_fifo_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_fifo_mode_t *val);
+
+typedef enum {
+  LSM6DSO_TEMP_NOT_BATCHED        = 0,
+  LSM6DSO_TEMP_BATCHED_AT_1Hz6    = 1,
+  LSM6DSO_TEMP_BATCHED_AT_12Hz5   = 2,
+  LSM6DSO_TEMP_BATCHED_AT_52Hz    = 3,
+} lsm6dso_odr_t_batch_t;
+int32_t lsm6dso_fifo_temp_batch_set(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_odr_t_batch_t val);
+int32_t lsm6dso_fifo_temp_batch_get(lsm6dso_ctx_t *ctx,
+                                    lsm6dso_odr_t_batch_t *val);
+
+typedef enum {
+  LSM6DSO_NO_DECIMATION = 0,
+  LSM6DSO_DEC_1         = 1,
+  LSM6DSO_DEC_8         = 2,
+  LSM6DSO_DEC_32        = 3,
+} lsm6dso_odr_ts_batch_t;
+int32_t lsm6dso_fifo_timestamp_decimation_set(lsm6dso_ctx_t *ctx,
+                                              lsm6dso_odr_ts_batch_t val);
+int32_t lsm6dso_fifo_timestamp_decimation_get(lsm6dso_ctx_t *ctx,
+                                              lsm6dso_odr_ts_batch_t *val);
+
+typedef enum {
+  LSM6DSO_XL_BATCH_EVENT   = 0,
+  LSM6DSO_GYRO_BATCH_EVENT = 1,
+} lsm6dso_trig_counter_bdr_t;
+
+typedef enum {
+  LSM6DSO_GYRO_NC_TAG		= 1,
+  LSM6DSO_XL_NC_TAG,
+  LSM6DSO_TEMPERATURE_TAG,
+  LSM6DSO_TIMESTAMP_TAG,
+  LSM6DSO_CFG_CHANGE_TAG,
+  LSM6DSO_XL_NC_T_2_TAG,
+  LSM6DSO_XL_NC_T_1_TAG,
+  LSM6DSO_XL_2XC_TAG,
+  LSM6DSO_XL_3XC_TAG,
+  LSM6DSO_GYRO_NC_T_2_TAG,
+  LSM6DSO_GYRO_NC_T_1_TAG,
+  LSM6DSO_GYRO_2XC_TAG,
+  LSM6DSO_GYRO_3XC_TAG,
+  LSM6DSO_SENSORHUB_SLAVE0_TAG,
+  LSM6DSO_SENSORHUB_SLAVE1_TAG,
+  LSM6DSO_SENSORHUB_SLAVE2_TAG,
+  LSM6DSO_SENSORHUB_SLAVE3_TAG,
+  LSM6DSO_STEP_CPUNTER_TAG,
+  LSM6DSO_GAME_ROTATION_TAG,
+  LSM6DSO_GEOMAG_ROTATION_TAG,
+  LSM6DSO_ROTATION_TAG,
+  LSM6DSO_SENSORHUB_NACK_TAG	= 0x19,
+} lsm6dso_fifo_tag_t;
+int32_t lsm6dso_fifo_cnt_event_batch_set(lsm6dso_ctx_t *ctx,
+                                          lsm6dso_trig_counter_bdr_t val);
+int32_t lsm6dso_fifo_cnt_event_batch_get(lsm6dso_ctx_t *ctx,
+                                          lsm6dso_trig_counter_bdr_t *val);
+
+int32_t lsm6dso_rst_batch_counter_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_rst_batch_counter_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_batch_counter_threshold_set(lsm6dso_ctx_t *ctx,
+                                            uint16_t val);
+int32_t lsm6dso_batch_counter_threshold_get(lsm6dso_ctx_t *ctx,
+                                            uint16_t *val);
+
+int32_t lsm6dso_fifo_data_level_get(lsm6dso_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dso_fifo_status_get(lsm6dso_ctx_t *ctx,
+                                lsm6dso_fifo_status2_t *val);
+
+int32_t lsm6dso_fifo_full_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_fifo_ovr_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_fifo_wtm_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_fifo_sensor_tag_get(lsm6dso_ctx_t *ctx,
+				    lsm6dso_fifo_tag_t *val);
+
+int32_t lsm6dso_fifo_pedo_batch_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_fifo_pedo_batch_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_sh_batch_slave_0_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_0_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_sh_batch_slave_1_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_1_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_sh_batch_slave_2_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_2_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_sh_batch_slave_3_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_3_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_DEN_DISABLE    = 0,
+  LSM6DSO_LEVEL_FIFO     = 6,
+  LSM6DSO_LEVEL_LETCHED  = 3,
+  LSM6DSO_LEVEL_TRIGGER  = 2,
+  LSM6DSO_EDGE_TRIGGER   = 4,
+} lsm6dso_den_mode_t;
+int32_t lsm6dso_den_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_den_mode_t val);
+int32_t lsm6dso_den_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_den_mode_t *val);
+
+typedef enum {
+  LSM6DSO_DEN_ACT_LOW  = 0,
+  LSM6DSO_DEN_ACT_HIGH = 1,
+} lsm6dso_den_lh_t;
+int32_t lsm6dso_den_polarity_set(lsm6dso_ctx_t *ctx, lsm6dso_den_lh_t val);
+int32_t lsm6dso_den_polarity_get(lsm6dso_ctx_t *ctx, lsm6dso_den_lh_t *val);
+
+typedef enum {
+  LSM6DSO_STAMP_IN_GY_DATA     = 0,
+  LSM6DSO_STAMP_IN_XL_DATA     = 1,
+  LSM6DSO_STAMP_IN_GY_XL_DATA  = 2,
+} lsm6dso_den_xl_g_t;
+int32_t lsm6dso_den_enable_set(lsm6dso_ctx_t *ctx, lsm6dso_den_xl_g_t val);
+int32_t lsm6dso_den_enable_get(lsm6dso_ctx_t *ctx, lsm6dso_den_xl_g_t *val);
+
+int32_t lsm6dso_den_mark_axis_x_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_den_mark_axis_x_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_den_mark_axis_y_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_den_mark_axis_y_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_den_mark_axis_z_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_den_mark_axis_z_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_PEDO_DISABLE              = 0x00,
+  LSM6DSO_PEDO_BASE_MODE            = 0x01,
+  LSM6DSO_PEDO_ADV_MODE             = 0x03,
+  LSM6DSO_FALSE_STEP_REJ            = 0x13,
+  LSM6DSO_FALSE_STEP_REJ_ADV_MODE   = 0x33,
+} lsm6dso_pedo_md_t;
+int32_t lsm6dso_pedo_sens_set(lsm6dso_ctx_t *ctx, lsm6dso_pedo_md_t val);
+int32_t lsm6dso_pedo_sens_get(lsm6dso_ctx_t *ctx, lsm6dso_pedo_md_t *val);
+
+int32_t lsm6dso_pedo_step_detect_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_pedo_debounce_steps_set(lsm6dso_ctx_t *ctx,
+                                             uint8_t *buff);
+int32_t lsm6dso_pedo_debounce_steps_get(lsm6dso_ctx_t *ctx,
+                                             uint8_t *buff);
+
+int32_t lsm6dso_pedo_steps_period_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_pedo_steps_period_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSO_EVERY_STEP     = 0,
+  LSM6DSO_COUNT_OVERFLOW = 1,
+} lsm6dso_carry_count_en_t;
+int32_t lsm6dso_pedo_int_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_carry_count_en_t val);
+int32_t lsm6dso_pedo_int_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_carry_count_en_t *val);
+
+int32_t lsm6dso_motion_sens_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_motion_sens_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_motion_flag_data_ready_get(lsm6dso_ctx_t *ctx,
+                                                uint8_t *val);
+
+int32_t lsm6dso_tilt_sens_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tilt_sens_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_tilt_flag_data_ready_get(lsm6dso_ctx_t *ctx,
+                                              uint8_t *val);
+
+int32_t lsm6dso_mag_sensitivity_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_sensitivity_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_mag_offset_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_offset_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_mag_soft_iron_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_soft_iron_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSO_Z_EQ_Y     = 0,
+  LSM6DSO_Z_EQ_MIN_Y = 1,
+  LSM6DSO_Z_EQ_X     = 2,
+  LSM6DSO_Z_EQ_MIN_X = 3,
+  LSM6DSO_Z_EQ_MIN_Z = 4,
+  LSM6DSO_Z_EQ_Z     = 5,
+} lsm6dso_mag_z_axis_t;
+int32_t lsm6dso_mag_z_orient_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_mag_z_axis_t val);
+int32_t lsm6dso_mag_z_orient_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_mag_z_axis_t *val);
+
+typedef enum {
+  LSM6DSO_Y_EQ_Y     = 0,
+  LSM6DSO_Y_EQ_MIN_Y = 1,
+  LSM6DSO_Y_EQ_X     = 2,
+  LSM6DSO_Y_EQ_MIN_X = 3,
+  LSM6DSO_Y_EQ_MIN_Z = 4,
+  LSM6DSO_Y_EQ_Z     = 5,
+} lsm6dso_mag_y_axis_t;
+int32_t lsm6dso_mag_y_orient_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_mag_y_axis_t val);
+int32_t lsm6dso_mag_y_orient_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_mag_y_axis_t *val);
+
+typedef enum {
+  LSM6DSO_X_EQ_Y     = 0,
+  LSM6DSO_X_EQ_MIN_Y = 1,
+  LSM6DSO_X_EQ_X     = 2,
+  LSM6DSO_X_EQ_MIN_X = 3,
+  LSM6DSO_X_EQ_MIN_Z = 4,
+  LSM6DSO_X_EQ_Z     = 5,
+} lsm6dso_mag_x_axis_t;
+int32_t lsm6dso_mag_x_orient_set(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_mag_x_axis_t val);
+int32_t lsm6dso_mag_x_orient_get(lsm6dso_ctx_t *ctx,
+                                         lsm6dso_mag_x_axis_t *val);
+
+int32_t lsm6dso_long_cnt_flag_data_ready_get(lsm6dso_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t lsm6dso_emb_fsm_en_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_emb_fsm_en_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+    lsm6dso_fsm_enable_a_t          fsm_enable_a;
+    lsm6dso_fsm_enable_b_t          fsm_enable_b;
+} lsm6dso_emb_fsm_enable_t;
+int32_t lsm6dso_fsm_enable_set(lsm6dso_ctx_t *ctx,
+                               lsm6dso_emb_fsm_enable_t *val);
+int32_t lsm6dso_fsm_enable_get(lsm6dso_ctx_t *ctx,
+                               lsm6dso_emb_fsm_enable_t *val);
+
+int32_t lsm6dso_long_cnt_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_long_cnt_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSO_LC_NORMAL     = 0,
+  LSM6DSO_LC_CLEAR      = 1,
+  LSM6DSO_LC_CLEAR_DONE = 2,
+} lsm6dso_fsm_lc_clr_t;
+int32_t lsm6dso_long_clr_set(lsm6dso_ctx_t *ctx, lsm6dso_fsm_lc_clr_t val);
+int32_t lsm6dso_long_clr_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_lc_clr_t *val);
+
+typedef struct {
+    lsm6dso_fsm_outs1_t    fsm_outs1;
+    lsm6dso_fsm_outs2_t    fsm_outs2;
+    lsm6dso_fsm_outs3_t    fsm_outs3;
+    lsm6dso_fsm_outs4_t    fsm_outs4;
+    lsm6dso_fsm_outs5_t    fsm_outs5;
+    lsm6dso_fsm_outs6_t    fsm_outs6;
+    lsm6dso_fsm_outs7_t    fsm_outs7;
+    lsm6dso_fsm_outs8_t    fsm_outs8;
+    lsm6dso_fsm_outs1_t    fsm_outs9;
+    lsm6dso_fsm_outs2_t    fsm_outs10;
+    lsm6dso_fsm_outs3_t    fsm_outs11;
+    lsm6dso_fsm_outs4_t    fsm_outs12;
+    lsm6dso_fsm_outs5_t    fsm_outs13;
+    lsm6dso_fsm_outs6_t    fsm_outs14;
+    lsm6dso_fsm_outs7_t    fsm_outs15;
+    lsm6dso_fsm_outs8_t    fsm_outs16;
+} lsm6dso_fsm_out_t;
+int32_t lsm6dso_fsm_out_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_out_t *val);
+
+typedef enum {
+  LSM6DSO_ODR_FSM_12Hz5 = 0,
+  LSM6DSO_ODR_FSM_26Hz  = 1,
+  LSM6DSO_ODR_FSM_52Hz  = 2,
+  LSM6DSO_ODR_FSM_104Hz = 3,
+} lsm6dso_fsm_odr_t;
+int32_t lsm6dso_fsm_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_fsm_odr_t val);
+int32_t lsm6dso_fsm_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_odr_t *val);
+
+int32_t lsm6dso_fsm_init_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_fsm_init_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dso_long_cnt_int_value_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_long_cnt_int_value_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_fsm_number_of_programs_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_fsm_number_of_programs_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dso_fsm_start_address_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_fsm_start_address_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+
+typedef struct {
+    lsm6dso_sensor_hub_1_t   sh_byte_1;
+    lsm6dso_sensor_hub_2_t   sh_byte_2;
+    lsm6dso_sensor_hub_3_t   sh_byte_3;
+    lsm6dso_sensor_hub_4_t   sh_byte_4;
+    lsm6dso_sensor_hub_5_t   sh_byte_5;
+    lsm6dso_sensor_hub_6_t   sh_byte_6;
+    lsm6dso_sensor_hub_7_t   sh_byte_7;
+    lsm6dso_sensor_hub_8_t   sh_byte_8;
+    lsm6dso_sensor_hub_9_t   sh_byte_9;
+    lsm6dso_sensor_hub_10_t  sh_byte_10;
+    lsm6dso_sensor_hub_11_t  sh_byte_11;
+    lsm6dso_sensor_hub_12_t  sh_byte_12;
+    lsm6dso_sensor_hub_13_t  sh_byte_13;
+    lsm6dso_sensor_hub_14_t  sh_byte_14;
+    lsm6dso_sensor_hub_15_t  sh_byte_15;
+    lsm6dso_sensor_hub_16_t  sh_byte_16;
+    lsm6dso_sensor_hub_17_t  sh_byte_17;
+    lsm6dso_sensor_hub_18_t  sh_byte_18;
+} lsm6dso_emb_sh_read_t;
+int32_t lsm6dso_sh_read_data_raw_get(lsm6dso_ctx_t *ctx,
+                                     lsm6dso_emb_sh_read_t *val);
+
+typedef enum {
+  LSM6DSO_SLV_0       = 0,
+  LSM6DSO_SLV_0_1     = 1,
+  LSM6DSO_SLV_0_1_2   = 2,
+  LSM6DSO_SLV_0_1_2_3 = 3,
+} lsm6dso_aux_sens_on_t;
+int32_t lsm6dso_sh_slave_connected_set(lsm6dso_ctx_t *ctx,
+                                       lsm6dso_aux_sens_on_t val);
+int32_t lsm6dso_sh_slave_connected_get(lsm6dso_ctx_t *ctx,
+                                       lsm6dso_aux_sens_on_t *val);
+
+int32_t lsm6dso_sh_master_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_master_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_EXT_PULL_UP      = 0,
+  LSM6DSO_INTERNAL_PULL_UP = 1,
+} lsm6dso_shub_pu_en_t;
+int32_t lsm6dso_sh_pin_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_shub_pu_en_t val);
+int32_t lsm6dso_sh_pin_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_shub_pu_en_t *val);
+
+int32_t lsm6dso_sh_pass_through_set(lsm6dso_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_pass_through_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_EXT_ON_INT2_PIN = 0,
+  LSM6DSO_XL_GY_DRDY      = 1,
+} lsm6dso_start_config_t;
+int32_t lsm6dso_sh_syncro_mode_set(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_start_config_t val);
+int32_t lsm6dso_sh_syncro_mode_get(lsm6dso_ctx_t *ctx,
+                                   lsm6dso_start_config_t *val);
+
+typedef enum {
+  LSM6DSO_EACH_SH_CYCLE    = 0,
+  LSM6DSO_ONLY_FIRST_CYCLE = 1,
+} lsm6dso_write_once_t;
+int32_t lsm6dso_sh_write_mode_set(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_write_once_t val);
+int32_t lsm6dso_sh_write_mode_get(lsm6dso_ctx_t *ctx,
+                                  lsm6dso_write_once_t *val);
+
+int32_t lsm6dso_sh_reset_set(lsm6dso_ctx_t *ctx);
+int32_t lsm6dso_sh_reset_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSO_SH_ODR_104Hz = 0,
+  LSM6DSO_SH_ODR_52Hz  = 1,
+  LSM6DSO_SH_ODR_26Hz  = 2,
+  LSM6DSO_SH_ODR_13Hz  = 3,
+} lsm6dso_shub_odr_t;
+int32_t lsm6dso_sh_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_shub_odr_t val);
+int32_t lsm6dso_sh_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_shub_odr_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} lsm6dso_sh_cfg_write_t;
+int32_t lsm6dso_sh_cfg_write(lsm6dso_ctx_t *ctx, lsm6dso_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} lsm6dso_sh_cfg_read_t;
+int32_t lsm6dso_sh_slv0_cfg_read(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sh_cfg_read_t *val);
+int32_t lsm6dso_sh_slv1_cfg_read(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sh_cfg_read_t *val);
+int32_t lsm6dso_sh_slv2_cfg_read(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sh_cfg_read_t *val);
+int32_t lsm6dso_sh_slv3_cfg_read(lsm6dso_ctx_t *ctx,
+                                 lsm6dso_sh_cfg_read_t *val);
+
+int32_t lsm6dso_sh_status_get(lsm6dso_ctx_t *ctx,
+                              lsm6dso_status_master_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*LSM6DSO_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dso_STdC/lib/fifo_utility/fifo_utility.c
+++ b/sensor/stmemsc/lsm6dso_STdC/lib/fifo_utility/fifo_utility.c
@@ -1,0 +1,711 @@
+/*
+ ******************************************************************************
+ * @file    fifo_utility.c
+ * @author  Sensor Solutions Software Team
+ * @brief   utility for decoding / decompressing data from FIFO
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <string.h>
+#include "fifo_utility.h"
+
+#define ODR_XL_MASK				(0x0F)
+#define ODR_XL_SHIFT			(0x00)
+#define BDR_XL_MASK				(0x0F)
+#define BDR_XL_SHIFT			(0x00)
+
+#define ODR_GY_MASK				(0xF0)
+#define ODR_GY_SHIFT			(0x04)
+#define BDR_GY_MASK				(0xF0)
+#define BDR_GY_SHIFT			(0x04)
+
+#define BDR_VSENS_MASK			(0x0F)
+#define BDR_VSENS_SHIFT			(0x00)
+
+#define TAG_COUNTER_MASK		(0x06)
+#define TAG_SENSOR_MASK			(0xF8)
+#define TAG_COUNTER_SHIFT		(0x01)
+#define TAG_SENSOR_SHIFT		(0x03)
+
+#define TAG_GY					(0x01)
+#define TAG_XL					(0x02)
+#define TAG_TEMP				(0x03)
+#define TAG_TS					(0x04)
+#define TAG_ODRCHG				(0x05)
+#define TAG_XL_UNCOMPRESSED_T_2	(0x06)
+#define TAG_XL_UNCOMPRESSED_T_1	(0x07)
+#define TAG_XL_COMPRESSED_2X	(0x08)
+#define TAG_XL_COMPRESSED_3X	(0x09)
+#define TAG_GY_UNCOMPRESSED_T_2	(0x0A)
+#define TAG_GY_UNCOMPRESSED_T_1	(0x0B)
+#define TAG_GY_COMPRESSED_2X	(0x0C)
+#define TAG_GY_COMPRESSED_3X	(0x0D)
+#define TAG_EXT_SENS_0			(0x0E)
+#define TAG_EXT_SENS_1			(0x0F)
+#define TAG_EXT_SENS_2			(0x10)
+#define TAG_EXT_SENS_3			(0x11)
+#define TAG_STEP_COUNTER		(0x12)
+#define TAG_GAME_RV				(0x13)
+#define TAG_GEOM_RV				(0x14)
+#define TAG_NORM_RV				(0x15)
+#define TAG_GYRO_BIAS			(0x16)
+#define TAG_GRAVITIY			(0x17)
+#define TAG_MAG_CAL				(0x18)
+#define TAG_EXT_SENS_NACK		(0x19)
+
+#define TAG_VALID_LIMIT			(0x19)
+
+#define TIMESTAMP_FREQ			(40000.0f)
+
+#define MAX(a, b)				((a) > (b) ? a : b)
+#define MIN(a, b)				((a) < (b) ? a : b)
+
+typedef enum {
+        ST_FIFO_COMPRESSION_NC,
+        ST_FIFO_COMPRESSION_NC_T_1,
+        ST_FIFO_COMPRESSION_NC_T_2,
+        ST_FIFO_COMPRESSION_2X,
+        ST_FIFO_COMPRESSION_3X
+} st_fifo_compression_type;
+
+static uint8_t has_even_parity(uint8_t x);
+static st_fifo_sensor_type get_sensor_type(uint8_t tag);
+static st_fifo_compression_type get_compression_type(uint8_t tag);
+static uint8_t is_tag_valid(uint8_t tag);
+static void get_diff_2x(int16_t diff[6], uint8_t input[6]);
+static void get_diff_3x(int16_t diff[9], uint8_t input[6]);
+
+static const float bdr_acc_vect_def[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		833, 1666, 3333, 6666, 1.625,
+		0, 0, 0, 0
+};
+
+static const float bdr_gyr_vect_def[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		833, 1666, 3333, 6666, 0, 0,
+		0, 0, 0
+};
+
+static const float bdr_vsens_vect_def[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		0, 0, 0, 0, 1.625, 0, 0, 0, 0
+};
+
+static uint8_t tag_counter_old = 0x00;
+static float bdr_xl = 0.0;
+static float bdr_gy = 0.0;
+static float bdr_vsens = 0.0;
+static float bdr_xl_old = 0.0;
+static float bdr_gy_old = 0.0;
+static float bdr_max = 0.0;
+static uint32_t timestamp = 0;
+static uint32_t last_timestamp_xl = 0;
+static uint32_t last_timestamp_gy = 0;
+static uint8_t bdr_chg_xl_flag = 0;
+static uint8_t bdr_chg_gy_flag = 0;
+static int16_t last_data_xl[3] = {0};
+static int16_t last_data_gy[3] = {0};
+static float bdr_acc_vect[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		833, 1666, 3333, 6666, 1.625,
+		0, 0, 0, 0
+};
+
+static float bdr_gyr_vect[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		833, 1666, 3333, 6666, 0, 0,
+		0, 0, 0
+};
+
+static float bdr_vsens_vect[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		0, 0, 0, 0, 1.625, 0, 0, 0, 0
+};
+
+st_fifo_status st_fifo_init(float bdr_xl_in,
+							float bdr_gy_in,
+							float bdr_vsens_in)
+{
+        if (bdr_xl_in < 0.0f || bdr_gy_in < 0.0f || bdr_vsens_in < 0.0f)
+                return ST_FIFO_ERR;
+
+        tag_counter_old = 0x00;
+        bdr_xl = bdr_xl_in;
+        bdr_gy = bdr_gy_in;
+        bdr_vsens = bdr_vsens_in;
+        bdr_xl_old = bdr_xl_in;
+        bdr_gy_old = bdr_gy_in;
+        bdr_max = MAX(bdr_xl, bdr_gy);
+        bdr_max = MAX(bdr_max, bdr_vsens);
+        timestamp = 0;
+        bdr_chg_xl_flag = 0;
+        bdr_chg_gy_flag = 0;
+        last_timestamp_xl = 0;
+        last_timestamp_gy = 0;
+
+        memcpy(bdr_acc_vect, bdr_acc_vect_def, sizeof(bdr_acc_vect_def));
+        memcpy(bdr_gyr_vect, bdr_gyr_vect_def, sizeof(bdr_gyr_vect_def));
+        memcpy(bdr_vsens_vect, bdr_vsens_vect_def, sizeof(bdr_vsens_vect_def));
+
+        for (uint8_t i = 0; i < 3; i++) {
+                last_data_xl[i] = 0;
+                last_data_gy[i] = 0;
+        }
+
+        return ST_FIFO_OK;
+}
+
+void st_fifo_rescale_bdr_array(float scale)
+{
+        for (uint8_t i = 0; i < 16; i++) {
+                bdr_acc_vect[i] *= scale;
+                bdr_gyr_vect[i] *= scale;
+                bdr_vsens_vect[i] *= scale;
+        }
+}
+
+st_fifo_status st_fifo_decode(st_fifo_out_slot *fifo_out_slot,
+							  st_fifo_raw_slot *fifo_raw_slot,
+							  uint16_t *out_slot_size,
+							  uint16_t stream_size)
+{
+        uint16_t j = 0;
+
+        for (uint16_t i = 0; i < stream_size; i++) {
+
+                uint8_t tag =
+                	(fifo_raw_slot[i].fifo_data_out[0] & TAG_SENSOR_MASK) >> TAG_SENSOR_SHIFT;
+                uint8_t tag_counter =
+                	(fifo_raw_slot[i].fifo_data_out[0] & TAG_COUNTER_MASK) >> TAG_COUNTER_SHIFT;
+
+                if (!has_even_parity(fifo_raw_slot[i].fifo_data_out[0]) || !is_tag_valid(tag))
+                        return ST_FIFO_ERR;
+
+                if ((tag_counter != (tag_counter_old)) && bdr_max != 0) {
+                        timestamp += (uint32_t)(TIMESTAMP_FREQ / bdr_max);
+                }
+
+                if (tag == TAG_ODRCHG) {
+
+                        uint8_t bdr_acc_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[6] & BDR_XL_MASK) >> BDR_XL_SHIFT;
+                        uint8_t bdr_gyr_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[6] & BDR_GY_MASK) >> BDR_GY_SHIFT;
+                        uint8_t bdr_vsens_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[3] & BDR_VSENS_MASK) >> BDR_VSENS_SHIFT;
+
+                        bdr_max = MAX(bdr_acc_vect[bdr_acc_cfg], bdr_gyr_vect[bdr_gyr_cfg]);
+                        bdr_max = MAX(bdr_max, bdr_vsens_vect[bdr_vsens_cfg]);
+
+                } else if (tag == TAG_TS) {
+
+                        memcpy(&timestamp, &fifo_raw_slot[i].fifo_data_out[1], 4);
+
+                } else {
+
+                        if (tag == TAG_STEP_COUNTER)
+                                memcpy(&fifo_out_slot[j].timestamp, &fifo_raw_slot[i].fifo_data_out[3], 4);
+                        else
+                                fifo_out_slot[j].timestamp = timestamp;
+
+                        fifo_out_slot[j].sensor_tag = get_sensor_type(tag);
+                        memcpy(fifo_out_slot[j].sensor_data.raw_data, &fifo_raw_slot[i].fifo_data_out[1], 6);
+                        j++;
+                        *out_slot_size = j;
+                }
+
+                tag_counter_old = tag_counter;
+        }
+
+        return ST_FIFO_OK;
+}
+
+st_fifo_status st_fifo_decompress(st_fifo_out_slot *fifo_out_slot,
+								  st_fifo_raw_slot *fifo_raw_slot,
+								  uint16_t *out_slot_size,
+								  uint16_t stream_size)
+{
+        uint16_t j = 0;
+
+        for (uint16_t i = 0; i < stream_size; i++) {
+
+                uint8_t tag =
+                	(fifo_raw_slot[i].fifo_data_out[0] & TAG_SENSOR_MASK) >> TAG_SENSOR_SHIFT;
+                uint8_t tag_counter =
+                	(fifo_raw_slot[i].fifo_data_out[0] & TAG_COUNTER_MASK) >> TAG_COUNTER_SHIFT;
+
+                if (!has_even_parity(fifo_raw_slot[i].fifo_data_out[0]) || !is_tag_valid(tag))
+                        continue;
+
+                if ((tag_counter != (tag_counter_old)) && bdr_max != 0) {
+
+                        uint8_t diff_tag_counter = 0;
+
+                        if (tag_counter < tag_counter_old)
+                                diff_tag_counter = tag_counter + 4 - tag_counter_old;
+                        else
+                                diff_tag_counter = tag_counter - tag_counter_old;
+
+                        timestamp += (uint32_t)(TIMESTAMP_FREQ / bdr_max) * diff_tag_counter;
+                }
+
+                if (tag == TAG_ODRCHG) {
+
+                        uint8_t bdr_acc_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[6] & BDR_XL_MASK) >> BDR_XL_SHIFT;
+                        uint8_t bdr_gyr_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[6] & BDR_GY_MASK) >> BDR_GY_SHIFT;
+                        uint8_t bdr_vsens_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[3] & BDR_VSENS_MASK) >> BDR_VSENS_SHIFT;
+
+                        bdr_xl_old = bdr_xl;
+                        bdr_gy_old = bdr_gy;
+
+                        bdr_xl = bdr_acc_vect[bdr_acc_cfg];
+                        bdr_gy = bdr_gyr_vect[bdr_gyr_cfg];
+                        bdr_vsens = bdr_vsens_vect[bdr_vsens_cfg];
+                        bdr_max = MAX(bdr_xl, bdr_gy);
+                        bdr_max = MAX(bdr_max, bdr_vsens);
+
+                        bdr_chg_xl_flag = 1;
+                        bdr_chg_gy_flag = 1;
+
+                } else if (tag == TAG_TS) {
+
+                        memcpy(&timestamp, &fifo_raw_slot[i].fifo_data_out[1], 4);
+
+                } else {
+
+                        st_fifo_compression_type compression_type = get_compression_type(tag);
+                        st_fifo_sensor_type sensor_type = get_sensor_type(tag);
+
+                        if (compression_type == ST_FIFO_COMPRESSION_NC) {
+
+                                if (tag == TAG_STEP_COUNTER)
+                                        memcpy(&fifo_out_slot[j].timestamp, &fifo_raw_slot[i].fifo_data_out[3], 4);
+                                else
+                                        fifo_out_slot[j].timestamp = timestamp;
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+                                memcpy(fifo_out_slot[j].sensor_data.raw_data, &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = timestamp;
+                                        bdr_chg_xl_flag = 0;
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = timestamp;
+                                        bdr_chg_gy_flag = 0;
+                                }
+
+                                j++;
+
+                        } else if (compression_type == ST_FIFO_COMPRESSION_NC_T_1) {
+
+                                fifo_out_slot[j].sensor_tag = get_sensor_type(tag);
+                                memcpy(fifo_out_slot[j].sensor_data.raw_data, &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        uint32_t last_timestamp;
+
+                                        if (bdr_chg_xl_flag)
+                                                last_timestamp = (uint32_t)(last_timestamp_xl + TIMESTAMP_FREQ / bdr_xl_old);
+                                        else
+                                                last_timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_xl);
+
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = last_timestamp;
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        uint32_t last_timestamp;
+
+                                        if (bdr_chg_gy_flag)
+                                                last_timestamp = (uint32_t)(last_timestamp_gy + TIMESTAMP_FREQ / bdr_gy_old);
+                                        else
+                                                last_timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_gy);
+
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = last_timestamp;
+                                }
+
+                                j++;
+
+                        } else if (compression_type == ST_FIFO_COMPRESSION_NC_T_2) {
+
+                                fifo_out_slot[j].sensor_tag = get_sensor_type(tag);
+                                memcpy(fifo_out_slot[j].sensor_data.raw_data, &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        uint32_t last_timestamp;
+
+                                        if (bdr_chg_xl_flag)
+                                                last_timestamp = (uint32_t)(last_timestamp_xl + TIMESTAMP_FREQ / bdr_xl_old);
+                                        else
+                                                last_timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_xl);
+
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = last_timestamp;
+                                }
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        uint32_t last_timestamp;
+
+                                        if (bdr_chg_gy_flag)
+                                                last_timestamp = (uint32_t)(last_timestamp_gy + TIMESTAMP_FREQ / bdr_gy_old);
+                                        else
+                                                last_timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_gy);
+
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = last_timestamp;
+                                }
+
+                                j++;
+
+                        } else if(compression_type == ST_FIFO_COMPRESSION_2X) {
+
+                                int16_t diff[6];
+                                get_diff_2x(diff, &fifo_raw_slot[i].fifo_data_out[1]);
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[0];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[1];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[2];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_xl);
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[0];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[1];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[2];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_gy);
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                j++;
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        uint32_t last_timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_xl);
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[3];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[4];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[5];
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = last_timestamp;
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        uint32_t last_timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_gy);
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[3];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[4];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[5];
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = last_timestamp;
+                                }
+
+                                j++;
+
+                        } else if (compression_type == ST_FIFO_COMPRESSION_3X) {
+
+                                int16_t diff[9];
+                                get_diff_3x(diff, &fifo_raw_slot[i].fifo_data_out[1]);
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[0];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[1];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[2];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_xl);
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[0];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[1];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[2];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_gy);
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                j++;
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[3];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[4];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[5];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_xl);
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[3];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[4];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[5];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_gy);
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                j++;
+
+                                fifo_out_slot[j].timestamp = timestamp;
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[6];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[7];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[8];
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = timestamp;
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[6];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[7];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[8];
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = timestamp;
+                                }
+
+                                j++;
+                        }
+
+                        *out_slot_size = j;
+                }
+
+                tag_counter_old = tag_counter;
+        }
+
+        return ST_FIFO_OK;
+}
+
+void st_fifo_sort(st_fifo_out_slot *fifo_out_slot, uint16_t out_slot_size)
+{
+        uint16_t i;
+        int32_t j;
+        st_fifo_out_slot temp;
+
+        for (i = 1; i < out_slot_size; i++) {
+
+                memcpy(&temp, &fifo_out_slot[i], sizeof(st_fifo_out_slot));
+
+                j = i - 1;
+
+                while (j >= 0 && fifo_out_slot[j].timestamp > temp.timestamp) {
+                        memcpy(&fifo_out_slot[j + 1], &fifo_out_slot[j], sizeof(st_fifo_out_slot));
+                        j--;
+                }
+
+                memcpy(&fifo_out_slot[j + 1], &temp, sizeof(st_fifo_out_slot));
+        }
+
+        return;
+}
+
+uint16_t  st_fifo_get_sensor_occurrence(st_fifo_out_slot *fifo_out_slot, uint16_t out_slot_size, st_fifo_sensor_type sensor_type)
+{
+        uint16_t occurrence = 0;
+
+        for (uint16_t i = 0; i < out_slot_size; i++) {
+                if (fifo_out_slot[i].sensor_tag == sensor_type)
+                        occurrence++;
+        }
+
+        return occurrence;
+}
+
+void st_fifo_extract_sensor(st_fifo_out_slot *sensor_out_slot,
+							st_fifo_out_slot *fifo_out_slot,
+							uint16_t  out_slot_size,
+							st_fifo_sensor_type sensor_type)
+{
+        uint16_t temp_i = 0;
+
+        for (uint16_t i = 0; i < out_slot_size; i++) {
+                if (fifo_out_slot[i].sensor_tag == sensor_type) {
+                        memcpy(&sensor_out_slot[temp_i], &fifo_out_slot[i], sizeof(st_fifo_out_slot));
+                        temp_i++;
+                }
+        }
+}
+
+static uint8_t is_tag_valid(uint8_t tag)
+{
+        if (tag > TAG_VALID_LIMIT)
+                return 0;
+        else
+                return 1;
+}
+
+static st_fifo_sensor_type get_sensor_type(uint8_t tag)
+{
+        switch (tag) {
+                case TAG_GY:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_XL:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_TEMP:
+                        return ST_FIFO_TEMPERATURE;
+                case TAG_EXT_SENS_0:
+                        return ST_FIFO_EXT_SENSOR0;
+                case TAG_EXT_SENS_1:
+                        return ST_FIFO_EXT_SENSOR1;
+                case TAG_EXT_SENS_2:
+                        return ST_FIFO_EXT_SENSOR2;
+                case TAG_EXT_SENS_3:
+                        return ST_FIFO_EXT_SENSOR3;
+                case TAG_STEP_COUNTER:
+                        return ST_FIFO_STEP_COUNTER;
+                case TAG_XL_UNCOMPRESSED_T_2:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_XL_UNCOMPRESSED_T_1:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_XL_COMPRESSED_2X:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_XL_COMPRESSED_3X:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_GY_UNCOMPRESSED_T_2:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_GY_UNCOMPRESSED_T_1:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_GY_COMPRESSED_2X:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_GY_COMPRESSED_3X:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_GAME_RV:
+                        return ST_FIFO_6X_GAME_RV;
+                case TAG_GEOM_RV:
+                        return ST_FIFO_6X_GEOM_RV;
+                case TAG_NORM_RV:
+                        return ST_FIFO_9X_RV;
+                case TAG_GYRO_BIAS:
+                        return ST_FIFO_GYRO_BIAS;
+                case TAG_GRAVITIY:
+                        return ST_FIFO_GRAVITY;
+                case TAG_MAG_CAL:
+                        return ST_FIFO_MAGNETOMETER_CALIB;
+                case TAG_EXT_SENS_NACK:
+                        return ST_FIFO_EXT_SENSOR_NACK;
+                default:
+                        return ST_FIFO_NONE;
+        }
+}
+
+static st_fifo_compression_type get_compression_type(uint8_t tag)
+{
+        switch (tag) {
+                case TAG_GY:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_XL:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_TEMP:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_EXT_SENS_0:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_EXT_SENS_1:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_EXT_SENS_2:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_EXT_SENS_3:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_STEP_COUNTER:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_XL_UNCOMPRESSED_T_2:
+                        return ST_FIFO_COMPRESSION_NC_T_2;
+                case TAG_XL_UNCOMPRESSED_T_1:
+                        return ST_FIFO_COMPRESSION_NC_T_1;
+                case TAG_XL_COMPRESSED_2X:
+                        return ST_FIFO_COMPRESSION_2X;
+                case TAG_XL_COMPRESSED_3X:
+                        return ST_FIFO_COMPRESSION_3X;
+                case TAG_GY_UNCOMPRESSED_T_2:
+                        return ST_FIFO_COMPRESSION_NC_T_2;
+                case TAG_GY_UNCOMPRESSED_T_1:
+                        return ST_FIFO_COMPRESSION_NC_T_1;
+                case TAG_GY_COMPRESSED_2X:
+                        return ST_FIFO_COMPRESSION_2X;
+                case TAG_GY_COMPRESSED_3X:
+                        return ST_FIFO_COMPRESSION_3X;
+                default:
+                        return ST_FIFO_COMPRESSION_NC;
+        }
+}
+
+static uint8_t has_even_parity(uint8_t x)
+{
+    uint8_t count = 0x00, i, b = 0x01;
+
+    for (i = 0; i < 8; i++) {
+        if(x & (b << i))
+                        count++;
+    }
+
+    if (count & 0x01)
+                return 0;
+
+    return 1;
+}
+
+static void get_diff_2x(int16_t diff[6], uint8_t input[6])
+{
+        for (uint8_t i = 0; i < 6; i++)
+                diff[i] = input[i] < 128 ? input[i] : (input[i] - 256);
+}
+
+
+static void get_diff_3x(int16_t diff[9], uint8_t input[6])
+{
+        uint16_t decode_temp;
+
+        for (uint8_t i = 0; i < 3; i++) {
+
+                memcpy(&decode_temp, &input[2 * i], 2);
+
+                for (uint8_t j = 0; j < 3; j++) {
+                        int16_t temp = (decode_temp & (0x001F << (5 * j))) >> (5 * j);
+                        diff[j + 3 * i] = temp < 16 ? temp : (temp - 32);
+                }
+        }
+}
+

--- a/sensor/stmemsc/lsm6dso_STdC/lib/fifo_utility/fifo_utility.h
+++ b/sensor/stmemsc/lsm6dso_STdC/lib/fifo_utility/fifo_utility.h
@@ -1,0 +1,109 @@
+/*
+ ******************************************************************************
+ * @file    fifo_utility.h
+ * @author  Sensor Solutions Software Team
+ * @brief   This file contains all the functions prototypes for the
+ *          fifo_utility.c.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _ST_FIFO_H_
+#define _ST_FIFO_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+typedef enum {
+        ST_FIFO_OK,
+        ST_FIFO_ERR
+} st_fifo_status;
+
+typedef enum {
+        ST_FIFO_GYROSCOPE,
+        ST_FIFO_ACCELEROMETER,
+        ST_FIFO_TEMPERATURE,
+        ST_FIFO_EXT_SENSOR0,
+        ST_FIFO_EXT_SENSOR1,
+        ST_FIFO_EXT_SENSOR2,
+        ST_FIFO_EXT_SENSOR3,
+        ST_FIFO_STEP_COUNTER,
+        ST_FIFO_6X_GAME_RV,
+        ST_FIFO_6X_GEOM_RV,
+        ST_FIFO_9X_RV,
+        ST_FIFO_GYRO_BIAS,
+        ST_FIFO_GRAVITY,
+        ST_FIFO_MAGNETOMETER_CALIB,
+        ST_FIFO_EXT_SENSOR_NACK,
+        ST_FIFO_NONE
+} st_fifo_sensor_type;
+
+typedef struct {
+        uint8_t fifo_data_out[7]; /* registers from mems (78h -> 7Dh) */
+} st_fifo_raw_slot;
+
+typedef struct {
+        uint32_t timestamp;
+        st_fifo_sensor_type sensor_tag;
+        union {
+                uint8_t raw_data[6]; 	/* bytes */
+                int16_t data[3]; 		/* 3 axes mems */
+                int16_t temp; 			/* temperature sensor */
+                uint16_t steps; 		/* step counter */
+                uint16_t quat[3]; 		/* quaternion 3 axes format [x,y,z] */
+                uint8_t nack; 			/* ext sensor nack index */
+        } sensor_data;
+} st_fifo_out_slot;
+
+st_fifo_status st_fifo_init(float bdr_xl, float bdr_gy, float bdr_vsens);
+void st_fifo_rescale_bdr_array(float scale);
+st_fifo_status st_fifo_decode(st_fifo_out_slot *fifo_out_slot,
+							  st_fifo_raw_slot *fifo_raw_slot,
+							  uint16_t *out_slot_size,
+							  uint16_t stream_size);
+st_fifo_status st_fifo_decompress(st_fifo_out_slot *fifo_out_slot,
+								  st_fifo_raw_slot *fifo_raw_slot,
+								  uint16_t *out_slot_size,
+								  uint16_t stream_size);
+void st_fifo_sort(st_fifo_out_slot *fifo_out_slot, uint16_t out_slot_size);
+uint16_t st_fifo_get_sensor_occurrence(st_fifo_out_slot *fifo_out_slot,
+									   uint16_t out_slot_size,
+									   st_fifo_sensor_type sensor_type);
+void st_fifo_extract_sensor(st_fifo_out_slot *sensor_out_slot,
+							st_fifo_out_slot *fifo_out_slot,
+							uint16_t out_slot_size,
+							st_fifo_sensor_type sensor_type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ST_FIFO_H_ */

--- a/sensor/stmemsc/lsm6dsox_STdC/driver/lsm6dsox_reg.c
+++ b/sensor/stmemsc/lsm6dsox_STdC/driver/lsm6dsox_reg.c
@@ -1,0 +1,9539 @@
+/*
+  ******************************************************************************
+  * @file    lsm6dsox_reg.c
+  * @author  Sensor Solutions Software Team
+  * @brief   LSM6DSOX driver file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions
+  * are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright
+  *      notice, this list of conditions and the following disclaimer in the
+  *      documentation and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its
+  *      contributors may be used to endorse or promote products derived from
+  *      this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  * POSSIBILITY OF SUCH DAMAGE.
+  *
+  */
+
+#include "lsm6dsox_reg.h"
+
+/**
+  * @defgroup  LSM6DSOX
+  * @brief     This file provides a set of functions needed to drive the
+  *            lsm6dsox enhanced inertial module.
+  * @{
+  *
+*/
+
+/**
+  * @defgroup  LSM6DSOX_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsox_read_reg(lsm6dsox_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsox_write_reg(lsm6dsox_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_Sensitivity
+  * @brief     These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+float_t lsm6dsox_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lsm6dsox_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t lsm6dsox_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t lsm6dsox_from_fs16_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) *0.488f;
+}
+
+float_t lsm6dsox_from_fs125_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *4.375f;
+}
+
+float_t lsm6dsox_from_fs500_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *17.50f;
+}
+
+float_t lsm6dsox_from_fs250_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *8.750f;
+}
+
+float_t lsm6dsox_from_fs1000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *35.0f;
+}
+
+float_t lsm6dsox_from_fs2000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb) *70.0f;
+}
+
+float_t lsm6dsox_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+float_t lsm6dsox_from_lsb_to_nsec(int16_t lsb)
+{
+  return ((float_t)lsb * 25000.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_Data_Generation
+  * @brief     This section groups all the functions concerning
+  *            data generation.
+  *
+  */
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dsox_xl_full_scale_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_fs_xl_t val)
+{
+  lsm6dsox_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fs_xl = (uint8_t) val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dsox_xl_full_scale_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_xl_t *val)
+{
+  lsm6dsox_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+  switch (reg.fs_xl) {
+    case LSM6DSOX_2g:
+      *val = LSM6DSOX_2g;
+      break;
+    case LSM6DSOX_16g:
+      *val = LSM6DSOX_16g;
+      break;
+    case LSM6DSOX_4g:
+      *val = LSM6DSOX_4g;
+      break;
+    case LSM6DSOX_8g:
+      *val = LSM6DSOX_8g;
+      break;
+    default:
+      *val = LSM6DSOX_2g;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dsox_xl_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_xl_t val)
+{
+  lsm6dsox_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odr_xl = (uint8_t) val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr_xl in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dsox_xl_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_xl_t *val)
+{
+  lsm6dsox_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+
+  switch (reg.odr_xl) {
+    case LSM6DSOX_XL_ODR_OFF:
+      *val = LSM6DSOX_XL_ODR_OFF;
+      break;
+    case LSM6DSOX_XL_ODR_12Hz5:
+      *val = LSM6DSOX_XL_ODR_12Hz5;
+      break;
+    case LSM6DSOX_XL_ODR_26Hz:
+      *val = LSM6DSOX_XL_ODR_26Hz;
+      break;
+    case LSM6DSOX_XL_ODR_52Hz:
+      *val = LSM6DSOX_XL_ODR_52Hz;
+      break;
+    case LSM6DSOX_XL_ODR_104Hz:
+      *val = LSM6DSOX_XL_ODR_104Hz;
+      break;
+    case LSM6DSOX_XL_ODR_208Hz:
+      *val = LSM6DSOX_XL_ODR_208Hz;
+      break;
+    case LSM6DSOX_XL_ODR_417Hz:
+      *val = LSM6DSOX_XL_ODR_417Hz;
+      break;
+    case LSM6DSOX_XL_ODR_833Hz:
+      *val = LSM6DSOX_XL_ODR_833Hz;
+      break;
+    case LSM6DSOX_XL_ODR_1667Hz:
+      *val = LSM6DSOX_XL_ODR_1667Hz;
+      break;
+    case LSM6DSOX_XL_ODR_3333Hz:
+      *val = LSM6DSOX_XL_ODR_3333Hz;
+      break;
+    case LSM6DSOX_XL_ODR_6667Hz:
+      *val = LSM6DSOX_XL_ODR_6667Hz;
+      break;
+    case LSM6DSOX_XL_ODR_6Hz5:
+      *val = LSM6DSOX_XL_ODR_6Hz5;
+      break;
+    default:
+      *val = LSM6DSOX_XL_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6dsox_gy_full_scale_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_g_t val)
+{
+  lsm6dsox_ctrl2_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL2_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fs_g = (uint8_t) val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL2_G, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6dsox_gy_full_scale_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_g_t *val)
+{
+  lsm6dsox_ctrl2_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL2_G, (uint8_t*)&reg, 1);
+  switch (reg.fs_g) {
+    case LSM6DSOX_250dps:
+      *val = LSM6DSOX_250dps;
+      break;
+    case LSM6DSOX_125dps:
+      *val = LSM6DSOX_125dps;
+      break;
+    case LSM6DSOX_500dps:
+      *val = LSM6DSOX_500dps;
+      break;
+    case LSM6DSOX_1000dps:
+      *val = LSM6DSOX_1000dps;
+      break;
+    case LSM6DSOX_2000dps:
+      *val = LSM6DSOX_2000dps;
+      break;
+    default:
+      *val = LSM6DSOX_250dps;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6dsox_gy_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_g_t val)
+{
+  lsm6dsox_ctrl2_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL2_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odr_g = (uint8_t) val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL2_G, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr_g in reg CTRL2_G
+  *
+  */
+int32_t lsm6dsox_gy_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_g_t *val)
+{
+  lsm6dsox_ctrl2_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL2_G, (uint8_t*)&reg, 1);
+  switch (reg.odr_g) {
+    case LSM6DSOX_GY_ODR_OFF:
+      *val = LSM6DSOX_GY_ODR_OFF;
+      break;
+    case LSM6DSOX_GY_ODR_12Hz5:
+      *val = LSM6DSOX_GY_ODR_12Hz5;
+      break;
+    case LSM6DSOX_GY_ODR_26Hz:
+      *val = LSM6DSOX_GY_ODR_26Hz;
+      break;
+    case LSM6DSOX_GY_ODR_52Hz:
+      *val = LSM6DSOX_GY_ODR_52Hz;
+      break;
+    case LSM6DSOX_GY_ODR_104Hz:
+      *val = LSM6DSOX_GY_ODR_104Hz;
+      break;
+    case LSM6DSOX_GY_ODR_208Hz:
+      *val = LSM6DSOX_GY_ODR_208Hz;
+      break;
+    case LSM6DSOX_GY_ODR_417Hz:
+      *val = LSM6DSOX_GY_ODR_417Hz;
+      break;
+    case LSM6DSOX_GY_ODR_833Hz:
+      *val = LSM6DSOX_GY_ODR_833Hz;
+      break;
+    case LSM6DSOX_GY_ODR_1667Hz:
+      *val = LSM6DSOX_GY_ODR_1667Hz;
+      break;
+    case LSM6DSOX_GY_ODR_3333Hz:
+      *val = LSM6DSOX_GY_ODR_3333Hz;
+      break;
+    case LSM6DSOX_GY_ODR_6667Hz:
+      *val = LSM6DSOX_GY_ODR_6667Hz;
+      break;
+    default:
+      *val = LSM6DSOX_GY_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_block_data_update_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_block_data_update_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_w in reg CTRL6_C
+  *
+  */
+int32_t lsm6dsox_xl_offset_weight_set(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_usr_off_w_t val)
+{
+  lsm6dsox_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.usr_off_w = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *           Y_OFS_USR (74h), Z_OFS_USR (75h).[get]
+  *
+  * @param    ctx      read / write interface definitions
+  * @param    val      Get the values of usr_off_w in reg CTRL6_C
+  *
+  */
+int32_t lsm6dsox_xl_offset_weight_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_usr_off_w_t *val)
+{
+  lsm6dsox_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+
+  switch (reg.usr_off_w) {
+    case LSM6DSOX_LSb_1mg:
+      *val = LSM6DSOX_LSb_1mg;
+      break;
+    case LSM6DSOX_LSb_16mg:
+      *val = LSM6DSOX_LSb_16mg;
+      break;
+    default:
+      *val = LSM6DSOX_LSb_1mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer power mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of xl_hm_mode in
+  *                               reg CTRL6_C
+  *
+  */
+int32_t lsm6dsox_xl_power_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_xl_hm_mode_t val)
+{
+  lsm6dsox_ctrl5_c_t ctrl5_c;
+  lsm6dsox_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*) &ctrl5_c, 1);
+  if (ret == 0) {
+    ctrl5_c.xl_ulp_en = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*) &ctrl5_c, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*) &ctrl6_c, 1);
+  }
+  if (ret == 0) {
+    ctrl6_c.xl_hm_mode = (uint8_t)val & 0x01U;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*) &ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer power mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of xl_hm_mode in reg CTRL6_C
+  *
+  */
+int32_t lsm6dsox_xl_power_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_xl_hm_mode_t *val)
+{
+  lsm6dsox_ctrl5_c_t ctrl5_c;
+  lsm6dsox_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*) &ctrl5_c, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*) &ctrl6_c, 1);
+    switch ( (ctrl5_c.xl_ulp_en << 1) | ctrl6_c.xl_hm_mode) {
+      case LSM6DSOX_HIGH_PERFORMANCE_MD:
+        *val = LSM6DSOX_HIGH_PERFORMANCE_MD;
+        break;
+      case LSM6DSOX_LOW_NORMAL_POWER_MD:
+        *val = LSM6DSOX_LOW_NORMAL_POWER_MD;
+        break;
+      case LSM6DSOX_ULTRA_LOW_POWER_MD:
+        *val = LSM6DSOX_ULTRA_LOW_POWER_MD;
+        break;
+      default:
+        *val = LSM6DSOX_HIGH_PERFORMANCE_MD;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode for gyroscope.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of g_hm_mode in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_gy_power_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_g_hm_mode_t val)
+{
+  lsm6dsox_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.g_hm_mode = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode for gyroscope.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of g_hm_mode in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_gy_power_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_g_hm_mode_t *val)
+{
+  lsm6dsox_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  switch (reg.g_hm_mode) {
+    case LSM6DSOX_GY_HIGH_PERFORMANCE:
+      *val = LSM6DSOX_GY_HIGH_PERFORMANCE;
+      break;
+    case LSM6DSOX_GY_NORMAL:
+      *val = LSM6DSOX_GY_NORMAL;
+      break;
+    default:
+      *val = LSM6DSOX_GY_HIGH_PERFORMANCE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers ALL_INT_SRC; WAKE_UP_SRC;
+  *                              TAP_SRC; D6D_SRC; STATUS_REG;
+  *                              EMB_FUNC_STATUS; FSM_STATUS_A/B
+  *
+  */
+int32_t lsm6dsox_all_sources_get(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_ALL_INT_SRC,
+                         (uint8_t*)&val->all_int_src, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_SRC,
+                           (uint8_t*)&val->wake_up_src, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_SRC,
+                           (uint8_t*)&val->tap_src, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_D6D_SRC,
+                           (uint8_t*)&val->d6d_src, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_STATUS_REG,
+                           (uint8_t*)&val->status_reg, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_STATUS,
+                           (uint8_t*)&val->emb_func_status, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_STATUS_A,
+                           (uint8_t*)&val->fsm_status_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_STATUS_B,
+                           (uint8_t*)&val->fsm_status_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register STATUS_REG
+  *
+  */
+int32_t lsm6dsox_status_reg_get(lsm6dsox_ctx_t *ctx, lsm6dsox_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of xlda in reg STATUS_REG
+  *
+  */
+int32_t lsm6dsox_xl_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_status_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of gda in reg STATUS_REG
+  *
+  */
+int32_t lsm6dsox_gy_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_status_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tda in reg STATUS_REG
+  *
+  */
+int32_t lsm6dsox_temp_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_status_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in
+  *         two’s complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_x_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_write_reg(ctx, LSM6DSOX_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_x_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_y_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_write_reg(ctx, LSM6DSOX_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_y_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_z_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_write_reg(ctx, LSM6DSOX_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_z_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enables user offset on out.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_out in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.usr_off_on_out = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  User offset on out flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      values of usr_off_on_out in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  *val = reg.usr_off_on_out;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_Timestamp
+  * @brief     This section groups all the functions that manage the
+  *            timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of timestamp_en in reg CTRL10_C
+  *
+  */
+int32_t lsm6dsox_timestamp_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl10_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL10_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.timestamp_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL10_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of timestamp_en in reg CTRL10_C
+  *
+  */
+int32_t lsm6dsox_timestamp_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl10_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL10_C, (uint8_t*)&reg, 1);
+  *val = reg.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp first data output register (r).
+  *         The value is expressed as a 32-bit word and the bit
+  *         resolution is 25 μs.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_timestamp_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TIMESTAMP0, buff, 4);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_Data output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read of the output
+  *         registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of rounding in reg CTRL5_C
+  *
+  */
+int32_t lsm6dsox_rounding_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_rounding_t val)
+{
+  lsm6dsox_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.rounding = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of rounding in reg CTRL5_C
+  *
+  */
+int32_t lsm6dsox_rounding_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_rounding_t *val)
+{
+  lsm6dsox_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  switch (reg.rounding) {
+    case LSM6DSOX_NO_ROUND:
+      *val = LSM6DSOX_NO_ROUND;
+      break;
+    case LSM6DSOX_ROUND_XL:
+      *val = LSM6DSOX_ROUND_XL;
+      break;
+    case LSM6DSOX_ROUND_GY:
+      *val = LSM6DSOX_ROUND_GY;
+      break;
+    case LSM6DSOX_ROUND_GY_XL:
+      *val = LSM6DSOX_ROUND_GY_XL;
+      break;
+    default:
+      *val = LSM6DSOX_NO_ROUND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  rounding_on_status: [set] Source register rounding function in
+  *                                   ALL_INT_SRC (1Ah), WAKE_UP_SRC(1Bh),
+  *                                   TAP_SRC (1Ch), D6D_SRC (1Dh),
+  *                                   STATUS_REG (1Eh) and
+  *                                   EMB_FUNC_STATUS_MAINPAGE(35h),
+  *                                   FSM_STATUS_A_MAINPAGE (36h),
+  *                                   FSM_STATUS_B_MAINPAGE (37h),
+  *                                   PROGSENS_STATUS_MAINPAGE (38h),
+  *                                   STATUS_MASTER_MAINPAGE (39h),
+  *                                   FIFO_STATUS1 (3Ah), FIFO_STATUS2(3Bh).
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  lsm6dsox_rounding_status_t: change the values of rounding_status
+  *                                    in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_rounding_on_status_set(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_rounding_status_t val)
+{
+  lsm6dsox_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.rounding_status = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  rounding_on_status: [get] Source register rounding function in
+  *                                   ALL_INT_SRC (1Ah), WAKE_UP_SRC(1Bh),
+  *                                   TAP_SRC (1Ch), D6D_SRC (1Dh),
+  *                                   STATUS_REG (1Eh) and
+  *                                   EMB_FUNC_STATUS_MAINPAGE(35h),
+  *                                   FSM_STATUS_A_MAINPAGE (36h),
+  *                                   FSM_STATUS_B_MAINPAGE (37h),
+  *                                   PROGSENS_STATUS_MAINPAGE (38h),
+  *                                   STATUS_MASTER_MAINPAGE (39h),
+  *                                   FIFO_STATUS1 (3Ah), FIFO_STATUS2(3Bh).
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  lsm6dsox_rounding_status_t: Get the values of rounding_status
+  *                                    in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_rounding_on_status_get(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_rounding_status_t *val)
+{
+  lsm6dsox_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  switch (reg.rounding_status) {
+    case LSM6DSOX_STAT_RND_DISABLE:
+      *val = LSM6DSOX_STAT_RND_DISABLE;
+      break;
+    case LSM6DSOX_STAT_RND_ENABLE:
+      *val = LSM6DSOX_STAT_RND_ENABLE;
+      break;
+    default:
+      *val = LSM6DSOX_STAT_RND_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r).
+  *         L and H registers together express a 16-bit word in two’s
+  *         complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_temperature_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit
+  *         word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register.
+  *         The value is expressed as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_OUTX_L_A, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  FIFO data output [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_fifo_out_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_DATA_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  ois_angular_rate_raw: [get]  OIS angular rate sensor.
+  *                                      The value is expressed as a
+  *                                      16-bit word in two’s complement.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_ois_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm6dsox_read_reg(ctx, LSM6DSOX_UI_OUTX_L_G_OIS, buff, 6);
+}
+
+/**
+  * @brief  ois_acceleration_raw: [get] OIS Linear acceleration output register.
+  *                                     The value is expressed as a
+  *                                     16-bit word in two’s complement.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_ois_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm6dsox_read_reg(ctx, LSM6DSOX_UI_OUTX_L_A_OIS, buff, 6);
+}
+
+/**
+  * @brief  aux_temperature_raw: [get]  Temperature from auxiliary
+  *                                     interface.
+  *                                     The value is expressed as a
+  *                                     16-bit word in two’s complement.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_aux_temperature_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm6dsox_read_reg(ctx, LSM6DSOX_SPI2_OUT_TEMP_L, buff, 2);
+}
+
+/**
+  * @brief  aux_ois_angular_rate_raw: [get] OIS angular rate sensor from
+  *                                         auxiliary interface.
+  *                                         The value is expressed as a
+  *                                         16-bit word in two’s complement.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_aux_ois_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm6dsox_read_reg(ctx, LSM6DSOX_SPI2_OUTX_L_G_OIS, buff, 6);
+}
+
+/**
+  * @brief  aux_ois_acceleration_raw: [get] OIS linear acceleration output
+  *                                         register from auxiliary interface.
+  *                                         The value is expressed as a
+  *                                         16-bit word in two’s complement.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_aux_ois_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  return lsm6dsox_read_reg(ctx, LSM6DSOX_SPI2_OUTX_L_A_OIS, buff, 6);
+}
+
+/**
+  * @brief  Step counter output register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_number_of_steps_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_STEP_COUNTER_L, buff, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  *
+  */
+int32_t lsm6dsox_steps_reset(lsm6dsox_ctx_t *ctx)
+{
+  lsm6dsox_emb_func_src_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_SRC, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.pedo_rst_step = PROPERTY_ENABLE;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_SRC, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  prgsens_out: [get] Output value of all PROGSENSx decision trees.
+  *
+  * @param  ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t * : buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_mlc_out_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MLC0_SRC, buff, 8);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_common
+  * @brief   This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Difference in percentage of the effective ODR(and timestamp rate)
+  *         with respect to the typical.
+  *         Step:  0.15%. 8-bit format, 2's complement.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of freq_fine in reg
+  *                      INTERNAL_FREQ_FINE
+  *
+  */
+int32_t lsm6dsox_odr_cal_reg_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_internal_freq_fine_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INTERNAL_FREQ_FINE, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.freq_fine = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_INTERNAL_FREQ_FINE,
+                            (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Difference in percentage of the effective ODR(and timestamp rate)
+  *         with respect to the typical.
+  *         Step:  0.15%. 8-bit format, 2's complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  *
+  */
+int32_t lsm6dsox_odr_cal_reg_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_internal_freq_fine_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INTERNAL_FREQ_FINE, (uint8_t*)&reg, 1);
+  *val = reg.freq_fine;
+
+  return ret;
+}
+
+
+/**
+  * @brief  Enable access to the embedded functions/sensor
+  *         hub configuration registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reg_access in
+  *                               reg FUNC_CFG_ACCESS
+  *
+  */
+int32_t lsm6dsox_mem_bank_set(lsm6dsox_ctx_t *ctx, lsm6dsox_reg_access_t val)
+{
+  lsm6dsox_func_cfg_access_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FUNC_CFG_ACCESS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.reg_access = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FUNC_CFG_ACCESS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor
+  *         hub configuration registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of reg_access in
+  *                               reg FUNC_CFG_ACCESS
+  *
+  */
+int32_t lsm6dsox_mem_bank_get(lsm6dsox_ctx_t *ctx, lsm6dsox_reg_access_t *val)
+{
+  lsm6dsox_func_cfg_access_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FUNC_CFG_ACCESS, (uint8_t*)&reg, 1);
+  switch (reg.reg_access) {
+    case LSM6DSOX_USER_BANK:
+      *val = LSM6DSOX_USER_BANK;
+      break;
+    case LSM6DSOX_SENSOR_HUB_BANK:
+      *val = LSM6DSOX_SENSOR_HUB_BANK;
+      break;
+    case LSM6DSOX_EMBEDDED_FUNC_BANK:
+      *val = LSM6DSOX_EMBEDDED_FUNC_BANK;
+      break;
+    default:
+      *val = LSM6DSOX_USER_BANK;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write a line(byte) in a page.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t address: page line address
+  * @param  val      value to write
+  *
+  */
+int32_t lsm6dsox_ln_pg_write_byte(lsm6dsox_ctx_t *ctx, uint16_t address,
+                                 uint8_t *val)
+{
+  lsm6dsox_page_rw_t page_rw;
+  lsm6dsox_page_sel_t page_sel;
+  lsm6dsox_page_address_t page_address;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x02; /* page_write enable */
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+
+  if (ret == 0) {
+    page_sel.page_sel = (((uint8_t)address >> 8) & 0x0FU);
+    page_sel.not_used_01 = 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_address.page_addr = (uint8_t)address & 0xFFU;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_ADDRESS,
+                            (uint8_t*)&page_address, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_VALUE, val, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x00; /* page_write disable */
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write buffer in a page.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t address: page line address
+  * @param  uint8_t *buf: buffer to write
+  * @param  uint8_t len: buffer len
+  *
+  */
+int32_t lsm6dsox_ln_pg_write(lsm6dsox_ctx_t *ctx, uint16_t address,
+                            uint8_t *buf, uint8_t len)
+{
+  lsm6dsox_page_rw_t page_rw;
+  lsm6dsox_page_sel_t page_sel;
+  lsm6dsox_page_address_t  page_address;
+  int32_t ret;
+  uint8_t msb, lsb;
+  uint8_t i ;
+
+  msb = (((uint8_t)address >> 8) & 0x0fU);
+  lsb = (uint8_t)address & 0xFFU;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x02; /* page_write enable*/
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_sel.page_sel = msb;
+    page_sel.not_used_01 = 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_address.page_addr = lsb;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_ADDRESS,
+                            (uint8_t*)&page_address, 1);
+  }
+
+  if (ret == 0) {
+
+    for (i = 0; ( (i < len) && (ret == 0) ); i++)
+    {
+      ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_VALUE, &buf[i], 1);
+
+      /* Check if page wrap */
+      if ( (lsb == 0x00U) && (ret == 0) ) {
+        lsb++;
+        msb++;
+        ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_SEL, (uint8_t*)&page_sel, 1);
+        if (ret == 0) {
+          page_sel.page_sel = msb;
+          page_sel.not_used_01 = 1;
+          ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_SEL,
+                                  (uint8_t*)&page_sel, 1);
+        }
+      }
+    }
+    page_sel.page_sel = 0;
+    page_sel.not_used_01 = 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x00; /* page_write disable */
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+
+  if (ret == 0) {
+
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read a line(byte) in a page.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t address: page line address
+  * @param  val      read value
+  *
+  */
+int32_t lsm6dsox_ln_pg_read_byte(lsm6dsox_ctx_t *ctx, uint16_t address,
+                                uint8_t *val)
+{
+  lsm6dsox_page_rw_t page_rw;
+  lsm6dsox_page_sel_t page_sel;
+  lsm6dsox_page_address_t  page_address;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x01; /* page_read enable*/
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_sel.page_sel = (((uint8_t)address >> 8) & 0x0FU);
+    page_sel.not_used_01 = 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_SEL, (uint8_t*) &page_sel, 1);
+  }
+  if (ret == 0) {
+    page_address.page_addr = (uint8_t)address & 0x00FFU;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_ADDRESS,
+                            (uint8_t*)&page_address, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_VALUE, val, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.page_rw = 0x00; /* page_read disable */
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of
+  *                                     dataready_pulsed in
+  *                                     reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dsox_data_ready_mode_set(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_dataready_pulsed_t val)
+{
+  lsm6dsox_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.dataready_pulsed = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of
+  *                                     dataready_pulsed in
+  *                                     reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dsox_data_ready_mode_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_dataready_pulsed_t *val)
+{
+  lsm6dsox_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  switch (reg.dataready_pulsed) {
+    case LSM6DSOX_DRDY_LATCHED:
+      *val = LSM6DSOX_DRDY_LATCHED;
+      break;
+    case LSM6DSOX_DRDY_PULSED:
+      *val = LSM6DSOX_DRDY_PULSED;
+      break;
+    default:
+      *val = LSM6DSOX_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Device "Who am I".[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_device_id_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values
+  *         in user registers[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sw_reset in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_reset_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sw_reset = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sw_reset in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_reset_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  *val = reg.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_inc in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_auto_increment_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.if_inc = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_inc in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_auto_increment_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  *val = reg.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_boot_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.boot = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_boot_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st_xl in reg CTRL5_C
+  *
+  */
+int32_t lsm6dsox_xl_self_test_set(lsm6dsox_ctx_t *ctx, lsm6dsox_st_xl_t val)
+{
+  lsm6dsox_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.st_xl = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st_xl in reg CTRL5_C
+  *
+  */
+int32_t lsm6dsox_xl_self_test_get(lsm6dsox_ctx_t *ctx, lsm6dsox_st_xl_t *val)
+{
+  lsm6dsox_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  switch (reg.st_xl) {
+    case LSM6DSOX_XL_ST_DISABLE:
+      *val = LSM6DSOX_XL_ST_DISABLE;
+      break;
+    case LSM6DSOX_XL_ST_POSITIVE:
+      *val = LSM6DSOX_XL_ST_POSITIVE;
+      break;
+    case LSM6DSOX_XL_ST_NEGATIVE:
+      *val = LSM6DSOX_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSOX_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st_g in reg CTRL5_C
+  *
+  */
+int32_t lsm6dsox_gy_self_test_set(lsm6dsox_ctx_t *ctx, lsm6dsox_st_g_t val)
+{
+  lsm6dsox_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.st_g = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st_g in reg CTRL5_C
+  *
+  */
+int32_t lsm6dsox_gy_self_test_get(lsm6dsox_ctx_t *ctx, lsm6dsox_st_g_t *val)
+{
+  lsm6dsox_ctrl5_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL5_C, (uint8_t*)&reg, 1);
+  switch (reg.st_g) {
+    case LSM6DSOX_GY_ST_DISABLE:
+      *val = LSM6DSOX_GY_ST_DISABLE;
+      break;
+    case LSM6DSOX_GY_ST_POSITIVE:
+      *val = LSM6DSOX_GY_ST_POSITIVE;
+      break;
+    case LSM6DSOX_GY_ST_NEGATIVE:
+      *val = LSM6DSOX_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSOX_GY_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_filters
+  * @brief     This section group all the functions concerning the
+  *            filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf2_xl_en in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dsox_xl_filter_lp2_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.lpf2_xl_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf2_xl_en in reg CTRL1_XL
+  *
+  */
+int32_t lsm6dsox_xl_filter_lp2_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl1_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL1_XL, (uint8_t*)&reg, 1);
+  *val = reg.lpf2_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0]
+  *         in CTRL6_C (15h).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf1_sel_g in reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_gy_filter_lp1_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.lpf1_sel_g = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0]
+  *         in CTRL6_C (15h).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpf1_sel_g in reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_gy_filter_lp1_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  *val = reg.lpf1_sel_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_mask in reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_filter_settling_mask_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.drdy_mask = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_mask in reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_filter_settling_mask_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  *val = reg.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope lp1 bandwidth.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ftype in reg CTRL6_C
+  *
+  */
+int32_t lsm6dsox_gy_lp1_bandwidth_set(lsm6dsox_ctx_t *ctx, lsm6dsox_ftype_t val)
+{
+  lsm6dsox_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ftype = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope lp1 bandwidth.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val       Get the values of ftype in reg CTRL6_C
+  *
+  */
+int32_t lsm6dsox_gy_lp1_bandwidth_get(lsm6dsox_ctx_t *ctx, lsm6dsox_ftype_t *val)
+{
+  lsm6dsox_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+  switch (reg.ftype) {
+    case LSM6DSOX_ULTRA_LIGHT:
+      *val = LSM6DSOX_ULTRA_LIGHT;
+      break;
+    case LSM6DSOX_VERY_LIGHT:
+      *val = LSM6DSOX_VERY_LIGHT;
+      break;
+    case LSM6DSOX_LIGHT:
+      *val = LSM6DSOX_LIGHT;
+      break;
+    case LSM6DSOX_MEDIUM:
+      *val = LSM6DSOX_MEDIUM;
+      break;
+    case LSM6DSOX_STRONG:
+      *val = LSM6DSOX_STRONG;
+      break;
+    case LSM6DSOX_VERY_STRONG:
+      *val = LSM6DSOX_VERY_STRONG;
+      break;
+    case LSM6DSOX_AGGRESSIVE:
+      *val = LSM6DSOX_AGGRESSIVE;
+      break;
+    case LSM6DSOX_XTREME:
+      *val = LSM6DSOX_XTREME;
+      break;
+    default:
+      *val = LSM6DSOX_ULTRA_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of low_pass_on_6d in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dsox_xl_lp2_on_6d_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.low_pass_on_6d = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of low_pass_on_6d in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dsox_xl_lp2_on_6d_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  *val = reg.low_pass_on_6d;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection
+  *         on output.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_slope_xl_en
+  *                                   in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dsox_xl_hp_path_on_out_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_hp_slope_xl_en_t val)
+{
+  lsm6dsox_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.hp_slope_xl_en = ((uint8_t)val & 0x10U) >> 4;
+    reg.hp_ref_mode_xl = ((uint8_t)val & 0x20U) >> 5;
+    reg.hpcf_xl = (uint8_t)val & 0x07U;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection
+  *         on output.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp_slope_xl_en
+  *                                   in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dsox_xl_hp_path_on_out_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_hp_slope_xl_en_t *val)
+{
+  lsm6dsox_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  switch ((reg.hp_ref_mode_xl << 5) | (reg.hp_slope_xl_en << 4) |
+          reg.hpcf_xl) {
+    case LSM6DSOX_HP_PATH_DISABLE_ON_OUT:
+      *val = LSM6DSOX_HP_PATH_DISABLE_ON_OUT;
+      break;
+    case LSM6DSOX_SLOPE_ODR_DIV_4:
+      *val = LSM6DSOX_SLOPE_ODR_DIV_4;
+      break;
+    case LSM6DSOX_HP_ODR_DIV_10:
+      *val = LSM6DSOX_HP_ODR_DIV_10;
+      break;
+    case LSM6DSOX_HP_ODR_DIV_20:
+      *val = LSM6DSOX_HP_ODR_DIV_20;
+      break;
+    case LSM6DSOX_HP_ODR_DIV_45:
+      *val = LSM6DSOX_HP_ODR_DIV_45;
+      break;
+    case LSM6DSOX_HP_ODR_DIV_100:
+      *val = LSM6DSOX_HP_ODR_DIV_100;
+      break;
+    case LSM6DSOX_HP_ODR_DIV_200:
+      *val = LSM6DSOX_HP_ODR_DIV_200;
+      break;
+    case LSM6DSOX_HP_ODR_DIV_400:
+      *val = LSM6DSOX_HP_ODR_DIV_400;
+      break;
+    case LSM6DSOX_HP_ODR_DIV_800:
+      *val = LSM6DSOX_HP_ODR_DIV_800;
+      break;
+    case LSM6DSOX_HP_REF_MD_ODR_DIV_10:
+      *val = LSM6DSOX_HP_REF_MD_ODR_DIV_10;
+      break;
+    case LSM6DSOX_HP_REF_MD_ODR_DIV_20:
+      *val = LSM6DSOX_HP_REF_MD_ODR_DIV_20;
+      break;
+    case LSM6DSOX_HP_REF_MD_ODR_DIV_45:
+      *val = LSM6DSOX_HP_REF_MD_ODR_DIV_45;
+      break;
+    case LSM6DSOX_HP_REF_MD_ODR_DIV_100:
+      *val = LSM6DSOX_HP_REF_MD_ODR_DIV_100;
+      break;
+    case LSM6DSOX_HP_REF_MD_ODR_DIV_200:
+      *val = LSM6DSOX_HP_REF_MD_ODR_DIV_200;
+      break;
+    case LSM6DSOX_HP_REF_MD_ODR_DIV_400:
+      *val = LSM6DSOX_HP_REF_MD_ODR_DIV_400;
+      break;
+    case LSM6DSOX_HP_REF_MD_ODR_DIV_800:
+      *val = LSM6DSOX_HP_REF_MD_ODR_DIV_800;
+      break;
+    case LSM6DSOX_LP_ODR_DIV_10:
+      *val = LSM6DSOX_LP_ODR_DIV_10;
+      break;
+    case LSM6DSOX_LP_ODR_DIV_20:
+      *val = LSM6DSOX_LP_ODR_DIV_20;
+      break;
+    case LSM6DSOX_LP_ODR_DIV_45:
+      *val = LSM6DSOX_LP_ODR_DIV_45;
+      break;
+    case LSM6DSOX_LP_ODR_DIV_100:
+      *val = LSM6DSOX_LP_ODR_DIV_100;
+      break;
+    case LSM6DSOX_LP_ODR_DIV_200:
+      *val = LSM6DSOX_LP_ODR_DIV_200;
+      break;
+    case LSM6DSOX_LP_ODR_DIV_400:
+      *val = LSM6DSOX_LP_ODR_DIV_400;
+      break;
+    case LSM6DSOX_LP_ODR_DIV_800:
+      *val = LSM6DSOX_LP_ODR_DIV_800;
+      break;
+    default:
+      *val = LSM6DSOX_HP_PATH_DISABLE_ON_OUT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing this bit.
+  *         Active only during device exit from power-down mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fastsettl_mode_xl in
+  *                  reg CTRL8_XL
+  *
+  */
+int32_t lsm6dsox_xl_fast_settling_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fastsettl_mode_xl = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing this bit.
+  *         Active only during device exit from power-down mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fastsettl_mode_xl in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dsox_xl_fast_settling_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  *val = reg.fastsettl_mode_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of slope_fds in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_xl_hp_path_internal_set(lsm6dsox_ctx_t *ctx,
+                                        lsm6dsox_slope_fds_t val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.slope_fds = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Change the values of slope_fds in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_xl_hp_path_internal_get(lsm6dsox_ctx_t *ctx,
+                                        lsm6dsox_slope_fds_t *val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  switch (reg.slope_fds) {
+    case LSM6DSOX_USE_SLOPE:
+      *val = LSM6DSOX_USE_SLOPE;
+      break;
+    case LSM6DSOX_USE_HPF:
+      *val = LSM6DSOX_USE_HPF;
+      break;
+    default:
+      *val = LSM6DSOX_USE_SLOPE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital high-pass filter. The filter is
+  *         enabled only if the gyro is in HP mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp_en_g and hp_en_g
+  *                            in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_gy_hp_path_internal_set(lsm6dsox_ctx_t *ctx,
+                                        lsm6dsox_hpm_g_t val)
+{
+  lsm6dsox_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.hp_en_g = ((uint8_t)val & 0x80U) >> 7;
+    reg.hpm_g = (uint8_t)val & 0x03U;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital high-pass filter. The filter is
+  *         enabled only if the gyro is in HP mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hp_en_g and hp_en_g
+  *                            in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_gy_hp_path_internal_get(lsm6dsox_ctx_t *ctx,
+                                        lsm6dsox_hpm_g_t *val)
+{
+  lsm6dsox_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  switch ((reg.hp_en_g << 7) + reg.hpm_g) {
+    case LSM6DSOX_HP_FILTER_NONE:
+      *val = LSM6DSOX_HP_FILTER_NONE;
+      break;
+    case LSM6DSOX_HP_FILTER_16mHz:
+      *val = LSM6DSOX_HP_FILTER_16mHz;
+      break;
+    case LSM6DSOX_HP_FILTER_65mHz:
+      *val = LSM6DSOX_HP_FILTER_65mHz;
+      break;
+    case LSM6DSOX_HP_FILTER_260mHz:
+      *val = LSM6DSOX_HP_FILTER_260mHz;
+      break;
+    case LSM6DSOX_HP_FILTER_1Hz04:
+      *val = LSM6DSOX_HP_FILTER_1Hz04;
+      break;
+    default:
+      *val = LSM6DSOX_HP_FILTER_NONE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_ Auxiliary_interface
+  * @brief     This section groups all the functions concerning
+  *            auxiliary interface.
+  * @{
+  *
+  */
+
+/**
+  * @brief   OIS data reading from Auxiliary / Main SPI.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of spi2_read_en in reg UI_INT_OIS
+  *
+  */
+int32_t lsm6dsox_ois_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_spi2_read_en_t val)
+{
+  lsm6dsox_func_cfg_access_t func_cfg_access;
+  lsm6dsox_ui_int_ois_t ui_int_ois;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*)&ui_int_ois, 1);
+  if (ret == 0) {
+    ui_int_ois.spi2_read_en = ((uint8_t)val & 0x01U);
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_INT_OIS,
+                             (uint8_t*)&ui_int_ois, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FUNC_CFG_ACCESS,
+                            (uint8_t*)&func_cfg_access, 1);
+  }
+  if (ret == 0) {
+    func_cfg_access.ois_ctrl_from_ui = ( ((uint8_t)val & 0x02U) >> 1 );
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FUNC_CFG_ACCESS,
+                             (uint8_t*)&func_cfg_access, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  aux_ois_data: [get] OIS data reading from Auxiliary / Main SPI
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of spi2_read_en
+  *                                 in reg UI_INT_OIS
+  *
+  */
+int32_t lsm6dsox_ois_mode_get(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_spi2_read_en_t *val)
+{
+  lsm6dsox_func_cfg_access_t func_cfg_access;
+  lsm6dsox_ui_int_ois_t ui_int_ois;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*)&ui_int_ois, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FUNC_CFG_ACCESS,
+                            (uint8_t*)&func_cfg_access, 1);
+  }
+  switch ((func_cfg_access.ois_ctrl_from_ui << 1) + ui_int_ois.spi2_read_en) {
+    case LSM6DSOX_OIS_CTRL_AUX_DATA_UI:
+      *val = LSM6DSOX_OIS_CTRL_AUX_DATA_UI;
+      break;
+    case LSM6DSOX_OIS_CTRL_AUX_DATA_UI_AUX:
+      *val = LSM6DSOX_OIS_CTRL_AUX_DATA_UI_AUX;
+      break;
+    case LSM6DSOX_OIS_CTRL_UI_AUX_DATA_UI:
+      *val = LSM6DSOX_OIS_CTRL_UI_AUX_DATA_UI;
+      break;
+    case LSM6DSOX_OIS_CTRL_UI_AUX_DATA_UI_AUX:
+      *val = LSM6DSOX_OIS_CTRL_UI_AUX_DATA_UI_AUX;
+      break;
+    default:
+      *val = LSM6DSOX_OIS_CTRL_AUX_DATA_UI;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  aOn auxiliary interface connect/disconnect SDO and OCS
+  *         internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ois_pu_dis in
+  *                               reg PIN_CTRL
+  *
+  */
+int32_t lsm6dsox_aux_sdo_ocs_mode_set(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_ois_pu_dis_t val)
+{
+  lsm6dsox_pin_ctrl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PIN_CTRL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ois_pu_dis = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PIN_CTRL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  On auxiliary interface connect/disconnect SDO and OCS
+  *         internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ois_pu_dis in reg PIN_CTRL
+  *
+  */
+int32_t lsm6dsox_aux_sdo_ocs_mode_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_ois_pu_dis_t *val)
+{
+  lsm6dsox_pin_ctrl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PIN_CTRL, (uint8_t*)&reg, 1);
+  switch (reg.ois_pu_dis) {
+    case LSM6DSOX_AUX_PULL_UP_DISC:
+      *val = LSM6DSOX_AUX_PULL_UP_DISC;
+      break;
+    case LSM6DSOX_AUX_PULL_UP_CONNECT:
+      *val = LSM6DSOX_AUX_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LSM6DSOX_AUX_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  OIS chain on aux interface power on mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ois_on in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_aux_pw_on_ctrl_set(lsm6dsox_ctx_t *ctx, lsm6dsox_ois_on_t val)
+{
+  lsm6dsox_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ois_on_en = (uint8_t)val & 0x01U;
+    reg.ois_on = (uint8_t)val & 0x01U;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  aux_pw_on_ctrl: [get]  OIS chain on aux interface power on mode
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ois_on in reg CTRL7_G
+  *
+  */
+int32_t lsm6dsox_aux_pw_on_ctrl_get(lsm6dsox_ctx_t *ctx, lsm6dsox_ois_on_t *val)
+{
+  lsm6dsox_ctrl7_g_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL7_G, (uint8_t*)&reg, 1);
+  switch (reg.ois_on) {
+    case LSM6DSOX_AUX_ON:
+      *val = LSM6DSOX_AUX_ON;
+      break;
+    case LSM6DSOX_AUX_ON_BY_AUX_INTERFACE:
+      *val = LSM6DSOX_AUX_ON_BY_AUX_INTERFACE;
+      break;
+    default:
+      *val = LSM6DSOX_AUX_ON;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale management between UI chain and
+  *         OIS chain. When XL UI is on, the full scale is the same
+  *         between UI/OIS and is chosen by the UI CTRL registers;
+  *         when XL UI is in PD, the OIS can choose the FS.
+  *         Full scales are independent between the UI/OIS chain
+  *         but both bound to 8 g.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of xl_fs_mode in
+  *                               reg CTRL8_XL
+  *
+  */
+int32_t lsm6dsox_aux_xl_fs_mode_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_xl_fs_mode_t val)
+{
+  lsm6dsox_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.xl_fs_mode = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale management between UI chain and
+  *         OIS chain. When XL UI is on, the full scale is the same
+  *         between UI/OIS and is chosen by the UI CTRL registers;
+  *         when XL UI is in PD, the OIS can choose the FS.
+  *         Full scales are independent between the UI/OIS chain
+  *         but both bound to 8 g.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of xl_fs_mode in reg CTRL8_XL
+  *
+  */
+int32_t lsm6dsox_aux_xl_fs_mode_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_xl_fs_mode_t *val)
+{
+  lsm6dsox_ctrl8_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL8_XL, (uint8_t*)&reg, 1);
+  switch (reg.xl_fs_mode) {
+    case LSM6DSOX_USE_SAME_XL_FS:
+      *val = LSM6DSOX_USE_SAME_XL_FS;
+      break;
+    case LSM6DSOX_USE_DIFFERENT_XL_FS:
+      *val = LSM6DSOX_USE_DIFFERENT_XL_FS;
+      break;
+    default:
+      *val = LSM6DSOX_USE_SAME_XL_FS;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_SPIAux register is read by the auxiliary SPI.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get registers STATUS_SPIAUX
+  *
+  */
+int32_t lsm6dsox_aux_status_reg_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_spi2_status_reg_ois_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SPI2_STATUS_REG_OIS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  aux_xl_flag_data_ready: [get]  AUX accelerometer data available
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of xlda in reg STATUS_SPIAUX
+  *
+  */
+int32_t lsm6dsox_aux_xl_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_spi2_status_reg_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SPI2_STATUS_REG_OIS, (uint8_t*)&reg, 1);
+  *val = reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  aux_gy_flag_data_ready: [get]  AUX gyroscope data available.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of gda in reg STATUS_SPIAUX
+  *
+  */
+int32_t lsm6dsox_aux_gy_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_spi2_status_reg_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SPI2_STATUS_REG_OIS, (uint8_t*)&reg, 1);
+  *val = reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  High when the gyroscope output is in the settling phase.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of gyro_settling in reg STATUS_SPIAUX
+  *
+  */
+int32_t lsm6dsox_aux_gy_flag_settling_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_spi2_status_reg_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SPI2_STATUS_REG_OIS, (uint8_t*)&reg, 1);
+  *val = reg.gyro_settling;
+
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_lh_ois in
+  *                  reg INT_OIS
+  *
+  */
+int32_t lsm6dsox_aux_den_polarity_set(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_den_lh_ois_t val)
+{
+  lsm6dsox_ui_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_lh_ois = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of den_lh_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dsox_aux_den_polarity_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_den_lh_ois_t *val)
+{
+  lsm6dsox_ui_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*)&reg, 1);
+  switch (reg.den_lh_ois) {
+    case LSM6DSOX_AUX_DEN_ACTIVE_LOW:
+      *val = LSM6DSOX_AUX_DEN_ACTIVE_LOW;
+      break;
+    case LSM6DSOX_AUX_DEN_ACTIVE_HIGH:
+      *val = LSM6DSOX_AUX_DEN_ACTIVE_HIGH;
+      break;
+    default:
+      *val = LSM6DSOX_AUX_DEN_ACTIVE_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lvl2_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dsox_aux_den_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_lvl2_ois_t val)
+{
+  lsm6dsox_ui_ctrl1_ois_t ctrl1_ois;
+  lsm6dsox_ui_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*) &int_ois, 1);
+  if (ret == 0) {
+    int_ois.lvl2_ois = (uint8_t)val & 0x01U;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*) &int_ois, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*) &ctrl1_ois, 1);
+  }
+  if (ret == 0) {
+    ctrl1_ois.lvl1_ois = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*) &ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lvl2_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dsox_aux_den_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_lvl2_ois_t *val)
+{
+  lsm6dsox_ui_ctrl1_ois_t ctrl1_ois;
+  lsm6dsox_ui_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*) &int_ois, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*) &ctrl1_ois, 1);
+    switch ((ctrl1_ois.lvl1_ois << 1) + int_ois.lvl2_ois) {
+      case LSM6DSOX_AUX_DEN_DISABLE:
+        *val = LSM6DSOX_AUX_DEN_DISABLE;
+        break;
+      case LSM6DSOX_AUX_DEN_LEVEL_LATCH:
+        *val = LSM6DSOX_AUX_DEN_LEVEL_LATCH;
+        break;
+      case LSM6DSOX_AUX_DEN_LEVEL_TRIG:
+        *val = LSM6DSOX_AUX_DEN_LEVEL_TRIG;
+        break;
+      default:
+        *val = LSM6DSOX_AUX_DEN_DISABLE;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin.
+  *         This setting has priority over all other INT2 settings.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_drdy_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dsox_aux_drdy_on_int2_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ui_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int2_drdy_ois = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin.
+  *         This setting has priority over all other INT2 settings.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_drdy_ois in reg INT_OIS
+  *
+  */
+int32_t lsm6dsox_aux_drdy_on_int2_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ui_int_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_INT_OIS, (uint8_t*)&reg, 1);
+  *val = reg.int2_drdy_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro in Mode 3 and Mode 4
+  *         (mode4_en = 1) and accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are available
+  *         through the SPI2 in registers OUTX_L_G (22h) through
+  *         OUTZ_H_G (27h) and STATUS_REG (1Eh) / STATUS_SPIAux, and
+  *         LPF1 is dedicated to this chain.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ois_en_spi2 in
+  *                                reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dsox_aux_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_ois_en_spi2_t val)
+{
+  lsm6dsox_ui_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ois_en_spi2 = (uint8_t)val & 0x01U;
+    reg.mode4_en = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro in Mode 3 and Mode 4
+  *         (mode4_en = 1) and accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are available
+  *         through the SPI2 in registers OUTX_L_G (22h) through
+  *         OUTZ_H_G (27h) and STATUS_REG (1Eh) / STATUS_SPIAux, and
+  *         LPF1 is dedicated to this chain.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ois_en_spi2 in
+  *                                reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dsox_aux_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_ois_en_spi2_t *val)
+{
+  lsm6dsox_ui_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch ((reg.mode4_en << 1) | reg.ois_en_spi2) {
+    case LSM6DSOX_AUX_DISABLE:
+      *val = LSM6DSOX_AUX_DISABLE;
+      break;
+    case LSM6DSOX_MODE_3_GY:
+      *val = LSM6DSOX_MODE_3_GY;
+      break;
+    case LSM6DSOX_MODE_4_GY_XL:
+      *val = LSM6DSOX_MODE_4_GY_XL;
+      break;
+    default:
+      *val = LSM6DSOX_AUX_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs_g_ois in reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dsox_aux_gy_full_scale_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_fs_g_ois_t val)
+{
+  lsm6dsox_ui_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fs_g_ois = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs_g_ois in reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dsox_aux_gy_full_scale_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_fs_g_ois_t *val)
+{
+  lsm6dsox_ui_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch (reg.fs_g_ois) {
+    case LSM6DSOX_250dps_AUX:
+      *val = LSM6DSOX_250dps_AUX;
+      break;
+    case LSM6DSOX_125dps_AUX:
+      *val = LSM6DSOX_125dps_AUX;
+      break;
+    case LSM6DSOX_500dps_AUX:
+      *val = LSM6DSOX_500dps_AUX;
+      break;
+    case LSM6DSOX_1000dps_AUX:
+      *val = LSM6DSOX_1000dps_AUX;
+      break;
+    case LSM6DSOX_2000dps_AUX:
+      *val = LSM6DSOX_2000dps_AUX;
+      break;
+    default:
+      *val = LSM6DSOX_250dps_AUX;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim_ois in reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dsox_aux_spi_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_sim_ois_t val)
+{
+  lsm6dsox_ui_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sim_ois = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim_ois in reg CTRL1_OIS
+  *
+  */
+int32_t lsm6dsox_aux_spi_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_sim_ois_t *val)
+{
+  lsm6dsox_ui_ctrl1_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL1_OIS, (uint8_t*)&reg, 1);
+  switch (reg.sim_ois) {
+    case LSM6DSOX_AUX_SPI_4_WIRE:
+      *val = LSM6DSOX_AUX_SPI_4_WIRE;
+      break;
+    case LSM6DSOX_AUX_SPI_3_WIRE:
+      *val = LSM6DSOX_AUX_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSOX_AUX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope digital LPF1 filter bandwidth.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ftype_ois in
+  *                              reg CTRL2_OIS
+  *
+  */
+int32_t lsm6dsox_aux_gy_lp1_bandwidth_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_ftype_ois_t val)
+{
+  lsm6dsox_ui_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL2_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ftype_ois = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL2_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope digital LPF1 filter bandwidth.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ftype_ois in reg CTRL2_OIS
+  *
+  */
+int32_t lsm6dsox_aux_gy_lp1_bandwidth_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_ftype_ois_t *val)
+{
+  lsm6dsox_ui_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL2_OIS, (uint8_t*)&reg, 1);
+  switch (reg.ftype_ois) {
+    case LSM6DSOX_351Hz39:
+      *val = LSM6DSOX_351Hz39;
+      break;
+    case LSM6DSOX_236Hz63:
+      *val = LSM6DSOX_236Hz63;
+      break;
+    case LSM6DSOX_172Hz70:
+      *val = LSM6DSOX_172Hz70;
+      break;
+    case LSM6DSOX_937Hz91:
+      *val = LSM6DSOX_937Hz91;
+      break;
+    default:
+      *val = LSM6DSOX_351Hz39;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain digital high-pass filter cutoff.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hpm_ois in reg CTRL2_OIS
+  *
+  */
+int32_t lsm6dsox_aux_gy_hp_bandwidth_set(lsm6dsox_ctx_t *ctx,
+                                        lsm6dsox_hpm_ois_t val)
+{
+  lsm6dsox_ui_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL2_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.hpm_ois = (uint8_t)val & 0x03U;
+    reg.hp_en_ois = ((uint8_t)val & 0x10U) >> 4;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL2_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain digital high-pass filter cutoff.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of hpm_ois in reg CTRL2_OIS
+  *
+  */
+int32_t lsm6dsox_aux_gy_hp_bandwidth_get(lsm6dsox_ctx_t *ctx,
+                                        lsm6dsox_hpm_ois_t *val)
+{
+  lsm6dsox_ui_ctrl2_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL2_OIS, (uint8_t*)&reg, 1);
+  switch ((reg.hp_en_ois << 4) | reg.hpm_ois) {
+    case LSM6DSOX_AUX_HP_DISABLE:
+      *val = LSM6DSOX_AUX_HP_DISABLE;
+      break;
+    case LSM6DSOX_AUX_HP_Hz016:
+      *val = LSM6DSOX_AUX_HP_Hz016;
+      break;
+    case LSM6DSOX_AUX_HP_Hz065:
+      *val = LSM6DSOX_AUX_HP_Hz065;
+      break;
+    case LSM6DSOX_AUX_HP_Hz260:
+      *val = LSM6DSOX_AUX_HP_Hz260;
+      break;
+    case LSM6DSOX_AUX_HP_1Hz040:
+      *val = LSM6DSOX_AUX_HP_1Hz040;
+      break;
+    default:
+      *val = LSM6DSOX_AUX_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp.
+  *         Enable: All OIS chain outputs = 8000h
+  *         during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full
+  *         scale selected.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st_ois_clampdis in
+  *                                    reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dsox_aux_gy_clamp_set(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_st_ois_clampdis_t val)
+{
+  lsm6dsox_ui_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.st_ois_clampdis = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp.
+  *         Enable: All OIS chain outputs = 8000h
+  *         during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full
+  *         scale selected.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st_ois_clampdis in
+  *                                    reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dsox_aux_gy_clamp_get(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_st_ois_clampdis_t *val)
+{
+  lsm6dsox_ui_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch (reg.st_ois_clampdis) {
+    case LSM6DSOX_ENABLE_CLAMP:
+      *val = LSM6DSOX_ENABLE_CLAMP;
+      break;
+    case LSM6DSOX_DISABLE_CLAMP:
+      *val = LSM6DSOX_DISABLE_CLAMP;
+      break;
+    default:
+      *val = LSM6DSOX_ENABLE_CLAMP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of
+  *                                       filter_xl_conf_ois in reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dsox_aux_xl_bandwidth_set(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_filter_xl_conf_ois_t val)
+{
+  lsm6dsox_ui_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.filter_xl_conf_ois = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of
+  *                                       filter_xl_conf_ois in reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dsox_aux_xl_bandwidth_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_filter_xl_conf_ois_t *val)
+{
+  lsm6dsox_ui_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+
+  switch (reg.filter_xl_conf_ois) {
+    case LSM6DSOX_289Hz:
+      *val = LSM6DSOX_289Hz;
+      break;
+    case LSM6DSOX_258Hz:
+      *val = LSM6DSOX_258Hz;
+      break;
+    case LSM6DSOX_120Hz:
+      *val = LSM6DSOX_120Hz;
+      break;
+    case LSM6DSOX_65Hz2:
+      *val = LSM6DSOX_65Hz2;
+      break;
+    case LSM6DSOX_33Hz2:
+      *val = LSM6DSOX_33Hz2;
+      break;
+    case LSM6DSOX_16Hz6:
+      *val = LSM6DSOX_16Hz6;
+      break;
+    case LSM6DSOX_8Hz30:
+      *val = LSM6DSOX_8Hz30;
+      break;
+    case LSM6DSOX_4Hz15:
+      *val = LSM6DSOX_4Hz15;
+      break;
+    default:
+      *val = LSM6DSOX_289Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs_xl_ois in
+  *                              reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dsox_aux_xl_full_scale_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_fs_xl_ois_t val)
+{
+  lsm6dsox_ui_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fs_xl_ois = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs_xl_ois in reg CTRL3_OIS
+  *
+  */
+int32_t lsm6dsox_aux_xl_full_scale_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_fs_xl_ois_t *val)
+{
+  lsm6dsox_ui_ctrl3_ois_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_UI_CTRL3_OIS, (uint8_t*)&reg, 1);
+  switch (reg.fs_xl_ois) {
+    case LSM6DSOX_AUX_2g:
+      *val = LSM6DSOX_AUX_2g;
+      break;
+    case LSM6DSOX_AUX_16g:
+      *val = LSM6DSOX_AUX_16g;
+      break;
+    case LSM6DSOX_AUX_4g:
+      *val = LSM6DSOX_AUX_4g;
+      break;
+    case LSM6DSOX_AUX_8g:
+      *val = LSM6DSOX_AUX_8g;
+      break;
+    default:
+      *val = LSM6DSOX_AUX_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_ main_serial_interface
+  * @brief     This section groups all the functions concerning main
+  *            serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sdo_pu_en in
+  *                              reg PIN_CTRL
+  *
+  */
+int32_t lsm6dsox_sdo_sa0_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_sdo_pu_en_t val)
+{
+  lsm6dsox_pin_ctrl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PIN_CTRL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sdo_pu_en = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PIN_CTRL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sdo_pu_en in reg PIN_CTRL
+  *
+  */
+int32_t lsm6dsox_sdo_sa0_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_sdo_pu_en_t *val)
+{
+  lsm6dsox_pin_ctrl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PIN_CTRL, (uint8_t*)&reg, 1);
+  switch (reg.sdo_pu_en) {
+    case LSM6DSOX_PULL_UP_DISC:
+      *val = LSM6DSOX_PULL_UP_DISC;
+      break;
+    case LSM6DSOX_PULL_UP_CONNECT:
+      *val = LSM6DSOX_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LSM6DSOX_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_spi_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_sim_t val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sim = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_spi_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_sim_t *val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  switch (reg.sim) {
+    case LSM6DSOX_SPI_4_WIRE:
+      *val = LSM6DSOX_SPI_4_WIRE;
+      break;
+    case LSM6DSOX_SPI_3_WIRE:
+      *val = LSM6DSOX_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSOX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_disable in
+  *                                reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_i2c_interface_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_i2c_disable_t val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.i2c_disable = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_disable in
+  *                                reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_i2c_interface_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_i2c_disable_t *val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  switch (reg.i2c_disable) {
+    case LSM6DSOX_I2C_ENABLE:
+      *val = LSM6DSOX_I2C_ENABLE;
+      break;
+    case LSM6DSOX_I2C_DISABLE:
+      *val = LSM6DSOX_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM6DSOX_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol[.set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i3c_disable
+  *                                    in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_i3c_disable_set(lsm6dsox_ctx_t *ctx, lsm6dsox_i3c_disable_t val)
+{
+  lsm6dsox_i3c_bus_avb_t i3c_bus_avb;
+  lsm6dsox_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if (ret == 0) {
+    ctrl9_xl.i3c_disable = ((uint8_t)val & 0x80U) >> 7;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_I3C_BUS_AVB,
+                           (uint8_t*)&i3c_bus_avb, 1);
+  }
+  if (ret == 0) {
+    i3c_bus_avb.i3c_bus_avb_sel = (uint8_t)val & 0x03U;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_I3C_BUS_AVB,
+                            (uint8_t*)&i3c_bus_avb, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i3c_disable in
+  *                                reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_i3c_disable_get(lsm6dsox_ctx_t *ctx, lsm6dsox_i3c_disable_t *val)
+{
+  lsm6dsox_ctrl9_xl_t ctrl9_xl;
+  lsm6dsox_i3c_bus_avb_t i3c_bus_avb;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_I3C_BUS_AVB,
+                           (uint8_t*)&i3c_bus_avb, 1);
+
+    switch ((ctrl9_xl.i3c_disable << 7) | i3c_bus_avb.i3c_bus_avb_sel) {
+      case LSM6DSOX_I3C_DISABLE:
+        *val = LSM6DSOX_I3C_DISABLE;
+        break;
+      case LSM6DSOX_I3C_ENABLE_T_50us:
+        *val = LSM6DSOX_I3C_ENABLE_T_50us;
+        break;
+      case LSM6DSOX_I3C_ENABLE_T_2us:
+        *val = LSM6DSOX_I3C_ENABLE_T_2us;
+        break;
+      case LSM6DSOX_I3C_ENABLE_T_1ms:
+        *val = LSM6DSOX_I3C_ENABLE_T_1ms;
+        break;
+      case LSM6DSOX_I3C_ENABLE_T_25ms:
+        *val = LSM6DSOX_I3C_ENABLE_T_25ms;
+        break;
+      default:
+        *val = LSM6DSOX_I3C_DISABLE;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_interrupt_pins
+  * @brief     This section groups all the functions that manage interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      struct of registers: INT1_CTRL,
+  *                  MD1_CFG, EMB_FUNC_INT1, FSM_INT1_A,
+  *                  FSM_INT1_B
+  *
+  */
+int32_t lsm6dsox_pin_int1_route_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_pin_int1_route_t *val)
+{
+  lsm6dsox_pin_int2_route_t pin_int2_route;
+  lsm6dsox_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MLC_INT1,
+                            (uint8_t*)&val->mlc_int1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_INT1,
+                            (uint8_t*)&val->emb_func_int1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FSM_INT1_A,
+                            (uint8_t*)&val->fsm_int1_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FSM_INT1_B,
+                            (uint8_t*)&val->fsm_int1_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  if (ret == 0) {
+    if ( ( val->emb_func_int1.int1_fsm_lc
+         | val->emb_func_int1.int1_sig_mot
+         | val->emb_func_int1.int1_step_detector
+         | val->emb_func_int1.int1_tilt
+         | val->fsm_int1_a.int1_fsm1
+         | val->fsm_int1_a.int1_fsm2
+         | val->fsm_int1_a.int1_fsm3
+         | val->fsm_int1_a.int1_fsm4
+         | val->fsm_int1_a.int1_fsm5
+         | val->fsm_int1_a.int1_fsm6
+         | val->fsm_int1_a.int1_fsm7
+         | val->fsm_int1_a.int1_fsm8
+         | val->fsm_int1_b.int1_fsm9
+         | val->fsm_int1_b.int1_fsm10
+         | val->fsm_int1_b.int1_fsm11
+         | val->fsm_int1_b.int1_fsm12
+         | val->fsm_int1_b.int1_fsm13
+         | val->fsm_int1_b.int1_fsm14
+         | val->fsm_int1_b.int1_fsm15
+         | val->fsm_int1_b.int1_fsm16
+         | val->mlc_int1.int1_mlc1
+         | val->mlc_int1.int1_mlc2
+         | val->mlc_int1.int1_mlc3
+         | val->mlc_int1.int1_mlc4
+         | val->mlc_int1.int1_mlc5
+         | val->mlc_int1.int1_mlc6
+         | val->mlc_int1.int1_mlc7
+         | val->mlc_int1.int1_mlc8) != PROPERTY_DISABLE){
+      val->md1_cfg.int1_emb_func = PROPERTY_ENABLE;
+    }
+    else{
+      val->md1_cfg.int1_emb_func = PROPERTY_DISABLE;
+    }
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_INT1_CTRL,
+                            (uint8_t*)&val->int1_ctrl, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MD1_CFG, (uint8_t*)&val->md1_cfg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*) &tap_cfg2, 1);
+  }
+
+  if (ret == 0) {
+    ret = lsm6dsox_pin_int2_route_get(ctx, &pin_int2_route);
+  }
+  if (ret == 0) {
+    if ( ( pin_int2_route.int2_ctrl.int2_cnt_bdr
+         | pin_int2_route.int2_ctrl.int2_drdy_g
+         | pin_int2_route.int2_ctrl.int2_drdy_temp
+         | pin_int2_route.int2_ctrl.int2_drdy_xl
+         | pin_int2_route.int2_ctrl.int2_fifo_full
+         | pin_int2_route.int2_ctrl.int2_fifo_ovr
+         | pin_int2_route.int2_ctrl.int2_fifo_th
+         | pin_int2_route.md2_cfg.int2_6d
+         | pin_int2_route.md2_cfg.int2_double_tap
+         | pin_int2_route.md2_cfg.int2_ff
+         | pin_int2_route.md2_cfg.int2_wu
+         | pin_int2_route.md2_cfg.int2_single_tap
+         | pin_int2_route.md2_cfg.int2_sleep_change
+         | val->int1_ctrl.den_drdy_flag
+         | val->int1_ctrl.int1_boot
+         | val->int1_ctrl.int1_cnt_bdr
+         | val->int1_ctrl.int1_drdy_g
+         | val->int1_ctrl.int1_drdy_xl
+         | val->int1_ctrl.int1_fifo_full
+         | val->int1_ctrl.int1_fifo_ovr
+         | val->int1_ctrl.int1_fifo_th
+         | val->md1_cfg.int1_shub
+         | val->md1_cfg.int1_6d
+         | val->md1_cfg.int1_double_tap
+         | val->md1_cfg.int1_ff
+         | val->md1_cfg.int1_wu
+         | val->md1_cfg.int1_single_tap
+         | val->md1_cfg.int1_sleep_change) != PROPERTY_DISABLE) {
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*) &tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      struct of registers: INT1_CTRL, MD1_CFG,
+  *                  EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
+  *
+  */
+int32_t lsm6dsox_pin_int1_route_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_pin_int1_route_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MLC_INT1,
+                            (uint8_t*)&val->mlc_int1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_INT1,
+                           (uint8_t*)&val->emb_func_int1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_INT1_A,
+                           (uint8_t*)&val->fsm_int1_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_INT1_B,
+                           (uint8_t*)&val->fsm_int1_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INT1_CTRL,
+                           (uint8_t*)&val->int1_ctrl, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MD1_CFG, (uint8_t*)&val->md1_cfg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers INT2_CTRL,  MD2_CFG,
+  *                  EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  *
+  */
+int32_t lsm6dsox_pin_int2_route_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_pin_int2_route_t *val)
+{
+  lsm6dsox_pin_int1_route_t pin_int1_route;
+  lsm6dsox_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MLC_INT1,
+                            (uint8_t*)&val->mlc_int2, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_INT2,
+                            (uint8_t*)&val->emb_func_int2, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FSM_INT2_A,
+                            (uint8_t*)&val->fsm_int2_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FSM_INT2_B,
+                            (uint8_t*)&val->fsm_int2_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  if (ret == 0) {
+    if (( val->emb_func_int2.int2_fsm_lc
+        | val->emb_func_int2.int2_sig_mot
+        | val->emb_func_int2.int2_step_detector
+        | val->emb_func_int2.int2_tilt
+        | val->fsm_int2_a.int2_fsm1
+        | val->fsm_int2_a.int2_fsm2
+        | val->fsm_int2_a.int2_fsm3
+        | val->fsm_int2_a.int2_fsm4
+        | val->fsm_int2_a.int2_fsm5
+        | val->fsm_int2_a.int2_fsm6
+        | val->fsm_int2_a.int2_fsm7
+        | val->fsm_int2_a.int2_fsm8
+        | val->fsm_int2_b.int2_fsm9
+        | val->fsm_int2_b.int2_fsm10
+        | val->fsm_int2_b.int2_fsm11
+        | val->fsm_int2_b.int2_fsm12
+        | val->fsm_int2_b.int2_fsm13
+        | val->fsm_int2_b.int2_fsm14
+        | val->fsm_int2_b.int2_fsm15
+        | val->fsm_int2_b.int2_fsm16
+        | val->mlc_int2.int2_mlc1
+        | val->mlc_int2.int2_mlc2
+        | val->mlc_int2.int2_mlc3
+        | val->mlc_int2.int2_mlc4
+        | val->mlc_int2.int2_mlc5
+        | val->mlc_int2.int2_mlc6
+        | val->mlc_int2.int2_mlc7
+        | val->mlc_int2.int2_mlc8)!= PROPERTY_DISABLE ){
+      val->md2_cfg.int2_emb_func = PROPERTY_ENABLE;
+    }
+    else{
+      val->md2_cfg.int2_emb_func = PROPERTY_DISABLE;
+    }
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_INT2_CTRL,
+                            (uint8_t*)&val->int2_ctrl, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MD2_CFG, (uint8_t*)&val->md2_cfg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*) &tap_cfg2, 1);
+  }
+
+  if (ret == 0) {
+    ret = lsm6dsox_pin_int1_route_get(ctx, &pin_int1_route);
+  }
+
+  if (ret == 0) {
+    if ( ( val->int2_ctrl.int2_cnt_bdr
+         | val->int2_ctrl.int2_drdy_g
+         | val->int2_ctrl.int2_drdy_temp
+         | val->int2_ctrl.int2_drdy_xl
+         | val->int2_ctrl.int2_fifo_full
+         | val->int2_ctrl.int2_fifo_ovr
+         | val->int2_ctrl.int2_fifo_th
+         | val->md2_cfg.int2_6d
+         | val->md2_cfg.int2_double_tap
+         | val->md2_cfg.int2_ff
+         | val->md2_cfg.int2_wu
+         | val->md2_cfg.int2_single_tap
+         | val->md2_cfg.int2_sleep_change
+         | pin_int1_route.int1_ctrl.den_drdy_flag
+         | pin_int1_route.int1_ctrl.int1_boot
+         | pin_int1_route.int1_ctrl.int1_cnt_bdr
+         | pin_int1_route.int1_ctrl.int1_drdy_g
+         | pin_int1_route.int1_ctrl.int1_drdy_xl
+         | pin_int1_route.int1_ctrl.int1_fifo_full
+         | pin_int1_route.int1_ctrl.int1_fifo_ovr
+         | pin_int1_route.int1_ctrl.int1_fifo_th
+         | pin_int1_route.md1_cfg.int1_6d
+         | pin_int1_route.md1_cfg.int1_double_tap
+         | pin_int1_route.md1_cfg.int1_ff
+         | pin_int1_route.md1_cfg.int1_wu
+         | pin_int1_route.md1_cfg.int1_single_tap
+         | pin_int1_route.md1_cfg.int1_sleep_change ) != PROPERTY_DISABLE) {
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*) &tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers INT2_CTRL,  MD2_CFG,
+  *                  EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  *
+  */
+int32_t lsm6dsox_pin_int2_route_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_pin_int2_route_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+      ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MLC_INT2,
+                            (uint8_t*)&val->mlc_int2, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_INT2,
+                           (uint8_t*)&val->emb_func_int2, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_INT2_A,
+                           (uint8_t*)&val->fsm_int2_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_INT2_B,
+                           (uint8_t*)&val->fsm_int2_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INT2_CTRL,
+                           (uint8_t*)&val->int2_ctrl, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MD2_CFG, (uint8_t*)&val->md2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pp_od in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_pin_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_pp_od_t val)
+{
+  lsm6dsox_i3c_bus_avb_t i3c_bus_avb;
+  lsm6dsox_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if (ret == 0) {
+    ctrl3_c.pp_od = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_I3C_BUS_AVB,
+                            (uint8_t*)&i3c_bus_avb, 1);
+  }
+  if (ret == 0) {
+    i3c_bus_avb.pd_dis_int1 = ( (uint8_t) val & 0x02U ) >> 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_I3C_BUS_AVB,
+                             (uint8_t*)&i3c_bus_avb, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pp_od in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_pin_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_pp_od_t *val)
+{
+  lsm6dsox_i3c_bus_avb_t i3c_bus_avb;
+  lsm6dsox_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_I3C_BUS_AVB,
+                            (uint8_t*)&i3c_bus_avb, 1);
+  }
+  
+  switch ( (i3c_bus_avb.pd_dis_int1 << 1) + ctrl3_c.pp_od) {
+    case LSM6DSOX_PUSH_PULL:
+      *val = LSM6DSOX_PUSH_PULL;
+      break;
+    case LSM6DSOX_OPEN_DRAIN:
+      *val = LSM6DSOX_OPEN_DRAIN;
+      break;
+    case LSM6DSOX_INT1_NOPULL_DOWN_INT2_PUSH_PULL:
+      *val = LSM6DSOX_INT1_NOPULL_DOWN_INT2_PUSH_PULL;
+      break;
+    case LSM6DSOX_INT1_NOPULL_DOWN_INT2_OPEN_DRAIN:
+      *val = LSM6DSOX_INT1_NOPULL_DOWN_INT2_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM6DSOX_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of h_lactive in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_pin_polarity_set(lsm6dsox_ctx_t *ctx, lsm6dsox_h_lactive_t val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.h_lactive = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of h_lactive in reg CTRL3_C
+  *
+  */
+int32_t lsm6dsox_pin_polarity_get(lsm6dsox_ctx_t *ctx, lsm6dsox_h_lactive_t *val)
+{
+  lsm6dsox_ctrl3_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL3_C, (uint8_t*)&reg, 1);
+
+  switch (reg.h_lactive) {
+    case LSM6DSOX_ACTIVE_HIGH:
+      *val = LSM6DSOX_ACTIVE_HIGH;
+      break;
+    case LSM6DSOX_ACTIVE_LOW:
+      *val = LSM6DSOX_ACTIVE_LOW;
+      break;
+    default:
+      *val = LSM6DSOX_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_all_on_int1_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int2_on_int1 = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_all_on_int1_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  *val = reg.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt notification mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_int_notification_set(lsm6dsox_ctx_t *ctx, lsm6dsox_lir_t val)
+{
+  lsm6dsox_tap_cfg0_t tap_cfg0;
+  lsm6dsox_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*) &tap_cfg0, 1);
+  if (ret == 0) {
+    tap_cfg0.lir = (uint8_t)val & 0x01U;
+    tap_cfg0.int_clr_on_read = (uint8_t)val & 0x01U;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*) &tap_cfg0, 1);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    page_rw.emb_func_lir = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt notification mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_int_notification_get(lsm6dsox_ctx_t *ctx, lsm6dsox_lir_t *val)
+{
+  lsm6dsox_tap_cfg0_t tap_cfg0;
+  lsm6dsox_page_rw_t page_rw;
+  int32_t ret;
+
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*) &tap_cfg0, 1);
+  if (ret == 0) {
+
+      ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  if (ret == 0) {
+    switch ((page_rw.emb_func_lir << 1) | tap_cfg0.lir) {
+      case LSM6DSOX_ALL_INT_PULSED:
+        *val = LSM6DSOX_ALL_INT_PULSED;
+        break;
+      case LSM6DSOX_BASE_LATCHED_EMB_PULSED:
+        *val = LSM6DSOX_BASE_LATCHED_EMB_PULSED;
+        break;
+      case LSM6DSOX_BASE_PULSED_EMB_LATCHED:
+        *val = LSM6DSOX_BASE_PULSED_EMB_LATCHED;
+        break;
+      case LSM6DSOX_ALL_INT_LATCHED:
+        *val = LSM6DSOX_ALL_INT_LATCHED;
+        break;
+      default:
+        *val = LSM6DSOX_ALL_INT_PULSED;
+        break;
+    }
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_PAGE_RW, (uint8_t*) &page_rw, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_Wake_Up_event
+  * @brief     This section groups all the functions that manage the Wake Up
+  *            event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[set]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_ths_w in
+  *                                 reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dsox_wkup_ths_weight_set(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_wake_ths_w_t val)
+{
+  lsm6dsox_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.wake_ths_w = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[get]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of wake_ths_w in
+  *                                 reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dsox_wkup_ths_weight_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_wake_ths_w_t *val)
+{
+  lsm6dsox_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+
+  switch (reg.wake_ths_w) {
+    case LSM6DSOX_LSb_FS_DIV_64:
+      *val = LSM6DSOX_LSb_FS_DIV_64;
+      break;
+    case LSM6DSOX_LSb_FS_DIV_256:
+      *val = LSM6DSOX_LSb_FS_DIV_256;
+      break;
+    default:
+      *val = LSM6DSOX_LSb_FS_DIV_64;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dsox_wkup_threshold_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.wk_ths = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dsox_wkup_threshold_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  *val = reg.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.[set]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_wu in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_on_wkup_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.usr_off_on_wu = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.[get]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_wu in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dsox_xl_usr_offset_on_wkup_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  *val = reg.usr_off_on_wu;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.[set]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dsox_wkup_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.wake_dur = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.[get]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dsox_wkup_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  *val = reg.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_ Activity/Inactivity_detection
+  * @brief     This section groups all the functions concerning
+  *            activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_g in reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_gy_sleep_mode_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sleep_g = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_g in reg CTRL4_C
+  *
+  */
+int32_t lsm6dsox_gy_sleep_mode_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl4_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL4_C, (uint8_t*)&reg, 1);
+  *val = reg.sleep_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of
+  *         sleep change on INT pins
+  *         (only if INT1_SLEEP_CHANGE or
+  *         INT2_SLEEP_CHANGE bits are enabled).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_status_on_int in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_act_pin_notification_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_sleep_status_on_int_t val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sleep_status_on_int = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of
+  *         sleep change on INT pins (only if
+  *         INT1_SLEEP_CHANGE or
+  *         INT2_SLEEP_CHANGE bits are enabled).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sleep_status_on_int in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_act_pin_notification_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_sleep_status_on_int_t *val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  switch (reg.sleep_status_on_int) {
+    case LSM6DSOX_DRIVE_SLEEP_CHG_EVENT:
+      *val = LSM6DSOX_DRIVE_SLEEP_CHG_EVENT;
+      break;
+    case LSM6DSOX_DRIVE_SLEEP_STATUS:
+      *val = LSM6DSOX_DRIVE_SLEEP_STATUS;
+      break;
+    default:
+      *val = LSM6DSOX_DRIVE_SLEEP_CHG_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of inact_en in reg TAP_CFG2
+  *
+  */
+int32_t lsm6dsox_act_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_inact_en_t val)
+{
+  lsm6dsox_tap_cfg2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.inact_en = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of inact_en in reg TAP_CFG2
+  *
+  */
+int32_t lsm6dsox_act_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_inact_en_t *val)
+{
+  lsm6dsox_tap_cfg2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*)&reg, 1);
+  switch (reg.inact_en) {
+    case LSM6DSOX_XL_AND_GY_NOT_AFFECTED:
+      *val = LSM6DSOX_XL_AND_GY_NOT_AFFECTED;
+      break;
+    case LSM6DSOX_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = LSM6DSOX_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case LSM6DSOX_XL_12Hz5_GY_SLEEP:
+      *val = LSM6DSOX_XL_12Hz5_GY_SLEEP;
+      break;
+    case LSM6DSOX_XL_12Hz5_GY_PD:
+      *val = LSM6DSOX_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = LSM6DSOX_XL_AND_GY_NOT_AFFECTED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.[set]
+  *         1 LSb = 512 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dsox_act_sleep_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sleep_dur = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.[get]
+  *         1 LSb = 512 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  *
+  */
+int32_t lsm6dsox_act_sleep_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&reg, 1);
+  *val = reg.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_tap_generator
+  * @brief     This section groups all the functions that manage the
+  *            tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_tap_detection_on_z_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_z_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_tap_detection_on_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  *val = reg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_tap_detection_on_y_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_y_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_tap_detection_on_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  *val = reg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_tap_detection_on_x_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_x_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_CFG0
+  *
+  */
+int32_t lsm6dsox_tap_detection_on_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_tap_cfg0_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG0, (uint8_t*)&reg, 1);
+  *val = reg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  X-axis tap recognition threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_x in reg TAP_CFG1
+  *
+  */
+int32_t lsm6dsox_tap_threshold_x_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_tap_cfg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_ths_x = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X-axis tap recognition threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_x in reg TAP_CFG1
+  *
+  */
+int32_t lsm6dsox_tap_threshold_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_tap_cfg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG1, (uint8_t*)&reg, 1);
+  *val = reg.tap_ths_x;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_priority in
+  *                                 reg TAP_CFG1
+  *
+  */
+int32_t lsm6dsox_tap_axis_priority_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_tap_priority_t val)
+{
+  lsm6dsox_tap_cfg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_priority = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tap_priority in
+  *                                 reg TAP_CFG1
+  *
+  */
+int32_t lsm6dsox_tap_axis_priority_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_tap_priority_t *val)
+{
+  lsm6dsox_tap_cfg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG1, (uint8_t*)&reg, 1);
+  switch (reg.tap_priority) {
+    case LSM6DSOX_XYZ:
+      *val = LSM6DSOX_XYZ;
+      break;
+    case LSM6DSOX_YXZ:
+      *val = LSM6DSOX_YXZ;
+      break;
+    case LSM6DSOX_XZY:
+      *val = LSM6DSOX_XZY;
+      break;
+    case LSM6DSOX_ZYX:
+      *val = LSM6DSOX_ZYX;
+      break;
+    case LSM6DSOX_YZX:
+      *val = LSM6DSOX_YZX;
+      break;
+    case LSM6DSOX_ZXY:
+      *val = LSM6DSOX_ZXY;
+      break;
+    default:
+      *val = LSM6DSOX_XYZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y-axis tap recognition threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_y in reg TAP_CFG2
+  *
+  */
+int32_t lsm6dsox_tap_threshold_y_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_tap_cfg2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_ths_y = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y-axis tap recognition threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_y in reg TAP_CFG2
+  *
+  */
+int32_t lsm6dsox_tap_threshold_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_tap_cfg2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_CFG2, (uint8_t*)&reg, 1);
+  *val = reg.tap_ths_y;
+
+  return ret;
+}
+
+/**
+  * @brief  Z-axis recognition threshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_z in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dsox_tap_threshold_z_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tap_ths_z = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z-axis recognition threshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_ths_z in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dsox_tap_threshold_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  *val = reg.tap_ths_z;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an
+  *         over threshold signal detection to be recognized
+  *         as a tap event. The default value of these bits
+  *         is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR2
+  *
+  */
+int32_t lsm6dsox_tap_shock_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.shock = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an
+  *         over threshold signal detection to be recognized
+  *         as a tap event. The default value of these bits
+  *         is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR2
+  *
+  */
+int32_t lsm6dsox_tap_shock_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  *val = reg.shock;
+
+  return ret;
+}
+
+/**
+  * @brief   Quiet time is the time after the first detected
+  *          tap in which there must not be any over threshold
+  *          event.
+  *          The default value of these bits is 00b which
+  *          corresponds to 2*ODR_XL time. If the QUIET[1:0]
+  *          bits are set to a different value,
+  *          1LSB corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR2
+  *
+  */
+int32_t lsm6dsox_tap_quiet_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.quiet = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected
+  *         tap in which there must not be any over threshold
+  *         event.
+  *         The default value of these bits is 00b which
+  *         corresponds to 2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR2
+  *
+  */
+int32_t lsm6dsox_tap_quiet_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  *val = reg.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled,
+  *         this register expresses the maximum time
+  *         between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,
+  *         1LSB corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of dur in reg INT_DUR2
+  *
+  */
+int32_t lsm6dsox_tap_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.dur = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled,
+  *         this register expresses the maximum time
+  *         between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time. If the DUR[3:0]
+  *         bits are set to a different value,
+  *         1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of dur in reg INT_DUR2
+  *
+  */
+int32_t lsm6dsox_tap_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_int_dur2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_INT_DUR2, (uint8_t*)&reg, 1);
+  *val = reg.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of single_double_tap in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dsox_tap_mode_set(lsm6dsox_ctx_t *ctx,
+                             lsm6dsox_single_double_tap_t val)
+{
+  lsm6dsox_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.single_double_tap = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of single_double_tap in reg WAKE_UP_THS
+  *
+  */
+int32_t lsm6dsox_tap_mode_get(lsm6dsox_ctx_t *ctx,
+                             lsm6dsox_single_double_tap_t *val)
+{
+  lsm6dsox_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_THS, (uint8_t*)&reg, 1);
+
+  switch (reg.single_double_tap) {
+    case LSM6DSOX_ONLY_SINGLE:
+      *val = LSM6DSOX_ONLY_SINGLE;
+      break;
+    case LSM6DSOX_BOTH_SINGLE_DOUBLE:
+      *val = LSM6DSOX_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LSM6DSOX_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_ Six_position_detection(6D/4D)
+  * @brief   This section groups all the functions concerning six position
+  *          detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sixd_ths in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dsox_6d_threshold_set(lsm6dsox_ctx_t *ctx, lsm6dsox_sixd_ths_t val)
+{
+  lsm6dsox_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.sixd_ths = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sixd_ths in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dsox_6d_threshold_get(lsm6dsox_ctx_t *ctx, lsm6dsox_sixd_ths_t *val)
+{
+  lsm6dsox_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  switch (reg.sixd_ths) {
+    case LSM6DSOX_DEG_80:
+      *val = LSM6DSOX_DEG_80;
+      break;
+    case LSM6DSOX_DEG_70:
+      *val = LSM6DSOX_DEG_70;
+      break;
+    case LSM6DSOX_DEG_60:
+      *val = LSM6DSOX_DEG_60;
+      break;
+    case LSM6DSOX_DEG_50:
+      *val = LSM6DSOX_DEG_50;
+      break;
+    default:
+      *val = LSM6DSOX_DEG_80;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_en in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dsox_4d_mode_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.d4d_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of d4d_en in reg TAP_THS_6D
+  *
+  */
+int32_t lsm6dsox_4d_mode_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_tap_ths_6d_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_TAP_THS_6D, (uint8_t*)&reg, 1);
+  *val = reg.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_free_fall
+  * @brief   This section group all the functions concerning the free
+  *          fall detection.
+  * @{
+  *
+*/
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lsm6dsox_ff_threshold_set(lsm6dsox_ctx_t *ctx, lsm6dsox_ff_ths_t val)
+{
+  lsm6dsox_free_fall_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FREE_FALL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.ff_ths = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FREE_FALL, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ff_ths in reg FREE_FALL
+  *
+  */
+int32_t lsm6dsox_ff_threshold_get(lsm6dsox_ctx_t *ctx, lsm6dsox_ff_ths_t *val)
+{
+  lsm6dsox_free_fall_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FREE_FALL, (uint8_t*)&reg, 1);
+  switch (reg.ff_ths) {
+    case LSM6DSOX_FF_TSH_156mg:
+      *val = LSM6DSOX_FF_TSH_156mg;
+      break;
+    case LSM6DSOX_FF_TSH_219mg:
+      *val = LSM6DSOX_FF_TSH_219mg;
+      break;
+    case LSM6DSOX_FF_TSH_250mg:
+      *val = LSM6DSOX_FF_TSH_250mg;
+      break;
+    case LSM6DSOX_FF_TSH_312mg:
+      *val = LSM6DSOX_FF_TSH_312mg;
+      break;
+    case LSM6DSOX_FF_TSH_344mg:
+      *val = LSM6DSOX_FF_TSH_344mg;
+      break;
+    case LSM6DSOX_FF_TSH_406mg:
+      *val = LSM6DSOX_FF_TSH_406mg;
+      break;
+    case LSM6DSOX_FF_TSH_469mg:
+      *val = LSM6DSOX_FF_TSH_469mg;
+      break;
+    case LSM6DSOX_FF_TSH_500mg:
+      *val = LSM6DSOX_FF_TSH_500mg;
+      break;
+    default:
+      *val = LSM6DSOX_FF_TSH_156mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event.[set]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in reg FREE_FALL
+  *
+  */
+int32_t lsm6dsox_ff_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_wake_up_dur_t wake_up_dur;
+  lsm6dsox_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  if (ret == 0) {
+    wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
+    free_fall.ff_dur = (uint8_t)val & 0x1FU;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event.[get]
+  *         1LSb = 1 / ODR
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in reg FREE_FALL
+  *
+  */
+int32_t lsm6dsox_ff_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_wake_up_dur_t wake_up_dur;
+  lsm6dsox_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FREE_FALL, (uint8_t*)&free_fall, 1);
+    *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_fifo
+  * @brief   This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_CTRL1
+  *
+  */
+int32_t lsm6dsox_fifo_watermark_set(lsm6dsox_ctx_t *ctx, uint16_t val)
+{
+  lsm6dsox_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dsox_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if (ret == 0) {
+    fifo_ctrl1.wtm = 0x00FFU & (uint8_t)val;
+    fifo_ctrl2.wtm = (uint8_t)(( 0x0100U & val ) >> 8);
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_CTRL1
+  *
+  */
+int32_t lsm6dsox_fifo_watermark_get(lsm6dsox_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsox_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dsox_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+    *val = ((uint16_t)fifo_ctrl2.wtm << 8) + (uint16_t)fifo_ctrl1.wtm;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO compression feature initialization request [set].
+  *
+  * @param  ctx       read / write interface definitions
+  * @param  val       change the values of FIFO_COMPR_INIT in
+  *                   reg EMB_FUNC_INIT_B
+  *
+  */
+int32_t lsm6dsox_compression_algo_init_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_emb_func_init_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.fifo_compr_init = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO compression feature initialization request [get].
+  *
+  * @param  ctx    read / write interface definitions
+  * @param  val    change the values of FIFO_COMPR_INIT in
+  *                reg EMB_FUNC_INIT_B
+  *
+  */
+int32_t lsm6dsox_compression_algo_init_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_init_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.fifo_compr_init;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable and configure compression algo.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of uncoptr_rate in
+  *                  reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dsox_compression_algo_set(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_uncoptr_rate_t val)
+{
+  lsm6dsox_emb_func_en_b_t emb_func_en_b;
+  lsm6dsox_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B,
+                           (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    emb_func_en_b.fifo_compr_en = ((uint8_t)val & 0x04U) >> 2;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B,
+                            (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  if (ret == 0) {
+
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  }
+  if (ret == 0) {
+    fifo_ctrl2.fifo_compr_rt_en = ((uint8_t)val & 0x04U) >> 2;
+    fifo_ctrl2.uncoptr_rate = (uint8_t)val & 0x03U;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable and configure compression algo.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of uncoptr_rate in
+  *                  reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dsox_compression_algo_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_uncoptr_rate_t *val)
+{
+  lsm6dsox_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+
+  switch ((reg.fifo_compr_rt_en<<2) | reg.uncoptr_rate) {
+    case LSM6DSOX_CMP_DISABLE:
+      *val = LSM6DSOX_CMP_DISABLE;
+      break;
+    case LSM6DSOX_CMP_ALWAYS:
+      *val = LSM6DSOX_CMP_ALWAYS;
+      break;
+    case LSM6DSOX_CMP_8_TO_1:
+      *val = LSM6DSOX_CMP_8_TO_1;
+      break;
+    case LSM6DSOX_CMP_16_TO_1:
+      *val = LSM6DSOX_CMP_16_TO_1;
+      break;
+    case LSM6DSOX_CMP_32_TO_1:
+      *val = LSM6DSOX_CMP_32_TO_1;
+      break;
+    default:
+      *val = LSM6DSOX_CMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odrchg_en in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dsox_fifo_virtual_sens_odr_chg_set(lsm6dsox_ctx_t *ctx,
+                                              uint8_t val)
+{
+  lsm6dsox_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odrchg_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odrchg_en in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dsox_fifo_virtual_sens_odr_chg_get(lsm6dsox_ctx_t *ctx,
+                                              uint8_t *val)
+{
+  lsm6dsox_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  *val = reg.odrchg_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_compr_rt_en in
+  *                  reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dsox_compression_algo_real_time_set(lsm6dsox_ctx_t *ctx,
+                                               uint8_t val)
+{
+  lsm6dsox_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fifo_compr_rt_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enables/Disables compression algorithm runtime. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_compr_rt_en in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dsox_compression_algo_real_time_get(lsm6dsox_ctx_t *ctx,
+                                               uint8_t *val)
+{
+  lsm6dsox_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_compr_rt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at
+  *         threshold level.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of stop_on_wtm in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dsox_fifo_stop_on_wtm_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.stop_on_wtm = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at
+  *         threshold level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of stop_on_wtm in reg FIFO_CTRL2
+  *
+  */
+int32_t lsm6dsox_fifo_stop_on_wtm_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_fifo_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL2, (uint8_t*)&reg, 1);
+  *val = reg.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdr_xl in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6dsox_fifo_xl_batch_set(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_xl_t val)
+{
+  lsm6dsox_fifo_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.bdr_xl = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of bdr_xl in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6dsox_fifo_xl_batch_get(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_xl_t *val)
+{
+  lsm6dsox_fifo_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  switch (reg.bdr_xl) {
+    case LSM6DSOX_XL_NOT_BATCHED:
+      *val = LSM6DSOX_XL_NOT_BATCHED;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_12Hz5:
+      *val = LSM6DSOX_XL_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_26Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_26Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_52Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_52Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_104Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_104Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_208Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_208Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_417Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_417Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_833Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_833Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_1667Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_1667Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_3333Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_3333Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_6667Hz:
+      *val = LSM6DSOX_XL_BATCHED_AT_6667Hz;
+      break;
+    case LSM6DSOX_XL_BATCHED_AT_6Hz5:
+      *val = LSM6DSOX_XL_BATCHED_AT_6Hz5;
+      break;
+    default:
+      *val = LSM6DSOX_XL_NOT_BATCHED;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdr_gy in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6dsox_fifo_gy_batch_set(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_gy_t val)
+{
+  lsm6dsox_fifo_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.bdr_gy = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of bdr_gy in reg FIFO_CTRL3
+  *
+  */
+int32_t lsm6dsox_fifo_gy_batch_get(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_gy_t *val)
+{
+  lsm6dsox_fifo_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL3, (uint8_t*)&reg, 1);
+  switch (reg.bdr_gy) {
+    case LSM6DSOX_GY_NOT_BATCHED:
+      *val = LSM6DSOX_GY_NOT_BATCHED;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_12Hz5:
+      *val = LSM6DSOX_GY_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_26Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_26Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_52Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_52Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_104Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_104Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_208Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_208Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_417Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_417Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_833Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_833Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_1667Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_1667Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_3333Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_3333Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_6667Hz:
+      *val = LSM6DSOX_GY_BATCHED_AT_6667Hz;
+      break;
+    case LSM6DSOX_GY_BATCHED_AT_6Hz5:
+      *val = LSM6DSOX_GY_BATCHED_AT_6Hz5;
+      break;
+    default:
+      *val = LSM6DSOX_GY_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_mode in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dsox_fifo_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fifo_mode_t val)
+{
+  lsm6dsox_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.fifo_mode = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fifo_mode in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dsox_fifo_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fifo_mode_t *val)
+{
+  lsm6dsox_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+
+  switch (reg.fifo_mode) {
+    case LSM6DSOX_BYPASS_MODE:
+      *val = LSM6DSOX_BYPASS_MODE;
+      break;
+    case LSM6DSOX_FIFO_MODE:
+      *val = LSM6DSOX_FIFO_MODE;
+      break;
+    case LSM6DSOX_STREAM_TO_FIFO_MODE:
+      *val = LSM6DSOX_STREAM_TO_FIFO_MODE;
+      break;
+    case LSM6DSOX_BYPASS_TO_STREAM_MODE:
+      *val = LSM6DSOX_BYPASS_TO_STREAM_MODE;
+      break;
+    case LSM6DSOX_STREAM_MODE:
+      *val = LSM6DSOX_STREAM_MODE;
+      break;
+    case LSM6DSOX_BYPASS_TO_FIFO_MODE:
+      *val = LSM6DSOX_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LSM6DSOX_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr_t_batch in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dsox_fifo_temp_batch_set(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_odr_t_batch_t val)
+{
+  lsm6dsox_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odr_t_batch = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr_t_batch in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dsox_fifo_temp_batch_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_odr_t_batch_t *val)
+{
+  lsm6dsox_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+
+  switch (reg.odr_t_batch) {
+    case LSM6DSOX_TEMP_NOT_BATCHED:
+      *val = LSM6DSOX_TEMP_NOT_BATCHED;
+      break;
+    case LSM6DSOX_TEMP_BATCHED_AT_1Hz6:
+      *val = LSM6DSOX_TEMP_BATCHED_AT_1Hz6;
+      break;
+    case LSM6DSOX_TEMP_BATCHED_AT_12Hz5:
+      *val = LSM6DSOX_TEMP_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSOX_TEMP_BATCHED_AT_52Hz:
+      *val = LSM6DSOX_TEMP_BATCHED_AT_52Hz;
+      break;
+    default:
+      *val = LSM6DSOX_TEMP_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr_ts_batch in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dsox_fifo_timestamp_decimation_set(lsm6dsox_ctx_t *ctx,
+                                              lsm6dsox_odr_ts_batch_t val)
+{
+  lsm6dsox_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.odr_ts_batch = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects decimation for timestamp batching in FIFO.
+  *          Writing rate will be the maximum rate between XL and
+  *          GYRO BDR divided by decimation decoder.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr_ts_batch in reg FIFO_CTRL4
+  *
+  */
+int32_t lsm6dsox_fifo_timestamp_decimation_get(lsm6dsox_ctx_t *ctx,
+                                              lsm6dsox_odr_ts_batch_t *val)
+{
+  lsm6dsox_fifo_ctrl4_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_CTRL4, (uint8_t*)&reg, 1);
+  switch (reg.odr_ts_batch) {
+    case LSM6DSOX_NO_DECIMATION:
+      *val = LSM6DSOX_NO_DECIMATION;
+      break;
+    case LSM6DSOX_DEC_1:
+      *val = LSM6DSOX_DEC_1;
+      break;
+    case LSM6DSOX_DEC_8:
+      *val = LSM6DSOX_DEC_8;
+      break;
+    case LSM6DSOX_DEC_32:
+      *val = LSM6DSOX_DEC_32;
+      break;
+    default:
+      *val = LSM6DSOX_NO_DECIMATION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *         between XL and gyro.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of trig_counter_bdr
+  *                  in reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dsox_fifo_cnt_event_batch_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_trig_counter_bdr_t val)
+{
+  lsm6dsox_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.trig_counter_bdr = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *         between XL and gyro.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of trig_counter_bdr
+  *                                     in reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dsox_fifo_cnt_event_batch_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_trig_counter_bdr_t *val)
+{
+  lsm6dsox_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  switch (reg.trig_counter_bdr) {
+    case LSM6DSOX_XL_BATCH_EVENT:
+      *val = LSM6DSOX_XL_BATCH_EVENT;
+      break;
+    case LSM6DSOX_GYRO_BATCH_EVENT:
+      *val = LSM6DSOX_GYRO_BATCH_EVENT;
+      break;
+    default:
+      *val = LSM6DSOX_XL_BATCH_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching vents for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of rst_counter_bdr in
+  *                      reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dsox_rst_batch_counter_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.rst_counter_bdr = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of rst_counter_bdr in
+  *                  reg COUNTER_BDR_REG1
+  *
+  */
+int32_t lsm6dsox_rst_batch_counter_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_counter_bdr_reg1_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1, (uint8_t*)&reg, 1);
+  *val = reg.rst_counter_bdr;
+
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of cnt_bdr_th in
+  *                  reg COUNTER_BDR_REG2 and COUNTER_BDR_REG1.
+  *
+  */
+int32_t lsm6dsox_batch_counter_threshold_set(lsm6dsox_ctx_t *ctx, uint16_t val)
+{
+  lsm6dsox_counter_bdr_reg1_t counter_bdr_reg1;
+  lsm6dsox_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1,
+                         (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0) {
+    counter_bdr_reg2.cnt_bdr_th =  0x00FFU & (uint8_t)val;
+    counter_bdr_reg1.cnt_bdr_th = (uint8_t)(0x0700U & val) >> 8;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1,
+                            (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_COUNTER_BDR_REG2,
+                            (uint8_t*)&counter_bdr_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of cnt_bdr_th in
+  *                  reg COUNTER_BDR_REG2 and COUNTER_BDR_REG1.
+  *
+  */
+int32_t lsm6dsox_batch_counter_threshold_get(lsm6dsox_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsox_counter_bdr_reg1_t counter_bdr_reg1;
+  lsm6dsox_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG1,
+                         (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_COUNTER_BDR_REG2,
+                           (uint8_t*)&counter_bdr_reg2, 1);
+
+    *val = ((uint16_t)counter_bdr_reg1.cnt_bdr_th << 8)
+    + (uint16_t)counter_bdr_reg2.cnt_bdr_th;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Number of unread sensor data(TAG + 6 bytes) stored in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of diff_fifo in reg FIFO_STATUS1
+  *
+  */
+int32_t lsm6dsox_fifo_data_level_get(lsm6dsox_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsox_fifo_status1_t fifo_status1;
+  lsm6dsox_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS1,
+                         (uint8_t*)&fifo_status1, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+    *val = ((uint16_t)fifo_status2.diff_fifo << 8) +
+            (uint16_t)fifo_status1.diff_fifo;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_STATUS2
+  *
+  */
+int32_t lsm6dsox_fifo_status_get(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_fifo_status2_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO full status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_full_ia in reg FIFO_STATUS2
+  *
+  */
+int32_t lsm6dsox_fifo_full_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_full_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  fifo_over_run_latched in
+  *                  reg FIFO_STATUS2
+  *
+  */
+int32_t lsm6dsox_fifo_ovr_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_ovr_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  *
+  */
+int32_t lsm6dsox_fifo_wtm_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_STATUS2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_wtm_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  Identifies the sensor in FIFO_DATA_OUT.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tag_sensor in reg FIFO_DATA_OUT_TAG
+  *
+  */
+int32_t lsm6dsox_fifo_sensor_tag_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_fifo_tag_t *val)
+{
+  lsm6dsox_fifo_data_out_tag_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FIFO_DATA_OUT_TAG, (uint8_t*)&reg, 1);
+  switch (reg.tag_sensor) {
+    case LSM6DSOX_GYRO_NC_TAG:
+      *val = LSM6DSOX_GYRO_NC_TAG;
+      break;
+    case LSM6DSOX_XL_NC_TAG:
+      *val = LSM6DSOX_XL_NC_TAG;
+      break;
+    case LSM6DSOX_TEMPERATURE_TAG:
+      *val = LSM6DSOX_TEMPERATURE_TAG;
+      break;
+    case LSM6DSOX_CFG_CHANGE_TAG:
+      *val = LSM6DSOX_CFG_CHANGE_TAG;
+      break;
+    case LSM6DSOX_XL_NC_T_2_TAG:
+      *val = LSM6DSOX_XL_NC_T_2_TAG;
+      break;
+    case LSM6DSOX_XL_NC_T_1_TAG:
+      *val = LSM6DSOX_XL_NC_T_1_TAG;
+      break;
+    case LSM6DSOX_XL_2XC_TAG:
+      *val = LSM6DSOX_XL_2XC_TAG;
+      break;
+    case LSM6DSOX_XL_3XC_TAG:
+      *val = LSM6DSOX_XL_3XC_TAG;
+      break;
+    case LSM6DSOX_GYRO_NC_T_2_TAG:
+      *val = LSM6DSOX_GYRO_NC_T_2_TAG;
+      break;
+    case LSM6DSOX_GYRO_NC_T_1_TAG:
+      *val = LSM6DSOX_GYRO_NC_T_1_TAG;
+      break;
+    case LSM6DSOX_GYRO_2XC_TAG:
+      *val = LSM6DSOX_GYRO_2XC_TAG;
+      break;
+    case LSM6DSOX_GYRO_3XC_TAG:
+      *val = LSM6DSOX_GYRO_3XC_TAG;
+      break;
+    case LSM6DSOX_SENSORHUB_SLAVE0_TAG:
+      *val = LSM6DSOX_SENSORHUB_SLAVE0_TAG;
+      break;
+    case LSM6DSOX_SENSORHUB_SLAVE1_TAG:
+      *val = LSM6DSOX_SENSORHUB_SLAVE1_TAG;
+      break;
+    case LSM6DSOX_SENSORHUB_SLAVE2_TAG:
+      *val = LSM6DSOX_SENSORHUB_SLAVE2_TAG;
+      break;
+    case LSM6DSOX_SENSORHUB_SLAVE3_TAG:
+      *val = LSM6DSOX_SENSORHUB_SLAVE3_TAG;
+      break;
+    case LSM6DSOX_STEP_CPUNTER_TAG:
+      *val = LSM6DSOX_STEP_CPUNTER_TAG;
+      break;
+    case LSM6DSOX_GAME_ROTATION_TAG:
+      *val = LSM6DSOX_GAME_ROTATION_TAG;
+      break;
+    case LSM6DSOX_GEOMAG_ROTATION_TAG:
+      *val = LSM6DSOX_GEOMAG_ROTATION_TAG;
+      break;
+    case LSM6DSOX_ROTATION_TAG:
+      *val = LSM6DSOX_ROTATION_TAG;
+      break;
+    case LSM6DSOX_SENSORHUB_NACK_TAG:
+      *val = LSM6DSOX_SENSORHUB_NACK_TAG;
+      break;
+    default:
+      *val = LSM6DSOX_GYRO_NC_TAG;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  :  Enable FIFO batching of pedometer embedded
+  *            function values.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of gbias_fifo_en in
+  *                  reg LSM6DSOX_EMB_FUNC_FIFO_CFG
+  *
+  */
+int32_t lsm6dsox_fifo_pedo_batch_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_emb_func_fifo_cfg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_FIFO_CFG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.pedo_fifo_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_FIFO_CFG,
+                            (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching of pedometer embedded function values.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pedo_fifo_en in
+  *                  reg LSM6DSOX_EMB_FUNC_FIFO_CFG
+  *
+  */
+int32_t lsm6dsox_fifo_pedo_batch_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_fifo_cfg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_FIFO_CFG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.pedo_fifo_en;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Enable FIFO batching data of first slave.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_0_en in
+  *                  reg SLV0_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_batch_slave_0_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_slv0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV0_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.batch_ext_sens_0_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV0_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of first slave.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_0_en in
+  *                  reg SLV0_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_batch_slave_0_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_slv0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV0_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.batch_ext_sens_0_en;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of second slave.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_1_en in
+  *                  reg SLV1_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_batch_slave_1_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_slv1_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.batch_ext_sens_1_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enable FIFO batching data of second slave.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_1_en in
+  *                  reg SLV1_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_batch_slave_1_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_slv1_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV1_CONFIG, (uint8_t*)&reg, 1);
+    *val = reg.batch_ext_sens_1_en;
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of third slave.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_2_en in
+  *                  reg SLV2_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_batch_slave_2_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_slv2_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV2_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.batch_ext_sens_2_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV2_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of third slave.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_2_en in
+  *                  reg SLV2_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_batch_slave_2_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_slv2_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV2_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.batch_ext_sens_2_en;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enable FIFO batching data of fourth slave.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_3_en
+  *                  in reg SLV3_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_batch_slave_3_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_slv3_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV3_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.batch_ext_sens_3_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV3_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of fourth slave.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of  batch_ext_sens_3_en in
+  *                  reg SLV3_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_batch_slave_3_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_slv3_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV3_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.batch_ext_sens_3_en;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_DEN_functionality
+  * @brief     This section groups all the functions concerning
+  *            DEN functionality.
+  * @{
+  *
+*/
+
+/**
+  * @brief  DEN functionality marking mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_mode in reg CTRL6_C
+  *
+  */
+int32_t lsm6dsox_den_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_mode_t val)
+{
+  lsm6dsox_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_mode = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of den_mode in reg CTRL6_C
+  *
+  */
+int32_t lsm6dsox_den_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_mode_t *val)
+{
+  lsm6dsox_ctrl6_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL6_C, (uint8_t*)&reg, 1);
+
+  switch (reg.den_mode) {
+    case LSM6DSOX_DEN_DISABLE:
+      *val = LSM6DSOX_DEN_DISABLE;
+      break;
+    case LSM6DSOX_LEVEL_FIFO:
+      *val = LSM6DSOX_LEVEL_FIFO;
+      break;
+    case LSM6DSOX_LEVEL_LETCHED:
+      *val = LSM6DSOX_LEVEL_LETCHED;
+      break;
+    case LSM6DSOX_LEVEL_TRIGGER:
+      *val = LSM6DSOX_LEVEL_TRIGGER;
+      break;
+    case LSM6DSOX_EDGE_TRIGGER:
+      *val = LSM6DSOX_EDGE_TRIGGER;
+      break;
+    default:
+      *val = LSM6DSOX_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_lh in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_polarity_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_lh_t val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_lh = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of den_lh in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_polarity_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_lh_t *val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+
+  switch (reg.den_lh) {
+    case LSM6DSOX_DEN_ACT_LOW:
+      *val = LSM6DSOX_DEN_ACT_LOW;
+      break;
+    case LSM6DSOX_DEN_ACT_HIGH:
+      *val = LSM6DSOX_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = LSM6DSOX_DEN_ACT_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_xl_g in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_enable_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_xl_g_t val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_xl_g = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of den_xl_g in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_enable_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_xl_g_t *val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+
+  switch (reg.den_xl_g) {
+    case LSM6DSOX_STAMP_IN_GY_DATA:
+      *val = LSM6DSOX_STAMP_IN_GY_DATA;
+      break;
+    case LSM6DSOX_STAMP_IN_XL_DATA:
+      *val = LSM6DSOX_STAMP_IN_XL_DATA;
+      break;
+    case LSM6DSOX_STAMP_IN_GY_XL_DATA:
+      *val = LSM6DSOX_STAMP_IN_GY_XL_DATA;
+      break;
+    default:
+      *val = LSM6DSOX_STAMP_IN_GY_DATA;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_z in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_mark_axis_x_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_z = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_z in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_mark_axis_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  *val = reg.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_y in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_mark_axis_y_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_y = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_y in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_mark_axis_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  *val = reg.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_x in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_mark_axis_z_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.den_x = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of den_x in reg CTRL9_XL
+  *
+  */
+int32_t lsm6dsox_den_mark_axis_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_ctrl9_xl_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_CTRL9_XL, (uint8_t*)&reg, 1);
+  *val = reg.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_Pedometer
+  * @brief     This section groups all the functions that manage pedometer.
+  * @{
+  *
+*/
+
+/**
+  * @brief  Enable pedometer algorithm.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      turn on and configure pedometer
+  *
+  */
+int32_t lsm6dsox_pedo_sens_set(lsm6dsox_ctx_t *ctx, lsm6dsox_pedo_md_t val)
+{
+  lsm6dsox_emb_func_en_a_t emb_func_en_a;
+  lsm6dsox_emb_func_en_b_t emb_func_en_b;
+  lsm6dsox_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_PEDO_CMD_REG,
+                                (uint8_t*)&pedo_cmd_reg);
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A,
+                           (uint8_t*)&emb_func_en_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B,
+                           (uint8_t*)&emb_func_en_b, 1);
+
+    emb_func_en_a.pedo_en = (uint8_t)val & 0x01U;
+    emb_func_en_b.mlc_en = ((uint8_t)val & 0x02U)>>1;
+    pedo_cmd_reg.fp_rejection_en = ((uint8_t)val & 0x10U)>>4;
+    pedo_cmd_reg.ad_det_en = ((uint8_t)val & 0x20U)>>5;
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A,
+                            (uint8_t*)&emb_func_en_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B,
+                            (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer algorithm.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      turn on and configure pedometer
+  *
+  */
+int32_t lsm6dsox_pedo_sens_get(lsm6dsox_ctx_t *ctx, lsm6dsox_pedo_md_t *val)
+{
+  lsm6dsox_emb_func_en_a_t emb_func_en_a;
+  lsm6dsox_emb_func_en_b_t emb_func_en_b;
+  lsm6dsox_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_PEDO_CMD_REG,
+                                (uint8_t*)&pedo_cmd_reg);
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A,
+                           (uint8_t*)&emb_func_en_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B,
+                           (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  switch ( (pedo_cmd_reg.ad_det_en <<5) | (pedo_cmd_reg.fp_rejection_en << 4) |
+           (emb_func_en_b.mlc_en << 1) | emb_func_en_a.pedo_en) {
+    case LSM6DSOX_PEDO_DISABLE:
+      *val = LSM6DSOX_PEDO_DISABLE;
+      break;
+    case LSM6DSOX_PEDO_BASE_MODE:
+      *val = LSM6DSOX_PEDO_BASE_MODE;
+      break;
+    case LSM6DSOX_PEDO_ADV_MODE:
+      *val = LSM6DSOX_PEDO_ADV_MODE;
+      break;
+    case LSM6DSOX_FALSE_STEP_REJ:
+      *val = LSM6DSOX_FALSE_STEP_REJ;
+      break;
+    case LSM6DSOX_FALSE_STEP_REJ_ADV_MODE:
+      *val = LSM6DSOX_FALSE_STEP_REJ_ADV_MODE;
+      break;
+    default:
+      *val = LSM6DSOX_PEDO_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for step detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of is_step_det in reg EMB_FUNC_STATUS
+  *
+  */
+int32_t lsm6dsox_pedo_step_detect_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_status_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_STATUS, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.is_step_det;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_pedo_debounce_steps_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_PEDO_DEB_STEPS_CONF, buff);
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_pedo_debounce_steps_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_PEDO_DEB_STEPS_CONF, buff);
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_pedo_steps_period_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_PEDO_SC_DELTAT_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_PEDO_SC_DELTAT_H,
+                                   &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Time period register for step detection on delta time (r/w).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_pedo_steps_period_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_PEDO_SC_DELTAT_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_PEDO_SC_DELTAT_H,
+                                  &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Set when user wants to generate interrupt on count overflow
+  *         event/every step.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of carry_count_en in reg PEDO_CMD_REG
+  *
+  */
+int32_t lsm6dsox_pedo_int_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_carry_count_en_t val)
+{
+  lsm6dsox_pedo_cmd_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_PEDO_CMD_REG, (uint8_t*)&reg);
+  if (ret == 0) {
+    reg.carry_count_en = (uint8_t)val;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_PEDO_CMD_REG,
+                                   (uint8_t*)&reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Set when user wants to generate interrupt on count overflow
+  *         event/every step.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of carry_count_en in reg PEDO_CMD_REG
+  *
+  */
+int32_t lsm6dsox_pedo_int_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_carry_count_en_t *val)
+{
+  lsm6dsox_pedo_cmd_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_PEDO_CMD_REG, (uint8_t*)&reg);
+  switch (reg.carry_count_en) {
+    case LSM6DSOX_EVERY_STEP:
+      *val = LSM6DSOX_EVERY_STEP;
+      break;
+    case LSM6DSOX_COUNT_OVERFLOW:
+      *val = LSM6DSOX_COUNT_OVERFLOW;
+      break;
+    default:
+      *val = LSM6DSOX_EVERY_STEP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_significant_motion
+  * @brief   This section groups all the functions that manage the
+  *          significant motion detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable significant motion detection function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sign_motion_en in reg EMB_FUNC_EN_A
+  *
+  */
+int32_t lsm6dsox_motion_sens_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_emb_func_en_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.sign_motion_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable significant motion detection function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sign_motion_en in reg EMB_FUNC_EN_A
+  *
+  */
+int32_t lsm6dsox_motion_sens_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_en_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.sign_motion_en;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt status bit for significant motion detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of is_sigmot in reg EMB_FUNC_STATUS
+  *
+  */
+int32_t lsm6dsox_motion_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_status_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_STATUS, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.is_sigmot;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_tilt_detection
+  * @brief     This section groups all the functions that manage the tilt
+  *            event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tilt_en in reg EMB_FUNC_EN_A
+  *
+  */
+int32_t lsm6dsox_tilt_sens_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_emb_func_en_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.tilt_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tilt_en in reg EMB_FUNC_EN_A
+  *
+  */
+int32_t lsm6dsox_tilt_sens_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_en_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_A, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.tilt_en;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for tilt detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of is_tilt in reg EMB_FUNC_STATUS
+  *
+  */
+int32_t lsm6dsox_tilt_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_status_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_STATUS, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.is_tilt;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_ magnetometer_sensor
+  * @brief     This section groups all the functions that manage additional
+  *            magnetometer sensor.
+  * @{
+  *
+  */
+
+/**
+  * @brief  External magnetometer sensitivity value register for
+  *         Sensor hub.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_sh_mag_sensitivity_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SENSITIVITY_L,
+                                 &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SENSITIVITY_H,
+                                   &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer sensitivity value register for
+  *         Sensor hub.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_sh_mag_sensitivity_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SENSITIVITY_L,
+                                &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SENSITIVITY_H,
+                                  &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer sensitivity value register for
+  *         Machine Learning Core.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_mlc_mag_sensitivity_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MLC_MAG_SENSITIVITY_L,
+                                  &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MLC_MAG_SENSITIVITY_H,
+                                    &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer sensitivity value register for
+  *         Machine Learning Core.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_mlc_mag_sensitivity_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MLC_MAG_SENSITIVITY_L,
+                                 &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MLC_MAG_SENSITIVITY_H,
+                                   &buff[index]);
+  }
+  return ret;
+}
+
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_mag_offset_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_OFFX_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_OFFX_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_OFFY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_OFFY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_OFFZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_OFFZ_H, &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_mag_offset_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_OFFX_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_OFFX_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_OFFY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_OFFY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_OFFZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_OFFZ_H, &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft-iron (3x3 symmetric) matrix correction
+  *         register (r/w). The value is expressed as
+  *         half-precision floating-point format:
+  *         SEEEEEFFFFFFFFFF
+  *         S: 1 sign bit;
+  *         E: 5 exponent bits;
+  *         F: 10 fraction bits).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_mag_soft_iron_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_XX_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_XX_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_XY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_XY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_XZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_XZ_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_YY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_YY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_YZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_YZ_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_ZZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_SI_ZZ_H, &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Soft-iron (3x3 symmetric) matrix
+  *         correction register (r/w).
+  *         The value is expressed as half-precision
+  *         floating-point format:
+  *         SEEEEEFFFFFFFFFF
+  *         S: 1 sign bit;
+  *         E: 5 exponent bits;
+  *         F: 10 fraction bits.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_mag_soft_iron_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_XX_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_XX_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_XY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_XY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_XZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_XZ_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_YY_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_YY_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_YZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_YZ_H, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_ZZ_L, &buff[index]);
+  }
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_SI_ZZ_H, &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Z-axis coordinates
+  *         rotation (to be aligned to
+  *         accelerometer/gyroscope axes
+  *         orientation).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mag_z_axis in reg MAG_CFG_A
+  *
+  */
+int32_t lsm6dsox_mag_z_orient_set(lsm6dsox_ctx_t *ctx, lsm6dsox_mag_z_axis_t val)
+{
+  lsm6dsox_mag_cfg_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_CFG_A, (uint8_t*)&reg);
+  if (ret == 0) {
+    reg.mag_z_axis = (uint8_t) val;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_CFG_A, (uint8_t*)&reg);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Z-axis coordinates
+  *         rotation (to be aligned to
+  *         accelerometer/gyroscope axes
+  *         orientation).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of mag_z_axis in reg MAG_CFG_A
+  *
+  */
+int32_t lsm6dsox_mag_z_orient_get(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_mag_z_axis_t *val)
+{
+  lsm6dsox_mag_cfg_a_t reg;
+  int32_t ret;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_CFG_A, (uint8_t*)&reg);
+  switch (reg.mag_z_axis) {
+    case LSM6DSOX_Z_EQ_Y:
+      *val = LSM6DSOX_Z_EQ_Y;
+      break;
+    case LSM6DSOX_Z_EQ_MIN_Y:
+      *val = LSM6DSOX_Z_EQ_MIN_Y;
+      break;
+    case LSM6DSOX_Z_EQ_X:
+      *val = LSM6DSOX_Z_EQ_X;
+      break;
+    case LSM6DSOX_Z_EQ_MIN_X:
+      *val = LSM6DSOX_Z_EQ_MIN_X;
+      break;
+    case LSM6DSOX_Z_EQ_MIN_Z:
+      *val = LSM6DSOX_Z_EQ_MIN_Z;
+      break;
+    case LSM6DSOX_Z_EQ_Z:
+      *val = LSM6DSOX_Z_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSOX_Z_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Magnetometer Y-axis coordinates
+  *          rotation (to be aligned to
+  *          accelerometer/gyroscope axes
+  *          orientation).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mag_y_axis in reg MAG_CFG_A
+  *
+  */
+int32_t lsm6dsox_mag_y_orient_set(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_mag_y_axis_t val)
+{
+  lsm6dsox_mag_cfg_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_CFG_A, (uint8_t*)&reg);
+  if (ret == 0) {
+    reg.mag_y_axis = (uint8_t)val;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_CFG_A,(uint8_t*) &reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Y-axis coordinates
+  *         rotation (to be aligned to
+  *         accelerometer/gyroscope axes
+  *         orientation).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of mag_y_axis in reg MAG_CFG_A
+  *
+  */
+int32_t lsm6dsox_mag_y_orient_get(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_mag_y_axis_t *val)
+{
+  lsm6dsox_mag_cfg_a_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_CFG_A, (uint8_t*)&reg);
+  switch (reg.mag_y_axis) {
+    case LSM6DSOX_Y_EQ_Y:
+      *val = LSM6DSOX_Y_EQ_Y;
+      break;
+    case LSM6DSOX_Y_EQ_MIN_Y:
+      *val = LSM6DSOX_Y_EQ_MIN_Y;
+      break;
+    case LSM6DSOX_Y_EQ_X:
+      *val = LSM6DSOX_Y_EQ_X;
+      break;
+    case LSM6DSOX_Y_EQ_MIN_X:
+      *val = LSM6DSOX_Y_EQ_MIN_X;
+      break;
+    case LSM6DSOX_Y_EQ_MIN_Z:
+      *val = LSM6DSOX_Y_EQ_MIN_Z;
+      break;
+    case LSM6DSOX_Y_EQ_Z:
+      *val = LSM6DSOX_Y_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSOX_Y_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer X-axis coordinates
+  *         rotation (to be aligned to
+  *         accelerometer/gyroscope axes
+  *         orientation).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mag_x_axis in reg MAG_CFG_B
+  *
+  */
+int32_t lsm6dsox_mag_x_orient_set(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_mag_x_axis_t val)
+{
+  lsm6dsox_mag_cfg_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_CFG_B, (uint8_t*)&reg);
+  if (ret == 0) {
+    reg.mag_x_axis = (uint8_t)val;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_MAG_CFG_B, (uint8_t*)&reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Magnetometer X-axis coordinates
+  *          rotation (to be aligned to
+  *          accelerometer/gyroscope axes
+  *          orientation).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of mag_x_axis in reg MAG_CFG_B
+  *
+  */
+int32_t lsm6dsox_mag_x_orient_get(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_mag_x_axis_t *val)
+{
+  lsm6dsox_mag_cfg_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_MAG_CFG_B, (uint8_t*)&reg);
+  switch (reg.mag_x_axis) {
+    case LSM6DSOX_X_EQ_Y:
+      *val = LSM6DSOX_X_EQ_Y;
+      break;
+    case LSM6DSOX_X_EQ_MIN_Y:
+      *val = LSM6DSOX_X_EQ_MIN_Y;
+      break;
+    case LSM6DSOX_X_EQ_X:
+      *val = LSM6DSOX_X_EQ_X;
+      break;
+    case LSM6DSOX_X_EQ_MIN_X:
+      *val = LSM6DSOX_X_EQ_MIN_X;
+      break;
+    case LSM6DSOX_X_EQ_MIN_Z:
+      *val = LSM6DSOX_X_EQ_MIN_Z;
+      break;
+    case LSM6DSOX_X_EQ_Z:
+      *val = LSM6DSOX_X_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSOX_X_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_significant_motion
+  * @brief     This section groups all the functions that manage the
+  *            state_machine.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Interrupt status bit for FSM long counter
+  *          timeout interrupt event.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of is_fsm_lc in reg EMB_FUNC_STATUS
+  *
+  */
+int32_t lsm6dsox_long_cnt_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_status_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_STATUS, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.is_fsm_lc;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Final State Machine global enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_en in reg EMB_FUNC_EN_B
+  *
+  */
+int32_t lsm6dsox_emb_fsm_en_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  lsm6dsox_emb_func_en_b_t reg;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.fsm_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Final State Machine global enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  uint8_t *: return the values of fsm_en in reg EMB_FUNC_EN_B
+  *
+  */
+int32_t lsm6dsox_emb_fsm_en_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  lsm6dsox_emb_func_en_b_t reg;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.fsm_en;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  *
+  */
+int32_t lsm6dsox_fsm_enable_set(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_emb_fsm_enable_t *val)
+{
+  int32_t ret;
+  lsm6dsox_emb_func_en_b_t emb_func_en_b;
+  lsm6dsox_emb_func_init_b_t emb_func_init_b;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FSM_ENABLE_A,
+                            (uint8_t*)&val->fsm_enable_a, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FSM_ENABLE_B,
+                            (uint8_t*)&val->fsm_enable_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B, 
+                            (uint8_t*)&emb_func_init_b, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B,
+                            (uint8_t*)&emb_func_en_b, 1);
+  }
+  if (ret == 0) {
+    if ( (val->fsm_enable_a.fsm1_en   |
+          val->fsm_enable_a.fsm2_en   |
+          val->fsm_enable_a.fsm3_en   |
+          val->fsm_enable_a.fsm4_en   |
+          val->fsm_enable_a.fsm5_en   |
+          val->fsm_enable_a.fsm6_en   |
+          val->fsm_enable_a.fsm7_en   |
+          val->fsm_enable_a.fsm8_en   |
+          val->fsm_enable_b.fsm9_en   |
+          val->fsm_enable_b.fsm10_en  |
+          val->fsm_enable_b.fsm11_en  |
+          val->fsm_enable_b.fsm12_en  |
+          val->fsm_enable_b.fsm13_en  |
+          val->fsm_enable_b.fsm14_en  |
+          val->fsm_enable_b.fsm15_en  |
+          val->fsm_enable_b.fsm16_en  )
+          != PROPERTY_DISABLE)
+    {
+      emb_func_en_b.fsm_en = PROPERTY_ENABLE;
+      emb_func_init_b.fsm_init = PROPERTY_ENABLE;
+    }
+    else
+    {
+      emb_func_en_b.fsm_en = PROPERTY_DISABLE;
+      emb_func_init_b.fsm_init = PROPERTY_DISABLE;
+    }
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+    if (ret == 0) {
+      ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B,
+                               (uint8_t*)&emb_func_init_b, 1);
+    }
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Final State Machine enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  *
+  */
+int32_t lsm6dsox_fsm_enable_get(lsm6dsox_ctx_t *ctx,
+                               lsm6dsox_emb_fsm_enable_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_ENABLE_A, (uint8_t*) val, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_long_cnt_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FSM_LONG_COUNTER_L, buff, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_long_cnt_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_LONG_COUNTER_L, buff, 2);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Clear FSM long counter value.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_lc_clr in
+  *                  reg FSM_LONG_COUNTER_CLEAR
+  *
+  */
+int32_t lsm6dsox_long_clr_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_lc_clr_t val)
+{
+  lsm6dsox_fsm_long_counter_clear_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_LONG_COUNTER_CLEAR,
+    (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg. fsm_lc_clr = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_FSM_LONG_COUNTER_CLEAR,
+    (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Clear FSM long counter value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fsm_lc_clr in
+  *                  reg FSM_LONG_COUNTER_CLEAR
+  *
+  */
+int32_t lsm6dsox_long_clr_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_lc_clr_t *val)
+{
+  lsm6dsox_fsm_long_counter_clear_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_LONG_COUNTER_CLEAR,
+    (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.fsm_lc_clr) {
+      case LSM6DSOX_LC_NORMAL:
+        *val = LSM6DSOX_LC_NORMAL;
+        break;
+      case LSM6DSOX_LC_CLEAR:
+        *val = LSM6DSOX_LC_CLEAR;
+        break;
+      case LSM6DSOX_LC_CLEAR_DONE:
+        *val = LSM6DSOX_LC_CLEAR_DONE;
+        break;
+      default:
+        *val = LSM6DSOX_LC_NORMAL;
+        break;
+    }
+  }
+
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM output registers[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      struct of registers from FSM_OUTS1 to FSM_OUTS16
+  *
+  */
+int32_t lsm6dsox_fsm_out_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_out_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_FSM_OUTS1, (uint8_t*) &val, 16);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  *
+  */
+int32_t lsm6dsox_fsm_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_odr_t val)
+{
+  lsm6dsox_emb_func_odr_cfg_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_ODR_CFG_B,
+                           (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.not_used_01 = 3; /* set default values */
+    reg.not_used_02 = 1; /* set default values */
+    reg.fsm_odr = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_ODR_CFG_B,
+                            (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  *
+  */
+int32_t lsm6dsox_fsm_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_odr_t *val)
+{
+  lsm6dsox_emb_func_odr_cfg_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_ODR_CFG_B,
+                           (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.fsm_odr) {
+      case LSM6DSOX_ODR_FSM_12Hz5:
+        *val = LSM6DSOX_ODR_FSM_12Hz5;
+        break;
+      case LSM6DSOX_ODR_FSM_26Hz:
+        *val = LSM6DSOX_ODR_FSM_26Hz;
+        break;
+      case LSM6DSOX_ODR_FSM_52Hz:
+        *val = LSM6DSOX_ODR_FSM_52Hz;
+        break;
+      case LSM6DSOX_ODR_FSM_104Hz:
+        *val = LSM6DSOX_ODR_FSM_104Hz;
+        break;
+      default:
+        *val = LSM6DSOX_ODR_FSM_12Hz5;
+        break;
+    }
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_init in reg FSM_INIT
+  *
+  */
+int32_t lsm6dsox_fsm_init_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_emb_func_init_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.fsm_init = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fsm_init in reg FSM_INIT
+  *
+  */
+int32_t lsm6dsox_fsm_init_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_init_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.fsm_init;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value,
+  *         the FSM generates an interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_long_cnt_int_value_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_FSM_LC_TIMEOUT_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_FSM_LC_TIMEOUT_H,
+                                   &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value,
+  *         the FSM generates an interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_long_cnt_int_value_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_FSM_LC_TIMEOUT_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_FSM_LC_TIMEOUT_H,
+                                  &buff[index]);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_fsm_number_of_programs_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_FSM_PROGRAMS, buff);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_fsm_number_of_programs_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_FSM_PROGRAMS, buff);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w).
+  *         First available address is 0x033C.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  *
+  */
+int32_t lsm6dsox_fsm_start_address_set(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_FSM_START_ADD_L, &buff[index]);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_write_byte(ctx, LSM6DSOX_FSM_START_ADD_H,
+                                   &buff[index]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w).
+  *         First available address is 0x033C.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  *
+  */
+int32_t lsm6dsox_fsm_start_address_get(lsm6dsox_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t index;
+
+  index = 0x00U;
+  ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_FSM_START_ADD_L, buff);
+  if (ret == 0) {
+    index++;
+    ret = lsm6dsox_ln_pg_read_byte(ctx, LSM6DSOX_FSM_START_ADD_H, buff);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  Machine Learning Core
+  * @brief   This section group all the functions concerning the
+  *          usage of Machine Learning Core
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable Machine Learning Core.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mlc_en in
+  *                  reg EMB_FUNC_EN_B and progsens_init
+  *                  in EMB_FUNC_INIT_B
+  *
+  */
+int32_t lsm6dsox_mlc_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_emb_func_en_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.mlc_en = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if ((val != PROPERTY_DISABLE) && (ret == 0)){
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B,
+                                 (uint8_t*)&reg, 1);
+    if (ret == 0) {
+      reg.mlc_en = val;
+      ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_INIT_B,
+                                  (uint8_t*)&reg, 1);
+    }
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Machine Learning Core.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of mlc_en in
+  *                  reg EMB_FUNC_EN_B
+  *
+  */
+int32_t lsm6dsox_mlc_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_emb_func_en_b_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_EN_B, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+    *val  = reg.mlc_en;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core status register[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register PROGSENS_STATUS_MAINPAGE
+  *
+  */
+int32_t lsm6dsox_mlc_status_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_progsens_status_mainpage_t *val)
+{
+  return lsm6dsox_read_reg(ctx, LSM6DSOX_PROGSENS_STATUS_MAINPAGE,
+                           (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  Machine Learning Core data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of progsens_odr in
+  *                  reg EMB_FUNC_ODR_CFG_C
+  *
+  */
+int32_t lsm6dsox_mlc_data_rate_set(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_mlc_odr_t val)
+{
+  lsm6dsox_emb_func_odr_cfg_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_ODR_CFG_C,
+                            (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.mlc_odr = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_EMB_FUNC_ODR_CFG_C, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of progsens_odr in
+  *                  reg EMB_FUNC_ODR_CFG_C
+  *
+  */
+int32_t lsm6dsox_mlc_data_rate_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_mlc_odr_t *val)
+{
+  lsm6dsox_emb_func_odr_cfg_c_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {  
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_EMB_FUNC_ODR_CFG_C, 
+                            (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.mlc_odr) {
+      case LSM6DSOX_ODR_PRGS_12Hz5:
+        *val = LSM6DSOX_ODR_PRGS_12Hz5;
+        break;
+      case LSM6DSOX_ODR_PRGS_26Hz:
+        *val = LSM6DSOX_ODR_PRGS_26Hz;
+        break;
+      case LSM6DSOX_ODR_PRGS_52Hz:
+        *val = LSM6DSOX_ODR_PRGS_52Hz;
+        break;
+      case LSM6DSOX_ODR_PRGS_104Hz:
+        *val = LSM6DSOX_ODR_PRGS_104Hz;
+        break;
+      default:
+        *val = LSM6DSOX_ODR_PRGS_12Hz5;
+        break;
+    }
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LSM6DSOX_Sensor_hub
+  * @brief     This section groups all the functions that manage the
+  *            sensor hub.
+  * @{
+  *
+  */
+
+/**
+* @brief  Sensor hub output registers.[get]
+*
+* @param  ctx      read / write interface definitions
+* @param  val      union of registers from SENSOR_HUB_1 to SENSOR_HUB_18
+*
+  */
+int32_t lsm6dsox_sh_read_data_raw_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_emb_sh_read_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SENSOR_HUB_1, (uint8_t*) val, 18U);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of aux_sens_on in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_slave_connected_set(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_aux_sens_on_t val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.aux_sens_on = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of aux_sens_on in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_slave_connected_get(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_aux_sens_on_t *val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.aux_sens_on) {
+      case LSM6DSOX_SLV_0:
+        *val = LSM6DSOX_SLV_0;
+        break;
+      case LSM6DSOX_SLV_0_1:
+        *val = LSM6DSOX_SLV_0_1;
+        break;
+      case LSM6DSOX_SLV_0_1_2:
+        *val = LSM6DSOX_SLV_0_1_2;
+        break;
+      case LSM6DSOX_SLV_0_1_2_3:
+        *val = LSM6DSOX_SLV_0_1_2_3;
+        break;
+      default:
+        *val = LSM6DSOX_SLV_0;
+        break;
+    }
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of master_on in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_master_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.master_on = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of master_on in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_master_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.master_on;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shub_pu_en in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_pin_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_pu_en_t val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.shub_pu_en = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of shub_pu_en in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_pin_mode_get(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_shub_pu_en_t *val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.shub_pu_en) {
+      case LSM6DSOX_EXT_PULL_UP:
+        *val = LSM6DSOX_EXT_PULL_UP;
+        break;
+      case LSM6DSOX_INTERNAL_PULL_UP:
+        *val = LSM6DSOX_INTERNAL_PULL_UP;
+        break;
+      default:
+        *val = LSM6DSOX_EXT_PULL_UP;
+        break;
+    }
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pass_through_mode in
+  *                  reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_pass_through_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.pass_through_mode = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pass_through_mode in
+  *                  reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_pass_through_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.pass_through_mode;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of start_config in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_syncro_mode_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_start_config_t val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.start_config = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of start_config in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_syncro_mode_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_start_config_t *val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.start_config) {
+      case LSM6DSOX_EXT_ON_INT2_PIN:
+        *val = LSM6DSOX_EXT_ON_INT2_PIN;
+        break;
+      case LSM6DSOX_XL_GY_DRDY:
+        *val = LSM6DSOX_XL_GY_DRDY;
+        break;
+      default:
+        *val = LSM6DSOX_EXT_ON_INT2_PIN;
+        break;
+    }
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first
+  *         sensor hub cycle.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of write_once in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_write_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_write_once_t val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.write_once = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of write_once in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_write_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_write_once_t *val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.write_once) {
+      case LSM6DSOX_EACH_SH_CYCLE:
+        *val = LSM6DSOX_EACH_SH_CYCLE;
+        break;
+      case LSM6DSOX_ONLY_FIRST_CYCLE:
+        *val = LSM6DSOX_ONLY_FIRST_CYCLE;
+        break;
+      default:
+        *val = LSM6DSOX_EACH_SH_CYCLE;
+        break;
+    }
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reset Master logic and output registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  *
+  */
+int32_t lsm6dsox_sh_reset_set(lsm6dsox_ctx_t *ctx)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.rst_master_regs = PROPERTY_ENABLE;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.rst_master_regs = PROPERTY_DISABLE;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reset Master logic and output registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of rst_master_regs in reg MASTER_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_reset_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_master_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_MASTER_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    *val = reg.rst_master_regs;
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the master communicates.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shub_odr in reg slv1_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_odr_t val)
+{
+  lsm6dsox_slv0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.shub_odr = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the master communicates.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of shub_odr in reg slv1_CONFIG
+  *
+  */
+int32_t lsm6dsox_sh_data_rate_get(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_shub_odr_t *val)
+{
+  lsm6dsox_slv0_config_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV1_CONFIG, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.shub_odr) {
+      case LSM6DSOX_SH_ODR_104Hz:
+        *val = LSM6DSOX_SH_ODR_104Hz;
+        break;
+      case LSM6DSOX_SH_ODR_52Hz:
+        *val = LSM6DSOX_SH_ODR_52Hz;
+        break;
+      case LSM6DSOX_SH_ODR_26Hz:
+        *val = LSM6DSOX_SH_ODR_26Hz;
+        break;
+      case LSM6DSOX_SH_ODR_13Hz:
+        *val = LSM6DSOX_SH_ODR_13Hz;
+        break;
+      default:
+        *val = LSM6DSOX_SH_ODR_104Hz;
+        break;
+    }
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      a structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_data;   8 bit data to write
+  *
+  */
+int32_t lsm6dsox_sh_cfg_write(lsm6dsox_ctx_t *ctx, lsm6dsox_sh_cfg_write_t *val)
+{
+  lsm6dsox_slv0_add_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    reg.slave0 = val->slv0_add;
+    reg.rw_0 = 0;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV0_ADD, (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV0_SUBADD,
+    &(val->slv0_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_DATAWRITE_SLV0,
+    &(val->slv0_data), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_len;    num of bit to read
+  *
+  */
+int32_t lsm6dsox_sh_slv0_cfg_read(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_sh_cfg_read_t *val)
+{
+  lsm6dsox_slv0_add_t slv0_add;
+  lsm6dsox_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    slv0_add.slave0 = val->slv_add;
+    slv0_add.rw_0 = 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV0_SUBADD,
+    &(val->slv_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV0_CONFIG,
+                           (uint8_t*)&slv0_config, 1);
+  }
+  if (ret == 0) {
+    slv0_config.slave0_numop = val->slv_len;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV0_CONFIG,
+                            (uint8_t*)&slv0_config, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write/read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t slv1_add;    8 bit i2c device address
+  *                      - uint8_t slv1_subadd; 8 bit register device address
+  *                      - uint8_t slv1_len;    num of bit to read
+  *
+  */
+int32_t lsm6dsox_sh_slv1_cfg_read(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_sh_cfg_read_t *val)
+{
+  lsm6dsox_slv1_add_t slv1_add;
+  lsm6dsox_slv1_config_t slv1_config;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    slv1_add.slave1_add = val->slv_add;
+    slv1_add.r_1 = 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV1_ADD, (uint8_t*)&slv1_add, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV1_SUBADD,
+    &(val->slv_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV1_CONFIG,
+                           (uint8_t*)&slv1_config, 1);
+  }
+  if (ret == 0) {
+    slv1_config.slave1_numop = val->slv_len;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV1_CONFIG,
+                            (uint8_t*)&slv1_config, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write/read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t slv2_add;    8 bit i2c device address
+  *                      - uint8_t slv2_subadd; 8 bit register device address
+  *                      - uint8_t slv2_len;    num of bit to read
+  *
+  */
+int32_t lsm6dsox_sh_slv2_cfg_read(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_sh_cfg_read_t *val)
+{
+  lsm6dsox_slv2_add_t slv2_add;
+  lsm6dsox_slv2_config_t slv2_config;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    slv2_add.slave2_add = val->slv_add;
+    slv2_add.r_2 = 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV2_ADD, (uint8_t*)&slv2_add, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV2_SUBADD,
+    &(val->slv_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV2_CONFIG,
+                           (uint8_t*)&slv2_config, 1);
+  }
+  if (ret == 0) {
+    slv2_config.slave2_numop = val->slv_len;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV2_CONFIG,
+                            (uint8_t*)&slv2_config, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief Configure slave 0 for perform a write/read.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Structure that contain
+  *                      - uint8_t slv3_add;    8 bit i2c device address
+  *                      - uint8_t slv3_subadd; 8 bit register device address
+  *                      - uint8_t slv3_len;    num of bit to read
+  *
+  */
+int32_t lsm6dsox_sh_slv3_cfg_read(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_sh_cfg_read_t *val)
+{
+  lsm6dsox_slv3_add_t slv3_add;
+  lsm6dsox_slv3_config_t slv3_config;
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    slv3_add.slave3_add = val->slv_add;
+    slv3_add.r_3 = 1;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV3_ADD, (uint8_t*)&slv3_add, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV3_SUBADD,
+    &(val->slv_subadd), 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_SLV3_CONFIG,
+                           (uint8_t*)&slv3_config, 1);
+  }
+  if (ret == 0) {
+    slv3_config.slave3_numop = val->slv_len;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_SLV3_CONFIG,
+                            (uint8_t*)&slv3_config, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS_MASTER to
+  *
+  */
+int32_t lsm6dsox_sh_status_get(lsm6dsox_ctx_t *ctx,
+                              lsm6dsox_status_master_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_SENSOR_HUB_BANK);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_STATUS_MASTER, (uint8_t*) val, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_mem_bank_set(ctx, LSM6DSOX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+  /**
+  * @addtogroup  Sensors for Smart Mobile Devices
+  * @brief   This section groups all the functions that manage the
+  *          Sensors for Smart Mobile Devices.
+  * @{
+  *
+  */
+
+/**
+  * @brief  s4s_tph_res: [set] Sensor synchronization time frame resolution
+  *
+  * @param  *ctx   read / write interface definitions
+  * @param  val    change the values of tph_h_sel in LSM6DSOX_S4S_TPH_L
+  *
+  */
+int32_t lsm6dsox_s4s_tph_res_set(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_s4s_tph_res_t val)
+{
+  lsm6dsox_s4s_tph_l_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_TPH_L, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.tph_h_sel = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_S4S_TPH_L, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s_tph_res: [get] Sensor synchronization time frame resolution
+  *
+  * @param  *ctx   read / write interface definitions
+  * @param  val    get the values of tph_h_sel in LSM6DSOX_S4S_TPH_L
+  *
+  */
+int32_t lsm6dsox_s4s_tph_res_get(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_s4s_tph_res_t *val)
+{
+  lsm6dsox_s4s_tph_l_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_TPH_L, (uint8_t*)&reg, 1);
+  switch (reg.tph_h_sel) {
+      case LSM6DSOX_S4S_TPH_7bit:
+        *val = LSM6DSOX_S4S_TPH_7bit;
+        break;
+      case LSM6DSOX_S4S_TPH_15bit:
+        *val = LSM6DSOX_S4S_TPH_15bit;
+        break;
+      default:
+        *val = LSM6DSOX_S4S_TPH_7bit;
+        break;
+    }
+
+  return ret;
+}
+
+/**
+  * @brief  s4s_tph_val: [set] Sensor synchronization time frame
+  *
+  * @param  *ctx   read / write interface definitions
+  * @param  val    change the values of tph_l in S4S_TPH_L and
+  *                tph_h in S4S_TPH_H
+  *
+  */
+int32_t lsm6dsox_s4s_tph_val_set(lsm6dsox_ctx_t *ctx, uint16_t val)
+{
+  lsm6dsox_s4s_tph_l_t s4s_tph_l;
+  lsm6dsox_s4s_tph_h_t s4s_tph_h;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_TPH_L, (uint8_t*)&s4s_tph_l, 1);
+  if (ret == 0) {
+    s4s_tph_l.tph_l = (uint8_t)(val & 0x007FU);
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_S4S_TPH_L, (uint8_t*)&s4s_tph_l, 1);
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_TPH_H, (uint8_t*)&s4s_tph_h, 1);
+    s4s_tph_h.tph_h = (uint8_t)(val & 0x7F80U) >> 7;
+  }
+  if (ret == 0) {
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_S4S_TPH_H, (uint8_t*)&s4s_tph_h, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s_tph_val: [get] Sensor synchronization time frame.
+  *
+  * @param  *ctx   read / write interface definitions
+  * @param  val    get the values of tph_l in S4S_TPH_L and
+  *                tph_h in S4S_TPH_H
+  *
+  */
+int32_t lsm6dsox_s4s_tph_val_get(lsm6dsox_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsox_s4s_tph_l_t s4s_tph_l;
+  lsm6dsox_s4s_tph_h_t s4s_tph_h;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_TPH_L, (uint8_t*)&s4s_tph_l, 1);
+  if (ret == 0) {
+    ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_TPH_H, (uint8_t*)&s4s_tph_h, 1);
+    *val =  s4s_tph_h.tph_h;
+    *val =  *val << 7;
+    *val += s4s_tph_l.tph_l;
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s_res_ratio: [set]Sensor synchronization resolution
+  *                        ratio register.
+  *
+  * @param  *ctx   read / write interface definitions.
+  * @param  val    change the values of rr in S4S_RR.
+  *
+  */
+int32_t lsm6dsox_s4s_res_ratio_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_s4s_res_ratio_t val)
+{
+  lsm6dsox_s4s_rr_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_RR, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.rr = (uint8_t)val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_S4S_RR, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s_res_ratio: [get]Sensor synchronization resolution
+  *                        ratio register.
+  *
+  * @param  *ctx   read / write interface definitions
+  * @param  val    get the values of rr in S4S_RR
+  *
+  */
+int32_t lsm6dsox_s4s_res_ratio_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_s4s_res_ratio_t *val)
+{
+  lsm6dsox_s4s_rr_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_RR, (uint8_t*)&reg, 1);
+  switch (reg.rr) {
+    case LSM6DSOX_S4S_DT_RES_11:
+      *val = LSM6DSOX_S4S_DT_RES_11;
+      break;
+    case LSM6DSOX_S4S_DT_RES_12:
+      *val = LSM6DSOX_S4S_DT_RES_12;
+      break;
+    case LSM6DSOX_S4S_DT_RES_13:
+      *val = LSM6DSOX_S4S_DT_RES_13;
+      break;
+    case LSM6DSOX_S4S_DT_RES_14:
+      *val = LSM6DSOX_S4S_DT_RES_14;
+      break;
+    default:
+      *val = LSM6DSOX_S4S_DT_RES_11;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s_command: [set] s4s master command.
+  *
+  * @param  *ctx   read / write interface definitions.
+  * @param  val    change the values of S4S_ST_CMD_CODE.
+  *
+  */
+int32_t lsm6dsox_s4s_command_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_s4s_st_cmd_code_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_ST_CMD_CODE, (uint8_t*)&reg, 1);
+ 
+  if (ret == 0) {
+    reg.s4s_st_cmd_code = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_S4S_ST_CMD_CODE, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s_command: [get] s4s master command.
+  *
+  * @param  *ctx   read / write interface definitions.
+  * @param  val    get the values of S4S_ST_CMD_CODE.
+  *
+  */
+int32_t lsm6dsox_s4s_command_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_s4s_st_cmd_code_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_ST_CMD_CODE, (uint8_t*)&reg, 1);
+  *val = reg.s4s_st_cmd_code;
+
+  return ret;
+}
+
+/**
+  * @brief  s4s_dt: [set] S4S DT register.
+  *
+  * @param  *ctx   read / write interface definitions.
+  * @param  val    change the values of S4S_DT_REG.
+  *
+  */
+int32_t lsm6dsox_s4s_dt_set(lsm6dsox_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsox_s4s_dt_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_DT_REG, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.dt = val;
+    ret = lsm6dsox_write_reg(ctx, LSM6DSOX_S4S_DT_REG, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s_dt: [get] S4S DT register.
+  *
+  * @param  *ctx   read / write interface definitions.
+  * @param  val    get the values of S4S_DT_REG.
+  *
+  */
+int32_t lsm6dsox_s4s_dt_get(lsm6dsox_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsox_s4s_dt_reg_t reg;
+  int32_t ret;
+
+  ret = lsm6dsox_read_reg(ctx, LSM6DSOX_S4S_DT_REG, (uint8_t*)&reg, 1);
+  *val = reg.dt;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsox_STdC/driver/lsm6dsox_reg.h
+++ b/sensor/stmemsc/lsm6dsox_STdC/driver/lsm6dsox_reg.h
@@ -1,0 +1,2949 @@
+/*
+ ******************************************************************************
+ * @file    lsm6dsox_reg.h
+ * @author  Sensor Solutions Software Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm6dsox_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DSOX_DRIVER_H
+#define LSM6DSOX_DRIVER_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM6DSOX
+  * @{
+  *
+  */
+
+/** @defgroup LSM6DSOX_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  LSM6DSOX_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lsm6dsox_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lsm6dsox_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lsm6dsox_write_ptr  write_reg;
+  lsm6dsox_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lsm6dsox_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DSOX_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define LSM6DSOX_I2C_ADD_L                    0xD5
+#define LSM6DSOX_I2C_ADD_H                    0xD7
+
+/** Device Identification (Who am I) **/
+#define LSM6DSOX_ID                           0x6C
+
+/**
+  * @}
+  *
+  */
+
+#define LSM6DSOX_FUNC_CFG_ACCESS              0x01U
+typedef struct {
+  uint8_t ois_ctrl_from_ui         : 1;
+  uint8_t not_used_01              : 5;
+  uint8_t reg_access               : 2; /* shub_reg_access + func_cfg_access */
+} lsm6dsox_func_cfg_access_t;
+
+#define LSM6DSOX_PIN_CTRL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t sdo_pu_en                : 1;
+  uint8_t ois_pu_dis               : 1;
+} lsm6dsox_pin_ctrl_t;
+
+#define LSM6DSOX_S4S_TPH_L                    0x04U
+typedef struct {
+  uint8_t tph_l                    : 7;
+  uint8_t tph_h_sel                : 1;
+} lsm6dsox_s4s_tph_l_t;
+
+#define LSM6DSOX_S4S_TPH_H                    0x05U
+typedef struct {
+  uint8_t tph_h                    : 8;
+} lsm6dsox_s4s_tph_h_t;
+
+#define LSM6DSOX_S4S_RR                       0x06U
+typedef struct {
+  uint8_t rr                       : 2;
+  uint8_t not_used_01              : 6;
+} lsm6dsox_s4s_rr_t;
+
+#define LSM6DSOX_FIFO_CTRL1                   0x07U
+typedef struct {
+  uint8_t wtm                      : 8;
+} lsm6dsox_fifo_ctrl1_t;
+
+#define LSM6DSOX_FIFO_CTRL2                   0x08U
+typedef struct {
+  uint8_t wtm                      : 1;
+  uint8_t uncoptr_rate             : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t odrchg_en                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t fifo_compr_rt_en         : 1;
+  uint8_t stop_on_wtm              : 1;
+} lsm6dsox_fifo_ctrl2_t;
+
+#define LSM6DSOX_FIFO_CTRL3                   0x09U
+typedef struct {
+  uint8_t bdr_xl                   : 4;
+  uint8_t bdr_gy                   : 4;
+} lsm6dsox_fifo_ctrl3_t;
+
+#define LSM6DSOX_FIFO_CTRL4                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t odr_t_batch              : 2;
+  uint8_t odr_ts_batch             : 2;
+} lsm6dsox_fifo_ctrl4_t;
+
+#define LSM6DSOX_COUNTER_BDR_REG1             0x0BU
+typedef struct {
+  uint8_t cnt_bdr_th               : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t trig_counter_bdr         : 1;
+  uint8_t rst_counter_bdr          : 1;
+  uint8_t dataready_pulsed         : 1;
+} lsm6dsox_counter_bdr_reg1_t;
+
+#define LSM6DSOX_COUNTER_BDR_REG2             0x0CU
+typedef struct {
+  uint8_t cnt_bdr_th               : 8;
+} lsm6dsox_counter_bdr_reg2_t;
+
+#define LSM6DSOX_INT1_CTRL                    0x0D
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fifo_th             : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_fifo_full           : 1;
+  uint8_t int1_cnt_bdr             : 1;
+  uint8_t den_drdy_flag            : 1;
+} lsm6dsox_int1_ctrl_t;
+
+#define LSM6DSOX_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fifo_th             : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_fifo_full           : 1;
+  uint8_t int2_cnt_bdr             : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsox_int2_ctrl_t;
+
+#define LSM6DSOX_WHO_AM_I                     0x0FU
+#define LSM6DSOX_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf2_xl_en               : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} lsm6dsox_ctrl1_xl_t;
+
+#define LSM6DSOX_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t fs_g                     : 3; /* fs_125 + fs_g */
+  uint8_t odr_g                    : 4;
+} lsm6dsox_ctrl2_g_t;
+
+#define LSM6DSOX_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} lsm6dsox_ctrl3_c_t;
+
+#define LSM6DSOX_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep_g                  : 1;
+  uint8_t not_used_03              : 1;
+} lsm6dsox_ctrl4_c_t;
+
+#define LSM6DSOX_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t rounding_status          : 1;
+  uint8_t rounding                 : 2;
+  uint8_t xl_ulp_en                : 1;
+} lsm6dsox_ctrl5_c_t;
+
+#define LSM6DSOX_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t ftype                    : 3;
+  uint8_t usr_off_w                : 1;
+  uint8_t xl_hm_mode               : 1;
+  uint8_t den_mode                 : 3;   /* trig_en + lvl1_en + lvl2_en */
+} lsm6dsox_ctrl6_c_t;
+
+#define LSM6DSOX_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t ois_on                   : 1;
+  uint8_t usr_off_on_out           : 1;
+  uint8_t ois_on_en                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t g_hm_mode                : 1;
+} lsm6dsox_ctrl7_g_t;
+
+#define LSM6DSOX_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t xl_fs_mode               : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t fastsettl_mode_xl        : 1;
+  uint8_t hp_ref_mode_xl           : 1;
+  uint8_t hpcf_xl                  : 3;
+} lsm6dsox_ctrl8_xl_t;
+
+#define LSM6DSOX_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t i3c_disable              : 1;
+  uint8_t den_lh                   : 1;
+  uint8_t den_xl_g                 : 2;   /* den_xl_en + den_xl_g */
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} lsm6dsox_ctrl9_xl_t;
+
+#define LSM6DSOX_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t timestamp_en             : 1;
+  uint8_t not_used_02              : 2;
+} lsm6dsox_ctrl10_c_t;
+
+#define LSM6DSOX_ALL_INT_SRC                  0x1AU
+typedef struct {
+  uint8_t ff_ia                    : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t single_tap               : 1;
+  uint8_t double_tap               : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t sleep_change_ia          : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t timestamp_endcount       : 1;
+} lsm6dsox_all_int_src_t;
+
+#define LSM6DSOX_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state              : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t sleep_change_ia          : 2;
+} lsm6dsox_wake_up_src_t;
+
+#define LSM6DSOX_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_02              : 1;
+} lsm6dsox_tap_src_t;
+
+#define LSM6DSOX_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} lsm6dsox_d6d_src_t;
+
+#define LSM6DSOX_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dsox_status_reg_t;
+
+#define LSM6DSOX_OUT_TEMP_L                   0x20U
+#define LSM6DSOX_OUT_TEMP_H                   0x21U
+#define LSM6DSOX_OUTX_L_G                     0x22U
+#define LSM6DSOX_OUTX_H_G                     0x23U
+#define LSM6DSOX_OUTY_L_G                     0x24U
+#define LSM6DSOX_OUTY_H_G                     0x25U
+#define LSM6DSOX_OUTZ_L_G                     0x26U
+#define LSM6DSOX_OUTZ_H_G                     0x27U
+#define LSM6DSOX_OUTX_L_A                     0x28U
+#define LSM6DSOX_OUTX_H_A                     0x29U
+#define LSM6DSOX_OUTY_L_A                     0x2AU
+#define LSM6DSOX_OUTY_H_A                     0x2BU
+#define LSM6DSOX_OUTZ_L_A                     0x2CU
+#define LSM6DSOX_OUTZ_H_A                     0x2DU
+#define LSM6DSOX_EMB_FUNC_STATUS_MAINPAGE     0x35U
+typedef struct {
+  uint8_t not_used_01             : 3;
+  uint8_t is_step_det             : 1;
+  uint8_t is_tilt                 : 1;
+  uint8_t is_sigmot               : 1;
+  uint8_t not_used_02             : 1;
+  uint8_t is_fsm_lc               : 1;
+} lsm6dsox_emb_func_status_mainpage_t;
+
+#define LSM6DSOX_FSM_STATUS_A_MAINPAGE        0x36U
+typedef struct {
+  uint8_t is_fsm1                 : 1;
+  uint8_t is_fsm2                 : 1;
+  uint8_t is_fsm3                 : 1;
+  uint8_t is_fsm4                 : 1;
+  uint8_t is_fsm5                 : 1;
+  uint8_t is_fsm6                 : 1;
+  uint8_t is_fsm7                 : 1;
+  uint8_t is_fsm8                 : 1;
+} lsm6dsox_fsm_status_a_mainpage_t;
+
+#define LSM6DSOX_FSM_STATUS_B_MAINPAGE        0x37U
+typedef struct {
+  uint8_t is_fsm9                 : 1;
+  uint8_t is_fsm10                : 1;
+  uint8_t is_fsm11                : 1;
+  uint8_t is_fsm12                : 1;
+  uint8_t is_fsm13                : 1;
+  uint8_t is_fsm14                : 1;
+  uint8_t is_fsm15                : 1;
+  uint8_t is_fsm16                : 1;
+} lsm6dsox_fsm_status_b_mainpage_t;
+
+#define LSM6DSOX_PROGSENS_STATUS_MAINPAGE     0x38U
+typedef struct {
+  uint8_t is_mlc1             : 1;
+  uint8_t is_mlc2             : 1;
+  uint8_t is_mlc3             : 1;
+  uint8_t is_mlc4             : 1;
+  uint8_t is_mlc5             : 1;
+  uint8_t is_mlc6             : 1;
+  uint8_t is_mlc7             : 1;
+  uint8_t is_mlc8             : 1;
+} lsm6dsox_progsens_status_mainpage_t;
+
+#define LSM6DSOX_STATUS_MASTER_MAINPAGE       0x39U
+typedef struct {
+  uint8_t sens_hub_endop          : 1;
+  uint8_t not_used_01             : 2;
+  uint8_t slave0_nack             : 1;
+  uint8_t slave1_nack             : 1;
+  uint8_t slave2_nack             : 1;
+  uint8_t slave3_nack             : 1;
+  uint8_t wr_once_done            : 1;
+} lsm6dsox_status_master_mainpage_t;
+
+#define LSM6DSOX_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;
+} lsm6dsox_fifo_status1_t;
+
+#define LSM6DSOX_FIFO_STATUS2                 0x3B
+typedef struct {
+  uint8_t diff_fifo                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t over_run_latched         : 1;
+  uint8_t counter_bdr_ia           : 1;
+  uint8_t fifo_full_ia             : 1;
+  uint8_t fifo_ovr_ia              : 1;
+  uint8_t fifo_wtm_ia              : 1;
+} lsm6dsox_fifo_status2_t;
+
+#define LSM6DSOX_TIMESTAMP0                   0x40U
+#define LSM6DSOX_TIMESTAMP1                   0x41U
+#define LSM6DSOX_TIMESTAMP2                   0x42U
+#define LSM6DSOX_TIMESTAMP3                   0x43U
+#define LSM6DSOX_UI_STATUS_REG_OIS            0x49U
+typedef struct {
+  uint8_t xlda                     : 3;
+  uint8_t gda                      : 1;
+  uint8_t gyro_settling            : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dsox_ui_status_reg_ois_t;
+
+#define LSM6DSOX_UI_OUTX_L_G_OIS              0x4AU
+#define LSM6DSOX_UI_OUTX_H_G_OIS              0x4BU
+#define LSM6DSOX_UI_OUTY_L_G_OIS              0x4CU
+#define LSM6DSOX_UI_OUTY_H_G_OIS              0x4DU
+#define LSM6DSOX_UI_OUTZ_L_G_OIS              0x4EU
+#define LSM6DSOX_UI_OUTZ_H_G_OIS              0x4FU
+#define LSM6DSOX_UI_OUTX_L_A_OIS              0x50U
+#define LSM6DSOX_UI_OUTX_H_A_OIS              0x51U
+#define LSM6DSOX_UI_OUTY_L_A_OIS              0x52U
+#define LSM6DSOX_UI_OUTY_H_A_OIS              0x53U
+#define LSM6DSOX_UI_OUTZ_L_A_OIS              0x54U
+#define LSM6DSOX_UI_OUTZ_H_A_OIS              0x55U
+
+#define LSM6DSOX_TAP_CFG0                     0x56U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t tap_z_en                 : 1;
+  uint8_t tap_y_en                 : 1;
+  uint8_t tap_x_en                 : 1;
+  uint8_t slope_fds                : 1;
+  uint8_t sleep_status_on_int      : 1;
+  uint8_t int_clr_on_read          : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsox_tap_cfg0_t;
+
+#define LSM6DSOX_TAP_CFG1                     0x57U
+typedef struct {
+  uint8_t tap_ths_x                : 5;
+  uint8_t tap_priority             : 3;
+} lsm6dsox_tap_cfg1_t;
+
+#define LSM6DSOX_TAP_CFG2                     0x58U
+typedef struct {
+  uint8_t tap_ths_y                : 5;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} lsm6dsox_tap_cfg2_t;
+
+#define LSM6DSOX_TAP_THS_6D                   0x59U
+typedef struct {
+  uint8_t tap_ths_z                : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} lsm6dsox_tap_ths_6d_t;
+
+#define LSM6DSOX_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} lsm6dsox_int_dur2_t;
+
+#define LSM6DSOX_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t usr_off_on_wu            : 1;
+  uint8_t single_double_tap        : 1;
+} lsm6dsox_wake_up_ths_t;
+
+#define LSM6DSOX_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t wake_ths_w               : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} lsm6dsox_wake_up_dur_t;
+
+#define LSM6DSOX_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} lsm6dsox_free_fall_t;
+
+#define LSM6DSOX_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t int1_shub                : 1;
+  uint8_t int1_emb_func            : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_sleep_change        : 1;
+} lsm6dsox_md1_cfg_t;
+
+#define LSM6DSOX_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_timestamp           : 1;
+  uint8_t int2_emb_func            : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_sleep_change        : 1;
+} lsm6dsox_md2_cfg_t;
+
+#define LSM6DSOX_S4S_ST_CMD_CODE              0x60U
+typedef struct {
+  uint8_t s4s_st_cmd_code          : 8;
+} lsm6dsox_s4s_st_cmd_code_t;
+
+#define LSM6DSOX_S4S_DT_REG                   0x61U
+typedef struct {
+  uint8_t dt                       : 8;
+} lsm6dsox_s4s_dt_reg_t;
+
+#define LSM6DSOX_I3C_BUS_AVB                  0x62U
+typedef struct {
+  uint8_t pd_dis_int1              : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t i3c_bus_avb_sel          : 2;
+  uint8_t not_used_02              : 3;
+} lsm6dsox_i3c_bus_avb_t;
+
+#define LSM6DSOX_INTERNAL_FREQ_FINE           0x63U
+typedef struct {
+  uint8_t freq_fine                : 8;
+} lsm6dsox_internal_freq_fine_t;
+
+#define LSM6DSOX_UI_INT_OIS                   0x6F
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t spi2_read_en             : 1;
+  uint8_t not_used_02              : 1;  
+  uint8_t den_lh_ois               : 1;
+  uint8_t lvl2_ois                 : 1;
+  uint8_t int2_drdy_ois            : 1;
+} lsm6dsox_ui_int_ois_t;
+
+#define LSM6DSOX_UI_CTRL1_OIS                 0x70U
+typedef struct {
+  uint8_t ois_en_spi2              : 1;
+  uint8_t fs_g_ois                 : 3; /* fs_125_ois + fs[1:0]_g_ois */
+  uint8_t mode4_en                 : 1;
+  uint8_t sim_ois                  : 1;
+  uint8_t lvl1_ois                 : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsox_ui_ctrl1_ois_t;
+
+#define LSM6DSOX_UI_CTRL2_OIS                 0x71U
+typedef struct {
+  uint8_t hp_en_ois                : 1;
+  uint8_t ftype_ois                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_ois                  : 2;
+  uint8_t not_used_02              : 2;
+} lsm6dsox_ui_ctrl2_ois_t;
+
+#define LSM6DSOX_UI_CTRL3_OIS                 0x72U
+typedef struct {
+  uint8_t st_ois_clampdis          : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t filter_xl_conf_ois       : 3;
+  uint8_t fs_xl_ois                : 2;
+} lsm6dsox_ui_ctrl3_ois_t;
+
+#define LSM6DSOX_X_OFS_USR                    0x73U
+#define LSM6DSOX_Y_OFS_USR                    0x74U
+#define LSM6DSOX_Z_OFS_USR                    0x75U
+#define LSM6DSOX_FIFO_DATA_OUT_TAG            0x78U
+typedef struct {
+  uint8_t tag_parity               : 1;
+  uint8_t tag_cnt                  : 2;
+  uint8_t tag_sensor               : 5;
+} lsm6dsox_fifo_data_out_tag_t;
+
+#define LSM6DSOX_FIFO_DATA_OUT_X_L            0x79
+#define LSM6DSOX_FIFO_DATA_OUT_X_H            0x7A
+#define LSM6DSOX_FIFO_DATA_OUT_Y_L            0x7B
+#define LSM6DSOX_FIFO_DATA_OUT_Y_H            0x7C
+#define LSM6DSOX_FIFO_DATA_OUT_Z_L            0x7D
+#define LSM6DSOX_FIFO_DATA_OUT_Z_H            0x7E
+
+#define LSM6DSOX_SPI2_WHO_AM_I                0x0F
+#define LSM6DSOX_SPI2_STATUS_REG_OIS          0x1E
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t gyro_settling            : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dsox_spi2_status_reg_ois_t;
+
+#define LSM6DSOX_SPI2_OUT_TEMP_L              0x20
+#define LSM6DSOX_SPI2_OUT_TEMP_H              0x21
+#define LSM6DSOX_SPI2_OUTX_L_G_OIS            0x22
+#define LSM6DSOX_SPI2_OUTX_H_G_OIS            0x23
+#define LSM6DSOX_SPI2_OUTY_L_G_OIS            0x24
+#define LSM6DSOX_SPI2_OUTY_H_G_OIS            0x25
+#define LSM6DSOX_SPI2_OUTZ_L_G_OIS            0x26
+#define LSM6DSOX_SPI2_OUTZ_H_G_OIS            0x27
+#define LSM6DSOX_SPI2_OUTX_L_A_OIS            0x28
+#define LSM6DSOX_SPI2_OUTX_H_A_OIS            0x29
+#define LSM6DSOX_SPI2_OUTY_L_A_OIS            0x2A
+#define LSM6DSOX_SPI2_OUTY_H_A_OIS            0x2B
+#define LSM6DSOX_SPI2_OUTZ_L_A_OIS            0x2C
+#define LSM6DSOX_SPI2_OUTZ_H_A_OIS            0x2D
+#define LSM6DSOX_SPI2_INT_OIS                 0x6F
+typedef struct {
+  uint8_t st_xl_ois                : 2;
+  uint8_t not_used_01              : 3;
+  uint8_t den_lh_ois               : 1;
+  uint8_t lvl2_ois                 : 1;
+  uint8_t int2_drdy_ois            : 1;
+} lsm6dsox_spi2_int_ois_t;
+
+#define LSM6DSOX_SPI2_CTRL1_OIS               0x70U
+typedef struct {
+  uint8_t ois_en_spi2              : 1;
+  uint8_t fs_g_ois                 : 3; /* fs_125_ois + fs[1:0]_g_ois */
+  uint8_t mode4_en                 : 1;
+  uint8_t sim_ois                  : 1;
+  uint8_t lvl1_ois                 : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsox_spi2_ctrl1_ois_t;
+
+#define LSM6DSOX_SPI2_CTRL2_OIS               0x71U
+typedef struct {
+  uint8_t hp_en_ois                : 1;
+  uint8_t ftype_ois                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_ois                  : 2;
+  uint8_t not_used_02              : 2;
+} lsm6dsox_spi2_ctrl2_ois_t;
+
+#define LSM6DSOX_SPI2_CTRL3_OIS               0x72U
+typedef struct {
+  uint8_t st_ois_clampdis          : 1;
+  uint8_t st_ois                   : 2;
+  uint8_t filter_xl_conf_ois       : 3;
+  uint8_t fs_xl_ois                : 2;
+} lsm6dsox_spi2_ctrl3_ois_t;
+
+#define LSM6DSOX_PAGE_SEL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 4;
+  uint8_t page_sel                 : 4;
+} lsm6dsox_page_sel_t;
+
+#define LSM6DSOX_EMB_FUNC_EN_A                0x04U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t pedo_en                  : 1;
+  uint8_t tilt_en                  : 1;
+  uint8_t sign_motion_en           : 1;
+  uint8_t not_used_02              : 2;
+} lsm6dsox_emb_func_en_a_t;
+
+#define LSM6DSOX_EMB_FUNC_EN_B                0x05U
+typedef struct {
+  uint8_t fsm_en                   : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t fifo_compr_en            : 1;
+  uint8_t mlc_en                   : 1;
+  uint8_t not_used_02              : 3;
+} lsm6dsox_emb_func_en_b_t;
+
+#define LSM6DSOX_PAGE_ADDRESS                 0x08U
+typedef struct {
+  uint8_t page_addr                : 8;
+} lsm6dsox_page_address_t;
+
+#define LSM6DSOX_PAGE_VALUE                   0x09U
+typedef struct {
+  uint8_t page_value               : 8;
+} lsm6dsox_page_value_t;
+
+#define LSM6DSOX_EMB_FUNC_INT1                0x0AU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t int1_step_detector       : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_sig_mot             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int1_fsm_lc              : 1;
+} lsm6dsox_emb_func_int1_t;
+
+#define LSM6DSOX_FSM_INT1_A                   0x0BU
+typedef struct {
+  uint8_t int1_fsm1                : 1;
+  uint8_t int1_fsm2                : 1;
+  uint8_t int1_fsm3                : 1;
+  uint8_t int1_fsm4                : 1;
+  uint8_t int1_fsm5                : 1;
+  uint8_t int1_fsm6                : 1;
+  uint8_t int1_fsm7                : 1;
+  uint8_t int1_fsm8                : 1;
+} lsm6dsox_fsm_int1_a_t;
+
+#define LSM6DSOX_FSM_INT1_B                   0x0CU
+typedef struct {
+  uint8_t int1_fsm9                : 1;
+  uint8_t int1_fsm10               : 1;
+  uint8_t int1_fsm11               : 1;
+  uint8_t int1_fsm12               : 1;
+  uint8_t int1_fsm13               : 1;
+  uint8_t int1_fsm14               : 1;
+  uint8_t int1_fsm15               : 1;
+  uint8_t int1_fsm16               : 1;
+} lsm6dsox_fsm_int1_b_t;
+
+#define LSM6DSOX_MLC_INT1                     0x0DU
+typedef struct {
+  uint8_t int1_mlc1                : 1;
+  uint8_t int1_mlc2                : 1;
+  uint8_t int1_mlc3                : 1;
+  uint8_t int1_mlc4                : 1;
+  uint8_t int1_mlc5                : 1;
+  uint8_t int1_mlc6                : 1;
+  uint8_t int1_mlc7                : 1;
+  uint8_t int1_mlc8                : 1;
+} lsm6dsox_mlc_int1_t;
+
+#define LSM6DSOX_EMB_FUNC_INT2                0x0EU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t int2_step_detector       : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_sig_mot             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_fsm_lc              : 1;
+} lsm6dsox_emb_func_int2_t;
+
+#define LSM6DSOX_FSM_INT2_A                   0x0FU
+typedef struct {
+  uint8_t int2_fsm1                : 1;
+  uint8_t int2_fsm2                : 1;
+  uint8_t int2_fsm3                : 1;
+  uint8_t int2_fsm4                : 1;
+  uint8_t int2_fsm5                : 1;
+  uint8_t int2_fsm6                : 1;
+  uint8_t int2_fsm7                : 1;
+  uint8_t int2_fsm8                : 1;
+} lsm6dsox_fsm_int2_a_t;
+
+#define LSM6DSOX_FSM_INT2_B                   0x10U
+typedef struct {
+  uint8_t int2_fsm9                : 1;
+  uint8_t int2_fsm10               : 1;
+  uint8_t int2_fsm11               : 1;
+  uint8_t int2_fsm12               : 1;
+  uint8_t int2_fsm13               : 1;
+  uint8_t int2_fsm14               : 1;
+  uint8_t int2_fsm15               : 1;
+  uint8_t int2_fsm16               : 1;
+} lsm6dsox_fsm_int2_b_t;
+
+#define LSM6DSOX_MLC_INT2                     0x11U
+typedef struct {
+  uint8_t int2_mlc1             : 1;
+  uint8_t int2_mlc2             : 1;
+  uint8_t int2_mlc3             : 1;
+  uint8_t int2_mlc4             : 1;
+  uint8_t int2_mlc5             : 1;
+  uint8_t int2_mlc6             : 1;
+  uint8_t int2_mlc7             : 1;
+  uint8_t int2_mlc8             : 1;
+} lsm6dsox_mlc_int2_t;
+
+#define LSM6DSOX_EMB_FUNC_STATUS              0x12U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t is_step_det              : 1;
+  uint8_t is_tilt                  : 1;
+  uint8_t is_sigmot                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t is_fsm_lc                : 1;
+} lsm6dsox_emb_func_status_t;
+
+#define LSM6DSOX_FSM_STATUS_A                 0x13U
+typedef struct {
+  uint8_t is_fsm1                  : 1;
+  uint8_t is_fsm2                  : 1;
+  uint8_t is_fsm3                  : 1;
+  uint8_t is_fsm4                  : 1;
+  uint8_t is_fsm5                  : 1;
+  uint8_t is_fsm6                  : 1;
+  uint8_t is_fsm7                  : 1;
+  uint8_t is_fsm8                  : 1;
+} lsm6dsox_fsm_status_a_t;
+
+#define LSM6DSOX_FSM_STATUS_B                 0x14U
+typedef struct {
+  uint8_t is_fsm9                  : 1;
+  uint8_t is_fsm10                 : 1;
+  uint8_t is_fsm11                 : 1;
+  uint8_t is_fsm12                 : 1;
+  uint8_t is_fsm13                 : 1;
+  uint8_t is_fsm14                 : 1;
+  uint8_t is_fsm15                 : 1;
+  uint8_t is_fsm16                 : 1;
+} lsm6dsox_fsm_status_b_t;
+
+#define LSM6DSOX_MLC_STATUS                   0x15U
+typedef struct {
+  uint8_t is_mlc1            : 1;
+  uint8_t is_mlc2            : 1;
+  uint8_t is_mlc3            : 1;
+  uint8_t is_mlc4            : 1;
+  uint8_t is_mlc5            : 1;
+  uint8_t is_mlc6            : 1;
+  uint8_t is_mlc7            : 1;
+  uint8_t is_mlc8            : 1;
+} lsm6dsox_mlc_status_t;
+
+#define LSM6DSOX_PAGE_RW                      0x17U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t page_rw                  : 2;  /* page_write + page_read */
+  uint8_t emb_func_lir             : 1;
+} lsm6dsox_page_rw_t;
+
+#define LSM6DSOX_EMB_FUNC_FIFO_CFG             0x44U
+typedef struct {
+  uint8_t not_used_00              : 6;
+  uint8_t pedo_fifo_en             : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsox_emb_func_fifo_cfg_t;
+
+#define LSM6DSOX_FSM_ENABLE_A                 0x46U
+typedef struct {
+  uint8_t fsm1_en                  : 1;
+  uint8_t fsm2_en                  : 1;
+  uint8_t fsm3_en                  : 1;
+  uint8_t fsm4_en                  : 1;
+  uint8_t fsm5_en                  : 1;
+  uint8_t fsm6_en                  : 1;
+  uint8_t fsm7_en                  : 1;
+  uint8_t fsm8_en                  : 1;
+} lsm6dsox_fsm_enable_a_t;
+
+#define LSM6DSOX_FSM_ENABLE_B                 0x47U
+typedef struct {
+  uint8_t fsm9_en                  : 1;
+  uint8_t fsm10_en                 : 1;
+  uint8_t fsm11_en                 : 1;
+  uint8_t fsm12_en                 : 1;
+  uint8_t fsm13_en                 : 1;
+  uint8_t fsm14_en                 : 1;
+  uint8_t fsm15_en                 : 1;
+  uint8_t fsm16_en                 : 1;
+} lsm6dsox_fsm_enable_b_t;
+
+#define LSM6DSOX_FSM_LONG_COUNTER_L           0x48U
+#define LSM6DSOX_FSM_LONG_COUNTER_H           0x49U
+#define LSM6DSOX_FSM_LONG_COUNTER_CLEAR       0x4AU
+typedef struct {
+  uint8_t fsm_lc_clr               : 2;  /* fsm_lc_cleared + fsm_lc_clear */
+  uint8_t not_used_01              : 6;
+} lsm6dsox_fsm_long_counter_clear_t;
+
+#define LSM6DSOX_FSM_OUTS1                    0x4CU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs1_t;
+
+#define LSM6DSOX_FSM_OUTS2                    0x4DU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs2_t;
+
+#define LSM6DSOX_FSM_OUTS3                    0x4EU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs3_t;
+
+#define LSM6DSOX_FSM_OUTS4                    0x4FU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs4_t;
+
+#define LSM6DSOX_FSM_OUTS5                    0x50U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs5_t;
+
+#define LSM6DSOX_FSM_OUTS6                    0x51U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs6_t;
+
+#define LSM6DSOX_FSM_OUTS7                    0x52U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs7_t;
+
+#define LSM6DSOX_FSM_OUTS8                    0x53U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs8_t;
+
+#define LSM6DSOX_FSM_OUTS9                    0x54U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs9_t;
+
+#define LSM6DSOX_FSM_OUTS10                   0x55U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs10_t;
+
+#define LSM6DSOX_FSM_OUTS11                   0x56U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs11_t;
+
+#define LSM6DSOX_FSM_OUTS12                   0x57U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs12_t;
+
+#define LSM6DSOX_FSM_OUTS13                   0x58U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs13_t;
+
+#define LSM6DSOX_FSM_OUTS14                   0x59U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs14_t;
+
+#define LSM6DSOX_FSM_OUTS15                   0x5AU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs15_t;
+
+#define LSM6DSOX_FSM_OUTS16                   0x5BU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsox_fsm_outs16_t;
+
+#define LSM6DSOX_EMB_FUNC_ODR_CFG_B           0x5FU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t fsm_odr                  : 2;
+  uint8_t not_used_02              : 3;
+} lsm6dsox_emb_func_odr_cfg_b_t;
+
+#define LSM6DSOX_EMB_FUNC_ODR_CFG_C           0x60U
+typedef struct {
+  uint8_t not_used_01             : 4;
+  uint8_t mlc_odr                 : 2;
+  uint8_t not_used_02             : 2;
+} lsm6dsox_emb_func_odr_cfg_c_t;
+
+#define LSM6DSOX_STEP_COUNTER_L               0x62U
+#define LSM6DSOX_STEP_COUNTER_H               0x63U
+#define LSM6DSOX_EMB_FUNC_SRC                 0x64U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t stepcounter_bit_set      : 1;
+  uint8_t step_overflow            : 1;
+  uint8_t step_count_delta_ia      : 1;
+  uint8_t step_detected            : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t pedo_rst_step            : 1;
+} lsm6dsox_emb_func_src_t;
+
+#define LSM6DSOX_EMB_FUNC_INIT_A              0x66U
+typedef struct {
+  uint8_t not_used_01               : 3;
+  uint8_t step_det_init             : 1;
+  uint8_t tilt_init                 : 1;
+  uint8_t sig_mot_init              : 1;
+  uint8_t not_used_02               : 2;
+} lsm6dsox_emb_func_init_a_t;
+
+#define LSM6DSOX_EMB_FUNC_INIT_B              0x67U
+typedef struct {
+  uint8_t fsm_init                 : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t fifo_compr_init          : 1;
+  uint8_t not_used_02              : 4;
+} lsm6dsox_emb_func_init_b_t;
+
+#define LSM6DSOX_MLC0_SRC                     0x70U
+#define LSM6DSOX_MLC1_SRC                     0x71U
+#define LSM6DSOX_MLC2_SRC                     0x72U
+#define LSM6DSOX_MLC3_SRC                     0x73U
+#define LSM6DSOX_MLC4_SRC                     0x74U
+#define LSM6DSOX_MLC5_SRC                     0x75U
+#define LSM6DSOX_MLC6_SRC                     0x76U
+#define LSM6DSOX_MLC7_SRC                     0x77U
+#define LSM6DSOX_MAG_SENSITIVITY_L            0xBAU
+#define LSM6DSOX_MAG_SENSITIVITY_H            0xBBU
+#define LSM6DSOX_MAG_OFFX_L                   0xC0U
+#define LSM6DSOX_MAG_OFFX_H                   0xC1U
+#define LSM6DSOX_MAG_OFFY_L                   0xC2U
+#define LSM6DSOX_MAG_OFFY_H                   0xC3U
+#define LSM6DSOX_MAG_OFFZ_L                   0xC4U
+#define LSM6DSOX_MAG_OFFZ_H                   0xC5U
+#define LSM6DSOX_MAG_SI_XX_L                  0xC6U
+#define LSM6DSOX_MAG_SI_XX_H                  0xC7U
+#define LSM6DSOX_MAG_SI_XY_L                  0xC8U
+#define LSM6DSOX_MAG_SI_XY_H                  0xC9U
+#define LSM6DSOX_MAG_SI_XZ_L                  0xCAU
+#define LSM6DSOX_MAG_SI_XZ_H                  0xCBU
+#define LSM6DSOX_MAG_SI_YY_L                  0xCCU
+#define LSM6DSOX_MAG_SI_YY_H                  0xCDU
+#define LSM6DSOX_MAG_SI_YZ_L                  0xCEU
+#define LSM6DSOX_MAG_SI_YZ_H                  0xCFU
+#define LSM6DSOX_MAG_SI_ZZ_L                  0xD0U
+#define LSM6DSOX_MAG_SI_ZZ_H                  0xD1U
+#define LSM6DSOX_MAG_CFG_A                    0xD4U
+typedef struct {
+  uint8_t mag_z_axis               : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t mag_y_axis               : 3;
+  uint8_t not_used_02              : 1;
+} lsm6dsox_mag_cfg_a_t;
+
+#define LSM6DSOX_MAG_CFG_B                    0xD5U
+typedef struct {
+  uint8_t mag_x_axis               : 3;
+  uint8_t not_used_01              : 5;
+} lsm6dsox_mag_cfg_b_t;
+
+#define LSM6DSOX_FSM_LC_TIMEOUT_L             0x17AU
+#define LSM6DSOX_FSM_LC_TIMEOUT_H             0x17BU
+#define LSM6DSOX_FSM_PROGRAMS                 0x17CU
+#define LSM6DSOX_FSM_START_ADD_L              0x17EU
+#define LSM6DSOX_FSM_START_ADD_H              0x17FU
+#define LSM6DSOX_PEDO_CMD_REG                 0x183U
+typedef struct {
+  uint8_t ad_det_en                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t fp_rejection_en          : 1;
+  uint8_t carry_count_en           : 1;
+  uint8_t not_used_02              : 4;
+} lsm6dsox_pedo_cmd_reg_t;
+
+#define LSM6DSOX_PEDO_DEB_STEPS_CONF          0x184U
+#define LSM6DSOX_PEDO_SC_DELTAT_L             0x1D0U
+#define LSM6DSOX_PEDO_SC_DELTAT_H             0x1D1U
+
+#define LSM6DSOX_MLC_MAG_SENSITIVITY_L        0x1E8U
+#define LSM6DSOX_MLC_MAG_SENSITIVITY_H        0x1E9U
+
+#define LSM6DSOX_SENSOR_HUB_1                 0x02U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_1_t;
+
+#define LSM6DSOX_SENSOR_HUB_2                 0x03U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_2_t;
+
+#define LSM6DSOX_SENSOR_HUB_3                 0x04U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_3_t;
+
+#define LSM6DSOX_SENSOR_HUB_4                 0x05U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_4_t;
+
+#define LSM6DSOX_SENSOR_HUB_5                 0x06U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_5_t;
+
+#define LSM6DSOX_SENSOR_HUB_6                 0x07U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_6_t;
+
+#define LSM6DSOX_SENSOR_HUB_7                 0x08U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_7_t;
+
+#define LSM6DSOX_SENSOR_HUB_8                 0x09U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_8_t;
+
+#define LSM6DSOX_SENSOR_HUB_9                 0x0AU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_9_t;
+
+#define LSM6DSOX_SENSOR_HUB_10                0x0BU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_10_t;
+
+#define LSM6DSOX_SENSOR_HUB_11                0x0CU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_11_t;
+
+#define LSM6DSOX_SENSOR_HUB_12                0x0DU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_12_t;
+
+#define LSM6DSOX_SENSOR_HUB_13                0x0EU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_13_t;
+
+#define LSM6DSOX_SENSOR_HUB_14                0x0FU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_14_t;
+
+#define LSM6DSOX_SENSOR_HUB_15                0x10U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_15_t;
+
+#define LSM6DSOX_SENSOR_HUB_16                0x11U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_16_t;
+
+#define LSM6DSOX_SENSOR_HUB_17                0x12U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_17_t;
+
+#define LSM6DSOX_SENSOR_HUB_18                0x13U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsox_sensor_hub_18_t;
+
+#define LSM6DSOX_MASTER_CONFIG                0x14U
+typedef struct {
+  uint8_t aux_sens_on              : 2;
+  uint8_t master_on                : 1;
+  uint8_t shub_pu_en               : 1;
+  uint8_t pass_through_mode        : 1;
+  uint8_t start_config             : 1;
+  uint8_t write_once               : 1;
+  uint8_t rst_master_regs          : 1;
+} lsm6dsox_master_config_t;
+
+#define LSM6DSOX_SLV0_ADD                     0x15U
+typedef struct {
+  uint8_t rw_0                     : 1;
+  uint8_t slave0                   : 7;
+} lsm6dsox_slv0_add_t;
+
+#define LSM6DSOX_SLV0_SUBADD                  0x16U
+typedef struct {
+  uint8_t slave0_reg               : 8;
+} lsm6dsox_slv0_subadd_t;
+
+#define LSM6DSOX_SLV0_CONFIG                  0x17U
+typedef struct {
+  uint8_t slave0_numop             : 3;
+  uint8_t batch_ext_sens_0_en      : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t shub_odr                 : 2;
+} lsm6dsox_slv0_config_t;
+
+#define LSM6DSOX_SLV1_ADD                     0x18U
+typedef struct {
+  uint8_t r_1                      : 1;
+  uint8_t slave1_add               : 7;
+} lsm6dsox_slv1_add_t;
+
+#define LSM6DSOX_SLV1_SUBADD                  0x19U
+typedef struct {
+  uint8_t slave1_reg               : 8;
+} lsm6dsox_slv1_subadd_t;
+
+#define LSM6DSOX_SLV1_CONFIG                  0x1AU
+typedef struct {
+  uint8_t slave1_numop             : 3;
+  uint8_t batch_ext_sens_1_en      : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dsox_slv1_config_t;
+
+#define LSM6DSOX_SLV2_ADD                     0x1BU
+typedef struct {
+  uint8_t r_2                      : 1;
+  uint8_t slave2_add               : 7;
+} lsm6dsox_slv2_add_t;
+
+#define LSM6DSOX_SLV2_SUBADD                  0x1CU
+typedef struct {
+  uint8_t slave2_reg               : 8;
+} lsm6dsox_slv2_subadd_t;
+
+#define LSM6DSOX_SLV2_CONFIG                  0x1DU
+typedef struct {
+  uint8_t slave2_numop             : 3;
+  uint8_t batch_ext_sens_2_en      : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dsox_slv2_config_t;
+
+#define LSM6DSOX_SLV3_ADD                     0x1EU
+typedef struct {
+  uint8_t r_3                      : 1;
+  uint8_t slave3_add               : 7;
+} lsm6dsox_slv3_add_t;
+
+#define LSM6DSOX_SLV3_SUBADD                  0x1FU
+typedef struct {
+  uint8_t slave3_reg               : 8;
+} lsm6dsox_slv3_subadd_t;
+
+#define LSM6DSOX_SLV3_CONFIG                  0x20U
+typedef struct {
+  uint8_t slave3_numop             : 3;
+  uint8_t  batch_ext_sens_3_en     : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dsox_slv3_config_t;
+
+#define LSM6DSOX_DATAWRITE_SLV0               0x21U
+typedef struct {
+  uint8_t slave0_dataw             : 8;
+} lsm6dsox_datawrite_slv0_t;
+
+#define LSM6DSOX_STATUS_MASTER                0x22U
+typedef struct {
+  uint8_t sens_hub_endop           : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t slave0_nack              : 1;
+  uint8_t slave1_nack              : 1;
+  uint8_t slave2_nack              : 1;
+  uint8_t slave3_nack              : 1;
+  uint8_t wr_once_done             : 1;
+} lsm6dsox_status_master_t;
+
+/**
+  * @defgroup LSM6DSOX_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lsm6dsox_func_cfg_access_t               func_cfg_access;
+  lsm6dsox_pin_ctrl_t                      pin_ctrl;
+  lsm6dsox_s4s_tph_l_t                     s4s_tph_l;
+  lsm6dsox_s4s_tph_h_t                     s4s_tph_h;
+  lsm6dsox_s4s_rr_t                        s4s_rr;
+  lsm6dsox_fifo_ctrl1_t                    fifo_ctrl1;
+  lsm6dsox_fifo_ctrl2_t                    fifo_ctrl2;
+  lsm6dsox_fifo_ctrl3_t                    fifo_ctrl3;
+  lsm6dsox_fifo_ctrl4_t                    fifo_ctrl4;
+  lsm6dsox_counter_bdr_reg1_t              counter_bdr_reg1;
+  lsm6dsox_counter_bdr_reg2_t              counter_bdr_reg2;
+  lsm6dsox_int1_ctrl_t                     int1_ctrl;
+  lsm6dsox_int2_ctrl_t                     int2_ctrl;
+  lsm6dsox_ctrl1_xl_t                      ctrl1_xl;
+  lsm6dsox_ctrl2_g_t                       ctrl2_g;
+  lsm6dsox_ctrl3_c_t                       ctrl3_c;
+  lsm6dsox_ctrl4_c_t                       ctrl4_c;
+  lsm6dsox_ctrl5_c_t                       ctrl5_c;
+  lsm6dsox_ctrl6_c_t                       ctrl6_c;
+  lsm6dsox_ctrl7_g_t                       ctrl7_g;
+  lsm6dsox_ctrl8_xl_t                      ctrl8_xl;
+  lsm6dsox_ctrl9_xl_t                      ctrl9_xl;
+  lsm6dsox_ctrl10_c_t                      ctrl10_c;
+  lsm6dsox_all_int_src_t                   all_int_src;
+  lsm6dsox_wake_up_src_t                   wake_up_src;
+  lsm6dsox_tap_src_t                       tap_src;
+  lsm6dsox_d6d_src_t                       d6d_src;
+  lsm6dsox_status_reg_t                    status_reg;
+  lsm6dsox_fifo_status1_t                  fifo_status1;
+  lsm6dsox_fifo_status2_t                  fifo_status2;
+  lsm6dsox_ui_status_reg_ois_t             ui_status_reg_ois;
+  lsm6dsox_tap_cfg0_t                      tap_cfg0;
+  lsm6dsox_tap_cfg1_t                      tap_cfg1;
+  lsm6dsox_tap_cfg2_t                      tap_cfg2;
+  lsm6dsox_tap_ths_6d_t                    tap_ths_6d;
+  lsm6dsox_int_dur2_t                      int_dur2;
+  lsm6dsox_wake_up_ths_t                   wake_up_ths;
+  lsm6dsox_wake_up_dur_t                   wake_up_dur;
+  lsm6dsox_free_fall_t                     free_fall;
+  lsm6dsox_md1_cfg_t                       md1_cfg;
+  lsm6dsox_md2_cfg_t                       md2_cfg;
+  lsm6dsox_s4s_st_cmd_code_t               s4s_st_cmd_code;
+  lsm6dsox_s4s_dt_reg_t                    s4s_dt_reg;
+  lsm6dsox_i3c_bus_avb_t                   i3c_bus_avb;
+  lsm6dsox_internal_freq_fine_t            internal_freq_fine;
+  lsm6dsox_ui_int_ois_t                    ui_int_ois;
+  lsm6dsox_ui_ctrl1_ois_t                  ui_ctrl1_ois;
+  lsm6dsox_ui_ctrl2_ois_t                  ui_ctrl2_ois;
+  lsm6dsox_ui_ctrl3_ois_t                  ui_ctrl3_ois;
+  lsm6dsox_fifo_data_out_tag_t             fifo_data_out_tag;
+  lsm6dsox_spi2_status_reg_ois_t           spi2_status_reg_ois;
+  lsm6dsox_spi2_int_ois_t                  spi2_int_ois;
+  lsm6dsox_spi2_ctrl1_ois_t                spi2_ctrl1_ois;
+  lsm6dsox_spi2_ctrl2_ois_t                spi2_ctrl2_ois;
+  lsm6dsox_spi2_ctrl3_ois_t                spi2_ctrl3_ois;
+  lsm6dsox_page_sel_t                      page_sel;
+  lsm6dsox_emb_func_en_a_t                 emb_func_en_a;
+  lsm6dsox_emb_func_en_b_t                 emb_func_en_b;
+  lsm6dsox_page_address_t                  page_address;
+  lsm6dsox_page_value_t                    page_value;
+  lsm6dsox_emb_func_int1_t                 emb_func_int1;
+  lsm6dsox_fsm_int1_a_t                    fsm_int1_a;
+  lsm6dsox_fsm_int1_b_t                    fsm_int1_b;
+  lsm6dsox_emb_func_int2_t                 emb_func_int2;
+  lsm6dsox_fsm_int2_a_t                    fsm_int2_a;
+  lsm6dsox_fsm_int2_b_t                    fsm_int2_b;
+  lsm6dsox_emb_func_status_t               emb_func_status;
+  lsm6dsox_fsm_status_a_t                  fsm_status_a;
+  lsm6dsox_fsm_status_b_t                  fsm_status_b;
+  lsm6dsox_page_rw_t                       page_rw;
+  lsm6dsox_emb_func_fifo_cfg_t	           emb_func_fifo_cfg;
+  lsm6dsox_fsm_enable_a_t                  fsm_enable_a;
+  lsm6dsox_fsm_enable_b_t                  fsm_enable_b;
+  lsm6dsox_fsm_long_counter_clear_t        fsm_long_counter_clear;
+  lsm6dsox_fsm_outs1_t                     fsm_outs1;
+  lsm6dsox_fsm_outs2_t                     fsm_outs2;
+  lsm6dsox_fsm_outs3_t                     fsm_outs3;
+  lsm6dsox_fsm_outs4_t                     fsm_outs4;
+  lsm6dsox_fsm_outs5_t                     fsm_outs5;
+  lsm6dsox_fsm_outs6_t                     fsm_outs6;
+  lsm6dsox_fsm_outs7_t                     fsm_outs7;
+  lsm6dsox_fsm_outs8_t                     fsm_outs8;
+  lsm6dsox_fsm_outs9_t                     fsm_outs9;
+  lsm6dsox_fsm_outs10_t                    fsm_outs10;
+  lsm6dsox_fsm_outs11_t                    fsm_outs11;
+  lsm6dsox_fsm_outs12_t                    fsm_outs12;
+  lsm6dsox_fsm_outs13_t                    fsm_outs13;
+  lsm6dsox_fsm_outs14_t                    fsm_outs14;
+  lsm6dsox_fsm_outs15_t                    fsm_outs15;
+  lsm6dsox_fsm_outs16_t                    fsm_outs16;
+  lsm6dsox_emb_func_odr_cfg_b_t            emb_func_odr_cfg_b;
+  lsm6dsox_emb_func_odr_cfg_c_t            emb_func_odr_cfg_c;  
+  lsm6dsox_emb_func_src_t                  emb_func_src;
+  lsm6dsox_emb_func_init_a_t               emb_func_init_a;
+  lsm6dsox_emb_func_init_b_t               emb_func_init_b;
+  lsm6dsox_mag_cfg_a_t                     mag_cfg_a;
+  lsm6dsox_mag_cfg_b_t                     mag_cfg_b;
+  lsm6dsox_pedo_cmd_reg_t                  pedo_cmd_reg;
+  lsm6dsox_sensor_hub_1_t                  sensor_hub_1;
+  lsm6dsox_sensor_hub_2_t                  sensor_hub_2;
+  lsm6dsox_sensor_hub_3_t                  sensor_hub_3;
+  lsm6dsox_sensor_hub_4_t                  sensor_hub_4;
+  lsm6dsox_sensor_hub_5_t                  sensor_hub_5;
+  lsm6dsox_sensor_hub_6_t                  sensor_hub_6;
+  lsm6dsox_sensor_hub_7_t                  sensor_hub_7;
+  lsm6dsox_sensor_hub_8_t                  sensor_hub_8;
+  lsm6dsox_sensor_hub_9_t                  sensor_hub_9;
+  lsm6dsox_sensor_hub_10_t                 sensor_hub_10;
+  lsm6dsox_sensor_hub_11_t                 sensor_hub_11;
+  lsm6dsox_sensor_hub_12_t                 sensor_hub_12;
+  lsm6dsox_sensor_hub_13_t                 sensor_hub_13;
+  lsm6dsox_sensor_hub_14_t                 sensor_hub_14;
+  lsm6dsox_sensor_hub_15_t                 sensor_hub_15;
+  lsm6dsox_sensor_hub_16_t                 sensor_hub_16;
+  lsm6dsox_sensor_hub_17_t                 sensor_hub_17;
+  lsm6dsox_sensor_hub_18_t                 sensor_hub_18;
+  lsm6dsox_master_config_t                 master_config;
+  lsm6dsox_slv0_add_t                      slv0_add;
+  lsm6dsox_slv0_subadd_t                   slv0_subadd;
+  lsm6dsox_slv0_config_t                   slv0_config;
+  lsm6dsox_slv1_add_t                      slv1_add;
+  lsm6dsox_slv1_subadd_t                   slv1_subadd;
+  lsm6dsox_slv1_config_t                   slv1_config;
+  lsm6dsox_slv2_add_t                      slv2_add;
+  lsm6dsox_slv2_subadd_t                   slv2_subadd;
+  lsm6dsox_slv2_config_t                   slv2_config;
+  lsm6dsox_slv3_add_t                      slv3_add;
+  lsm6dsox_slv3_subadd_t                   slv3_subadd;
+  lsm6dsox_slv3_config_t                   slv3_config;
+  lsm6dsox_datawrite_slv0_t                datawrite_slv0;
+  lsm6dsox_status_master_t                 status_master;
+  bitwise_t                                bitwise;
+  uint8_t                                  byte;
+} lsm6dsox_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm6dsox_read_reg(lsm6dsox_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lsm6dsox_write_reg(lsm6dsox_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t lsm6dsox_from_fs2_to_mg(int16_t lsb);
+extern float_t lsm6dsox_from_fs4_to_mg(int16_t lsb);
+extern float_t lsm6dsox_from_fs8_to_mg(int16_t lsb);
+extern float_t lsm6dsox_from_fs16_to_mg(int16_t lsb);
+extern float_t lsm6dsox_from_fs125_to_mdps(int16_t lsb);
+extern float_t lsm6dsox_from_fs500_to_mdps(int16_t lsb);
+extern float_t lsm6dsox_from_fs250_to_mdps(int16_t lsb);
+extern float_t lsm6dsox_from_fs1000_to_mdps(int16_t lsb);
+extern float_t lsm6dsox_from_fs2000_to_mdps(int16_t lsb);
+extern float_t lsm6dsox_from_lsb_to_celsius(int16_t lsb);
+extern float_t lsm6dsox_from_lsb_to_nsec(int16_t lsb);
+
+typedef enum {
+  LSM6DSOX_2g   = 0,
+  LSM6DSOX_16g  = 1, /* if XL_FS_MODE = ‘1’ -> LSM6DSOX_2g */
+  LSM6DSOX_4g   = 2,
+  LSM6DSOX_8g   = 3,
+} lsm6dsox_fs_xl_t;
+int32_t lsm6dsox_xl_full_scale_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_xl_t val);
+int32_t lsm6dsox_xl_full_scale_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_xl_t *val);
+
+typedef enum {
+  LSM6DSOX_XL_ODR_OFF    = 0,
+  LSM6DSOX_XL_ODR_12Hz5  = 1,
+  LSM6DSOX_XL_ODR_26Hz   = 2,
+  LSM6DSOX_XL_ODR_52Hz   = 3,
+  LSM6DSOX_XL_ODR_104Hz  = 4,
+  LSM6DSOX_XL_ODR_208Hz  = 5,
+  LSM6DSOX_XL_ODR_417Hz  = 6,
+  LSM6DSOX_XL_ODR_833Hz  = 7,
+  LSM6DSOX_XL_ODR_1667Hz = 8,
+  LSM6DSOX_XL_ODR_3333Hz = 9,
+  LSM6DSOX_XL_ODR_6667Hz = 10,
+  LSM6DSOX_XL_ODR_6Hz5   = 11, /* (low power only) */
+} lsm6dsox_odr_xl_t;
+int32_t lsm6dsox_xl_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_xl_t val);
+int32_t lsm6dsox_xl_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_xl_t *val);
+
+typedef enum {
+  LSM6DSOX_250dps   = 0,
+  LSM6DSOX_125dps   = 1,
+  LSM6DSOX_500dps   = 2,
+  LSM6DSOX_1000dps  = 4,
+  LSM6DSOX_2000dps  = 6,
+} lsm6dsox_fs_g_t;
+int32_t lsm6dsox_gy_full_scale_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_g_t val);
+int32_t lsm6dsox_gy_full_scale_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_g_t *val);
+
+typedef enum {
+  LSM6DSOX_GY_ODR_OFF    = 0,
+  LSM6DSOX_GY_ODR_12Hz5  = 1,
+  LSM6DSOX_GY_ODR_26Hz   = 2,
+  LSM6DSOX_GY_ODR_52Hz   = 3,
+  LSM6DSOX_GY_ODR_104Hz  = 4,
+  LSM6DSOX_GY_ODR_208Hz  = 5,
+  LSM6DSOX_GY_ODR_417Hz  = 6,
+  LSM6DSOX_GY_ODR_833Hz  = 7,
+  LSM6DSOX_GY_ODR_1667Hz = 8,
+  LSM6DSOX_GY_ODR_3333Hz = 9,
+  LSM6DSOX_GY_ODR_6667Hz = 10,
+} lsm6dsox_odr_g_t;
+int32_t lsm6dsox_gy_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_g_t val);
+int32_t lsm6dsox_gy_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_g_t *val);
+
+int32_t lsm6dsox_block_data_update_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_block_data_update_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_LSb_1mg  = 0,
+  LSM6DSOX_LSb_16mg = 1,
+} lsm6dsox_usr_off_w_t;
+int32_t lsm6dsox_xl_offset_weight_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_usr_off_w_t val);
+int32_t lsm6dsox_xl_offset_weight_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_usr_off_w_t *val);
+
+typedef enum {
+  LSM6DSOX_HIGH_PERFORMANCE_MD  = 0,
+  LSM6DSOX_LOW_NORMAL_POWER_MD  = 1,
+  LSM6DSOX_ULTRA_LOW_POWER_MD   = 2,
+} lsm6dsox_xl_hm_mode_t;
+int32_t lsm6dsox_xl_power_mode_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_xl_hm_mode_t val);
+int32_t lsm6dsox_xl_power_mode_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_xl_hm_mode_t *val);
+
+typedef enum {
+  LSM6DSOX_GY_HIGH_PERFORMANCE  = 0,
+  LSM6DSOX_GY_NORMAL            = 1,
+} lsm6dsox_g_hm_mode_t;
+int32_t lsm6dsox_gy_power_mode_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_g_hm_mode_t val);
+int32_t lsm6dsox_gy_power_mode_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_g_hm_mode_t *val);
+
+typedef struct {
+  lsm6dsox_all_int_src_t       all_int_src;
+  lsm6dsox_wake_up_src_t       wake_up_src;
+  lsm6dsox_tap_src_t           tap_src;
+  lsm6dsox_d6d_src_t           d6d_src;
+  lsm6dsox_status_reg_t        status_reg;
+  lsm6dsox_emb_func_status_t   emb_func_status;
+  lsm6dsox_fsm_status_a_t      fsm_status_a;
+  lsm6dsox_fsm_status_b_t      fsm_status_b;
+} lsm6dsox_all_sources_t;
+int32_t lsm6dsox_all_sources_get(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_all_sources_t *val);
+
+int32_t lsm6dsox_status_reg_get(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_status_reg_t *val);
+
+int32_t lsm6dsox_xl_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_gy_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_temp_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_xl_usr_offset_x_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_x_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_xl_usr_offset_y_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_y_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_xl_usr_offset_z_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_z_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_xl_usr_offset_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_usr_offset_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_timestamp_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_timestamp_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_timestamp_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSOX_NO_ROUND      = 0,
+  LSM6DSOX_ROUND_XL      = 1,
+  LSM6DSOX_ROUND_GY      = 2,
+  LSM6DSOX_ROUND_GY_XL   = 3,
+} lsm6dsox_rounding_t;
+int32_t lsm6dsox_rounding_mode_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_rounding_t val);
+int32_t lsm6dsox_rounding_mode_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_rounding_t *val);
+
+typedef enum {
+  LSM6DSOX_STAT_RND_DISABLE  = 0,
+  LSM6DSOX_STAT_RND_ENABLE   = 1,
+} lsm6dsox_rounding_status_t;
+int32_t lsm6dsox_rounding_on_status_set(lsm6dsox_ctx_t *ctx,
+                                        lsm6dsox_rounding_status_t val);
+int32_t lsm6dsox_rounding_on_status_get(lsm6dsox_ctx_t *ctx,
+                                        lsm6dsox_rounding_status_t *val);
+
+int32_t lsm6dsox_temperature_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_fifo_out_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_ois_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_ois_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_aux_temperature_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_aux_ois_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_aux_ois_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_number_of_steps_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_steps_reset(lsm6dsox_ctx_t *ctx);
+
+int32_t lsm6dsox_mlc_out_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_odr_cal_reg_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_odr_cal_reg_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_USER_BANK           = 0,
+  LSM6DSOX_SENSOR_HUB_BANK     = 1,
+  LSM6DSOX_EMBEDDED_FUNC_BANK  = 2,
+} lsm6dsox_reg_access_t;
+int32_t lsm6dsox_mem_bank_set(lsm6dsox_ctx_t *ctx, lsm6dsox_reg_access_t val);
+int32_t lsm6dsox_mem_bank_get(lsm6dsox_ctx_t *ctx, lsm6dsox_reg_access_t *val);
+
+int32_t lsm6dsox_ln_pg_write_byte(lsm6dsox_ctx_t *ctx, uint16_t address,
+                                  uint8_t *val);
+int32_t lsm6dsox_ln_pg_read_byte(lsm6dsox_ctx_t *ctx, uint16_t address,
+                                 uint8_t *val);
+                                
+int32_t lsm6dsox_ln_pg_write(lsm6dsox_ctx_t *ctx, uint16_t address,
+                             uint8_t *buf, uint8_t len);
+int32_t lsm6dsox_ln_pg_read(lsm6dsox_ctx_t *ctx, uint16_t address,
+                            uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_DRDY_LATCHED = 0,
+  LSM6DSOX_DRDY_PULSED  = 1,
+} lsm6dsox_dataready_pulsed_t;
+int32_t lsm6dsox_data_ready_mode_set(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_dataready_pulsed_t val);
+int32_t lsm6dsox_data_ready_mode_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_dataready_pulsed_t *val);
+
+int32_t lsm6dsox_device_id_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_reset_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_reset_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_auto_increment_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_auto_increment_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_boot_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_boot_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_XL_ST_DISABLE  = 0,
+  LSM6DSOX_XL_ST_POSITIVE = 1,
+  LSM6DSOX_XL_ST_NEGATIVE = 2,
+} lsm6dsox_st_xl_t;
+int32_t lsm6dsox_xl_self_test_set(lsm6dsox_ctx_t *ctx, lsm6dsox_st_xl_t val);
+int32_t lsm6dsox_xl_self_test_get(lsm6dsox_ctx_t *ctx, lsm6dsox_st_xl_t *val);
+
+typedef enum {
+  LSM6DSOX_GY_ST_DISABLE  = 0,
+  LSM6DSOX_GY_ST_POSITIVE = 1,
+  LSM6DSOX_GY_ST_NEGATIVE = 3,
+} lsm6dsox_st_g_t;
+int32_t lsm6dsox_gy_self_test_set(lsm6dsox_ctx_t *ctx, lsm6dsox_st_g_t val);
+int32_t lsm6dsox_gy_self_test_get(lsm6dsox_ctx_t *ctx, lsm6dsox_st_g_t *val);
+
+int32_t lsm6dsox_xl_filter_lp2_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_filter_lp2_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_gy_filter_lp1_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_gy_filter_lp1_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_filter_settling_mask_set(lsm6dsox_ctx_t *ctx,
+                                          uint8_t val);
+int32_t lsm6dsox_filter_settling_mask_get(lsm6dsox_ctx_t *ctx,
+                                          uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_ULTRA_LIGHT  = 0,
+  LSM6DSOX_VERY_LIGHT   = 1,
+  LSM6DSOX_LIGHT        = 2,
+  LSM6DSOX_MEDIUM       = 3,
+  LSM6DSOX_STRONG       = 4,
+  LSM6DSOX_VERY_STRONG  = 5,
+  LSM6DSOX_AGGRESSIVE   = 6,
+  LSM6DSOX_XTREME       = 7,
+} lsm6dsox_ftype_t;
+int32_t lsm6dsox_gy_lp1_bandwidth_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_ftype_t val);
+int32_t lsm6dsox_gy_lp1_bandwidth_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_ftype_t *val);
+
+int32_t lsm6dsox_xl_lp2_on_6d_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_lp2_on_6d_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_HP_PATH_DISABLE_ON_OUT    = 0x00,
+  LSM6DSOX_SLOPE_ODR_DIV_4           = 0x10,
+  LSM6DSOX_HP_ODR_DIV_10             = 0x11,
+  LSM6DSOX_HP_ODR_DIV_20             = 0x12,
+  LSM6DSOX_HP_ODR_DIV_45             = 0x13,
+  LSM6DSOX_HP_ODR_DIV_100            = 0x14,
+  LSM6DSOX_HP_ODR_DIV_200            = 0x15,
+  LSM6DSOX_HP_ODR_DIV_400            = 0x16,
+  LSM6DSOX_HP_ODR_DIV_800            = 0x17,
+  LSM6DSOX_HP_REF_MD_ODR_DIV_10      = 0x31,
+  LSM6DSOX_HP_REF_MD_ODR_DIV_20      = 0x32,
+  LSM6DSOX_HP_REF_MD_ODR_DIV_45      = 0x33,
+  LSM6DSOX_HP_REF_MD_ODR_DIV_100     = 0x34,
+  LSM6DSOX_HP_REF_MD_ODR_DIV_200     = 0x35,
+  LSM6DSOX_HP_REF_MD_ODR_DIV_400     = 0x36,
+  LSM6DSOX_HP_REF_MD_ODR_DIV_800     = 0x37,
+  LSM6DSOX_LP_ODR_DIV_10             = 0x01,
+  LSM6DSOX_LP_ODR_DIV_20             = 0x02,
+  LSM6DSOX_LP_ODR_DIV_45             = 0x03,
+  LSM6DSOX_LP_ODR_DIV_100            = 0x04,
+  LSM6DSOX_LP_ODR_DIV_200            = 0x05,
+  LSM6DSOX_LP_ODR_DIV_400            = 0x06,
+  LSM6DSOX_LP_ODR_DIV_800            = 0x07,
+} lsm6dsox_hp_slope_xl_en_t;
+int32_t lsm6dsox_xl_hp_path_on_out_set(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_hp_slope_xl_en_t val);
+int32_t lsm6dsox_xl_hp_path_on_out_get(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_hp_slope_xl_en_t *val);
+
+int32_t lsm6dsox_xl_fast_settling_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_fast_settling_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_USE_SLOPE = 0,
+  LSM6DSOX_USE_HPF   = 1,
+} lsm6dsox_slope_fds_t;
+int32_t lsm6dsox_xl_hp_path_internal_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_slope_fds_t val);
+int32_t lsm6dsox_xl_hp_path_internal_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_slope_fds_t *val);
+
+typedef enum {
+  LSM6DSOX_HP_FILTER_NONE     = 0x00,
+  LSM6DSOX_HP_FILTER_16mHz    = 0x80,
+  LSM6DSOX_HP_FILTER_65mHz    = 0x81,
+  LSM6DSOX_HP_FILTER_260mHz   = 0x82,
+  LSM6DSOX_HP_FILTER_1Hz04    = 0x83,
+} lsm6dsox_hpm_g_t;
+int32_t lsm6dsox_gy_hp_path_internal_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_hpm_g_t val);
+int32_t lsm6dsox_gy_hp_path_internal_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_hpm_g_t *val);
+
+typedef enum {
+  LSM6DSOX_OIS_CTRL_AUX_DATA_UI          = 0x00,
+  LSM6DSOX_OIS_CTRL_AUX_DATA_UI_AUX      = 0x01,
+  LSM6DSOX_OIS_CTRL_UI_AUX_DATA_UI       = 0x02,
+  LSM6DSOX_OIS_CTRL_UI_AUX_DATA_UI_AUX   = 0x03,
+} lsm6dsox_spi2_read_en_t;
+int32_t lsm6dsox_ois_mode_set(lsm6dsox_ctx_t *ctx,
+                              lsm6dsox_spi2_read_en_t val);
+int32_t lsm6dsox_ois_mode_get(lsm6dsox_ctx_t *ctx,
+                              lsm6dsox_spi2_read_en_t *val);
+
+typedef enum {
+  LSM6DSOX_AUX_PULL_UP_DISC       = 0,
+  LSM6DSOX_AUX_PULL_UP_CONNECT    = 1,
+} lsm6dsox_ois_pu_dis_t;
+int32_t lsm6dsox_aux_sdo_ocs_mode_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_ois_pu_dis_t val);
+int32_t lsm6dsox_aux_sdo_ocs_mode_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_ois_pu_dis_t *val);
+
+typedef enum {
+  LSM6DSOX_AUX_ON                    = 1,
+  LSM6DSOX_AUX_ON_BY_AUX_INTERFACE   = 0,
+} lsm6dsox_ois_on_t;
+int32_t lsm6dsox_aux_pw_on_ctrl_set(lsm6dsox_ctx_t *ctx, lsm6dsox_ois_on_t val);
+int32_t lsm6dsox_aux_pw_on_ctrl_get(lsm6dsox_ctx_t *ctx, lsm6dsox_ois_on_t *val);
+
+typedef enum {
+  LSM6DSOX_USE_SAME_XL_FS        = 0,
+  LSM6DSOX_USE_DIFFERENT_XL_FS   = 1,
+} lsm6dsox_xl_fs_mode_t;
+int32_t lsm6dsox_aux_xl_fs_mode_set(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_xl_fs_mode_t val);
+int32_t lsm6dsox_aux_xl_fs_mode_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_xl_fs_mode_t *val);
+
+int32_t lsm6dsox_aux_status_reg_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_spi2_status_reg_ois_t *val);
+
+int32_t lsm6dsox_aux_xl_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_aux_gy_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_aux_gy_flag_settling_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_AUX_DEN_ACTIVE_LOW     = 0,
+  LSM6DSOX_AUX_DEN_ACTIVE_HIGH    = 1,
+} lsm6dsox_den_lh_ois_t;
+int32_t lsm6dsox_aux_den_polarity_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_den_lh_ois_t val);
+int32_t lsm6dsox_aux_den_polarity_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_den_lh_ois_t *val);
+
+typedef enum {
+  LSM6DSOX_AUX_DEN_DISABLE         = 0,
+  LSM6DSOX_AUX_DEN_LEVEL_LATCH     = 3,
+  LSM6DSOX_AUX_DEN_LEVEL_TRIG      = 2,
+} lsm6dsox_lvl2_ois_t;
+int32_t lsm6dsox_aux_den_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_lvl2_ois_t val);
+int32_t lsm6dsox_aux_den_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_lvl2_ois_t *val);
+
+int32_t lsm6dsox_aux_drdy_on_int2_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_aux_drdy_on_int2_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_AUX_DISABLE  = 0,
+  LSM6DSOX_MODE_3_GY    = 1,
+  LSM6DSOX_MODE_4_GY_XL = 3,
+} lsm6dsox_ois_en_spi2_t;
+int32_t lsm6dsox_aux_mode_set(lsm6dsox_ctx_t *ctx,
+                              lsm6dsox_ois_en_spi2_t val);
+int32_t lsm6dsox_aux_mode_get(lsm6dsox_ctx_t *ctx,
+                              lsm6dsox_ois_en_spi2_t *val);
+
+typedef enum {
+  LSM6DSOX_250dps_AUX  = 0,
+  LSM6DSOX_125dps_AUX  = 1,
+  LSM6DSOX_500dps_AUX  = 2,
+  LSM6DSOX_1000dps_AUX = 4,
+  LSM6DSOX_2000dps_AUX = 6,
+} lsm6dsox_fs_g_ois_t;
+int32_t lsm6dsox_aux_gy_full_scale_set(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_fs_g_ois_t val);
+int32_t lsm6dsox_aux_gy_full_scale_get(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_fs_g_ois_t *val);
+
+typedef enum {
+  LSM6DSOX_AUX_SPI_4_WIRE = 0,
+  LSM6DSOX_AUX_SPI_3_WIRE = 1,
+} lsm6dsox_sim_ois_t;
+int32_t lsm6dsox_aux_spi_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_sim_ois_t val);
+int32_t lsm6dsox_aux_spi_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_sim_ois_t *val);
+
+typedef enum {
+  LSM6DSOX_351Hz39 = 0,
+  LSM6DSOX_236Hz63 = 1,
+  LSM6DSOX_172Hz70 = 2,
+  LSM6DSOX_937Hz91 = 3,
+} lsm6dsox_ftype_ois_t;
+int32_t lsm6dsox_aux_gy_lp1_bandwidth_set(lsm6dsox_ctx_t *ctx,
+                                          lsm6dsox_ftype_ois_t val);
+int32_t lsm6dsox_aux_gy_lp1_bandwidth_get(lsm6dsox_ctx_t *ctx,
+                                          lsm6dsox_ftype_ois_t *val);
+
+typedef enum {
+  LSM6DSOX_AUX_HP_DISABLE = 0x00,
+  LSM6DSOX_AUX_HP_Hz016   = 0x10,
+  LSM6DSOX_AUX_HP_Hz065   = 0x11,
+  LSM6DSOX_AUX_HP_Hz260   = 0x12,
+  LSM6DSOX_AUX_HP_1Hz040  = 0x13,
+} lsm6dsox_hpm_ois_t;
+int32_t lsm6dsox_aux_gy_hp_bandwidth_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_hpm_ois_t val);
+int32_t lsm6dsox_aux_gy_hp_bandwidth_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_hpm_ois_t *val);
+
+typedef enum {
+  LSM6DSOX_ENABLE_CLAMP  = 0,
+  LSM6DSOX_DISABLE_CLAMP = 1,
+} lsm6dsox_st_ois_clampdis_t;
+int32_t lsm6dsox_aux_gy_clamp_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_st_ois_clampdis_t val);
+int32_t lsm6dsox_aux_gy_clamp_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_st_ois_clampdis_t *val);
+
+typedef enum {
+  LSM6DSOX_289Hz = 0,
+  LSM6DSOX_258Hz = 1,
+  LSM6DSOX_120Hz = 2,
+  LSM6DSOX_65Hz2 = 3,
+  LSM6DSOX_33Hz2 = 4,
+  LSM6DSOX_16Hz6 = 5,
+  LSM6DSOX_8Hz30 = 6,
+  LSM6DSOX_4Hz15 = 7,
+} lsm6dsox_filter_xl_conf_ois_t;
+int32_t lsm6dsox_aux_xl_bandwidth_set(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_filter_xl_conf_ois_t val);
+int32_t lsm6dsox_aux_xl_bandwidth_get(lsm6dsox_ctx_t *ctx,
+                                      lsm6dsox_filter_xl_conf_ois_t *val);
+
+typedef enum {
+  LSM6DSOX_AUX_2g  = 0,
+  LSM6DSOX_AUX_16g = 1,
+  LSM6DSOX_AUX_4g  = 2,
+  LSM6DSOX_AUX_8g  = 3,
+} lsm6dsox_fs_xl_ois_t;
+int32_t lsm6dsox_aux_xl_full_scale_set(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_fs_xl_ois_t val);
+int32_t lsm6dsox_aux_xl_full_scale_get(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_fs_xl_ois_t *val);
+
+typedef enum {
+  LSM6DSOX_PULL_UP_DISC       = 0,
+  LSM6DSOX_PULL_UP_CONNECT    = 1,
+} lsm6dsox_sdo_pu_en_t;
+int32_t lsm6dsox_sdo_sa0_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_sdo_pu_en_t val);
+int32_t lsm6dsox_sdo_sa0_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_sdo_pu_en_t *val);
+
+typedef enum {
+  LSM6DSOX_SPI_4_WIRE = 0,
+  LSM6DSOX_SPI_3_WIRE = 1,
+} lsm6dsox_sim_t;
+int32_t lsm6dsox_spi_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_sim_t val);
+int32_t lsm6dsox_spi_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_sim_t *val);
+
+typedef enum {
+  LSM6DSOX_I2C_ENABLE  = 0,
+  LSM6DSOX_I2C_DISABLE = 1,
+} lsm6dsox_i2c_disable_t;
+int32_t lsm6dsox_i2c_interface_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_i2c_disable_t val);
+int32_t lsm6dsox_i2c_interface_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_i2c_disable_t *val);
+
+typedef enum {
+  LSM6DSOX_I3C_DISABLE         = 0x00,
+  LSM6DSOX_I3C_ENABLE_T_50us   = 0x80,
+  LSM6DSOX_I3C_ENABLE_T_2us    = 0x81,
+  LSM6DSOX_I3C_ENABLE_T_1ms    = 0x82,
+  LSM6DSOX_I3C_ENABLE_T_25ms   = 0x83,
+} lsm6dsox_i3c_disable_t;
+int32_t lsm6dsox_i3c_disable_set(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_i3c_disable_t val);
+int32_t lsm6dsox_i3c_disable_get(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_i3c_disable_t *val);
+typedef struct {
+    lsm6dsox_int1_ctrl_t          int1_ctrl;
+    lsm6dsox_md1_cfg_t            md1_cfg;
+    lsm6dsox_emb_func_int1_t      emb_func_int1;
+    lsm6dsox_fsm_int1_a_t         fsm_int1_a;
+    lsm6dsox_fsm_int1_b_t         fsm_int1_b;
+    lsm6dsox_mlc_int1_t           mlc_int1;
+} lsm6dsox_pin_int1_route_t;
+int32_t lsm6dsox_pin_int1_route_set(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_pin_int1_route_t *val);
+int32_t lsm6dsox_pin_int1_route_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_pin_int1_route_t *val);
+
+typedef struct {
+  lsm6dsox_int2_ctrl_t          int2_ctrl;
+  lsm6dsox_md2_cfg_t            md2_cfg;
+  lsm6dsox_emb_func_int2_t      emb_func_int2;
+  lsm6dsox_fsm_int2_a_t         fsm_int2_a;
+  lsm6dsox_fsm_int2_b_t         fsm_int2_b;
+  lsm6dsox_mlc_int2_t           mlc_int2;
+} lsm6dsox_pin_int2_route_t;
+int32_t lsm6dsox_pin_int2_route_set(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_pin_int2_route_t *val);
+int32_t lsm6dsox_pin_int2_route_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_pin_int2_route_t *val);
+
+typedef enum {
+  LSM6DSOX_PUSH_PULL                         = 0x00,
+  LSM6DSOX_OPEN_DRAIN                        = 0x01,
+  LSM6DSOX_INT1_NOPULL_DOWN_INT2_PUSH_PULL   = 0x02,
+  LSM6DSOX_INT1_NOPULL_DOWN_INT2_OPEN_DRAIN  = 0x03,
+} lsm6dsox_pp_od_t;
+int32_t lsm6dsox_pin_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_pp_od_t val);
+int32_t lsm6dsox_pin_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_pp_od_t *val);
+
+typedef enum {
+  LSM6DSOX_ACTIVE_HIGH = 0,
+  LSM6DSOX_ACTIVE_LOW  = 1,
+} lsm6dsox_h_lactive_t;
+int32_t lsm6dsox_pin_polarity_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_h_lactive_t val);
+int32_t lsm6dsox_pin_polarity_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_h_lactive_t *val);
+
+int32_t lsm6dsox_all_on_int1_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_all_on_int1_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_ALL_INT_PULSED            = 0,
+  LSM6DSOX_BASE_LATCHED_EMB_PULSED   = 1,
+  LSM6DSOX_BASE_PULSED_EMB_LATCHED   = 2,
+  LSM6DSOX_ALL_INT_LATCHED           = 3,
+} lsm6dsox_lir_t;
+int32_t lsm6dsox_int_notification_set(lsm6dsox_ctx_t *ctx, lsm6dsox_lir_t val);
+int32_t lsm6dsox_int_notification_get(lsm6dsox_ctx_t *ctx, lsm6dsox_lir_t *val);
+
+typedef enum {
+  LSM6DSOX_LSb_FS_DIV_64       = 0,
+  LSM6DSOX_LSb_FS_DIV_256      = 1,
+} lsm6dsox_wake_ths_w_t;
+int32_t lsm6dsox_wkup_ths_weight_set(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_wake_ths_w_t val);
+int32_t lsm6dsox_wkup_ths_weight_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_wake_ths_w_t *val);
+
+int32_t lsm6dsox_wkup_threshold_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_wkup_threshold_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_xl_usr_offset_on_wkup_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_usr_offset_on_wkup_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_wkup_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_wkup_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_gy_sleep_mode_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_gy_sleep_mode_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_DRIVE_SLEEP_CHG_EVENT = 0,
+  LSM6DSOX_DRIVE_SLEEP_STATUS    = 1,
+} lsm6dsox_sleep_status_on_int_t;
+int32_t lsm6dsox_act_pin_notification_set(lsm6dsox_ctx_t *ctx,
+                                          lsm6dsox_sleep_status_on_int_t val);
+int32_t lsm6dsox_act_pin_notification_get(lsm6dsox_ctx_t *ctx,
+                                          lsm6dsox_sleep_status_on_int_t *val);
+
+typedef enum {
+  LSM6DSOX_XL_AND_GY_NOT_AFFECTED      = 0,
+  LSM6DSOX_XL_12Hz5_GY_NOT_AFFECTED    = 1,
+  LSM6DSOX_XL_12Hz5_GY_SLEEP           = 2,
+  LSM6DSOX_XL_12Hz5_GY_PD              = 3,
+} lsm6dsox_inact_en_t;
+int32_t lsm6dsox_act_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_inact_en_t val);
+int32_t lsm6dsox_act_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_inact_en_t *val);
+
+int32_t lsm6dsox_act_sleep_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_act_sleep_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tap_detection_on_z_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_detection_on_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tap_detection_on_y_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_detection_on_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tap_detection_on_x_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_detection_on_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tap_threshold_x_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_threshold_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_XYZ = 0,
+  LSM6DSOX_YXZ = 1,
+  LSM6DSOX_XZY = 2,
+  LSM6DSOX_ZYX = 3,
+  LSM6DSOX_YZX = 5,
+  LSM6DSOX_ZXY = 6,
+} lsm6dsox_tap_priority_t;
+int32_t lsm6dsox_tap_axis_priority_set(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_tap_priority_t val);
+int32_t lsm6dsox_tap_axis_priority_get(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_tap_priority_t *val);
+
+int32_t lsm6dsox_tap_threshold_y_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_threshold_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tap_threshold_z_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_threshold_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tap_shock_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_shock_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tap_quiet_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_quiet_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tap_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_ONLY_SINGLE = 0,
+  LSM6DSOX_BOTH_SINGLE_DOUBLE = 1,
+} lsm6dsox_single_double_tap_t;
+int32_t lsm6dsox_tap_mode_set(lsm6dsox_ctx_t *ctx,
+                              lsm6dsox_single_double_tap_t val);
+int32_t lsm6dsox_tap_mode_get(lsm6dsox_ctx_t *ctx,
+                              lsm6dsox_single_double_tap_t *val);
+
+typedef enum {
+  LSM6DSOX_DEG_80  = 0,
+  LSM6DSOX_DEG_70  = 1,
+  LSM6DSOX_DEG_60  = 2,
+  LSM6DSOX_DEG_50  = 3,
+} lsm6dsox_sixd_ths_t;
+int32_t lsm6dsox_6d_threshold_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_sixd_ths_t val);
+int32_t lsm6dsox_6d_threshold_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_sixd_ths_t *val);
+
+int32_t lsm6dsox_4d_mode_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_4d_mode_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_FF_TSH_156mg = 0,
+  LSM6DSOX_FF_TSH_219mg = 1,
+  LSM6DSOX_FF_TSH_250mg = 2,
+  LSM6DSOX_FF_TSH_312mg = 3,
+  LSM6DSOX_FF_TSH_344mg = 4,
+  LSM6DSOX_FF_TSH_406mg = 5,
+  LSM6DSOX_FF_TSH_469mg = 6,
+  LSM6DSOX_FF_TSH_500mg = 7,
+} lsm6dsox_ff_ths_t;
+int32_t lsm6dsox_ff_threshold_set(lsm6dsox_ctx_t *ctx, lsm6dsox_ff_ths_t val);
+int32_t lsm6dsox_ff_threshold_get(lsm6dsox_ctx_t *ctx, lsm6dsox_ff_ths_t *val);
+
+int32_t lsm6dsox_ff_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_ff_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_fifo_watermark_set(lsm6dsox_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsox_fifo_watermark_get(lsm6dsox_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsox_compression_algo_init_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_compression_algo_init_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_CMP_DISABLE  = 0x00,
+  LSM6DSOX_CMP_ALWAYS   = 0x04,
+  LSM6DSOX_CMP_8_TO_1   = 0x05,
+  LSM6DSOX_CMP_16_TO_1  = 0x06,
+  LSM6DSOX_CMP_32_TO_1  = 0x07,
+} lsm6dsox_uncoptr_rate_t;
+int32_t lsm6dsox_compression_algo_set(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_uncoptr_rate_t val);
+int32_t lsm6dsox_compression_algo_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_uncoptr_rate_t *val);
+
+int32_t lsm6dsox_fifo_virtual_sens_odr_chg_set(lsm6dsox_ctx_t *ctx,
+                                              uint8_t val);
+int32_t lsm6dsox_fifo_virtual_sens_odr_chg_get(lsm6dsox_ctx_t *ctx,
+                                              uint8_t *val);
+
+int32_t lsm6dsox_compression_algo_real_time_set(lsm6dsox_ctx_t *ctx,
+                                               uint8_t val);
+int32_t lsm6dsox_compression_algo_real_time_get(lsm6dsox_ctx_t *ctx,
+                                               uint8_t *val);
+
+int32_t lsm6dsox_fifo_stop_on_wtm_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_fifo_stop_on_wtm_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_XL_NOT_BATCHED     	=  0,
+  LSM6DSOX_XL_BATCHED_AT_12Hz5   =  1,
+  LSM6DSOX_XL_BATCHED_AT_26Hz    =  2,
+  LSM6DSOX_XL_BATCHED_AT_52Hz    =  3,
+  LSM6DSOX_XL_BATCHED_AT_104Hz   =  4,
+  LSM6DSOX_XL_BATCHED_AT_208Hz   =  5,
+  LSM6DSOX_XL_BATCHED_AT_417Hz   =  6,
+  LSM6DSOX_XL_BATCHED_AT_833Hz   =  7,
+  LSM6DSOX_XL_BATCHED_AT_1667Hz  =  8,
+  LSM6DSOX_XL_BATCHED_AT_3333Hz  =  9,
+  LSM6DSOX_XL_BATCHED_AT_6667Hz  = 10,
+  LSM6DSOX_XL_BATCHED_AT_6Hz5    = 11,
+} lsm6dsox_bdr_xl_t;
+int32_t lsm6dsox_fifo_xl_batch_set(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_xl_t val);
+int32_t lsm6dsox_fifo_xl_batch_get(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_xl_t *val);
+
+typedef enum {
+  LSM6DSOX_GY_NOT_BATCHED         = 0,
+  LSM6DSOX_GY_BATCHED_AT_12Hz5    = 1,
+  LSM6DSOX_GY_BATCHED_AT_26Hz     = 2,
+  LSM6DSOX_GY_BATCHED_AT_52Hz     = 3,
+  LSM6DSOX_GY_BATCHED_AT_104Hz    = 4,
+  LSM6DSOX_GY_BATCHED_AT_208Hz    = 5,
+  LSM6DSOX_GY_BATCHED_AT_417Hz    = 6,
+  LSM6DSOX_GY_BATCHED_AT_833Hz    = 7,
+  LSM6DSOX_GY_BATCHED_AT_1667Hz   = 8,
+  LSM6DSOX_GY_BATCHED_AT_3333Hz   = 9,
+  LSM6DSOX_GY_BATCHED_AT_6667Hz   = 10,
+  LSM6DSOX_GY_BATCHED_AT_6Hz5     = 11,
+} lsm6dsox_bdr_gy_t;
+int32_t lsm6dsox_fifo_gy_batch_set(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_gy_t val);
+int32_t lsm6dsox_fifo_gy_batch_get(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_gy_t *val);
+
+typedef enum {
+  LSM6DSOX_BYPASS_MODE             = 0,
+  LSM6DSOX_FIFO_MODE               = 1,
+  LSM6DSOX_STREAM_TO_FIFO_MODE     = 3,
+  LSM6DSOX_BYPASS_TO_STREAM_MODE   = 4,
+  LSM6DSOX_STREAM_MODE             = 6,
+  LSM6DSOX_BYPASS_TO_FIFO_MODE     = 7,
+} lsm6dsox_fifo_mode_t;
+int32_t lsm6dsox_fifo_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fifo_mode_t val);
+int32_t lsm6dsox_fifo_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fifo_mode_t *val);
+
+typedef enum {
+  LSM6DSOX_TEMP_NOT_BATCHED        = 0,
+  LSM6DSOX_TEMP_BATCHED_AT_1Hz6    = 1,
+  LSM6DSOX_TEMP_BATCHED_AT_12Hz5   = 2,
+  LSM6DSOX_TEMP_BATCHED_AT_52Hz    = 3,
+} lsm6dsox_odr_t_batch_t;
+int32_t lsm6dsox_fifo_temp_batch_set(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_odr_t_batch_t val);
+int32_t lsm6dsox_fifo_temp_batch_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_odr_t_batch_t *val);
+
+typedef enum {
+  LSM6DSOX_NO_DECIMATION = 0,
+  LSM6DSOX_DEC_1         = 1,
+  LSM6DSOX_DEC_8         = 2,
+  LSM6DSOX_DEC_32        = 3,
+} lsm6dsox_odr_ts_batch_t;
+int32_t lsm6dsox_fifo_timestamp_decimation_set(lsm6dsox_ctx_t *ctx,
+                                              lsm6dsox_odr_ts_batch_t val);
+int32_t lsm6dsox_fifo_timestamp_decimation_get(lsm6dsox_ctx_t *ctx,
+                                              lsm6dsox_odr_ts_batch_t *val);
+
+typedef enum {
+  LSM6DSOX_XL_BATCH_EVENT   = 0,
+  LSM6DSOX_GYRO_BATCH_EVENT = 1,
+} lsm6dsox_trig_counter_bdr_t;
+
+typedef enum {
+  LSM6DSOX_GYRO_NC_TAG		= 1,
+  LSM6DSOX_XL_NC_TAG,
+  LSM6DSOX_TEMPERATURE_TAG,
+  LSM6DSOX_TIMESTAMP_TAG,
+  LSM6DSOX_CFG_CHANGE_TAG,
+  LSM6DSOX_XL_NC_T_2_TAG,
+  LSM6DSOX_XL_NC_T_1_TAG,
+  LSM6DSOX_XL_2XC_TAG,
+  LSM6DSOX_XL_3XC_TAG,
+  LSM6DSOX_GYRO_NC_T_2_TAG,
+  LSM6DSOX_GYRO_NC_T_1_TAG,
+  LSM6DSOX_GYRO_2XC_TAG,
+  LSM6DSOX_GYRO_3XC_TAG,
+  LSM6DSOX_SENSORHUB_SLAVE0_TAG,
+  LSM6DSOX_SENSORHUB_SLAVE1_TAG,
+  LSM6DSOX_SENSORHUB_SLAVE2_TAG,
+  LSM6DSOX_SENSORHUB_SLAVE3_TAG,
+  LSM6DSOX_STEP_CPUNTER_TAG,
+  LSM6DSOX_GAME_ROTATION_TAG,
+  LSM6DSOX_GEOMAG_ROTATION_TAG,
+  LSM6DSOX_ROTATION_TAG,
+  LSM6DSOX_SENSORHUB_NACK_TAG	= 0x19,
+} lsm6dsox_fifo_tag_t;
+int32_t lsm6dsox_fifo_cnt_event_batch_set(lsm6dsox_ctx_t *ctx,
+                                          lsm6dsox_trig_counter_bdr_t val);
+int32_t lsm6dsox_fifo_cnt_event_batch_get(lsm6dsox_ctx_t *ctx,
+                                          lsm6dsox_trig_counter_bdr_t *val);
+
+int32_t lsm6dsox_rst_batch_counter_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_rst_batch_counter_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_batch_counter_threshold_set(lsm6dsox_ctx_t *ctx,
+                                            uint16_t val);
+int32_t lsm6dsox_batch_counter_threshold_get(lsm6dsox_ctx_t *ctx,
+                                            uint16_t *val);
+
+int32_t lsm6dsox_fifo_data_level_get(lsm6dsox_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsox_fifo_status_get(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_fifo_status2_t *val);
+
+int32_t lsm6dsox_fifo_full_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_fifo_ovr_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_fifo_wtm_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_fifo_sensor_tag_get(lsm6dsox_ctx_t *ctx,
+				    lsm6dsox_fifo_tag_t *val);
+
+int32_t lsm6dsox_fifo_pedo_batch_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_fifo_pedo_batch_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_sh_batch_slave_0_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_batch_slave_0_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_sh_batch_slave_1_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_batch_slave_1_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_sh_batch_slave_2_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_batch_slave_2_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_sh_batch_slave_3_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_batch_slave_3_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_DEN_DISABLE    = 0,
+  LSM6DSOX_LEVEL_FIFO     = 6,
+  LSM6DSOX_LEVEL_LETCHED  = 3,
+  LSM6DSOX_LEVEL_TRIGGER  = 2,
+  LSM6DSOX_EDGE_TRIGGER   = 4,
+} lsm6dsox_den_mode_t;
+int32_t lsm6dsox_den_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_mode_t val);
+int32_t lsm6dsox_den_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_mode_t *val);
+
+typedef enum {
+  LSM6DSOX_DEN_ACT_LOW  = 0,
+  LSM6DSOX_DEN_ACT_HIGH = 1,
+} lsm6dsox_den_lh_t;
+int32_t lsm6dsox_den_polarity_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_lh_t val);
+int32_t lsm6dsox_den_polarity_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_lh_t *val);
+
+typedef enum {
+  LSM6DSOX_STAMP_IN_GY_DATA     = 0,
+  LSM6DSOX_STAMP_IN_XL_DATA     = 1,
+  LSM6DSOX_STAMP_IN_GY_XL_DATA  = 2,
+} lsm6dsox_den_xl_g_t;
+int32_t lsm6dsox_den_enable_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_xl_g_t val);
+int32_t lsm6dsox_den_enable_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_xl_g_t *val);
+
+int32_t lsm6dsox_den_mark_axis_x_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_den_mark_axis_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_den_mark_axis_y_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_den_mark_axis_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_den_mark_axis_z_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_den_mark_axis_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_PEDO_DISABLE              = 0x00,
+  LSM6DSOX_PEDO_BASE_MODE            = 0x01,
+  LSM6DSOX_PEDO_ADV_MODE             = 0x03,
+  LSM6DSOX_FALSE_STEP_REJ            = 0x13,
+  LSM6DSOX_FALSE_STEP_REJ_ADV_MODE   = 0x33,
+} lsm6dsox_pedo_md_t;
+int32_t lsm6dsox_pedo_sens_set(lsm6dsox_ctx_t *ctx, lsm6dsox_pedo_md_t val);
+int32_t lsm6dsox_pedo_sens_get(lsm6dsox_ctx_t *ctx, lsm6dsox_pedo_md_t *val);
+
+int32_t lsm6dsox_pedo_step_detect_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_pedo_debounce_steps_set(lsm6dsox_ctx_t *ctx,
+                                             uint8_t *buff);
+int32_t lsm6dsox_pedo_debounce_steps_get(lsm6dsox_ctx_t *ctx,
+                                             uint8_t *buff);
+
+int32_t lsm6dsox_pedo_steps_period_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_pedo_steps_period_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_pedo_adv_detection_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_pedo_adv_detection_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_pedo_false_step_rejection_set(lsm6dsox_ctx_t *ctx,
+                                              uint8_t val);
+int32_t lsm6dsox_pedo_false_step_rejection_get(lsm6dsox_ctx_t *ctx,
+                                              uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_EVERY_STEP     = 0,
+  LSM6DSOX_COUNT_OVERFLOW = 1,
+} lsm6dsox_carry_count_en_t;
+int32_t lsm6dsox_pedo_int_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_carry_count_en_t val);
+int32_t lsm6dsox_pedo_int_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_carry_count_en_t *val);
+
+int32_t lsm6dsox_motion_sens_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_motion_sens_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_motion_flag_data_ready_get(lsm6dsox_ctx_t *ctx,
+                                                uint8_t *val);
+
+int32_t lsm6dsox_tilt_sens_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tilt_sens_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_tilt_flag_data_ready_get(lsm6dsox_ctx_t *ctx,
+                                              uint8_t *val);
+
+int32_t lsm6dsox_sh_mag_sensitivity_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_sh_mag_sensitivity_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_mlc_mag_sensitivity_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mlc_mag_sensitivity_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_mag_offset_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mag_offset_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_mag_soft_iron_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mag_soft_iron_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSOX_Z_EQ_Y     = 0,
+  LSM6DSOX_Z_EQ_MIN_Y = 1,
+  LSM6DSOX_Z_EQ_X     = 2,
+  LSM6DSOX_Z_EQ_MIN_X = 3,
+  LSM6DSOX_Z_EQ_MIN_Z = 4,
+  LSM6DSOX_Z_EQ_Z     = 5,
+} lsm6dsox_mag_z_axis_t;
+int32_t lsm6dsox_mag_z_orient_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_mag_z_axis_t val);
+int32_t lsm6dsox_mag_z_orient_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_mag_z_axis_t *val);
+
+typedef enum {
+  LSM6DSOX_Y_EQ_Y     = 0,
+  LSM6DSOX_Y_EQ_MIN_Y = 1,
+  LSM6DSOX_Y_EQ_X     = 2,
+  LSM6DSOX_Y_EQ_MIN_X = 3,
+  LSM6DSOX_Y_EQ_MIN_Z = 4,
+  LSM6DSOX_Y_EQ_Z     = 5,
+} lsm6dsox_mag_y_axis_t;
+int32_t lsm6dsox_mag_y_orient_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_mag_y_axis_t val);
+int32_t lsm6dsox_mag_y_orient_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_mag_y_axis_t *val);
+
+typedef enum {
+  LSM6DSOX_X_EQ_Y     = 0,
+  LSM6DSOX_X_EQ_MIN_Y = 1,
+  LSM6DSOX_X_EQ_X     = 2,
+  LSM6DSOX_X_EQ_MIN_X = 3,
+  LSM6DSOX_X_EQ_MIN_Z = 4,
+  LSM6DSOX_X_EQ_Z     = 5,
+} lsm6dsox_mag_x_axis_t;
+int32_t lsm6dsox_mag_x_orient_set(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_mag_x_axis_t val);
+int32_t lsm6dsox_mag_x_orient_get(lsm6dsox_ctx_t *ctx,
+                                         lsm6dsox_mag_x_axis_t *val);
+
+int32_t lsm6dsox_long_cnt_flag_data_ready_get(lsm6dsox_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t lsm6dsox_emb_fsm_en_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_emb_fsm_en_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+    lsm6dsox_fsm_enable_a_t          fsm_enable_a;
+    lsm6dsox_fsm_enable_b_t          fsm_enable_b;
+} lsm6dsox_emb_fsm_enable_t;
+int32_t lsm6dsox_fsm_enable_set(lsm6dsox_ctx_t *ctx,
+                               lsm6dsox_emb_fsm_enable_t *val);
+int32_t lsm6dsox_fsm_enable_get(lsm6dsox_ctx_t *ctx,
+                               lsm6dsox_emb_fsm_enable_t *val);
+
+int32_t lsm6dsox_long_cnt_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_long_cnt_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSOX_LC_NORMAL     = 0,
+  LSM6DSOX_LC_CLEAR      = 1,
+  LSM6DSOX_LC_CLEAR_DONE = 2,
+} lsm6dsox_fsm_lc_clr_t;
+int32_t lsm6dsox_long_clr_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_lc_clr_t val);
+int32_t lsm6dsox_long_clr_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_lc_clr_t *val);
+
+typedef struct {
+    lsm6dsox_fsm_outs1_t    fsm_outs1;
+    lsm6dsox_fsm_outs2_t    fsm_outs2;
+    lsm6dsox_fsm_outs3_t    fsm_outs3;
+    lsm6dsox_fsm_outs4_t    fsm_outs4;
+    lsm6dsox_fsm_outs5_t    fsm_outs5;
+    lsm6dsox_fsm_outs6_t    fsm_outs6;
+    lsm6dsox_fsm_outs7_t    fsm_outs7;
+    lsm6dsox_fsm_outs8_t    fsm_outs8;
+    lsm6dsox_fsm_outs1_t    fsm_outs9;
+    lsm6dsox_fsm_outs2_t    fsm_outs10;
+    lsm6dsox_fsm_outs3_t    fsm_outs11;
+    lsm6dsox_fsm_outs4_t    fsm_outs12;
+    lsm6dsox_fsm_outs5_t    fsm_outs13;
+    lsm6dsox_fsm_outs6_t    fsm_outs14;
+    lsm6dsox_fsm_outs7_t    fsm_outs15;
+    lsm6dsox_fsm_outs8_t    fsm_outs16;
+} lsm6dsox_fsm_out_t;
+int32_t lsm6dsox_fsm_out_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_out_t *val);
+
+typedef enum {
+  LSM6DSOX_ODR_FSM_12Hz5 = 0,
+  LSM6DSOX_ODR_FSM_26Hz  = 1,
+  LSM6DSOX_ODR_FSM_52Hz  = 2,
+  LSM6DSOX_ODR_FSM_104Hz = 3,
+} lsm6dsox_fsm_odr_t;
+int32_t lsm6dsox_fsm_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_odr_t val);
+int32_t lsm6dsox_fsm_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_odr_t *val);
+
+int32_t lsm6dsox_fsm_init_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_fsm_init_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_long_cnt_int_value_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_long_cnt_int_value_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_fsm_number_of_programs_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_fsm_number_of_programs_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_fsm_start_address_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_fsm_start_address_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsox_mlc_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_mlc_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_mlc_status_get(lsm6dsox_ctx_t *ctx,
+                                    lsm6dsox_progsens_status_mainpage_t *val);
+
+typedef enum {
+  LSM6DSOX_ODR_PRGS_12Hz5 = 0,
+  LSM6DSOX_ODR_PRGS_26Hz  = 1,
+  LSM6DSOX_ODR_PRGS_52Hz  = 2,
+  LSM6DSOX_ODR_PRGS_104Hz = 3,
+} lsm6dsox_mlc_odr_t;
+int32_t lsm6dsox_mlc_data_rate_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_mlc_odr_t val);
+int32_t lsm6dsox_mlc_data_rate_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_mlc_odr_t *val);
+
+typedef struct {
+    lsm6dsox_sensor_hub_1_t   sh_byte_1;
+    lsm6dsox_sensor_hub_2_t   sh_byte_2;
+    lsm6dsox_sensor_hub_3_t   sh_byte_3;
+    lsm6dsox_sensor_hub_4_t   sh_byte_4;
+    lsm6dsox_sensor_hub_5_t   sh_byte_5;
+    lsm6dsox_sensor_hub_6_t   sh_byte_6;
+    lsm6dsox_sensor_hub_7_t   sh_byte_7;
+    lsm6dsox_sensor_hub_8_t   sh_byte_8;
+    lsm6dsox_sensor_hub_9_t   sh_byte_9;
+    lsm6dsox_sensor_hub_10_t  sh_byte_10;
+    lsm6dsox_sensor_hub_11_t  sh_byte_11;
+    lsm6dsox_sensor_hub_12_t  sh_byte_12;
+    lsm6dsox_sensor_hub_13_t  sh_byte_13;
+    lsm6dsox_sensor_hub_14_t  sh_byte_14;
+    lsm6dsox_sensor_hub_15_t  sh_byte_15;
+    lsm6dsox_sensor_hub_16_t  sh_byte_16;
+    lsm6dsox_sensor_hub_17_t  sh_byte_17;
+    lsm6dsox_sensor_hub_18_t  sh_byte_18;
+} lsm6dsox_emb_sh_read_t;
+int32_t lsm6dsox_sh_read_data_raw_get(lsm6dsox_ctx_t *ctx,
+                                     lsm6dsox_emb_sh_read_t *val);
+
+typedef enum {
+  LSM6DSOX_SLV_0       = 0,
+  LSM6DSOX_SLV_0_1     = 1,
+  LSM6DSOX_SLV_0_1_2   = 2,
+  LSM6DSOX_SLV_0_1_2_3 = 3,
+} lsm6dsox_aux_sens_on_t;
+int32_t lsm6dsox_sh_slave_connected_set(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_aux_sens_on_t val);
+int32_t lsm6dsox_sh_slave_connected_get(lsm6dsox_ctx_t *ctx,
+                                       lsm6dsox_aux_sens_on_t *val);
+
+int32_t lsm6dsox_sh_master_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_master_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_EXT_PULL_UP      = 0,
+  LSM6DSOX_INTERNAL_PULL_UP = 1,
+} lsm6dsox_shub_pu_en_t;
+int32_t lsm6dsox_sh_pin_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_pu_en_t val);
+int32_t lsm6dsox_sh_pin_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_pu_en_t *val);
+
+int32_t lsm6dsox_sh_pass_through_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_pass_through_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_EXT_ON_INT2_PIN = 0,
+  LSM6DSOX_XL_GY_DRDY      = 1,
+} lsm6dsox_start_config_t;
+int32_t lsm6dsox_sh_syncro_mode_set(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_start_config_t val);
+int32_t lsm6dsox_sh_syncro_mode_get(lsm6dsox_ctx_t *ctx,
+                                   lsm6dsox_start_config_t *val);
+
+typedef enum {
+  LSM6DSOX_EACH_SH_CYCLE    = 0,
+  LSM6DSOX_ONLY_FIRST_CYCLE = 1,
+} lsm6dsox_write_once_t;
+int32_t lsm6dsox_sh_write_mode_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_write_once_t val);
+int32_t lsm6dsox_sh_write_mode_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_write_once_t *val);
+
+int32_t lsm6dsox_sh_reset_set(lsm6dsox_ctx_t *ctx);
+int32_t lsm6dsox_sh_reset_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSOX_SH_ODR_104Hz = 0,
+  LSM6DSOX_SH_ODR_52Hz  = 1,
+  LSM6DSOX_SH_ODR_26Hz  = 2,
+  LSM6DSOX_SH_ODR_13Hz  = 3,
+} lsm6dsox_shub_odr_t;
+int32_t lsm6dsox_sh_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_odr_t val);
+int32_t lsm6dsox_sh_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_odr_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} lsm6dsox_sh_cfg_write_t;
+int32_t lsm6dsox_sh_cfg_write(lsm6dsox_ctx_t *ctx, lsm6dsox_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} lsm6dsox_sh_cfg_read_t;
+int32_t lsm6dsox_sh_slv0_cfg_read(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_sh_cfg_read_t *val);
+int32_t lsm6dsox_sh_slv1_cfg_read(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_sh_cfg_read_t *val);
+int32_t lsm6dsox_sh_slv2_cfg_read(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_sh_cfg_read_t *val);
+int32_t lsm6dsox_sh_slv3_cfg_read(lsm6dsox_ctx_t *ctx,
+                                 lsm6dsox_sh_cfg_read_t *val);
+
+int32_t lsm6dsox_sh_status_get(lsm6dsox_ctx_t *ctx,
+                              lsm6dsox_status_master_t *val);
+typedef enum {
+  LSM6DSOX_S4S_TPH_7bit   = 0,
+  LSM6DSOX_S4S_TPH_15bit  = 1,
+} lsm6dsox_s4s_tph_res_t;
+int32_t lsm6dsox_s4s_tph_res_set(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_s4s_tph_res_t val);
+int32_t lsm6dsox_s4s_tph_res_get(lsm6dsox_ctx_t *ctx,
+                                lsm6dsox_s4s_tph_res_t *val);
+
+int32_t lsm6dsox_s4s_tph_val_set(lsm6dsox_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsox_s4s_tph_val_get(lsm6dsox_ctx_t *ctx, uint16_t *val);
+
+typedef enum {
+  LSM6DSOX_S4S_DT_RES_11 = 0,
+  LSM6DSOX_S4S_DT_RES_12 = 1,
+  LSM6DSOX_S4S_DT_RES_13 = 2,
+  LSM6DSOX_S4S_DT_RES_14 = 3,
+} lsm6dsox_s4s_res_ratio_t;
+int32_t lsm6dsox_s4s_res_ratio_set(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_s4s_res_ratio_t val);
+int32_t lsm6dsox_s4s_res_ratio_get(lsm6dsox_ctx_t *ctx,
+                                  lsm6dsox_s4s_res_ratio_t *val);
+
+int32_t lsm6dsox_s4s_command_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_s4s_command_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsox_s4s_dt_set(lsm6dsox_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_s4s_dt_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*LSM6DSOX_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsox_STdC/lib/fifo_utility/fifo_utility.c
+++ b/sensor/stmemsc/lsm6dsox_STdC/lib/fifo_utility/fifo_utility.c
@@ -1,0 +1,711 @@
+/*
+ ******************************************************************************
+ * @file    fifo_utility.c
+ * @author  Sensor Solutions Software Team
+ * @brief   utility for decoding / decompressing data from FIFO
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <string.h>
+#include "fifo_utility.h"
+
+#define ODR_XL_MASK				(0x0F)
+#define ODR_XL_SHIFT			(0x00)
+#define BDR_XL_MASK				(0x0F)
+#define BDR_XL_SHIFT			(0x00)
+
+#define ODR_GY_MASK				(0xF0)
+#define ODR_GY_SHIFT			(0x04)
+#define BDR_GY_MASK				(0xF0)
+#define BDR_GY_SHIFT			(0x04)
+
+#define BDR_VSENS_MASK			(0x0F)
+#define BDR_VSENS_SHIFT			(0x00)
+
+#define TAG_COUNTER_MASK		(0x06)
+#define TAG_SENSOR_MASK			(0xF8)
+#define TAG_COUNTER_SHIFT		(0x01)
+#define TAG_SENSOR_SHIFT		(0x03)
+
+#define TAG_GY					(0x01)
+#define TAG_XL					(0x02)
+#define TAG_TEMP				(0x03)
+#define TAG_TS					(0x04)
+#define TAG_ODRCHG				(0x05)
+#define TAG_XL_UNCOMPRESSED_T_2	(0x06)
+#define TAG_XL_UNCOMPRESSED_T_1	(0x07)
+#define TAG_XL_COMPRESSED_2X	(0x08)
+#define TAG_XL_COMPRESSED_3X	(0x09)
+#define TAG_GY_UNCOMPRESSED_T_2	(0x0A)
+#define TAG_GY_UNCOMPRESSED_T_1	(0x0B)
+#define TAG_GY_COMPRESSED_2X	(0x0C)
+#define TAG_GY_COMPRESSED_3X	(0x0D)
+#define TAG_EXT_SENS_0			(0x0E)
+#define TAG_EXT_SENS_1			(0x0F)
+#define TAG_EXT_SENS_2			(0x10)
+#define TAG_EXT_SENS_3			(0x11)
+#define TAG_STEP_COUNTER		(0x12)
+#define TAG_GAME_RV				(0x13)
+#define TAG_GEOM_RV				(0x14)
+#define TAG_NORM_RV				(0x15)
+#define TAG_GYRO_BIAS			(0x16)
+#define TAG_GRAVITIY			(0x17)
+#define TAG_MAG_CAL				(0x18)
+#define TAG_EXT_SENS_NACK		(0x19)
+
+#define TAG_VALID_LIMIT			(0x19)
+
+#define TIMESTAMP_FREQ			(40000.0f)
+
+#define MAX(a, b)				((a) > (b) ? a : b)
+#define MIN(a, b)				((a) < (b) ? a : b)
+
+typedef enum {
+        ST_FIFO_COMPRESSION_NC,
+        ST_FIFO_COMPRESSION_NC_T_1,
+        ST_FIFO_COMPRESSION_NC_T_2,
+        ST_FIFO_COMPRESSION_2X,
+        ST_FIFO_COMPRESSION_3X
+} st_fifo_compression_type;
+
+static uint8_t has_even_parity(uint8_t x);
+static st_fifo_sensor_type get_sensor_type(uint8_t tag);
+static st_fifo_compression_type get_compression_type(uint8_t tag);
+static uint8_t is_tag_valid(uint8_t tag);
+static void get_diff_2x(int16_t diff[6], uint8_t input[6]);
+static void get_diff_3x(int16_t diff[9], uint8_t input[6]);
+
+static const float bdr_acc_vect_def[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		833, 1666, 3333, 6666, 1.625,
+		0, 0, 0, 0
+};
+
+static const float bdr_gyr_vect_def[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		833, 1666, 3333, 6666, 0, 0,
+		0, 0, 0
+};
+
+static const float bdr_vsens_vect_def[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		0, 0, 0, 0, 1.625, 0, 0, 0, 0
+};
+
+static uint8_t tag_counter_old = 0x00;
+static float bdr_xl = 0.0;
+static float bdr_gy = 0.0;
+static float bdr_vsens = 0.0;
+static float bdr_xl_old = 0.0;
+static float bdr_gy_old = 0.0;
+static float bdr_max = 0.0;
+static uint32_t timestamp = 0;
+static uint32_t last_timestamp_xl = 0;
+static uint32_t last_timestamp_gy = 0;
+static uint8_t bdr_chg_xl_flag = 0;
+static uint8_t bdr_chg_gy_flag = 0;
+static int16_t last_data_xl[3] = {0};
+static int16_t last_data_gy[3] = {0};
+static float bdr_acc_vect[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		833, 1666, 3333, 6666, 1.625,
+		0, 0, 0, 0
+};
+
+static float bdr_gyr_vect[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		833, 1666, 3333, 6666, 0, 0,
+		0, 0, 0
+};
+
+static float bdr_vsens_vect[] = {
+		0, 13, 26, 52, 104, 208, 416,
+		0, 0, 0, 0, 1.625, 0, 0, 0, 0
+};
+
+st_fifo_status st_fifo_init(float bdr_xl_in,
+							float bdr_gy_in,
+							float bdr_vsens_in)
+{
+        if (bdr_xl_in < 0.0f || bdr_gy_in < 0.0f || bdr_vsens_in < 0.0f)
+                return ST_FIFO_ERR;
+
+        tag_counter_old = 0x00;
+        bdr_xl = bdr_xl_in;
+        bdr_gy = bdr_gy_in;
+        bdr_vsens = bdr_vsens_in;
+        bdr_xl_old = bdr_xl_in;
+        bdr_gy_old = bdr_gy_in;
+        bdr_max = MAX(bdr_xl, bdr_gy);
+        bdr_max = MAX(bdr_max, bdr_vsens);
+        timestamp = 0;
+        bdr_chg_xl_flag = 0;
+        bdr_chg_gy_flag = 0;
+        last_timestamp_xl = 0;
+        last_timestamp_gy = 0;
+
+        memcpy(bdr_acc_vect, bdr_acc_vect_def, sizeof(bdr_acc_vect_def));
+        memcpy(bdr_gyr_vect, bdr_gyr_vect_def, sizeof(bdr_gyr_vect_def));
+        memcpy(bdr_vsens_vect, bdr_vsens_vect_def, sizeof(bdr_vsens_vect_def));
+
+        for (uint8_t i = 0; i < 3; i++) {
+                last_data_xl[i] = 0;
+                last_data_gy[i] = 0;
+        }
+
+        return ST_FIFO_OK;
+}
+
+void st_fifo_rescale_bdr_array(float scale)
+{
+        for (uint8_t i = 0; i < 16; i++) {
+                bdr_acc_vect[i] *= scale;
+                bdr_gyr_vect[i] *= scale;
+                bdr_vsens_vect[i] *= scale;
+        }
+}
+
+st_fifo_status st_fifo_decode(st_fifo_out_slot *fifo_out_slot,
+							  st_fifo_raw_slot *fifo_raw_slot,
+							  uint16_t *out_slot_size,
+							  uint16_t stream_size)
+{
+        uint16_t j = 0;
+
+        for (uint16_t i = 0; i < stream_size; i++) {
+
+                uint8_t tag =
+                	(fifo_raw_slot[i].fifo_data_out[0] & TAG_SENSOR_MASK) >> TAG_SENSOR_SHIFT;
+                uint8_t tag_counter =
+                	(fifo_raw_slot[i].fifo_data_out[0] & TAG_COUNTER_MASK) >> TAG_COUNTER_SHIFT;
+
+                if (!has_even_parity(fifo_raw_slot[i].fifo_data_out[0]) || !is_tag_valid(tag))
+                        return ST_FIFO_ERR;
+
+                if ((tag_counter != (tag_counter_old)) && bdr_max != 0) {
+                        timestamp += (uint32_t)(TIMESTAMP_FREQ / bdr_max);
+                }
+
+                if (tag == TAG_ODRCHG) {
+
+                        uint8_t bdr_acc_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[6] & BDR_XL_MASK) >> BDR_XL_SHIFT;
+                        uint8_t bdr_gyr_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[6] & BDR_GY_MASK) >> BDR_GY_SHIFT;
+                        uint8_t bdr_vsens_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[3] & BDR_VSENS_MASK) >> BDR_VSENS_SHIFT;
+
+                        bdr_max = MAX(bdr_acc_vect[bdr_acc_cfg], bdr_gyr_vect[bdr_gyr_cfg]);
+                        bdr_max = MAX(bdr_max, bdr_vsens_vect[bdr_vsens_cfg]);
+
+                } else if (tag == TAG_TS) {
+
+                        memcpy(&timestamp, &fifo_raw_slot[i].fifo_data_out[1], 4);
+
+                } else {
+
+                        if (tag == TAG_STEP_COUNTER)
+                                memcpy(&fifo_out_slot[j].timestamp, &fifo_raw_slot[i].fifo_data_out[3], 4);
+                        else
+                                fifo_out_slot[j].timestamp = timestamp;
+
+                        fifo_out_slot[j].sensor_tag = get_sensor_type(tag);
+                        memcpy(fifo_out_slot[j].sensor_data.raw_data, &fifo_raw_slot[i].fifo_data_out[1], 6);
+                        j++;
+                        *out_slot_size = j;
+                }
+
+                tag_counter_old = tag_counter;
+        }
+
+        return ST_FIFO_OK;
+}
+
+st_fifo_status st_fifo_decompress(st_fifo_out_slot *fifo_out_slot,
+								  st_fifo_raw_slot *fifo_raw_slot,
+								  uint16_t *out_slot_size,
+								  uint16_t stream_size)
+{
+        uint16_t j = 0;
+
+        for (uint16_t i = 0; i < stream_size; i++) {
+
+                uint8_t tag =
+                	(fifo_raw_slot[i].fifo_data_out[0] & TAG_SENSOR_MASK) >> TAG_SENSOR_SHIFT;
+                uint8_t tag_counter =
+                	(fifo_raw_slot[i].fifo_data_out[0] & TAG_COUNTER_MASK) >> TAG_COUNTER_SHIFT;
+
+                if (!has_even_parity(fifo_raw_slot[i].fifo_data_out[0]) || !is_tag_valid(tag))
+                        continue;
+
+                if ((tag_counter != (tag_counter_old)) && bdr_max != 0) {
+
+                        uint8_t diff_tag_counter = 0;
+
+                        if (tag_counter < tag_counter_old)
+                                diff_tag_counter = tag_counter + 4 - tag_counter_old;
+                        else
+                                diff_tag_counter = tag_counter - tag_counter_old;
+
+                        timestamp += (uint32_t)(TIMESTAMP_FREQ / bdr_max) * diff_tag_counter;
+                }
+
+                if (tag == TAG_ODRCHG) {
+
+                        uint8_t bdr_acc_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[6] & BDR_XL_MASK) >> BDR_XL_SHIFT;
+                        uint8_t bdr_gyr_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[6] & BDR_GY_MASK) >> BDR_GY_SHIFT;
+                        uint8_t bdr_vsens_cfg =
+                        	(fifo_raw_slot[i].fifo_data_out[3] & BDR_VSENS_MASK) >> BDR_VSENS_SHIFT;
+
+                        bdr_xl_old = bdr_xl;
+                        bdr_gy_old = bdr_gy;
+
+                        bdr_xl = bdr_acc_vect[bdr_acc_cfg];
+                        bdr_gy = bdr_gyr_vect[bdr_gyr_cfg];
+                        bdr_vsens = bdr_vsens_vect[bdr_vsens_cfg];
+                        bdr_max = MAX(bdr_xl, bdr_gy);
+                        bdr_max = MAX(bdr_max, bdr_vsens);
+
+                        bdr_chg_xl_flag = 1;
+                        bdr_chg_gy_flag = 1;
+
+                } else if (tag == TAG_TS) {
+
+                        memcpy(&timestamp, &fifo_raw_slot[i].fifo_data_out[1], 4);
+
+                } else {
+
+                        st_fifo_compression_type compression_type = get_compression_type(tag);
+                        st_fifo_sensor_type sensor_type = get_sensor_type(tag);
+
+                        if (compression_type == ST_FIFO_COMPRESSION_NC) {
+
+                                if (tag == TAG_STEP_COUNTER)
+                                        memcpy(&fifo_out_slot[j].timestamp, &fifo_raw_slot[i].fifo_data_out[3], 4);
+                                else
+                                        fifo_out_slot[j].timestamp = timestamp;
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+                                memcpy(fifo_out_slot[j].sensor_data.raw_data, &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = timestamp;
+                                        bdr_chg_xl_flag = 0;
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = timestamp;
+                                        bdr_chg_gy_flag = 0;
+                                }
+
+                                j++;
+
+                        } else if (compression_type == ST_FIFO_COMPRESSION_NC_T_1) {
+
+                                fifo_out_slot[j].sensor_tag = get_sensor_type(tag);
+                                memcpy(fifo_out_slot[j].sensor_data.raw_data, &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        uint32_t last_timestamp;
+
+                                        if (bdr_chg_xl_flag)
+                                                last_timestamp = (uint32_t)(last_timestamp_xl + TIMESTAMP_FREQ / bdr_xl_old);
+                                        else
+                                                last_timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_xl);
+
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = last_timestamp;
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        uint32_t last_timestamp;
+
+                                        if (bdr_chg_gy_flag)
+                                                last_timestamp = (uint32_t)(last_timestamp_gy + TIMESTAMP_FREQ / bdr_gy_old);
+                                        else
+                                                last_timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_gy);
+
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = last_timestamp;
+                                }
+
+                                j++;
+
+                        } else if (compression_type == ST_FIFO_COMPRESSION_NC_T_2) {
+
+                                fifo_out_slot[j].sensor_tag = get_sensor_type(tag);
+                                memcpy(fifo_out_slot[j].sensor_data.raw_data, &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        uint32_t last_timestamp;
+
+                                        if (bdr_chg_xl_flag)
+                                                last_timestamp = (uint32_t)(last_timestamp_xl + TIMESTAMP_FREQ / bdr_xl_old);
+                                        else
+                                                last_timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_xl);
+
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = last_timestamp;
+                                }
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        uint32_t last_timestamp;
+
+                                        if (bdr_chg_gy_flag)
+                                                last_timestamp = (uint32_t)(last_timestamp_gy + TIMESTAMP_FREQ / bdr_gy_old);
+                                        else
+                                                last_timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_gy);
+
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = last_timestamp;
+                                }
+
+                                j++;
+
+                        } else if(compression_type == ST_FIFO_COMPRESSION_2X) {
+
+                                int16_t diff[6];
+                                get_diff_2x(diff, &fifo_raw_slot[i].fifo_data_out[1]);
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[0];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[1];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[2];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_xl);
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[0];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[1];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[2];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_gy);
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                j++;
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        uint32_t last_timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_xl);
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[3];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[4];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[5];
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = last_timestamp;
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        uint32_t last_timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_gy);
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[3];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[4];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[5];
+                                        fifo_out_slot[j].timestamp = last_timestamp;
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = last_timestamp;
+                                }
+
+                                j++;
+
+                        } else if (compression_type == ST_FIFO_COMPRESSION_3X) {
+
+                                int16_t diff[9];
+                                get_diff_3x(diff, &fifo_raw_slot[i].fifo_data_out[1]);
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[0];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[1];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[2];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_xl);
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[0];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[1];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[2];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - 2 * TIMESTAMP_FREQ / bdr_gy);
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                j++;
+
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[3];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[4];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[5];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_xl);
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[3];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[4];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[5];
+                                        fifo_out_slot[j].timestamp = (uint32_t)(timestamp - TIMESTAMP_FREQ / bdr_gy);
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                }
+
+                                j++;
+
+                                fifo_out_slot[j].timestamp = timestamp;
+                                fifo_out_slot[j].sensor_tag = sensor_type;
+
+                                if (sensor_type == ST_FIFO_ACCELEROMETER) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_xl[0] + diff[6];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_xl[1] + diff[7];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_xl[2] + diff[8];
+                                        memcpy(last_data_xl, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_xl = timestamp;
+                                }
+
+                                if (sensor_type == ST_FIFO_GYROSCOPE) {
+                                        fifo_out_slot[j].sensor_data.data[0] = last_data_gy[0] + diff[6];
+                                        fifo_out_slot[j].sensor_data.data[1] = last_data_gy[1] + diff[7];
+                                        fifo_out_slot[j].sensor_data.data[2] = last_data_gy[2] + diff[8];
+                                        memcpy(last_data_gy, fifo_out_slot[j].sensor_data.raw_data, 6);
+                                        last_timestamp_gy = timestamp;
+                                }
+
+                                j++;
+                        }
+
+                        *out_slot_size = j;
+                }
+
+                tag_counter_old = tag_counter;
+        }
+
+        return ST_FIFO_OK;
+}
+
+void st_fifo_sort(st_fifo_out_slot *fifo_out_slot, uint16_t out_slot_size)
+{
+        uint16_t i;
+        int32_t j;
+        st_fifo_out_slot temp;
+
+        for (i = 1; i < out_slot_size; i++) {
+
+                memcpy(&temp, &fifo_out_slot[i], sizeof(st_fifo_out_slot));
+
+                j = i - 1;
+
+                while (j >= 0 && fifo_out_slot[j].timestamp > temp.timestamp) {
+                        memcpy(&fifo_out_slot[j + 1], &fifo_out_slot[j], sizeof(st_fifo_out_slot));
+                        j--;
+                }
+
+                memcpy(&fifo_out_slot[j + 1], &temp, sizeof(st_fifo_out_slot));
+        }
+
+        return;
+}
+
+uint16_t  st_fifo_get_sensor_occurrence(st_fifo_out_slot *fifo_out_slot, uint16_t out_slot_size, st_fifo_sensor_type sensor_type)
+{
+        uint16_t occurrence = 0;
+
+        for (uint16_t i = 0; i < out_slot_size; i++) {
+                if (fifo_out_slot[i].sensor_tag == sensor_type)
+                        occurrence++;
+        }
+
+        return occurrence;
+}
+
+void st_fifo_extract_sensor(st_fifo_out_slot *sensor_out_slot,
+							st_fifo_out_slot *fifo_out_slot,
+							uint16_t  out_slot_size,
+							st_fifo_sensor_type sensor_type)
+{
+        uint16_t temp_i = 0;
+
+        for (uint16_t i = 0; i < out_slot_size; i++) {
+                if (fifo_out_slot[i].sensor_tag == sensor_type) {
+                        memcpy(&sensor_out_slot[temp_i], &fifo_out_slot[i], sizeof(st_fifo_out_slot));
+                        temp_i++;
+                }
+        }
+}
+
+static uint8_t is_tag_valid(uint8_t tag)
+{
+        if (tag > TAG_VALID_LIMIT)
+                return 0;
+        else
+                return 1;
+}
+
+static st_fifo_sensor_type get_sensor_type(uint8_t tag)
+{
+        switch (tag) {
+                case TAG_GY:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_XL:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_TEMP:
+                        return ST_FIFO_TEMPERATURE;
+                case TAG_EXT_SENS_0:
+                        return ST_FIFO_EXT_SENSOR0;
+                case TAG_EXT_SENS_1:
+                        return ST_FIFO_EXT_SENSOR1;
+                case TAG_EXT_SENS_2:
+                        return ST_FIFO_EXT_SENSOR2;
+                case TAG_EXT_SENS_3:
+                        return ST_FIFO_EXT_SENSOR3;
+                case TAG_STEP_COUNTER:
+                        return ST_FIFO_STEP_COUNTER;
+                case TAG_XL_UNCOMPRESSED_T_2:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_XL_UNCOMPRESSED_T_1:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_XL_COMPRESSED_2X:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_XL_COMPRESSED_3X:
+                        return ST_FIFO_ACCELEROMETER;
+                case TAG_GY_UNCOMPRESSED_T_2:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_GY_UNCOMPRESSED_T_1:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_GY_COMPRESSED_2X:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_GY_COMPRESSED_3X:
+                        return ST_FIFO_GYROSCOPE;
+                case TAG_GAME_RV:
+                        return ST_FIFO_6X_GAME_RV;
+                case TAG_GEOM_RV:
+                        return ST_FIFO_6X_GEOM_RV;
+                case TAG_NORM_RV:
+                        return ST_FIFO_9X_RV;
+                case TAG_GYRO_BIAS:
+                        return ST_FIFO_GYRO_BIAS;
+                case TAG_GRAVITIY:
+                        return ST_FIFO_GRAVITY;
+                case TAG_MAG_CAL:
+                        return ST_FIFO_MAGNETOMETER_CALIB;
+                case TAG_EXT_SENS_NACK:
+                        return ST_FIFO_EXT_SENSOR_NACK;
+                default:
+                        return ST_FIFO_NONE;
+        }
+}
+
+static st_fifo_compression_type get_compression_type(uint8_t tag)
+{
+        switch (tag) {
+                case TAG_GY:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_XL:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_TEMP:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_EXT_SENS_0:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_EXT_SENS_1:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_EXT_SENS_2:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_EXT_SENS_3:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_STEP_COUNTER:
+                        return ST_FIFO_COMPRESSION_NC;
+                case TAG_XL_UNCOMPRESSED_T_2:
+                        return ST_FIFO_COMPRESSION_NC_T_2;
+                case TAG_XL_UNCOMPRESSED_T_1:
+                        return ST_FIFO_COMPRESSION_NC_T_1;
+                case TAG_XL_COMPRESSED_2X:
+                        return ST_FIFO_COMPRESSION_2X;
+                case TAG_XL_COMPRESSED_3X:
+                        return ST_FIFO_COMPRESSION_3X;
+                case TAG_GY_UNCOMPRESSED_T_2:
+                        return ST_FIFO_COMPRESSION_NC_T_2;
+                case TAG_GY_UNCOMPRESSED_T_1:
+                        return ST_FIFO_COMPRESSION_NC_T_1;
+                case TAG_GY_COMPRESSED_2X:
+                        return ST_FIFO_COMPRESSION_2X;
+                case TAG_GY_COMPRESSED_3X:
+                        return ST_FIFO_COMPRESSION_3X;
+                default:
+                        return ST_FIFO_COMPRESSION_NC;
+        }
+}
+
+static uint8_t has_even_parity(uint8_t x)
+{
+    uint8_t count = 0x00, i, b = 0x01;
+
+    for (i = 0; i < 8; i++) {
+        if(x & (b << i))
+                        count++;
+    }
+
+    if (count & 0x01)
+                return 0;
+
+    return 1;
+}
+
+static void get_diff_2x(int16_t diff[6], uint8_t input[6])
+{
+        for (uint8_t i = 0; i < 6; i++)
+                diff[i] = input[i] < 128 ? input[i] : (input[i] - 256);
+}
+
+
+static void get_diff_3x(int16_t diff[9], uint8_t input[6])
+{
+        uint16_t decode_temp;
+
+        for (uint8_t i = 0; i < 3; i++) {
+
+                memcpy(&decode_temp, &input[2 * i], 2);
+
+                for (uint8_t j = 0; j < 3; j++) {
+                        int16_t temp = (decode_temp & (0x001F << (5 * j))) >> (5 * j);
+                        diff[j + 3 * i] = temp < 16 ? temp : (temp - 32);
+                }
+        }
+}
+

--- a/sensor/stmemsc/lsm6dsox_STdC/lib/fifo_utility/fifo_utility.h
+++ b/sensor/stmemsc/lsm6dsox_STdC/lib/fifo_utility/fifo_utility.h
@@ -1,0 +1,109 @@
+/*
+ ******************************************************************************
+ * @file    fifo_utility.h
+ * @author  Sensor Solutions Software Team
+ * @brief   This file contains all the functions prototypes for the
+ *          fifo_utility.c.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _ST_FIFO_H_
+#define _ST_FIFO_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+typedef enum {
+        ST_FIFO_OK,
+        ST_FIFO_ERR
+} st_fifo_status;
+
+typedef enum {
+        ST_FIFO_GYROSCOPE,
+        ST_FIFO_ACCELEROMETER,
+        ST_FIFO_TEMPERATURE,
+        ST_FIFO_EXT_SENSOR0,
+        ST_FIFO_EXT_SENSOR1,
+        ST_FIFO_EXT_SENSOR2,
+        ST_FIFO_EXT_SENSOR3,
+        ST_FIFO_STEP_COUNTER,
+        ST_FIFO_6X_GAME_RV,
+        ST_FIFO_6X_GEOM_RV,
+        ST_FIFO_9X_RV,
+        ST_FIFO_GYRO_BIAS,
+        ST_FIFO_GRAVITY,
+        ST_FIFO_MAGNETOMETER_CALIB,
+        ST_FIFO_EXT_SENSOR_NACK,
+        ST_FIFO_NONE
+} st_fifo_sensor_type;
+
+typedef struct {
+        uint8_t fifo_data_out[7]; /* registers from mems (78h -> 7Dh) */
+} st_fifo_raw_slot;
+
+typedef struct {
+        uint32_t timestamp;
+        st_fifo_sensor_type sensor_tag;
+        union {
+                uint8_t raw_data[6]; 	/* bytes */
+                int16_t data[3]; 		/* 3 axes mems */
+                int16_t temp; 			/* temperature sensor */
+                uint16_t steps; 		/* step counter */
+                uint16_t quat[3]; 		/* quaternion 3 axes format [x,y,z] */
+                uint8_t nack; 			/* ext sensor nack index */
+        } sensor_data;
+} st_fifo_out_slot;
+
+st_fifo_status st_fifo_init(float bdr_xl, float bdr_gy, float bdr_vsens);
+void st_fifo_rescale_bdr_array(float scale);
+st_fifo_status st_fifo_decode(st_fifo_out_slot *fifo_out_slot,
+							  st_fifo_raw_slot *fifo_raw_slot,
+							  uint16_t *out_slot_size,
+							  uint16_t stream_size);
+st_fifo_status st_fifo_decompress(st_fifo_out_slot *fifo_out_slot,
+								  st_fifo_raw_slot *fifo_raw_slot,
+								  uint16_t *out_slot_size,
+								  uint16_t stream_size);
+void st_fifo_sort(st_fifo_out_slot *fifo_out_slot, uint16_t out_slot_size);
+uint16_t st_fifo_get_sensor_occurrence(st_fifo_out_slot *fifo_out_slot,
+									   uint16_t out_slot_size,
+									   st_fifo_sensor_type sensor_type);
+void st_fifo_extract_sensor(st_fifo_out_slot *sensor_out_slot,
+							st_fifo_out_slot *fifo_out_slot,
+							uint16_t out_slot_size,
+							st_fifo_sensor_type sensor_type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ST_FIFO_H_ */

--- a/sensor/stmemsc/lsm9ds1_STdC/driver/lsm9ds1_reg.c
+++ b/sensor/stmemsc/lsm9ds1_STdC/driver/lsm9ds1_reg.c
@@ -1,0 +1,4092 @@
+/*
+ ******************************************************************************
+ * @file    lsm9ds1_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LSM9DS1 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "lsm9ds1_reg.h"
+
+/**
+  * @defgroup    LSM9DS1
+  * @brief       This file provides a set of functions needed to drive the
+  *              lsm9ds1 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LSM9DS1_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm9ds1_read_reg(lsm9ds1_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm9ds1_write_reg(lsm9ds1_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM9DS1_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lsm9ds1_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.061f);
+}
+
+float_t lsm9ds1_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.122f);
+}
+
+float_t lsm9ds1_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.244f);
+}
+
+float_t lsm9ds1_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.732f);
+}
+
+float_t lsm9ds1_from_fs245dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb *8.75f);
+}
+
+float_t lsm9ds1_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb *17.50f);
+}
+
+float_t lsm9ds1_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb *70.0f);
+}
+
+float_t lsm9ds1_from_fs4gauss_to_mG(int16_t lsb)
+{
+  return ((float_t)lsb *0.14f);
+}
+
+float_t lsm9ds1_from_fs8gauss_to_mG(int16_t lsb)
+{
+  return ((float_t)lsb *0.29f);
+}
+
+float_t lsm9ds1_from_fs12gauss_to_mG(int16_t lsb)
+{
+  return ((float_t)lsb *0.43f);
+}
+
+float_t lsm9ds1_from_fs16gauss_to_mG(int16_t lsb)
+{
+  return ((float_t)lsb *0.58f);
+}
+
+float_t lsm9ds1_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 16.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM9DS1_Data_generation
+  * @brief      This section groups all the functions concerning data
+  *             generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Gyroscope full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fs_g" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t val)
+{
+  lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_G, (uint8_t*)&ctrl_reg1_g, 1);
+  if(ret == 0){
+    ctrl_reg1_g.fs_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG1_G,
+                            (uint8_t*)&ctrl_reg1_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_g in reg CTRL_REG1_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t *val)
+{
+  lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_G, (uint8_t*)&ctrl_reg1_g, 1);
+  switch (ctrl_reg1_g.fs_g){
+    case LSM9DS1_245dps:
+      *val = LSM9DS1_245dps;
+      break;
+    case LSM9DS1_500dps:
+      *val = LSM9DS1_500dps;
+      break;
+    case LSM9DS1_2000dps:
+      *val = LSM9DS1_2000dps;
+      break;
+    default:
+      *val = LSM9DS1_245dps;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data rate selection when both the accelerometer and gyroscope
+  *         are activated.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "odr_g" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_imu_data_rate_set(lsm9ds1_ctx_t *ctx, lsm9ds1_imu_odr_t val)
+{
+  lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
+  lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
+  lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_G, (uint8_t*)&ctrl_reg1_g, 1);
+  if(ret == 0){
+    ctrl_reg1_g.odr_g = (uint8_t)val & 0x07U;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG1_G,
+                            (uint8_t*)&ctrl_reg1_g, 1);
+  }
+  if(ret == 0){
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                         (uint8_t*)&ctrl_reg6_xl, 1);
+  }
+  if(ret == 0){
+    ctrl_reg6_xl.odr_xl = (((uint8_t)val & 0x70U) >> 4);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                            (uint8_t*)&ctrl_reg6_xl, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                           (uint8_t*)&ctrl_reg3_g, 1);
+  }
+  if(ret == 0){
+    ctrl_reg3_g.lp_mode = (((uint8_t)val & 0x80U) >> 7);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                            (uint8_t*)&ctrl_reg3_g, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data rate selection when both the accelerometer and gyroscope
+  *         are activated.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_g in reg CTRL_REG1_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_imu_data_rate_get(lsm9ds1_ctx_t *ctx, lsm9ds1_imu_odr_t *val)
+{
+  lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
+  lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
+  lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_G, (uint8_t*)&ctrl_reg1_g, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                           (uint8_t*)&ctrl_reg6_xl, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                           (uint8_t*)&ctrl_reg3_g, 1);
+  }
+  switch ((ctrl_reg3_g.lp_mode << 7) | (ctrl_reg6_xl.odr_xl << 4) |
+          ctrl_reg1_g.odr_g){
+    case LSM9DS1_IMU_OFF:
+      *val = LSM9DS1_IMU_OFF;
+      break;
+    case LSM9DS1_GY_OFF_XL_10Hz:
+      *val = LSM9DS1_GY_OFF_XL_10Hz;
+      break;
+    case LSM9DS1_GY_OFF_XL_50Hz:
+      *val = LSM9DS1_GY_OFF_XL_50Hz;
+      break;
+    case LSM9DS1_GY_OFF_XL_119Hz:
+      *val = LSM9DS1_GY_OFF_XL_119Hz;
+      break;
+    case LSM9DS1_GY_OFF_XL_238Hz:
+      *val = LSM9DS1_GY_OFF_XL_238Hz;
+      break;
+    case LSM9DS1_GY_OFF_XL_476Hz:
+      *val = LSM9DS1_GY_OFF_XL_476Hz;
+      break;
+    case LSM9DS1_GY_OFF_XL_952Hz:
+      *val = LSM9DS1_GY_OFF_XL_952Hz;
+      break;
+    case LSM9DS1_XL_OFF_GY_14Hz9:
+      *val = LSM9DS1_XL_OFF_GY_14Hz9;
+      break;
+    case LSM9DS1_XL_OFF_GY_59Hz5:
+      *val = LSM9DS1_XL_OFF_GY_59Hz5;
+      break;
+    case LSM9DS1_XL_OFF_GY_119Hz:
+      *val = LSM9DS1_XL_OFF_GY_119Hz;
+      break;
+    case LSM9DS1_XL_OFF_GY_238Hz:
+      *val = LSM9DS1_XL_OFF_GY_238Hz;
+      break;
+    case LSM9DS1_XL_OFF_GY_476Hz:
+      *val = LSM9DS1_XL_OFF_GY_476Hz;
+      break;
+    case LSM9DS1_XL_OFF_GY_952Hz:
+      *val = LSM9DS1_XL_OFF_GY_952Hz;
+      break;
+    case LSM9DS1_IMU_14Hz9:
+      *val = LSM9DS1_IMU_14Hz9;
+      break;
+    case LSM9DS1_IMU_59Hz5:
+      *val = LSM9DS1_IMU_59Hz5;
+      break;
+    case LSM9DS1_IMU_119Hz:
+      *val = LSM9DS1_IMU_119Hz;
+      break;
+    case LSM9DS1_IMU_238Hz:
+      *val = LSM9DS1_IMU_238Hz;
+      break;
+    case LSM9DS1_IMU_476Hz:
+      *val = LSM9DS1_IMU_476Hz;
+      break;
+    case LSM9DS1_IMU_952Hz:
+      *val = LSM9DS1_IMU_952Hz;
+      break;
+    case LSM9DS1_XL_OFF_GY_14Hz9_LP:
+      *val = LSM9DS1_XL_OFF_GY_14Hz9_LP;
+      break;
+    case LSM9DS1_XL_OFF_GY_59Hz5_LP:
+      *val = LSM9DS1_XL_OFF_GY_59Hz5_LP;
+      break;
+    case LSM9DS1_XL_OFF_GY_119Hz_LP:
+      *val = LSM9DS1_XL_OFF_GY_119Hz_LP;
+      break;
+    case LSM9DS1_IMU_14Hz9_LP:
+      *val = LSM9DS1_IMU_14Hz9_LP;
+      break;
+    case LSM9DS1_IMU_59Hz5_LP:
+      *val = LSM9DS1_IMU_59Hz5_LP;
+      break;
+    case LSM9DS1_IMU_119Hz_LP:
+      *val = LSM9DS1_IMU_119Hz_LP;
+      break;
+    default:
+      *val = LSM9DS1_IMU_OFF;
+    break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Configure gyro orientation.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Directional user orientation selection.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_orient_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t val)
+{
+  lsm9ds1_orient_cfg_g_t orient_cfg_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_ORIENT_CFG_G,
+                         (uint8_t*)&orient_cfg_g, 1);
+  if(ret == 0) {
+    orient_cfg_g.orient   = val.orient;
+    orient_cfg_g.signx_g  = val.signx_g;
+    orient_cfg_g.signy_g  = val.signy_g;
+    orient_cfg_g.signz_g  = val.signz_g;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_ORIENT_CFG_G, (uint8_t*)&orient_cfg_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Configure gyro orientation.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Directional user orientation selection.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_orient_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t *val)
+{
+  lsm9ds1_orient_cfg_g_t orient_cfg_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_ORIENT_CFG_G,
+                         (uint8_t*)&orient_cfg_g, 1);
+  val->orient = orient_cfg_g.orient;
+  val->signz_g = orient_cfg_g.signz_g;
+  val->signy_g = orient_cfg_g.signy_g;
+  val->signx_g = orient_cfg_g.signx_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "xlda" in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "gda" in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "tda" in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_temp_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable gyroscope axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Gyroscope’s pitch axis (X) output enable.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t val)
+{
+  lsm9ds1_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0) {
+    ctrl_reg4.xen_g = val.xen_g;
+    ctrl_reg4.yen_g = val.yen_g;
+    ctrl_reg4.zen_g = val.zen_g;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable gyroscope axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Gyroscope’s pitch axis (X) output enable.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t *val)
+{
+  lsm9ds1_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  val->xen_g = ctrl_reg4.xen_g;
+  val->yen_g = ctrl_reg4.yen_g;
+  val->zen_g = ctrl_reg4.zen_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable accelerometer axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer’s X-axis output enable.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t val)
+{
+  lsm9ds1_ctrl_reg5_xl_t ctrl_reg5_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG5_XL,
+                         (uint8_t*)&ctrl_reg5_xl, 1);
+  if(ret == 0) {
+    ctrl_reg5_xl.xen_xl = val.xen_xl;
+    ctrl_reg5_xl.yen_xl = val.yen_xl;
+    ctrl_reg5_xl.zen_xl = val.zen_xl;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG5_XL, (uint8_t*)&ctrl_reg5_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable accelerometer axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer’s X-axis output enable.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t *val)
+{
+  lsm9ds1_ctrl_reg5_xl_t ctrl_reg5_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG5_XL,
+                         (uint8_t*)&ctrl_reg5_xl, 1);
+  val->xen_xl = ctrl_reg5_xl.xen_xl;
+  val->yen_xl = ctrl_reg5_xl.yen_xl;
+  val->zen_xl = ctrl_reg5_xl.zen_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of acceleration data on OUT REG and FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dec" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_decimation_set(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t val)
+{
+  lsm9ds1_ctrl_reg5_xl_t ctrl_reg5_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG5_XL,
+                         (uint8_t*)&ctrl_reg5_xl, 1);
+  if(ret == 0){
+    ctrl_reg5_xl.dec = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG5_XL,
+                            (uint8_t*)&ctrl_reg5_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of acceleration data on OUT REG and FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dec in reg CTRL_REG5_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_decimation_get(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t *val)
+{
+  lsm9ds1_ctrl_reg5_xl_t ctrl_reg5_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG5_XL,
+                         (uint8_t*)&ctrl_reg5_xl, 1);
+  switch (ctrl_reg5_xl.dec){
+    case LSM9DS1_NO_DECIMATION:
+      *val = LSM9DS1_NO_DECIMATION;
+      break;
+    case LSM9DS1_EVERY_2_SAMPLES:
+      *val = LSM9DS1_EVERY_2_SAMPLES;
+      break;
+    case LSM9DS1_EVERY_4_SAMPLES:
+      *val = LSM9DS1_EVERY_4_SAMPLES;
+      break;
+    case LSM9DS1_EVERY_8_SAMPLES:
+      *val = LSM9DS1_EVERY_8_SAMPLES;
+      break;
+    default:
+      *val = LSM9DS1_NO_DECIMATION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fs_xl" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t val)
+{
+  lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                         (uint8_t*)&ctrl_reg6_xl, 1);
+  if(ret == 0){
+    ctrl_reg6_xl.fs_xl = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                            (uint8_t*)&ctrl_reg6_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_xl in reg CTRL_REG6_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t *val)
+{
+  lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                         (uint8_t*)&ctrl_reg6_xl, 1);
+  switch (ctrl_reg6_xl.fs_xl){
+    case LSM9DS1_2g:
+      *val = LSM9DS1_2g;
+      break;
+    case LSM9DS1_16g:
+      *val = LSM9DS1_16g;
+      break;
+    case LSM9DS1_4g:
+      *val = LSM9DS1_4g;
+      break;
+    case LSM9DS1_8g:
+      *val = LSM9DS1_8g;
+      break;
+    default:
+      *val = LSM9DS1_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[set]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Change the values of bdu in reg CTRL_REG8.
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_block_data_update_set(lsm9ds1_ctx_t *ctx_mag,
+                                      lsm9ds1_ctx_t *ctx_imu, uint8_t val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  lsm9ds1_ctrl_reg5_m_t ctrl_reg5_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ctrl_reg8.bdu = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG5_M,
+                           (uint8_t*)&ctrl_reg5_m, 1);
+  }
+  if(ret == 0){
+    ctrl_reg5_m.fast_read = (uint8_t)(~val);
+    ctrl_reg5_m.bdu = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_CTRL_REG5_M,
+                            (uint8_t*)&ctrl_reg5_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Get the values of bdu in reg CTRL_REG8.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_block_data_update_get(lsm9ds1_ctx_t *ctx_mag,
+                                      lsm9ds1_ctx_t *ctx_imu, uint8_t *val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  lsm9ds1_ctrl_reg5_m_t ctrl_reg5_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG5_M, (uint8_t*)&ctrl_reg5_m, 1);
+    *val = (uint8_t)(ctrl_reg5_m.bdu & ctrl_reg8.bdu);
+  }
+  return ret;
+}
+
+/**
+  * @brief  This register is a 16-bit register and represents the X offset
+  *         used to compensate environmental effects (data is expressed as
+  *         two’s complement).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data to be write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_offset_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_write_reg(ctx, LSM9DS1_OFFSET_X_REG_L_M, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  This register is a 16-bit register and represents the X offset
+  *         used to compensate environmental effects (data is expressed as
+  *         two’s complement).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_offset_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_OFFSET_X_REG_L_M, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fast_odr" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_data_rate_set(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_mag_data_rate_t val)
+{
+  lsm9ds1_ctrl_reg1_m_t ctrl_reg1_m;
+  lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
+  lsm9ds1_ctrl_reg4_m_t ctrl_reg4_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_M, (uint8_t*)&ctrl_reg1_m, 1);
+  if(ret == 0){
+    ctrl_reg1_m.fast_odr = (((uint8_t)val & 0x08U) >> 3);
+    ctrl_reg1_m._do = ((uint8_t)val & 0x07U);
+    ctrl_reg1_m.om = (((uint8_t)val & 0x30U) >> 4);
+    ctrl_reg1_m.temp_comp = PROPERTY_ENABLE;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG1_M,
+                            (uint8_t*)&ctrl_reg1_m, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_M,
+                           (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  if(ret == 0){
+    ctrl_reg3_m.md = (((uint8_t)val & 0xC0U) >> 6);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG3_M,
+                            (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG4_M, (uint8_t*)&ctrl_reg4_m, 1);
+  }
+  if(ret == 0){
+    ctrl_reg4_m.omz = (((uint8_t)val & 0x30U) >> 4);;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG4_M,
+                            (uint8_t*)&ctrl_reg4_m, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fast_odr in reg CTRL_REG1_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_data_rate_get(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_mag_data_rate_t *val)
+{
+  lsm9ds1_ctrl_reg1_m_t ctrl_reg1_m;
+  lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_M, (uint8_t*)&ctrl_reg1_m, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_M, (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  switch ((ctrl_reg3_m.md << 6) | (ctrl_reg1_m.om << 4) |
+          (ctrl_reg1_m.fast_odr << 3) | ctrl_reg1_m._do){
+    case LSM9DS1_MAG_POWER_DOWN:
+      *val = LSM9DS1_MAG_POWER_DOWN;
+      break;
+    case LSM9DS1_MAG_LP_0Hz625:
+      *val = LSM9DS1_MAG_LP_0Hz625;
+      break;
+    case LSM9DS1_MAG_LP_1Hz25:
+      *val = LSM9DS1_MAG_LP_1Hz25;
+      break;
+    case LSM9DS1_MAG_LP_2Hz5:
+      *val = LSM9DS1_MAG_LP_2Hz5;
+      break;
+    case LSM9DS1_MAG_LP_5Hz:
+      *val = LSM9DS1_MAG_LP_5Hz;
+      break;
+    case LSM9DS1_MAG_LP_10Hz:
+      *val = LSM9DS1_MAG_LP_10Hz;
+      break;
+    case LSM9DS1_MAG_LP_20Hz:
+      *val = LSM9DS1_MAG_LP_20Hz;
+      break;
+    case LSM9DS1_MAG_LP_40Hz:
+      *val = LSM9DS1_MAG_LP_40Hz;
+      break;
+    case LSM9DS1_MAG_LP_80Hz:
+      *val = LSM9DS1_MAG_LP_80Hz;
+      break;
+    case LSM9DS1_MAG_MP_0Hz625:
+      *val = LSM9DS1_MAG_MP_0Hz625;
+      break;
+    case LSM9DS1_MAG_MP_1Hz25:
+      *val = LSM9DS1_MAG_MP_1Hz25;
+      break;
+    case LSM9DS1_MAG_MP_2Hz5:
+      *val = LSM9DS1_MAG_MP_2Hz5;
+      break;
+    case LSM9DS1_MAG_MP_5Hz:
+      *val = LSM9DS1_MAG_MP_5Hz;
+      break;
+    case LSM9DS1_MAG_MP_10Hz:
+      *val = LSM9DS1_MAG_MP_10Hz;
+      break;
+    case LSM9DS1_MAG_MP_20Hz:
+      *val = LSM9DS1_MAG_MP_20Hz;
+      break;
+    case LSM9DS1_MAG_MP_40Hz:
+      *val = LSM9DS1_MAG_MP_40Hz;
+      break;
+    case LSM9DS1_MAG_MP_80Hz:
+      *val = LSM9DS1_MAG_MP_80Hz;
+      break;
+    case LSM9DS1_MAG_HP_0Hz625:
+      *val = LSM9DS1_MAG_HP_0Hz625;
+      break;
+    case LSM9DS1_MAG_HP_1Hz25:
+      *val = LSM9DS1_MAG_HP_1Hz25;
+      break;
+    case LSM9DS1_MAG_HP_2Hz5:
+      *val = LSM9DS1_MAG_HP_2Hz5;
+      break;
+    case LSM9DS1_MAG_HP_5Hz:
+      *val = LSM9DS1_MAG_HP_5Hz;
+      break;
+    case LSM9DS1_MAG_HP_10Hz:
+      *val = LSM9DS1_MAG_HP_10Hz;
+      break;
+    case LSM9DS1_MAG_HP_20Hz:
+      *val = LSM9DS1_MAG_HP_20Hz;
+      break;
+    case LSM9DS1_MAG_HP_40Hz:
+      *val = LSM9DS1_MAG_HP_40Hz;
+      break;
+    case LSM9DS1_MAG_HP_80Hz:
+      *val = LSM9DS1_MAG_HP_80Hz;
+      break;
+    case LSM9DS1_MAG_UHP_0Hz625:
+      *val = LSM9DS1_MAG_UHP_0Hz625;
+      break;
+    case LSM9DS1_MAG_UHP_1Hz25:
+      *val = LSM9DS1_MAG_UHP_1Hz25;
+      break;
+    case LSM9DS1_MAG_UHP_2Hz5:
+      *val = LSM9DS1_MAG_UHP_2Hz5;
+      break;
+    case LSM9DS1_MAG_UHP_5Hz:
+      *val = LSM9DS1_MAG_UHP_5Hz;
+      break;
+    case LSM9DS1_MAG_UHP_10Hz:
+      *val = LSM9DS1_MAG_UHP_10Hz;
+      break;
+    case LSM9DS1_MAG_UHP_20Hz:
+      *val = LSM9DS1_MAG_UHP_20Hz;
+      break;
+    case LSM9DS1_MAG_UHP_40Hz:
+      *val = LSM9DS1_MAG_UHP_40Hz;
+      break;
+    case LSM9DS1_MAG_UHP_80Hz:
+      *val = LSM9DS1_MAG_UHP_80Hz;
+      break;
+    case LSM9DS1_MAG_UHP_155Hz:
+      *val = LSM9DS1_MAG_UHP_155Hz;
+      break;
+    case LSM9DS1_MAG_HP_300Hz:
+      *val = LSM9DS1_MAG_HP_300Hz;
+      break;
+    case LSM9DS1_MAG_MP_560Hz:
+      *val = LSM9DS1_MAG_MP_560Hz;
+      break;
+    case LSM9DS1_MAG_LP_1000Hz:
+      *val = LSM9DS1_MAG_LP_1000Hz;
+      break;
+    case LSM9DS1_MAG_ONE_SHOT:
+      *val = LSM9DS1_MAG_ONE_SHOT;
+      break;
+    default:
+      *val = LSM9DS1_MAG_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer full Scale Selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fs" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_mag_fs_t val)
+{
+  lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG2_M, (uint8_t*)&ctrl_reg2_m, 1);
+  if(ret == 0){
+    ctrl_reg2_m.fs = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG2_M,
+                            (uint8_t*)&ctrl_reg2_m, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer full scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs in reg CTRL_REG2_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_mag_fs_t *val)
+{
+  lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG2_M, (uint8_t*)&ctrl_reg2_m, 1);
+  switch (ctrl_reg2_m.fs){
+    case LSM9DS1_4Ga:
+      *val = LSM9DS1_4Ga;
+      break;
+    case LSM9DS1_8Ga:
+      *val = LSM9DS1_8Ga;
+      break;
+    case LSM9DS1_12Ga:
+      *val = LSM9DS1_12Ga;
+      break;
+    case LSM9DS1_16Ga:
+      *val = LSM9DS1_16Ga;
+      break;
+    default:
+      *val = LSM9DS1_4Ga;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  New data available from magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "zyxda" in reg STATUS_REG_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_status_reg_m_t status_reg_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_STATUS_REG_M,
+                         (uint8_t*)&status_reg_m, 1);
+  *val = status_reg_m.zyxda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup     LSM9DS1_Dataoutput
+  * @brief        This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data output register (r). L and H registers
+  *         together express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_temperature_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_angular_rate_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_OUT_X_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as
+  *         a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_acceleration_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_OUT_X_L_XL, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Magnetic sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_magnetic_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_OUT_X_L_M, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Internal measurement range overflow on magnetic value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "mroi" in reg INT_SRC_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_magnetic_overflow_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_int_src_m_t int_src_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_SRC_M, (uint8_t*)&int_src_m, 1);
+  *val = int_src_m.mroi;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM9DS1_Common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  buff      Buffer that stores the data read.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_dev_id_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                           lsm9ds1_id_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_WHO_AM_I,
+                         (uint8_t*)&(buff->imu), 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_WHO_AM_I_M,
+                           (uint8_t*)&(buff->mag), 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Device status register.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Device status registers.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_dev_status_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                               lsm9ds1_status_t *val)
+{
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_STATUS_REG,
+                         (uint8_t*)&(val->status_imu), 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_STATUS_REG_M,
+                           (uint8_t*)&(val->status_mag), 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL_REG8.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_dev_reset_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                              uint8_t val)
+{
+  lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ctrl_reg8.sw_reset = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_CTRL_REG8,
+                            (uint8_t*)&ctrl_reg8, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG2_M,
+                           (uint8_t*)&ctrl_reg2_m, 1);
+  }
+  if(ret == 0){
+    ctrl_reg2_m.soft_rst = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_CTRL_REG2_M,
+                            (uint8_t*)&ctrl_reg2_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Get the values of sw_reset in reg CTRL_REG8.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_dev_reset_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                              uint8_t *val)
+{
+  lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG2_M,
+                           (uint8_t*)&ctrl_reg2_m, 1);
+    *val = (uint8_t)(ctrl_reg2_m.soft_rst & ctrl_reg8.sw_reset);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Change the values of "ble" in reg LSM9DS1.
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_dev_data_format_set(lsm9ds1_ctx_t *ctx_mag,
+                                    lsm9ds1_ctx_t *ctx_imu,
+                                    lsm9ds1_ble_t val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  lsm9ds1_ctrl_reg4_m_t ctrl_reg4_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8,
+                         (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ctrl_reg8.ble = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_CTRL_REG8,
+                            (uint8_t*)&ctrl_reg8, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG4_M,
+                           (uint8_t*)&ctrl_reg4_m, 1);
+  }
+  if(ret == 0){
+    ctrl_reg4_m.ble = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_CTRL_REG4_M,
+                            (uint8_t*)&ctrl_reg4_m, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Get the values of ble in reg CTRL_REG8.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_dev_data_format_get(lsm9ds1_ctx_t *ctx_mag,
+                                    lsm9ds1_ctx_t *ctx_imu,
+                                    lsm9ds1_ble_t *val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  lsm9ds1_ctrl_reg4_m_t ctrl_reg4_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG4_M,
+                           (uint8_t*)&ctrl_reg4_m, 1);
+  }
+  switch (ctrl_reg8.ble & ctrl_reg4_m.ble){
+    case LSM9DS1_LSB_LOW_ADDRESS:
+      *val = LSM9DS1_LSB_LOW_ADDRESS;
+      break;
+    case LSM9DS1_MSB_LOW_ADDRESS:
+      *val = LSM9DS1_MSB_LOW_ADDRESS;
+      break;
+    default:
+      *val = LSM9DS1_LSB_LOW_ADDRESS;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Change the values of boot in reg CTRL_REG8.
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_dev_boot_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                             uint8_t val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8,
+                         (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ctrl_reg8.boot = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_CTRL_REG8,
+                            (uint8_t*)&ctrl_reg8, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG2_M,
+                           (uint8_t*)&ctrl_reg2_m, 1);
+  }
+  if(ret == 0){
+    ctrl_reg2_m.reboot = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_CTRL_REG2_M,
+                            (uint8_t*)&ctrl_reg2_m, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Get the values of boot in reg CTRL_REG8.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_dev_boot_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                             uint8_t *val)
+{
+  lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+  ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG2_M,
+                         (uint8_t*)&ctrl_reg2_m, 1);
+    *val = (uint8_t)ctrl_reg2_m.reboot & ctrl_reg8.boot;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM9DS1_Filters
+  * @brief       This section group all the functions concerning the
+                 filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Reference value for gyroscope’s digital high-pass filter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data to be write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_reference_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_write_reg(ctx, LSM9DS1_REFERENCE_G, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for gyroscope’s digital high-pass filter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_reference_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_REFERENCE_G, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope lowpass filter bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "bw_g" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_gy_lp_bw_t val)
+{
+  lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_G, (uint8_t*)&ctrl_reg1_g, 1);
+  if(ret == 0){
+    ctrl_reg1_g.bw_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG1_G,
+                            (uint8_t*)&ctrl_reg1_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope lowpass filter bandwidth selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bw_g in reg CTRL_REG1_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_gy_lp_bw_t *val)
+{
+  lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_G, (uint8_t*)&ctrl_reg1_g, 1);
+  switch (ctrl_reg1_g.bw_g){
+    case LSM9DS1_LP_STRONG:
+      *val = LSM9DS1_LP_STRONG;
+      break;
+    case LSM9DS1_LP_MEDIUM:
+      *val = LSM9DS1_LP_MEDIUM;
+      break;
+    case LSM9DS1_LP_LIGHT:
+      *val = LSM9DS1_LP_LIGHT;
+      break;
+    case LSM9DS1_LP_ULTRA_LIGHT:
+      *val = LSM9DS1_LP_ULTRA_LIGHT;
+      break;
+    default:
+      *val = LSM9DS1_LP_STRONG;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyro output filter path configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "out_sel" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_out_path_set(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_gy_out_path_t val)
+{
+  lsm9ds1_ctrl_reg2_g_t ctrl_reg2_g;
+  lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG2_G,
+                         (uint8_t*)&ctrl_reg2_g, 1);
+  if(ret == 0){
+    ctrl_reg2_g.out_sel = ((uint8_t)val & 0x03U);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG2_G,
+                            (uint8_t*)&ctrl_reg2_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                           (uint8_t*)&ctrl_reg3_g, 1);
+  }
+  if(ret == 0){
+    ctrl_reg3_g.hp_en = (((uint8_t)val & 0x10U) >> 4 );
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                            (uint8_t*)&ctrl_reg3_g, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyro output filter path configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of out_sel in reg CTRL_REG2_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_out_path_get(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_gy_out_path_t *val)
+{
+  lsm9ds1_ctrl_reg2_g_t ctrl_reg2_g;
+  lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG2_G,
+                         (uint8_t*)&ctrl_reg2_g, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                           (uint8_t*)&ctrl_reg3_g, 1);
+  }
+  switch ( (ctrl_reg3_g.hp_en << 4) | ctrl_reg2_g.out_sel){
+    case LSM9DS1_LPF1_OUT:
+      *val = LSM9DS1_LPF1_OUT;
+      break;
+    case LSM9DS1_LPF1_HPF_OUT:
+      *val = LSM9DS1_LPF1_HPF_OUT;
+      break;
+    case LSM9DS1_LPF1_LPF2_OUT:
+      *val = LSM9DS1_LPF1_LPF2_OUT;
+      break;
+    case LSM9DS1_LPF1_HPF_LPF2_OUT:
+      *val = LSM9DS1_LPF1_HPF_LPF2_OUT;
+      break;
+    default:
+      *val = LSM9DS1_LPF1_OUT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyro interrupt filter path configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "int_sel" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_int_path_set(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_gy_int_path_t val)
+{
+  lsm9ds1_ctrl_reg2_g_t ctrl_reg2_g;
+  lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG2_G,
+                         (uint8_t*)&ctrl_reg2_g, 1);
+  if(ret == 0){
+    ctrl_reg2_g.int_sel = ((uint8_t)val & 0x03U);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG2_G,
+                            (uint8_t*)&ctrl_reg2_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                           (uint8_t*)&ctrl_reg3_g, 1);
+  }
+  if(ret == 0){
+    ctrl_reg3_g.hp_en = (((uint8_t)val & 0x10U) >> 4 );
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                            (uint8_t*)&ctrl_reg3_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyro interrupt filter path configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_sel in reg CTRL_REG2_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_int_path_get(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_gy_int_path_t *val)
+{
+  lsm9ds1_ctrl_reg2_g_t ctrl_reg2_g;
+  lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG2_G,
+                         (uint8_t*)&ctrl_reg2_g, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                           (uint8_t*)&ctrl_reg3_g, 1);
+  }
+  switch ( (ctrl_reg3_g.hp_en << 4) | ctrl_reg2_g.int_sel){
+    case LSM9DS1_LPF1_INT:
+      *val = LSM9DS1_LPF1_INT;
+      break;
+    case LSM9DS1_LPF1_HPF_INT:
+      *val = LSM9DS1_LPF1_HPF_INT;
+      break;
+    case LSM9DS1_LPF1_LPF2_INT:
+      *val = LSM9DS1_LPF1_LPF2_INT;
+      break;
+    case LSM9DS1_LPF1_HPF_LPF2_INT:
+      *val = LSM9DS1_LPF1_HPF_LPF2_INT;
+      break;
+    default:
+      *val = LSM9DS1_LPF1_INT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope high-pass filter bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "hpcf_g" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_gy_hp_bw_t val)
+{
+  lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_G, (uint8_t*)&ctrl_reg3_g, 1);
+  if(ret == 0){
+    ctrl_reg3_g.hpcf_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                            (uint8_t*)&ctrl_reg3_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope high-pass filter bandwidth selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpcf_g in reg CTRL_REG3_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_gy_hp_bw_t *val)
+{
+  lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG3_G,
+                         (uint8_t*)&ctrl_reg3_g, 1);
+  switch (ctrl_reg3_g.hpcf_g){
+    case LSM9DS1_HP_EXTREME:
+      *val = LSM9DS1_HP_EXTREME;
+      break;
+    case LSM9DS1_HP_ULTRA_STRONG:
+      *val = LSM9DS1_HP_ULTRA_STRONG;
+      break;
+    case LSM9DS1_HP_STRONG:
+      *val = LSM9DS1_HP_STRONG;
+      break;
+    case LSM9DS1_HP_ULTRA_HIGH:
+      *val = LSM9DS1_HP_ULTRA_HIGH;
+      break;
+    case LSM9DS1_HP_HIGH:
+      *val = LSM9DS1_HP_HIGH;
+      break;
+    case LSM9DS1_HP_MEDIUM:
+      *val = LSM9DS1_HP_MEDIUM;
+      break;
+    case LSM9DS1_HP_LOW:
+      *val = LSM9DS1_HP_LOW;
+      break;
+    case LSM9DS1_HP_ULTRA_LOW:
+      *val = LSM9DS1_HP_ULTRA_LOW;
+      break;
+    case LSM9DS1_HP_LIGHT:
+      *val = LSM9DS1_HP_LIGHT;
+      break;
+    case LSM9DS1_HP_ULTRA_LIGHT:
+      *val = LSM9DS1_HP_ULTRA_LIGHT;
+      break;
+    default:
+      *val = LSM9DS1_HP_EXTREME;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure accelerometer anti aliasing filter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "bw_xl" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_aalias_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                               lsm9ds1_xl_aa_bw_t val)
+{
+  lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                         (uint8_t*)&ctrl_reg6_xl, 1);
+  if(ret == 0){
+    ctrl_reg6_xl.bw_xl = ((uint8_t)val & 0x03U);
+    ctrl_reg6_xl.bw_scal_odr = (((uint8_t)val & 0x10U) >> 4 );
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                            (uint8_t*)&ctrl_reg6_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure accelerometer anti aliasing filter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bw_xl in reg CTRL_REG6_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_aalias_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                               lsm9ds1_xl_aa_bw_t *val)
+{
+  lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG6_XL,
+                         (uint8_t*)&ctrl_reg6_xl, 1);
+  switch ((ctrl_reg6_xl.bw_scal_odr << 4) | ctrl_reg6_xl.bw_xl){
+    case LSM9DS1_AUTO:
+      *val = LSM9DS1_AUTO;
+      break;
+    case LSM9DS1_408Hz:
+      *val = LSM9DS1_408Hz;
+      break;
+    case LSM9DS1_211Hz:
+      *val = LSM9DS1_211Hz;
+      break;
+    case LSM9DS1_105Hz:
+      *val = LSM9DS1_105Hz;
+      break;
+    case LSM9DS1_50Hz:
+      *val = LSM9DS1_50Hz;
+      break;
+    default:
+      *val = LSM9DS1_AUTO;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure HP accelerometer filter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "hpis1" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_int_path_set(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_xl_hp_path_t val)
+{
+  lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                         (uint8_t*)&ctrl_reg7_xl, 1);
+  if(ret == 0){
+    ctrl_reg7_xl.hpis1 = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                            (uint8_t*)&ctrl_reg7_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  .[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpis1 in reg CTRL_REG7_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_int_path_get(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_xl_hp_path_t *val)
+{
+  lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                         (uint8_t*)&ctrl_reg7_xl, 1);
+  switch (ctrl_reg7_xl.hpis1){
+    case LSM9DS1_HP_DIS:
+      *val = LSM9DS1_HP_DIS;
+      break;
+    case LSM9DS1_HP_EN:
+      *val = LSM9DS1_HP_EN;
+      break;
+    default:
+      *val = LSM9DS1_HP_DIS;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output filter path configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fds" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_out_path_set(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_xl_out_path_t val)
+{
+  lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                         (uint8_t*)&ctrl_reg7_xl, 1);
+  if(ret == 0){
+    ctrl_reg7_xl.fds = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                            (uint8_t*)&ctrl_reg7_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output filter path configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fds in reg CTRL_REG7_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_out_path_get(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_xl_out_path_t *val)
+{
+  lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                         (uint8_t*)&ctrl_reg7_xl, 1);
+  switch (ctrl_reg7_xl.fds){
+    case LSM9DS1_LP_OUT:
+      *val = LSM9DS1_LP_OUT;
+      break;
+    case LSM9DS1_HP_OUT:
+      *val = LSM9DS1_HP_OUT;
+      break;
+    default:
+      *val = LSM9DS1_LP_OUT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer digital filter low pass cutoff frequency
+  *         selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dcf" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_xl_lp_bw_t val)
+{
+  lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                         (uint8_t*)&ctrl_reg7_xl, 1);
+  if(ret == 0){
+    ctrl_reg7_xl.dcf = ((uint8_t)val & 0x10U) >> 4;
+    ctrl_reg7_xl.hr = ((uint8_t)val & 0x03U);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                            (uint8_t*)&ctrl_reg7_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer digital filter low pass cutoff frequency
+  *         selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dcf in reg CTRL_REG7_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_xl_lp_bw_t *val)
+{
+  lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                         (uint8_t*)&ctrl_reg7_xl, 1);
+  switch ((ctrl_reg7_xl.dcf << 4) + ctrl_reg7_xl.hr){
+    case LSM9DS1_LP_DISABLE:
+      *val = LSM9DS1_LP_DISABLE;
+      break;
+    case LSM9DS1_LP_ODR_DIV_50:
+      *val = LSM9DS1_LP_ODR_DIV_50;
+      break;
+    case LSM9DS1_LP_ODR_DIV_100:
+      *val = LSM9DS1_LP_ODR_DIV_100;
+      break;
+    case LSM9DS1_LP_ODR_DIV_9:
+      *val = LSM9DS1_LP_ODR_DIV_9;
+      break;
+    case LSM9DS1_LP_ODR_DIV_400:
+      *val = LSM9DS1_LP_ODR_DIV_400;
+      break;
+    default:
+      *val = LSM9DS1_LP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer digital filter high pass cutoff frequency
+  *         selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dcf" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_xl_hp_bw_t val)
+{
+  lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                         (uint8_t*)&ctrl_reg7_xl, 1);
+  if(ret == 0){
+    ctrl_reg7_xl.dcf = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                            (uint8_t*)&ctrl_reg7_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer digital filter high pass cutoff frequency
+  *         selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dcf in reg CTRL_REG7_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_xl_hp_bw_t *val)
+{
+  lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
+                         (uint8_t*)&ctrl_reg7_xl, 1);
+
+  switch (ctrl_reg7_xl.dcf){
+    case LSM9DS1_HP_ODR_DIV_50:
+      *val = LSM9DS1_HP_ODR_DIV_50;
+      break;
+    case LSM9DS1_HP_ODR_DIV_100:
+      *val = LSM9DS1_HP_ODR_DIV_100;
+      break;
+    case LSM9DS1_HP_ODR_DIV_9:
+      *val = LSM9DS1_HP_ODR_DIV_9;
+      break;
+    case LSM9DS1_HP_ODR_DIV_400:
+      *val = LSM9DS1_HP_ODR_DIV_400;
+      break;
+    default:
+      *val = LSM9DS1_HP_ODR_DIV_50;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask_bit in reg CTRL_REG9.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_filter_settling_mask_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  if(ret == 0){
+    ctrl_reg9.drdy_mask_bit = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_mask_bit in reg CTRL_REG9.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_filter_settling_mask_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  *val = (uint8_t)ctrl_reg9.drdy_mask_bit;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup     LSM9DS1_Serial_interface
+  * @brief        This section groups all the functions concerning main
+  *               serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  Register address automatically incremented during a multiple
+  *         byte access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "if_add_inc" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_auto_increment_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ctrl_reg8.if_add_inc = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple
+  *         byte access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_add_inc in reg CTRL_REG8.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_auto_increment_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  *val = (uint8_t)ctrl_reg8.if_add_inc;
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Change the values of "sim" in reg LSM9DS1.
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_spi_mode_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                             lsm9ds1_sim_t val)
+{
+  lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ctrl_reg8.sim = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  }
+  if(ret == 0){
+      ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG3_M,
+                             (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  if(ret == 0){
+    ctrl_reg3_m.sim = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_CTRL_REG3_M,
+                            (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Get the values of sim in reg CTRL_REG8.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_spi_mode_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                             lsm9ds1_sim_t *val)
+{
+  lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+      ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG3_M,
+                             (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  switch (ctrl_reg8.sim & ctrl_reg3_m.sim){
+    case LSM9DS1_SPI_4_WIRE:
+      *val = LSM9DS1_SPI_4_WIRE;
+      break;
+    case LSM9DS1_SPI_3_WIRE:
+      *val = LSM9DS1_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM9DS1_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disable I2C interface.[set]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Change the values of "i2c_disable" in reg LSM9DS1.
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_i2c_interface_set(lsm9ds1_ctx_t *ctx_mag,
+                                  lsm9ds1_ctx_t *ctx_imu,
+                                  lsm9ds1_i2c_dis_t val)
+{
+  lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  if(ret == 0){
+    ctrl_reg9.i2c_disable = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_CTRL_REG9,
+                            (uint8_t*)&ctrl_reg9, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG3_M,
+                           (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  if(ret == 0){
+    ctrl_reg3_m.i2c_disable = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_CTRL_REG3_M,
+                            (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disable I2C interface.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Get the values of i2c_disable in reg CTRL_REG9.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_i2c_interface_get(lsm9ds1_ctx_t *ctx_mag,
+                                  lsm9ds1_ctx_t *ctx_imu,
+                                  lsm9ds1_i2c_dis_t *val)
+{
+  lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_CTRL_REG3_M,
+                           (uint8_t*)&ctrl_reg3_m, 1);
+  }
+  switch (ctrl_reg9.i2c_disable & ctrl_reg3_m.i2c_disable){
+    case LSM9DS1_I2C_ENABLE:
+      *val = LSM9DS1_I2C_ENABLE;
+      break;
+    case LSM9DS1_I2C_DISABLE:
+      *val = LSM9DS1_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM9DS1_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup     LSM9DS1_Interrupt_pins
+  * @brief        This section groups all the functions that manage
+  *               interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  AND/OR combination of accelerometer’s interrupt events.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "aoi_xl" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_logic_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t val)
+{
+  lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
+  lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_XL,
+                         (uint8_t*)&int_gen_cfg_xl, 1);
+  if(ret == 0){
+    int_gen_cfg_xl.aoi_xl = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_CFG_XL,
+                            (uint8_t*)&int_gen_cfg_xl, 1);
+  }
+  if(ret == 0){
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_G,
+                         (uint8_t*)&int_gen_cfg_g, 1);
+  }
+  if(ret == 0){
+    int_gen_cfg_g.aoi_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_CFG_G,
+                            (uint8_t*)&int_gen_cfg_g, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of accelerometer’s interrupt events.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of aoi_xl in reg INT_GEN_CFG_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_logic_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t *val)
+{
+  lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
+  lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_XL,
+                         (uint8_t*)&int_gen_cfg_xl, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_G,
+                           (uint8_t*)&int_gen_cfg_g, 1);
+  }
+  switch (int_gen_cfg_xl.aoi_xl & int_gen_cfg_g.aoi_g){
+    case LSM9DS1_LOGIC_OR:
+      *val = LSM9DS1_LOGIC_OR;
+      break;
+    case LSM9DS1_LOGIC_AND:
+      *val = LSM9DS1_LOGIC_AND;
+      break;
+    default:
+      *val = LSM9DS1_LOGIC_OR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT 1_A/G pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer data ready on INT 1_A/G pin.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_int1_route_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_pin_int1_route_t val)
+{
+  lsm9ds1_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0) {
+    int1_ctrl.int1_drdy_xl  = val.int1_drdy_xl;
+    int1_ctrl.int1_drdy_g  = val.int1_drdy_g;
+    int1_ctrl.int1_boot  = val.int1_boot;
+    int1_ctrl.int1_fth  = val.int1_fth;
+    int1_ctrl.int1_ovr  = val.int1_ovr;
+    int1_ctrl.int1_fss5  = val.int1_fss5;
+    int1_ctrl.int1_ig_xl  = val.int1_ig_xl;
+    int1_ctrl.int1_ig_g  = val.int1_ig_g;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT 1_A/G pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer data ready on INT 1_A/G pin.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_int1_route_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_pin_int1_route_t *val)
+{
+  lsm9ds1_int1_ctrl_t int1_ctrl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+
+  val->int1_drdy_xl = int1_ctrl.int1_drdy_xl;
+  val->int1_drdy_g = int1_ctrl.int1_drdy_g;
+  val->int1_boot = int1_ctrl.int1_boot;
+  val->int1_fth = int1_ctrl.int1_fth;
+  val->int1_ovr = int1_ctrl.int1_ovr;
+  val->int1_fss5 = int1_ctrl.int1_fss5;
+  val->int1_ig_xl = int1_ctrl.int1_ig_xl;
+  val->int1_ig_g = int1_ctrl.int1_ig_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT 2_A/G pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer data ready on INT2_A/G pin.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_int2_route_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_pin_int2_route_t val)
+{
+  lsm9ds1_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0) {
+    int2_ctrl.int2_drdy_xl  = val.int2_drdy_xl;
+    int2_ctrl.int2_inact  = val.int2_inact;
+    int2_ctrl.int2_drdy_g  = val.int2_drdy_g;
+    int2_ctrl.int2_drdy_temp  = val.int2_drdy_temp;
+    int2_ctrl.int2_fth  = val.int2_fth;
+    int2_ctrl.int2_ovr  = val.int2_ovr;
+    int2_ctrl.int2_fss5  = val.int2_fss5;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT 2_A/G pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer data ready on INT2_A/G pin.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_int2_route_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_pin_int2_route_t *val)
+{
+  lsm9ds1_int2_ctrl_t int2_ctrl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  val->int2_drdy_xl = int2_ctrl.int2_drdy_xl;
+  val->int2_inact = int2_ctrl.int2_inact;
+  val->int2_fss5 = int2_ctrl.int2_fss5;
+  val->int2_ovr = int2_ctrl.int2_ovr;
+  val->int2_fth = int2_ctrl.int2_fth;
+  val->int2_drdy_temp = int2_ctrl.int2_drdy_temp;
+  val->int2_drdy_g = int2_ctrl.int2_drdy_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Change the values of "lir_xl1" in reg LSM9DS1.
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_notification_set(lsm9ds1_ctx_t *ctx_mag,
+                                     lsm9ds1_ctx_t *ctx_imu,
+                                     lsm9ds1_lir_t val)
+{
+  lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
+  lsm9ds1_int_cfg_m_t int_cfg_m;
+  lsm9ds1_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG4,
+                         (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.lir_xl1 = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_INT_GEN_CFG_G,
+                           (uint8_t*)&int_gen_cfg_g, 1);
+  }
+  if(ret == 0){
+    int_gen_cfg_g.lir_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_INT_GEN_CFG_G,
+                            (uint8_t*)&int_gen_cfg_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_INT_CFG_M,
+                           (uint8_t*)&int_cfg_m, 1);
+  }
+  if(ret == 0){
+    int_cfg_m.iel = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_INT_CFG_M,
+                            (uint8_t*)&int_cfg_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt notification mode.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Get the values of iel in reg INT_CFG_M.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_notification_get(lsm9ds1_ctx_t *ctx_mag,
+                                     lsm9ds1_ctx_t *ctx_imu,
+                                     lsm9ds1_lir_t *val)
+{
+  lsm9ds1_int_cfg_m_t int_cfg_m;
+  lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
+  lsm9ds1_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG4,
+                         (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_INT_GEN_CFG_G,
+                           (uint8_t*)&int_gen_cfg_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_INT_CFG_M,
+                           (uint8_t*)&int_cfg_m, 1);
+  }
+  switch (int_cfg_m.iel & int_gen_cfg_g.lir_g & ctrl_reg4.lir_xl1){
+    case LSM9DS1_INT_LATCHED:
+      *val = LSM9DS1_INT_LATCHED;
+      break;
+    case LSM9DS1_INT_PULSED:
+      *val = LSM9DS1_INT_PULSED;
+      break;
+    default:
+      *val = LSM9DS1_INT_LATCHED;
+      break;
+  }
+
+  return ret;
+}
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "pp_od" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  if(ret == 0){
+    ctrl_reg8.pp_od = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL_REG8.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t *val)
+{
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG8, (uint8_t*)&ctrl_reg8, 1);
+  switch (ctrl_reg8.pp_od){
+    case LSM9DS1_PUSH_PULL:
+      *val = LSM9DS1_PUSH_PULL;
+      break;
+    case LSM9DS1_OPEN_DRAIN:
+      *val = LSM9DS1_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM9DS1_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT_M pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val      Interrupt enable on the INT_M pin.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_int_m_route_set(lsm9ds1_ctx_t *ctx,
+                                    lsm9ds1_pin_m_route_t val)
+{
+  lsm9ds1_int_cfg_m_t int_cfg_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_CFG_M, (uint8_t*)&int_cfg_m, 1);
+  if(ret == 0) {
+    int_cfg_m.ien  = val.ien;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_CFG_M, (uint8_t*)&int_cfg_m, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT_M pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val      Interrupt enable on the INT_M pin.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_int_m_route_get(lsm9ds1_ctx_t *ctx,
+                                    lsm9ds1_pin_m_route_t *val)
+{
+  lsm9ds1_int_cfg_m_t int_cfg_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_CFG_M, (uint8_t*)&int_cfg_m, 1);
+  val->ien = int_cfg_m.ien;
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt pin polarity.[set]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Change the values of "iea" in reg LSM9DS1.
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_polarity_set(lsm9ds1_ctx_t *ctx_mag,
+                                 lsm9ds1_ctx_t *ctx_imu,
+                                 lsm9ds1_polarity_t val)
+{
+  lsm9ds1_int_cfg_m_t int_cfg_m;
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_INT_CFG_M,
+                         (uint8_t*)&int_cfg_m, 1);
+  if(ret == 0){
+    int_cfg_m.iea = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_INT_CFG_M,
+                            (uint8_t*)&int_cfg_m, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8,
+                           (uint8_t*)&ctrl_reg8, 1);
+  }
+  if(ret == 0){
+    ctrl_reg8.h_lactive = (uint8_t)(~val);
+    ret = lsm9ds1_write_reg(ctx_imu, LSM9DS1_CTRL_REG8,
+                            (uint8_t*)&ctrl_reg8, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure the interrupt pin polarity.[get]
+  *
+  * @param  ctx_mag   Read / write magnetometer interface definitions.(ptr)
+  * @param  ctx_imu   Read / write imu interface definitions.(ptr)
+  * @param  val       Get the values of iea in reg INT_CFG_M.(ptr)
+  * @retval           Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_pin_polarity_get(lsm9ds1_ctx_t *ctx_mag,
+                                 lsm9ds1_ctx_t *ctx_imu,
+                                 lsm9ds1_polarity_t *val)
+{
+  lsm9ds1_int_cfg_m_t int_cfg_m;
+  lsm9ds1_ctrl_reg8_t ctrl_reg8;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx_mag, LSM9DS1_INT_CFG_M, (uint8_t*)&int_cfg_m, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx_imu, LSM9DS1_CTRL_REG8,
+                           (uint8_t*)&ctrl_reg8, 1);
+  }
+  switch (int_cfg_m.iea & (~ctrl_reg8.h_lactive)){
+    case LSM9DS1_ACTIVE_LOW:
+      *val = LSM9DS1_ACTIVE_LOW;
+      break;
+    case LSM9DS1_ACTIVE_HIGH:
+      *val = LSM9DS1_ACTIVE_HIGH;
+      break;
+    default:
+      *val = LSM9DS1_ACTIVE_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup     LSM9DS1_Interrupt_on_threshold
+  * @brief        This section group all the functions concerning the
+  *               interrupt on threshold configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable interrupt generation on threshold event.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Enable interrupt generation on accelerometer’s X-axis
+  *                low event.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_xl_trshld_en_t val)
+{
+  lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_XL,
+                         (uint8_t*)&int_gen_cfg_xl, 1);
+  if(ret == 0) {
+    int_gen_cfg_xl.xlie_xl  = val.xlie_xl;
+    int_gen_cfg_xl.xhie_xl  = val.xhie_xl;
+    int_gen_cfg_xl.ylie_xl  = val.ylie_xl;
+    int_gen_cfg_xl.zhie_xl  = val.zhie_xl;
+    int_gen_cfg_xl.yhie_xl  = val.yhie_xl;
+    int_gen_cfg_xl.zlie_xl  = val.zlie_xl;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_CFG_XL, (uint8_t*)&int_gen_cfg_xl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on threshold event.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Enable interrupt generation on accelerometer’s X-axis
+  *                low event.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_xl_trshld_en_t *val)
+{
+  lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_XL,
+                         (uint8_t*)&int_gen_cfg_xl, 1);
+  val->xlie_xl = int_gen_cfg_xl.xlie_xl;
+  val->xhie_xl = int_gen_cfg_xl.xhie_xl;
+  val->ylie_xl = int_gen_cfg_xl.ylie_xl;
+  val->yhie_xl = int_gen_cfg_xl.yhie_xl;
+  val->zlie_xl = int_gen_cfg_xl.zlie_xl;
+  val->zhie_xl = int_gen_cfg_xl.zhie_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  Axis interrupt threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data to be write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_trshld_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_X_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Axis interrupt threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_X_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Enter/exit interrupt duration value.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dur_xl in reg INT_GEN_DUR_XL.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_int_gen_dur_xl_t int_gen_dur_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_DUR_XL,
+                         (uint8_t*)&int_gen_dur_xl, 1);
+  if(ret == 0){
+    int_gen_dur_xl.dur_xl = (uint8_t)val;
+    if (val != 0x00U){
+      int_gen_dur_xl.wait_xl = PROPERTY_ENABLE;
+    } else {
+      int_gen_dur_xl.wait_xl = PROPERTY_DISABLE;
+    }
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_DUR_XL,
+                            (uint8_t*)&int_gen_dur_xl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enter/exit interrupt duration value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dur_xl in reg INT_GEN_DUR_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_int_gen_dur_xl_t int_gen_dur_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_DUR_XL,
+                         (uint8_t*)&int_gen_dur_xl, 1);
+  *val = (uint8_t)int_gen_dur_xl.dur_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt on threshold source.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Pitch(X)low.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_src_get(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_gy_trshld_src_t *val)
+{
+  lsm9ds1_int_gen_src_g_t int_gen_src_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_SRC_G,
+                         (uint8_t*)&int_gen_src_g, 1);
+  val->xl_g = int_gen_src_g.xl_g;
+  val->xh_g = int_gen_src_g.xh_g;
+  val->yl_g = int_gen_src_g.yl_g;
+  val->yh_g = int_gen_src_g.yh_g;
+  val->zl_g = int_gen_src_g.zl_g;
+  val->zh_g = int_gen_src_g.zh_g;
+  val->ia_g = int_gen_src_g.ia_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer interrupt on threshold source.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Accelerometer’s X low. event.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_trshld_src_get(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_xl_trshld_src_t *val)
+{
+  lsm9ds1_int_gen_src_xl_t int_gen_src_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_SRC_XL,
+                         (uint8_t*)&int_gen_src_xl, 1);
+  val->xl_xl = int_gen_src_xl.xl_xl;
+  val->xh_xl = int_gen_src_xl.xh_xl;
+  val->yl_xl = int_gen_src_xl.yl_xl;
+  val->yh_xl = int_gen_src_xl.yh_xl;
+  val->zl_xl = int_gen_src_xl.zl_xl;
+  val->zh_xl = int_gen_src_xl.zh_xl;
+  val->ia_xl = int_gen_src_xl.ia_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on threshold event.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Enable interrupt generation on gyroscope’s pitch
+  *                (X) axis low event.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_gy_trshld_en_t val)
+{
+  lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_G,
+                         (uint8_t*)&int_gen_cfg_g, 1);
+  if(ret == 0) {
+    int_gen_cfg_g.xlie_g  = val.xlie_g;
+    int_gen_cfg_g.xhie_g  = val.xhie_g;
+    int_gen_cfg_g.ylie_g  = val.ylie_g;
+    int_gen_cfg_g.yhie_g  = val.yhie_g;
+    int_gen_cfg_g.zlie_g  = val.zlie_g;
+    int_gen_cfg_g.zhie_g  = val.zhie_g;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_CFG_G,
+                            (uint8_t*)&int_gen_cfg_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on threshold event.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Enable interrupt generation on gyroscope’s pitch
+  *                 (X) axis low event.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_gy_trshld_en_t *val)
+{
+  lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_G,
+                         (uint8_t*)&int_gen_cfg_g, 1);
+  val->xlie_g = int_gen_cfg_g.xlie_g;
+  val->xhie_g = int_gen_cfg_g.xhie_g;
+  val->ylie_g = int_gen_cfg_g.ylie_g;
+  val->yhie_g = int_gen_cfg_g.yhie_g;
+  val->zlie_g = int_gen_cfg_g.zlie_g;
+  val->zhie_g = int_gen_cfg_g.zhie_g;
+  return ret;
+}
+
+/**
+  * @brief  Decrement or reset counter mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dcrm_g" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_dcrm_g_t val)
+{
+  lsm9ds1_int_gen_ths_xh_g_t int_gen_ths_xh_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_XH_G,
+                         (uint8_t*)&int_gen_ths_xh_g, 1);
+  if(ret == 0){
+    int_gen_ths_xh_g.dcrm_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_XH_G,
+                            (uint8_t*)&int_gen_ths_xh_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decrement or reset counter mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dcrm_g in reg INT_GEN_THS_XH_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_dcrm_g_t *val)
+{
+  lsm9ds1_int_gen_ths_xh_g_t int_gen_ths_xh_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_XH_G,
+                         (uint8_t*)&int_gen_ths_xh_g, 1);
+  switch (int_gen_ths_xh_g.dcrm_g){
+    case LSM9DS1_RESET_MODE:
+      *val = LSM9DS1_RESET_MODE;
+      break;
+    case LSM9DS1_DECREMENT_MODE:
+      *val = LSM9DS1_DECREMENT_MODE;
+      break;
+    default:
+      *val = LSM9DS1_RESET_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on pitch (X) axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ths_g_x in reg INT_GEN_THS_XH_G.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_x_set(lsm9ds1_ctx_t *ctx, uint16_t val)
+{
+  lsm9ds1_int_gen_ths_xh_g_t int_gen_ths_xh_g;
+  lsm9ds1_int_gen_ths_xl_g_t int_gen_ths_xl_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_XH_G,
+                         (uint8_t*)&int_gen_ths_xh_g, 1);
+  if(ret == 0){
+    int_gen_ths_xh_g.ths_g_x = (uint8_t)((val & 0x7F00U) >> 8);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_XH_G,
+                            (uint8_t*)&int_gen_ths_xh_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_XL_G,
+                           (uint8_t*)&int_gen_ths_xl_g, 1);
+  }
+  if(ret == 0){
+    int_gen_ths_xl_g.ths_g_x = (uint8_t)(val & 0x00FFU);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_XL_G,
+                            (uint8_t*)&int_gen_ths_xl_g, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on pitch (X) axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ths_g_x in reg INT_GEN_THS_XH_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_x_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
+{
+  lsm9ds1_int_gen_ths_xh_g_t int_gen_ths_xh_g;
+  lsm9ds1_int_gen_ths_xl_g_t int_gen_ths_xl_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_XH_G,
+                         (uint8_t*)&int_gen_ths_xh_g, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_XL_G,
+                           (uint8_t*)&int_gen_ths_xl_g, 1);
+  }
+  *val = int_gen_ths_xh_g.ths_g_x;
+  *val = *val << 8;
+  *val += int_gen_ths_xl_g.ths_g_x;
+  return ret;
+}
+
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on roll (Y) axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ths_g_y in reg INT_GEN_THS_YH_G.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_y_set(lsm9ds1_ctx_t *ctx, uint16_t val)
+{
+  lsm9ds1_int_gen_ths_yh_g_t int_gen_ths_yh_g;
+  lsm9ds1_int_gen_ths_yl_g_t int_gen_ths_yl_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_YH_G,
+                         (uint8_t*)&int_gen_ths_yh_g, 1);
+  if(ret == 0){
+    int_gen_ths_yh_g.ths_g_y = (uint8_t)((val & 0x7F00U) >> 8);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_YH_G,
+                            (uint8_t*)&int_gen_ths_yh_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_YL_G,
+                           (uint8_t*)&int_gen_ths_yl_g, 1);
+  }
+  if(ret == 0){
+    int_gen_ths_yl_g.ths_g_y = (uint8_t)(val & 0x00FFU);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_YL_G,
+                            (uint8_t*)&int_gen_ths_yl_g, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on roll (Y) axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ths_g_y in reg INT_GEN_THS_YH_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_y_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
+{
+  lsm9ds1_int_gen_ths_yh_g_t int_gen_ths_yh_g;
+  lsm9ds1_int_gen_ths_yl_g_t int_gen_ths_yl_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_YH_G,
+                         (uint8_t*)&int_gen_ths_yh_g, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_YL_G,
+                           (uint8_t*)&int_gen_ths_yl_g, 1);
+  }
+  *val = (uint8_t)int_gen_ths_yh_g.ths_g_y;
+  *val = *val << 8;
+  *val += int_gen_ths_yl_g.ths_g_y;
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt thresholds on yaw (Z) axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ths_g_z in reg INT_GEN_THS_ZH_G.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_z_set(lsm9ds1_ctx_t *ctx, uint16_t val)
+{
+  lsm9ds1_int_gen_ths_zh_g_t int_gen_ths_zh_g;
+  lsm9ds1_int_gen_ths_zl_g_t int_gen_ths_zl_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_ZH_G,
+                         (uint8_t*)&int_gen_ths_zh_g, 1);
+  if(ret == 0){
+    int_gen_ths_zh_g.ths_g_z = (uint8_t)((val & 0x7F00U) >> 8);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_ZH_G,
+                            (uint8_t*)&int_gen_ths_zh_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_ZL_G,
+                           (uint8_t*)&int_gen_ths_zl_g, 1);
+  }
+  if(ret == 0){
+    int_gen_ths_zl_g.ths_g_z = (uint8_t)(val & 0x00FFU);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_ZL_G,
+                            (uint8_t*)&int_gen_ths_zl_g, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt thresholds on yaw (Z) axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ths_g_z in reg INT_GEN_THS_ZH_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_z_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
+{
+  lsm9ds1_int_gen_ths_zh_g_t int_gen_ths_zh_g;
+  lsm9ds1_int_gen_ths_zl_g_t int_gen_ths_zl_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_ZH_G,
+                         (uint8_t*)&int_gen_ths_zh_g, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_ZL_G,
+                           (uint8_t*)&int_gen_ths_zl_g, 1);
+  }
+  *val = int_gen_ths_zh_g.ths_g_z;
+  *val = *val << 8;
+  *val += int_gen_ths_zl_g.ths_g_z;
+
+  return ret;
+}
+
+/**
+  * @brief  Enter/exit interrupt duration value.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dur_g in reg INT_GEN_DUR_G.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_int_gen_dur_g_t int_gen_dur_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_DUR_G,
+                         (uint8_t*)&int_gen_dur_g, 1);
+  if(ret == 0){
+    if (val != 0x00U){
+      int_gen_dur_g.wait_g = PROPERTY_ENABLE;
+    } else {
+      int_gen_dur_g.wait_g = PROPERTY_DISABLE;
+    }
+    int_gen_dur_g.dur_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_DUR_G,
+                            (uint8_t*)&int_gen_dur_g, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enter/exit interrupt duration value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dur_g in reg INT_GEN_DUR_G.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_int_gen_dur_g_t int_gen_dur_g;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_DUR_G,
+                         (uint8_t*)&int_gen_dur_g, 1);
+  *val = (uint8_t)int_gen_dur_g.dur_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on threshold event.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Enable interrupt generation on Z-axis. .
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+                                    lsm9ds1_mag_trshld_axis_t val)
+{
+  lsm9ds1_int_cfg_m_t int_cfg_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_CFG_M, (uint8_t*)&int_cfg_m, 1);
+  if(ret == 0) {
+    int_cfg_m.zien  = val.zien;
+    int_cfg_m.xien  = val.xien;
+    int_cfg_m.yien  = val.yien;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_CFG_M, (uint8_t*)&int_cfg_m, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on threshold event.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Enable interrupt generation on Z-axis. .(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+                                    lsm9ds1_mag_trshld_axis_t *val)
+{
+  lsm9ds1_int_cfg_m_t int_cfg_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_CFG_M, (uint8_t*)&int_cfg_m, 1);
+  val->zien = int_cfg_m.zien;
+  val->yien = int_cfg_m.yien;
+  val->xien = int_cfg_m.xien;
+
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer interrupt on threshold source.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     This bit signals when the interrupt event occurs.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_trshld_src_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_mag_trshld_src_t *val)
+{
+  lsm9ds1_int_src_m_t int_src_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_SRC_M, (uint8_t*)&int_src_m, 1);
+  val->_int = int_src_m._int;
+  val->nth_z = int_src_m.nth_z;
+  val->nth_y = int_src_m.nth_y;
+  val->nth_x = int_src_m.nth_x;
+  val->pth_z = int_src_m.pth_z;
+  val->pth_y = int_src_m.pth_y;
+  val->pth_x = int_src_m.pth_x;
+
+  return ret;
+}
+
+/**
+  * @brief  The value is expressed in 15-bit unsigned.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "ths" in reg INT_THS_L_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_int_ths_l_m_t int_ths_l_m;
+  lsm9ds1_int_ths_h_m_t int_ths_h_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_THS_L_M,
+                         (uint8_t*)&int_ths_l_m, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_THS_H_M,
+                           (uint8_t*)&int_ths_h_m, 1);
+  }
+
+  *val = int_ths_h_m.ths;
+  *val = *val << 8;
+  *val += int_ths_l_m.ths;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup     LSM9DS1_ Activity/Inactivity_detection
+  * @brief        This section groups all the functions concerning
+  *               activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Inactivity threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of act_ths in reg ACT_THS.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_act_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_ACT_THS, (uint8_t*)&act_ths, 1);
+  if(ret == 0){
+    act_ths.act_ths = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_ACT_THS, (uint8_t*)&act_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Inactivity threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of act_ths in reg ACT_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_act_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_act_ths_t act_ths;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_ACT_THS, (uint8_t*)&act_ths, 1);
+  *val = (uint8_t)act_ths.act_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope operating mode during inactivity.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "sleep_on_inact_en" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_act_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t val)
+{
+  lsm9ds1_act_ths_t act_ths;
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_ACT_THS, (uint8_t*)&act_ths, 1);
+  if(ret == 0){
+    act_ths.sleep_on_inact_en = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_ACT_THS, (uint8_t*)&act_ths, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  }
+  if(ret == 0){
+    ctrl_reg9.sleep_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope operating mode during inactivity.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_on_inact_en in reg ACT_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_act_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t *val)
+{
+  lsm9ds1_act_ths_t act_ths;
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_ACT_THS, (uint8_t*)&act_ths, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  }
+  switch (act_ths.sleep_on_inact_en & ctrl_reg9.sleep_g){
+    case LSM9DS1_GYRO_POWER_DOWN:
+      *val = LSM9DS1_GYRO_POWER_DOWN;
+      break;
+    case LSM9DS1_GYRO_SLEEP:
+      *val = LSM9DS1_GYRO_SLEEP;
+      break;
+    default:
+      *val = LSM9DS1_GYRO_POWER_DOWN;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Inactivity duration in number of sample.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data to be write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_act_duration_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_write_reg(ctx, LSM9DS1_ACT_DUR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Inactivity duration in number of sample.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_act_duration_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_ACT_DUR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Inactivity interrupt output signal.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Return an option of "lsm9ds1_inact_t".(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_act_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_inact_t *val)
+{
+  lsm9ds1_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_STATUS_REG, (uint8_t*)&status_reg, 1);
+  switch (status_reg.inact){
+    case LSM9DS1_ACTIVITY:
+      *val = LSM9DS1_ACTIVITY;
+      break;
+    case LSM9DS1_INACTIVITY:
+      *val = LSM9DS1_INACTIVITY;
+      break;
+    default:
+      *val = LSM9DS1_ACTIVITY;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup     LSM9DS1_ Six_position_detection(6D/4D).
+  * @brief        This section groups all the functions concerning six
+  *               position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  6D feature working mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "6d" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_6d_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t val)
+{
+  lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
+  lsm9ds1_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_XL,
+                         (uint8_t*)&int_gen_cfg_xl, 1);
+  if(ret == 0){
+    int_gen_cfg_xl._6d = ((uint8_t)val & 0x01U);
+    int_gen_cfg_xl.aoi_xl = ( ( (uint8_t)val & 0x02U ) >> 1 );
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_CFG_XL,
+                            (uint8_t*)&int_gen_cfg_xl, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG4,
+                           (uint8_t*)&ctrl_reg4, 1);
+  }
+  if(ret == 0){
+    ctrl_reg4._4d_xl1 = ( ( (uint8_t)val & 0x04U ) >> 2 );
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG4,
+                            (uint8_t*)&ctrl_reg4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  6D feature working mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of 6d in reg INT_GEN_CFG_XL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_6d_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t *val)
+{
+  lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
+  lsm9ds1_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_CFG_XL,
+                         (uint8_t*)&int_gen_cfg_xl, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG4,
+                           (uint8_t*)&ctrl_reg4, 1);
+  }
+  switch ( (ctrl_reg4._4d_xl1 << 2) | (int_gen_cfg_xl.aoi_xl << 1)
+          | int_gen_cfg_xl.aoi_xl ){
+    case LSM9DS1_POS_MOVE_RECO_DISABLE:
+      *val = LSM9DS1_POS_MOVE_RECO_DISABLE;
+      break;
+    case LSM9DS1_6D_MOVE_RECO:
+      *val = LSM9DS1_6D_MOVE_RECO;
+      break;
+    case LSM9DS1_4D_MOVE_RECO:
+      *val = LSM9DS1_4D_MOVE_RECO;
+      break;
+    case LSM9DS1_6D_POS_RECO:
+      *val = LSM9DS1_6D_POS_RECO;
+      break;
+    case LSM9DS1_4D_POS_RECO:
+      *val = LSM9DS1_4D_POS_RECO;
+      break;
+    default:
+      *val = LSM9DS1_POS_MOVE_RECO_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  6D functionality axis interrupt threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data to be write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_6d_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_X_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  6D functionality axis interrupt threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_6d_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_X_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  .[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    .(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_6d_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_src_t *val)
+{
+  lsm9ds1_int_gen_src_xl_t int_gen_src_xl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_SRC_XL,
+                         (uint8_t*)&int_gen_src_xl, 1);
+  val->xl_xl = int_gen_src_xl.xl_xl;
+  val->xh_xl = int_gen_src_xl.xh_xl;
+  val->yl_xl = int_gen_src_xl.yl_xl;
+  val->yh_xl = int_gen_src_xl.yh_xl;
+  val->zl_xl = int_gen_src_xl.zl_xl;
+  val->zh_xl = int_gen_src_xl.zh_xl;
+  val->ia_xl = int_gen_src_xl.ia_xl;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup     LSM9DS1_Fifo
+  * @brief        This section group all the functions concerning the
+  *               fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_fth in reg CTRL_REG9.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_stop_on_wtm_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  if(ret == 0){
+    ctrl_reg9.stop_on_fth = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at
+  *         threshold level.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of stop_on_fth in reg CTRL_REG9.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_stop_on_wtm_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  *val = (uint8_t)ctrl_reg9.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fifo_en" in reg LSM9DS1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t val)
+{
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  lsm9ds1_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  if(ret == 0){
+    ctrl_reg9.fifo_en = ( ( (uint8_t)val & 0x10U ) >> 4);
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  }
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl.fmode = ( (uint8_t)val & 0x0FU );
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL_REG9.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t *val)
+{
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  lsm9ds1_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  if(ret == 0){
+    ret = lsm9ds1_read_reg(ctx, LSM9DS1_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  switch ((ctrl_reg9.fifo_en << 4) | ctrl_reg9.fifo_en){
+    case LSM9DS1_FIFO_OFF:
+      *val = LSM9DS1_FIFO_OFF;
+      break;
+    case LSM9DS1_BYPASS_MODE:
+      *val = LSM9DS1_BYPASS_MODE;
+      break;
+    case LSM9DS1_FIFO_MODE:
+      *val = LSM9DS1_FIFO_MODE;
+      break;
+    case LSM9DS1_STREAM_TO_FIFO_MODE:
+      *val = LSM9DS1_STREAM_TO_FIFO_MODE;
+      break;
+    case LSM9DS1_BYPASS_TO_STREAM_MODE:
+      *val = LSM9DS1_BYPASS_TO_STREAM_MODE;
+      break;
+    case LSM9DS1_STREAM_MODE:
+      *val = LSM9DS1_STREAM_MODE;
+      break;
+    default:
+      *val = LSM9DS1_FIFO_OFF;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_temp_en in reg CTRL_REG9.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_temp_batch_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  if(ret == 0){
+    ctrl_reg9.fifo_temp_en = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_temp_en in reg CTRL_REG9.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_temp_batch_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_ctrl_reg9_t ctrl_reg9;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG9, (uint8_t*)&ctrl_reg9, 1);
+  *val = (uint8_t)ctrl_reg9.fifo_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fth in reg FIFO_CTRL.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_watermark_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.fth = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_watermark_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = (uint8_t)fifo_ctrl.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFOfullstatus.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "fss" in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_full_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  Number of unread words (16-bit axes) stored in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "fss" in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_data_level_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "ovrn" in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_ovr_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.ovrn;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "fth" in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_fifo_wtm_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fth;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup     LSM9DS1_Self_test
+  * @brief        This section groups all the functions that manage self
+  *               test configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable/disable self-test mode for accelerometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_xl in reg CTRL_REG10.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_ctrl_reg10_t ctrl_reg10;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG10, (uint8_t*)&ctrl_reg10, 1);
+  if(ret == 0){
+    ctrl_reg10.st_xl = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG10, (uint8_t*)&ctrl_reg10, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable self-test mode for accelerometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_xl in reg CTRL_REG10.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_xl_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_ctrl_reg10_t ctrl_reg10;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG10, (uint8_t*)&ctrl_reg10, 1);
+  *val = (uint8_t)ctrl_reg10.st_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable self-test mode for gyroscope.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_g in reg CTRL_REG10.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_ctrl_reg10_t ctrl_reg10;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG10, (uint8_t*)&ctrl_reg10, 1);
+  if(ret == 0){
+    ctrl_reg10.st_g = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG10, (uint8_t*)&ctrl_reg10, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable self-test mode for gyroscope.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_g in reg CTRL_REG10.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_gy_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_ctrl_reg10_t ctrl_reg10;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG10, (uint8_t*)&ctrl_reg10, 1);
+  *val = (uint8_t)ctrl_reg10.st_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable self-test mode for magnatic sensor.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st in reg CTRL_REG1_M.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+{
+  lsm9ds1_ctrl_reg1_m_t ctrl_reg1_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_M, (uint8_t*)&ctrl_reg1_m, 1);
+  if(ret == 0){
+    ctrl_reg1_m.st = (uint8_t)val;
+    ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG1_M,
+                            (uint8_t*)&ctrl_reg1_m, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable self-test mode for magnatic sensor.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL_REG1_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm9ds1_mag_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+{
+  lsm9ds1_ctrl_reg1_m_t ctrl_reg1_m;
+  int32_t ret;
+
+  ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG1_M, (uint8_t*)&ctrl_reg1_m, 1);
+  *val = (uint8_t)ctrl_reg1_m.st;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm9ds1_STdC/driver/lsm9ds1_reg.h
+++ b/sensor/stmemsc/lsm9ds1_STdC/driver/lsm9ds1_reg.h
@@ -1,0 +1,1214 @@
+/*
+ ******************************************************************************
+ * @file    lsm9ds1_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm9ds1_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM9DS1_REGS_H
+#define LSM9DS1_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM9DS1
+  * @{
+  *
+  */
+
+/** @defgroup LSM9DS1_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+  /** @addtogroup  LSM9DS1_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*lsm9ds1_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*lsm9ds1_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  lsm9ds1_write_ptr  write_reg;
+  lsm9ds1_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} lsm9ds1_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM9DS1_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0xD5 if SA0=1 -> 0xD7 **/
+#define LSM9DS1_IMU_I2C_ADD_L      0xD5U
+#define LSM9DS1_IMU_I2C_ADD_H      0xD7U
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0x3D if SA0=1 -> 0x39 **/
+#define LSM9DS1_MAG_I2C_ADD_L      0x3DU
+#define LSM9DS1_MAG_I2C_ADD_H      0x39U
+
+/** Device Identification (Who am I) **/
+#define LSM9DS1_IMU_ID             0x68U
+
+/** Device Identification (Who am I) **/
+#define LSM9DS1_MAG_ID             0x3DU
+
+/**
+  * @}
+  *
+  */
+
+#define LSM9DS1_ACT_THS            0x04U
+typedef struct {
+  uint8_t act_ths                  : 7;
+  uint8_t sleep_on_inact_en        : 1;
+} lsm9ds1_act_ths_t;
+
+#define LSM9DS1_ACT_DUR            0x05U
+#define LSM9DS1_INT_GEN_CFG_XL     0x06U
+typedef struct {
+  uint8_t xlie_xl                  : 1;
+  uint8_t xhie_xl                  : 1;
+  uint8_t ylie_xl                  : 1;
+  uint8_t yhie_xl                  : 1;
+  uint8_t zlie_xl                  : 1;
+  uint8_t zhie_xl                  : 1;
+  uint8_t _6d                      : 1;
+  uint8_t aoi_xl                   : 1;
+} lsm9ds1_int_gen_cfg_xl_t;
+
+#define LSM9DS1_INT_GEN_THS_X_XL   0x07U
+#define LSM9DS1_INT_GEN_THS_Y_XL   0x08U
+#define LSM9DS1_INT_GEN_THS_Z_XL   0x09U
+#define LSM9DS1_INT_GEN_DUR_XL     0x0AU
+typedef struct {
+  uint8_t dur_xl                   : 7;
+  uint8_t wait_xl                  : 1;
+} lsm9ds1_int_gen_dur_xl_t;
+
+#define LSM9DS1_REFERENCE_G        0x0BU
+#define LSM9DS1_INT1_CTRL          0x0CU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_ovr                 : 1;
+  uint8_t int1_fss5                : 1;
+  uint8_t int1_ig_xl               : 1;
+  uint8_t int1_ig_g                : 1;
+} lsm9ds1_int1_ctrl_t;
+
+#define LSM9DS1_INT2_CTRL          0x0DU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_ovr                 : 1;
+  uint8_t int2_fss5                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t int2_inact               : 1;
+} lsm9ds1_int2_ctrl_t;
+
+#define LSM9DS1_WHO_AM_I           0x0FU
+#define LSM9DS1_CTRL_REG1_G        0x10U
+typedef struct {
+  uint8_t bw_g                     : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t fs_g                     : 2;
+  uint8_t odr_g                    : 3;
+} lsm9ds1_ctrl_reg1_g_t;
+
+#define LSM9DS1_CTRL_REG2_G        0x11U
+typedef struct {
+  uint8_t out_sel                  : 2;
+  uint8_t int_sel                  : 2;
+  uint8_t not_used_01              : 4;
+} lsm9ds1_ctrl_reg2_g_t;
+
+#define LSM9DS1_CTRL_REG3_G        0x12U
+typedef struct {
+  uint8_t hpcf_g                   : 4;
+  uint8_t not_used_01              : 2;
+  uint8_t hp_en                    : 1;
+  uint8_t lp_mode                  : 1;
+} lsm9ds1_ctrl_reg3_g_t;
+
+#define LSM9DS1_ORIENT_CFG_G       0x13U
+typedef struct {
+  uint8_t orient                   : 3;
+  uint8_t signz_g                  : 1;
+  uint8_t signy_g                  : 1;
+  uint8_t signx_g                  : 1;
+  uint8_t not_used_01              : 2;
+} lsm9ds1_orient_cfg_g_t;
+
+#define LSM9DS1_INT_GEN_SRC_G      0x14U
+typedef struct {
+  uint8_t xl_g                     : 1;
+  uint8_t xh_g                     : 1;
+  uint8_t yl_g                     : 1;
+  uint8_t yh_g                     : 1;
+  uint8_t zl_g                     : 1;
+  uint8_t zh_g                     : 1;
+  uint8_t ia_g                     : 1;
+  uint8_t not_used_01              : 1;
+} lsm9ds1_int_gen_src_g_t;
+
+#define LSM9DS1_OUT_TEMP_L         0x15U
+#define LSM9DS1_OUT_TEMP_H         0x16U
+#define LSM9DS1_STATUS_REG         0x17U
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t boot_status              : 1;
+  uint8_t inact                    : 1;
+  uint8_t ig_g                     : 1;
+  uint8_t ig_xl                    : 1;
+  uint8_t not_used_01              : 1;
+} lsm9ds1_status_reg_t;
+
+#define LSM9DS1_OUT_X_L_G          0x18U
+#define LSM9DS1_OUT_X_H_G          0x19U
+#define LSM9DS1_OUT_Y_L_G          0x1AU
+#define LSM9DS1_OUT_Y_H_G          0x1BU
+#define LSM9DS1_OUT_Z_L_G          0x1CU
+#define LSM9DS1_OUT_Z_H_G          0x1DU
+#define LSM9DS1_CTRL_REG4          0x1EU
+typedef struct {
+  uint8_t _4d_xl1                   : 1;
+  uint8_t lir_xl1                  : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t xen_g                    : 1;
+  uint8_t yen_g                    : 1;
+  uint8_t zen_g                    : 1;
+  uint8_t not_used_02              : 2;
+} lsm9ds1_ctrl_reg4_t;
+
+#define LSM9DS1_CTRL_REG5_XL       0x1FU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t xen_xl                   : 1;
+  uint8_t yen_xl                   : 1;
+  uint8_t zen_xl                   : 1;
+  uint8_t dec                      : 2;
+} lsm9ds1_ctrl_reg5_xl_t;
+
+#define LSM9DS1_CTRL_REG6_XL       0x20U
+typedef struct {
+  uint8_t bw_xl                    : 2;
+  uint8_t bw_scal_odr              : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 3;
+} lsm9ds1_ctrl_reg6_xl_t;
+
+#define LSM9DS1_CTRL_REG7_XL       0x21U
+typedef struct {
+  uint8_t hpis1                    : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t fds                      : 1;
+  uint8_t not_used_02              : 2;
+  uint8_t dcf                      : 2;
+  uint8_t hr                       : 1;
+} lsm9ds1_ctrl_reg7_xl_t;
+
+#define LSM9DS1_CTRL_REG8          0x22U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t ble                      : 1;
+  uint8_t if_add_inc               : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} lsm9ds1_ctrl_reg8_t;
+
+#define LSM9DS1_CTRL_REG9          0x23U
+typedef struct {
+  uint8_t stop_on_fth              : 1;
+  uint8_t fifo_en                  : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask_bit            : 1;
+  uint8_t fifo_temp_en             : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t sleep_g                  : 1;
+  uint8_t not_used_02              : 1;
+} lsm9ds1_ctrl_reg9_t;
+
+#define LSM9DS1_CTRL_REG10         0x24U
+typedef struct {
+  uint8_t st_xl                    : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t st_g                     : 1;
+  uint8_t not_used_02              : 5;
+} lsm9ds1_ctrl_reg10_t;
+
+#define LSM9DS1_INT_GEN_SRC_XL     0x26U
+typedef struct {
+  uint8_t xl_xl                    : 1;
+  uint8_t xh_xl                    : 1;
+  uint8_t yl_xl                    : 1;
+  uint8_t yh_xl                    : 1;
+  uint8_t zl_xl                    : 1;
+  uint8_t zh_xl                    : 1;
+  uint8_t ia_xl                    : 1;
+  uint8_t not_used_01              : 1;
+} lsm9ds1_int_gen_src_xl_t;
+
+#define LSM9DS1_OUT_X_L_XL         0x28U
+#define LSM9DS1_OUT_X_H_XL         0x29U
+#define LSM9DS1_OUT_Y_L_XL         0x2AU
+#define LSM9DS1_OUT_Y_H_XL         0x2BU
+#define LSM9DS1_OUT_Z_L_XL         0x2CU
+#define LSM9DS1_OUT_Z_H_XL         0x2DU
+#define LSM9DS1_FIFO_CTRL          0x2EU
+typedef struct {
+  uint8_t fth                      : 5;
+  uint8_t fmode                    : 3;
+} lsm9ds1_fifo_ctrl_t;
+
+#define LSM9DS1_FIFO_SRC           0x2FU
+typedef struct {
+  uint8_t fss                      : 6;
+  uint8_t ovrn                     : 1;
+  uint8_t fth                      : 1;
+} lsm9ds1_fifo_src_t;
+
+#define LSM9DS1_INT_GEN_CFG_G      0x30U
+typedef struct {
+  uint8_t xlie_g                   : 1;
+  uint8_t xhie_g                   : 1;
+  uint8_t ylie_g                   : 1;
+  uint8_t yhie_g                   : 1;
+  uint8_t zlie_g                   : 1;
+  uint8_t zhie_g                   : 1;
+  uint8_t lir_g                    : 1;
+  uint8_t aoi_g                    : 1;
+} lsm9ds1_int_gen_cfg_g_t;
+
+#define LSM9DS1_INT_GEN_THS_XH_G   0x31U
+typedef struct {
+  uint8_t ths_g_x                  : 7;
+  uint8_t dcrm_g                   : 1;
+} lsm9ds1_int_gen_ths_xh_g_t;
+
+#define LSM9DS1_INT_GEN_THS_XL_G   0x32U
+typedef struct {
+  uint8_t ths_g_x                  : 8;
+} lsm9ds1_int_gen_ths_xl_g_t;
+#define LSM9DS1_INT_GEN_THS_YH_G   0x33U
+typedef struct {
+  uint8_t ths_g_y                  : 7;
+  uint8_t not_used_01              : 1;
+} lsm9ds1_int_gen_ths_yh_g_t;
+
+#define LSM9DS1_INT_GEN_THS_YL_G   0x34U
+typedef struct {
+  uint8_t ths_g_y                  : 8;
+} lsm9ds1_int_gen_ths_yl_g_t;
+#define LSM9DS1_INT_GEN_THS_ZH_G   0x35U
+typedef struct {
+  uint8_t ths_g_z                  : 7;
+  uint8_t not_used_01              : 1;
+} lsm9ds1_int_gen_ths_zh_g_t;
+
+#define LSM9DS1_INT_GEN_THS_ZL_G   0x36U
+typedef struct {
+  uint8_t ths_g_z                  : 8;
+} lsm9ds1_int_gen_ths_zl_g_t;
+#define LSM9DS1_INT_GEN_DUR_G      0x37U
+typedef struct {
+  uint8_t dur_g                    : 7;
+  uint8_t wait_g                   : 1;
+} lsm9ds1_int_gen_dur_g_t;
+
+#define LSM9DS1_OFFSET_X_REG_L_M   0x05U
+#define LSM9DS1_OFFSET_X_REG_H_M   0x06U
+#define LSM9DS1_OFFSET_Y_REG_L_M   0x07U
+#define LSM9DS1_OFFSET_Y_REG_H_M   0x08U
+#define LSM9DS1_OFFSET_Z_REG_L_M   0x09U
+#define LSM9DS1_OFFSET_Z_REG_H_M   0x0AU
+
+#define LSM9DS1_WHO_AM_I_M         0x0FU
+#define LSM9DS1_CTRL_REG1_M        0x20U
+typedef struct {
+  uint8_t st                       : 1;
+  uint8_t fast_odr                 : 1;
+  uint8_t _do                       : 3;
+  uint8_t om                       : 2;
+  uint8_t temp_comp                : 1;
+} lsm9ds1_ctrl_reg1_m_t;
+
+#define LSM9DS1_CTRL_REG2_M        0x21U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t soft_rst                 : 1;
+  uint8_t reboot                   : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t fs                       : 2;
+  uint8_t not_used_03              : 1;
+} lsm9ds1_ctrl_reg2_m_t;
+
+#define LSM9DS1_CTRL_REG3_M        0x22U
+typedef struct {
+  uint8_t md                       : 2;
+  uint8_t sim                      : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t lp                       : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t i2c_disable              : 1;
+} lsm9ds1_ctrl_reg3_m_t;
+
+#define LSM9DS1_CTRL_REG4_M        0x23U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t ble                      : 1;
+  uint8_t omz                      : 2;
+  uint8_t not_used_02              : 4;
+} lsm9ds1_ctrl_reg4_m_t;
+
+#define LSM9DS1_CTRL_REG5_M        0x24U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t bdu                      : 1;
+  uint8_t fast_read                : 1;
+} lsm9ds1_ctrl_reg5_m_t;
+
+#define LSM9DS1_STATUS_REG_M       0x27U
+typedef struct {
+  uint8_t xda                      : 1;
+  uint8_t yda                      : 1;
+  uint8_t zda                      : 1;
+  uint8_t zyxda                    : 1;
+  uint8_t _xor                     : 1;
+  uint8_t yor                      : 1;
+  uint8_t zor                      : 1;
+  uint8_t zyxor                    : 1;
+} lsm9ds1_status_reg_m_t;
+
+#define LSM9DS1_OUT_X_L_M          0x28U
+#define LSM9DS1_OUT_X_H_M          0x29U
+#define LSM9DS1_OUT_Y_L_M          0x2AU
+#define LSM9DS1_OUT_Y_H_M          0x2BU
+#define LSM9DS1_OUT_Z_L_M          0x2CU
+#define LSM9DS1_OUT_Z_H_M          0x2DU
+#define LSM9DS1_INT_CFG_M          0x30U
+typedef struct {
+  uint8_t ien                      : 1;
+  uint8_t iel                      : 1;
+  uint8_t iea                      : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t zien                     : 1;
+  uint8_t yien                     : 1;
+  uint8_t xien                     : 1;
+} lsm9ds1_int_cfg_m_t;
+
+#define LSM9DS1_INT_SRC_M          0x31U
+typedef struct {
+  uint8_t _int                      : 1;
+  uint8_t mroi                     : 1;
+  uint8_t nth_z                    : 1;
+  uint8_t nth_y                    : 1;
+  uint8_t nth_x                    : 1;
+  uint8_t pth_z                    : 1;
+  uint8_t pth_y                    : 1;
+  uint8_t pth_x                    : 1;
+} lsm9ds1_int_src_m_t;
+
+#define LSM9DS1_INT_THS_L_M        0x32U
+typedef struct {
+  uint8_t ths                      : 8;
+} lsm9ds1_int_ths_l_m_t;
+
+#define LSM9DS1_INT_THS_H_M        0x33U
+typedef struct {
+  uint8_t ths                      : 7;
+  uint8_t not_used_01              : 1;
+} lsm9ds1_int_ths_h_m_t;
+
+/**
+  * @defgroup LSM9DS1_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lsm9ds1_act_ths_t                act_ths;
+  lsm9ds1_int_gen_cfg_xl_t         int_gen_cfg_xl;
+  lsm9ds1_int_gen_dur_xl_t         int_gen_dur_xl;
+  lsm9ds1_int1_ctrl_t              int1_ctrl;
+  lsm9ds1_int2_ctrl_t              int2_ctrl;
+  lsm9ds1_ctrl_reg1_g_t            ctrl_reg1_g;
+  lsm9ds1_ctrl_reg2_g_t            ctrl_reg2_g;
+  lsm9ds1_ctrl_reg3_g_t            ctrl_reg3_g;
+  lsm9ds1_orient_cfg_g_t           orient_cfg_g;
+  lsm9ds1_int_gen_src_g_t          int_gen_src_g;
+  lsm9ds1_status_reg_t             status_reg;
+  lsm9ds1_ctrl_reg4_t              ctrl_reg4;
+  lsm9ds1_ctrl_reg5_xl_t           ctrl_reg5_xl;
+  lsm9ds1_ctrl_reg6_xl_t           ctrl_reg6_xl;
+  lsm9ds1_ctrl_reg7_xl_t           ctrl_reg7_xl;
+  lsm9ds1_ctrl_reg8_t              ctrl_reg8;
+  lsm9ds1_ctrl_reg9_t              ctrl_reg9;
+  lsm9ds1_ctrl_reg10_t             ctrl_reg10;
+  lsm9ds1_int_gen_src_xl_t         int_gen_src_xl;
+  lsm9ds1_fifo_ctrl_t              fifo_ctrl;
+  lsm9ds1_fifo_src_t               fifo_src;
+  lsm9ds1_int_gen_cfg_g_t          int_gen_cfg_g;
+  lsm9ds1_int_gen_ths_xh_g_t       int_gen_ths_xh_g;
+  lsm9ds1_int_gen_ths_xl_g_t       int_gen_ths_xl_g;
+  lsm9ds1_int_gen_ths_yh_g_t       int_gen_ths_yh_g;
+  lsm9ds1_int_gen_ths_yl_g_t       int_gen_ths_yl_g;
+  lsm9ds1_int_gen_ths_zh_g_t       int_gen_ths_zh_g;
+  lsm9ds1_int_gen_ths_zl_g_t       int_gen_ths_zl_g;
+  lsm9ds1_int_gen_dur_g_t          int_gen_dur_g;
+  lsm9ds1_ctrl_reg1_m_t            ctrl_reg1_m;
+  lsm9ds1_ctrl_reg2_m_t            ctrl_reg2_m;
+  lsm9ds1_ctrl_reg3_m_t            ctrl_reg3_m;
+  lsm9ds1_ctrl_reg4_m_t            ctrl_reg4_m;
+  lsm9ds1_ctrl_reg5_m_t            ctrl_reg5_m;
+  lsm9ds1_status_reg_m_t           status_reg_m;
+  lsm9ds1_int_cfg_m_t              int_cfg_m;
+  lsm9ds1_int_src_m_t              int_src_m;
+  lsm9ds1_int_ths_l_m_t            int_ths_l_m;
+  lsm9ds1_int_ths_h_m_t            int_ths_h_m;
+  bitwise_t                        bitwise;
+  uint8_t                          byte;
+} lsm9ds1_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm9ds1_read_reg(lsm9ds1_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lsm9ds1_write_reg(lsm9ds1_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lsm9ds1_from_fs2g_to_mg(int16_t lsb);
+extern float_t lsm9ds1_from_fs4g_to_mg(int16_t lsb);
+extern float_t lsm9ds1_from_fs8g_to_mg(int16_t lsb);
+extern float_t lsm9ds1_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t lsm9ds1_from_fs245dps_to_mdps(int16_t lsb);
+extern float_t lsm9ds1_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t lsm9ds1_from_fs2000dps_to_mdps(int16_t lsb);
+
+extern float_t lsm9ds1_from_fs4gauss_to_mG(int16_t lsb);
+extern float_t lsm9ds1_from_fs8gauss_to_mG(int16_t lsb);
+extern float_t lsm9ds1_from_fs12gauss_to_mG(int16_t lsb);
+extern float_t lsm9ds1_from_fs16gauss_to_mG(int16_t lsb);
+
+extern float_t lsm9ds1_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  LSM9DS1_245dps = 0,
+  LSM9DS1_500dps = 1,
+  LSM9DS1_2000dps = 3,
+} lsm9ds1_gy_fs_t;
+int32_t lsm9ds1_gy_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t val);
+int32_t lsm9ds1_gy_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t *val);
+
+typedef enum {
+  LSM9DS1_IMU_OFF              = 0x00,
+  LSM9DS1_GY_OFF_XL_10Hz       = 0x10,
+  LSM9DS1_GY_OFF_XL_50Hz       = 0x20,
+  LSM9DS1_GY_OFF_XL_119Hz      = 0x30,
+  LSM9DS1_GY_OFF_XL_238Hz      = 0x40,
+  LSM9DS1_GY_OFF_XL_476Hz      = 0x50,
+  LSM9DS1_GY_OFF_XL_952Hz      = 0x60,
+  LSM9DS1_XL_OFF_GY_14Hz9      = 0x01,
+  LSM9DS1_XL_OFF_GY_59Hz5      = 0x02,
+  LSM9DS1_XL_OFF_GY_119Hz      = 0x03,
+  LSM9DS1_XL_OFF_GY_238Hz      = 0x04,
+  LSM9DS1_XL_OFF_GY_476Hz      = 0x05,
+  LSM9DS1_XL_OFF_GY_952Hz      = 0x06,
+  LSM9DS1_IMU_14Hz9            = 0x11,
+  LSM9DS1_IMU_59Hz5            = 0x22,
+  LSM9DS1_IMU_119Hz            = 0x33,
+  LSM9DS1_IMU_238Hz            = 0x44,
+  LSM9DS1_IMU_476Hz            = 0x55,
+  LSM9DS1_IMU_952Hz            = 0x66,
+  LSM9DS1_XL_OFF_GY_14Hz9_LP   = 0x81,
+  LSM9DS1_XL_OFF_GY_59Hz5_LP   = 0x82,
+  LSM9DS1_XL_OFF_GY_119Hz_LP   = 0x83,
+  LSM9DS1_IMU_14Hz9_LP         = 0x91,
+  LSM9DS1_IMU_59Hz5_LP         = 0xA2,
+  LSM9DS1_IMU_119Hz_LP         = 0xB3,
+} lsm9ds1_imu_odr_t;
+int32_t lsm9ds1_imu_data_rate_set(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_imu_odr_t val);
+int32_t lsm9ds1_imu_data_rate_get(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_imu_odr_t *val);
+
+typedef struct {
+  uint8_t orient              : 3;
+  uint8_t signz_g             : 1; /*(0: positive; 1: negative)*/
+  uint8_t signy_g             : 1; /*(0: positive; 1: negative)*/
+  uint8_t signx_g             : 1; /*(0: positive; 1: negative)*/
+} lsm9ds1_gy_orient_t;
+int32_t lsm9ds1_gy_orient_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t val);
+int32_t lsm9ds1_gy_orient_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t *val);
+
+int32_t lsm9ds1_xl_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_gy_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_temp_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t xen_g             : 1;
+  uint8_t yen_g             : 1;
+  uint8_t zen_g             : 1;
+} lsm9ds1_gy_axis_t;
+int32_t lsm9ds1_gy_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t val);
+int32_t lsm9ds1_gy_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t *val);
+
+typedef struct {
+  uint8_t xen_xl             : 1;
+  uint8_t yen_xl             : 1;
+  uint8_t zen_xl             : 1;
+} lsm9ds1_xl_axis_t;
+int32_t lsm9ds1_xl_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t val);
+int32_t lsm9ds1_xl_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t *val);
+
+typedef enum {
+  LSM9DS1_NO_DECIMATION     = 0,
+  LSM9DS1_EVERY_2_SAMPLES   = 1,
+  LSM9DS1_EVERY_4_SAMPLES   = 2,
+  LSM9DS1_EVERY_8_SAMPLES   = 3,
+} lsm9ds1_dec_t;
+int32_t lsm9ds1_xl_decimation_set(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t val);
+int32_t lsm9ds1_xl_decimation_get(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t *val);
+
+typedef enum {
+  LSM9DS1_2g     = 0,
+  LSM9DS1_16g    = 1,
+  LSM9DS1_4g     = 2,
+  LSM9DS1_8g     = 3,
+} lsm9ds1_xl_fs_t;
+int32_t lsm9ds1_xl_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t val);
+int32_t lsm9ds1_xl_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t *val);
+
+int32_t lsm9ds1_block_data_update_set(lsm9ds1_ctx_t *ctx_mag,
+                                      lsm9ds1_ctx_t *ctx_imu, uint8_t val);
+int32_t lsm9ds1_block_data_update_get(lsm9ds1_ctx_t *ctx_mag,
+                                      lsm9ds1_ctx_t *ctx_imu, uint8_t *val);
+
+int32_t lsm9ds1_mag_offset_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_mag_offset_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM9DS1_MAG_POWER_DOWN    = 0xC0,
+  LSM9DS1_MAG_LP_0Hz625     = 0x00,
+  LSM9DS1_MAG_LP_1Hz25      = 0x01,
+  LSM9DS1_MAG_LP_2Hz5       = 0x02,
+  LSM9DS1_MAG_LP_5Hz        = 0x03,
+  LSM9DS1_MAG_LP_10Hz       = 0x04,
+  LSM9DS1_MAG_LP_20Hz       = 0x05,
+  LSM9DS1_MAG_LP_40Hz       = 0x06,
+  LSM9DS1_MAG_LP_80Hz       = 0x07,
+  LSM9DS1_MAG_MP_0Hz625     = 0x10,
+  LSM9DS1_MAG_MP_1Hz25      = 0x11,
+  LSM9DS1_MAG_MP_2Hz5       = 0x12,
+  LSM9DS1_MAG_MP_5Hz        = 0x13,
+  LSM9DS1_MAG_MP_10Hz       = 0x14,
+  LSM9DS1_MAG_MP_20Hz       = 0x15,
+  LSM9DS1_MAG_MP_40Hz       = 0x16,
+  LSM9DS1_MAG_MP_80Hz       = 0x17,
+  LSM9DS1_MAG_HP_0Hz625     = 0x20,
+  LSM9DS1_MAG_HP_1Hz25      = 0x21,
+  LSM9DS1_MAG_HP_2Hz5       = 0x22,
+  LSM9DS1_MAG_HP_5Hz        = 0x23,
+  LSM9DS1_MAG_HP_10Hz       = 0x24,
+  LSM9DS1_MAG_HP_20Hz       = 0x25,
+  LSM9DS1_MAG_HP_40Hz       = 0x26,
+  LSM9DS1_MAG_HP_80Hz       = 0x27,
+  LSM9DS1_MAG_UHP_0Hz625    = 0x30,
+  LSM9DS1_MAG_UHP_1Hz25     = 0x31,
+  LSM9DS1_MAG_UHP_2Hz5      = 0x32,
+  LSM9DS1_MAG_UHP_5Hz       = 0x33,
+  LSM9DS1_MAG_UHP_10Hz      = 0x34,
+  LSM9DS1_MAG_UHP_20Hz      = 0x35,
+  LSM9DS1_MAG_UHP_40Hz      = 0x36,
+  LSM9DS1_MAG_UHP_80Hz      = 0x37,
+  LSM9DS1_MAG_UHP_155Hz     = 0x38,
+  LSM9DS1_MAG_HP_300Hz      = 0x28,
+  LSM9DS1_MAG_MP_560Hz      = 0x18,
+  LSM9DS1_MAG_LP_1000Hz     = 0x08,
+  LSM9DS1_MAG_ONE_SHOT      = 0x70,
+} lsm9ds1_mag_data_rate_t;
+int32_t lsm9ds1_mag_data_rate_set(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_mag_data_rate_t val);
+int32_t lsm9ds1_mag_data_rate_get(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_mag_data_rate_t *val);
+
+typedef enum {
+  LSM9DS1_4Ga    = 0,
+  LSM9DS1_8Ga    = 1,
+  LSM9DS1_12Ga   = 2,
+  LSM9DS1_16Ga   = 3,
+} lsm9ds1_mag_fs_t;
+int32_t lsm9ds1_mag_full_scale_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_mag_fs_t val);
+int32_t lsm9ds1_mag_full_scale_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_mag_fs_t *val);
+
+int32_t lsm9ds1_mag_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_temperature_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm9ds1_angular_rate_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm9ds1_acceleration_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm9ds1_magnetic_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm9ds1_magnetic_overflow_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t imu;
+  uint8_t mag;
+} lsm9ds1_id_t;
+int32_t lsm9ds1_dev_id_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                           lsm9ds1_id_t *buff);
+
+typedef struct {
+  lsm9ds1_status_reg_m_t status_mag;
+  lsm9ds1_status_reg_t   status_imu;
+} lsm9ds1_status_t;
+int32_t lsm9ds1_dev_status_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                               lsm9ds1_status_t *val);
+
+int32_t lsm9ds1_dev_reset_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                              uint8_t val);
+int32_t lsm9ds1_dev_reset_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                              uint8_t *val);
+
+typedef enum {
+  LSM9DS1_LSB_LOW_ADDRESS = 0,
+  LSM9DS1_MSB_LOW_ADDRESS = 1,
+} lsm9ds1_ble_t;
+int32_t lsm9ds1_dev_data_format_set(lsm9ds1_ctx_t *ctx_mag,
+                                    lsm9ds1_ctx_t *ctx_imu,
+                                    lsm9ds1_ble_t val);
+int32_t lsm9ds1_dev_data_format_get(lsm9ds1_ctx_t *ctx_mag,
+                                    lsm9ds1_ctx_t *ctx_imu,
+                                    lsm9ds1_ble_t *val);
+
+int32_t lsm9ds1_dev_boot_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                             uint8_t val);
+int32_t lsm9ds1_dev_boot_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                             uint8_t *val);
+
+int32_t lsm9ds1_gy_filter_reference_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_gy_filter_reference_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM9DS1_LP_STRONG        = 0,
+  LSM9DS1_LP_MEDIUM        = 1,
+  LSM9DS1_LP_LIGHT         = 2,
+  LSM9DS1_LP_ULTRA_LIGHT   = 3,
+} lsm9ds1_gy_lp_bw_t;
+int32_t lsm9ds1_gy_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_gy_lp_bw_t val);
+int32_t lsm9ds1_gy_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_gy_lp_bw_t *val);
+
+typedef enum {
+  LSM9DS1_LPF1_OUT              = 0x00,
+  LSM9DS1_LPF1_HPF_OUT          = 0x01,
+  LSM9DS1_LPF1_LPF2_OUT         = 0x02,
+  LSM9DS1_LPF1_HPF_LPF2_OUT     = 0x12,
+} lsm9ds1_gy_out_path_t;
+int32_t lsm9ds1_gy_filter_out_path_set(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_gy_out_path_t val);
+int32_t lsm9ds1_gy_filter_out_path_get(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_gy_out_path_t *val);
+
+typedef enum {
+  LSM9DS1_LPF1_INT              = 0x00,
+  LSM9DS1_LPF1_HPF_INT          = 0x01,
+  LSM9DS1_LPF1_LPF2_INT         = 0x02,
+  LSM9DS1_LPF1_HPF_LPF2_INT     = 0x12,
+} lsm9ds1_gy_int_path_t;
+int32_t lsm9ds1_gy_filter_int_path_set(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_gy_int_path_t val);
+int32_t lsm9ds1_gy_filter_int_path_get(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_gy_int_path_t *val);
+
+typedef enum {
+  LSM9DS1_HP_EXTREME       = 0,
+  LSM9DS1_HP_ULTRA_STRONG  = 1,
+  LSM9DS1_HP_STRONG        = 2,
+  LSM9DS1_HP_ULTRA_HIGH    = 3,
+  LSM9DS1_HP_HIGH          = 4,
+  LSM9DS1_HP_MEDIUM        = 5,
+  LSM9DS1_HP_LOW           = 6,
+  LSM9DS1_HP_ULTRA_LOW     = 7,
+  LSM9DS1_HP_LIGHT         = 8,
+  LSM9DS1_HP_ULTRA_LIGHT   = 9,
+} lsm9ds1_gy_hp_bw_t;
+int32_t lsm9ds1_gy_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_gy_hp_bw_t val);
+int32_t lsm9ds1_gy_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_gy_hp_bw_t *val);
+
+typedef enum {
+  LSM9DS1_AUTO      = 0x00,
+  LSM9DS1_408Hz     = 0x10,
+  LSM9DS1_211Hz     = 0x11,
+  LSM9DS1_105Hz     = 0x12,
+  LSM9DS1_50Hz      = 0x13,
+} lsm9ds1_xl_aa_bw_t;
+int32_t lsm9ds1_xl_filter_aalias_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                               lsm9ds1_xl_aa_bw_t val);
+int32_t lsm9ds1_xl_filter_aalias_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                               lsm9ds1_xl_aa_bw_t *val);
+typedef enum {
+  LSM9DS1_HP_DIS  = 0,
+  LSM9DS1_HP_EN   = 1,
+} lsm9ds1_xl_hp_path_t;
+int32_t lsm9ds1_xl_filter_int_path_set(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_xl_hp_path_t val);
+int32_t lsm9ds1_xl_filter_int_path_get(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_xl_hp_path_t *val);
+
+typedef enum {
+  LSM9DS1_LP_OUT     = 0,
+  LSM9DS1_HP_OUT     = 1,
+} lsm9ds1_xl_out_path_t;
+int32_t lsm9ds1_xl_filter_out_path_set(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_xl_out_path_t val);
+int32_t lsm9ds1_xl_filter_out_path_get(lsm9ds1_ctx_t *ctx,
+                                       lsm9ds1_xl_out_path_t *val);
+
+typedef enum {
+  LSM9DS1_LP_DISABLE     = 0x00,
+  LSM9DS1_LP_ODR_DIV_50     = 0x10,
+  LSM9DS1_LP_ODR_DIV_100    = 0x11,
+  LSM9DS1_LP_ODR_DIV_9      = 0x12,
+  LSM9DS1_LP_ODR_DIV_400    = 0x13,
+} lsm9ds1_xl_lp_bw_t;
+int32_t lsm9ds1_xl_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_xl_lp_bw_t val);
+int32_t lsm9ds1_xl_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_xl_lp_bw_t *val);
+
+typedef enum {
+  LSM9DS1_HP_ODR_DIV_50   = 0,
+  LSM9DS1_HP_ODR_DIV_100  = 1,
+  LSM9DS1_HP_ODR_DIV_9    = 2,
+  LSM9DS1_HP_ODR_DIV_400  = 3,
+} lsm9ds1_xl_hp_bw_t;
+int32_t lsm9ds1_xl_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_xl_hp_bw_t val);
+int32_t lsm9ds1_xl_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+                                           lsm9ds1_xl_hp_bw_t *val);
+
+int32_t lsm9ds1_filter_settling_mask_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_filter_settling_mask_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_auto_increment_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_auto_increment_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM9DS1_SPI_4_WIRE = 0,
+  LSM9DS1_SPI_3_WIRE = 1,
+} lsm9ds1_sim_t;
+int32_t lsm9ds1_spi_mode_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                             lsm9ds1_sim_t val);
+int32_t lsm9ds1_spi_mode_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+                             lsm9ds1_sim_t *val);
+
+typedef enum {
+  LSM9DS1_I2C_ENABLE = 0,
+  LSM9DS1_I2C_DISABLE = 1,
+} lsm9ds1_i2c_dis_t;
+int32_t lsm9ds1_i2c_interface_set(lsm9ds1_ctx_t *ctx_mag,
+                                  lsm9ds1_ctx_t *ctx_imu,
+                                  lsm9ds1_i2c_dis_t val);
+int32_t lsm9ds1_i2c_interface_get(lsm9ds1_ctx_t *ctx_mag,
+                                  lsm9ds1_ctx_t *ctx_imu,
+                                  lsm9ds1_i2c_dis_t *val);
+
+typedef enum {
+  LSM9DS1_LOGIC_OR    = 0,
+  LSM9DS1_LOGIC_AND   = 1,
+} lsm9ds1_pin_logic_t;
+int32_t lsm9ds1_pin_logic_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t val);
+int32_t lsm9ds1_pin_logic_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t *val);
+
+typedef struct {
+  uint8_t int1_drdy_xl      : 1;
+  uint8_t int1_drdy_g       : 1;
+  uint8_t int1_boot         : 1;
+  uint8_t int1_fth          : 1;
+  uint8_t int1_ovr          : 1;
+  uint8_t int1_fss5         : 1;
+  uint8_t int1_ig_xl        : 1;
+  uint8_t int1_ig_g         : 1;
+} lsm9ds1_pin_int1_route_t;
+int32_t lsm9ds1_pin_int1_route_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_pin_int1_route_t val);
+int32_t lsm9ds1_pin_int1_route_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_pin_int1_route_t *val);
+typedef struct {
+  uint8_t int2_drdy_xl       : 1;
+  uint8_t int2_drdy_g        : 1;
+  uint8_t int2_drdy_temp     : 1;
+  uint8_t int2_fth           : 1;
+  uint8_t int2_ovr           : 1;
+  uint8_t int2_fss5          : 1;
+  uint8_t int2_inact         : 1;
+} lsm9ds1_pin_int2_route_t;
+int32_t lsm9ds1_pin_int2_route_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_pin_int2_route_t val);
+int32_t lsm9ds1_pin_int2_route_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_pin_int2_route_t *val);
+
+typedef enum {
+  LSM9DS1_INT_PULSED  = 0,
+  LSM9DS1_INT_LATCHED = 1,
+} lsm9ds1_lir_t;
+int32_t lsm9ds1_pin_notification_set(lsm9ds1_ctx_t *ctx_mag,
+                                     lsm9ds1_ctx_t *ctx_imu,
+                                     lsm9ds1_lir_t val);
+int32_t lsm9ds1_pin_notification_get(lsm9ds1_ctx_t *ctx_mag,
+                                     lsm9ds1_ctx_t *ctx_imu,
+                                     lsm9ds1_lir_t *val);
+
+typedef enum {
+  LSM9DS1_PUSH_PULL   = 0,
+  LSM9DS1_OPEN_DRAIN  = 1,
+} lsm9ds1_pp_od_t;
+int32_t lsm9ds1_pin_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t val);
+int32_t lsm9ds1_pin_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t *val);
+
+typedef struct {
+  uint8_t ien             : 1;
+} lsm9ds1_pin_m_route_t;
+int32_t lsm9ds1_pin_int_m_route_set(lsm9ds1_ctx_t *ctx,
+                                    lsm9ds1_pin_m_route_t val);
+int32_t lsm9ds1_pin_int_m_route_get(lsm9ds1_ctx_t *ctx,
+                                    lsm9ds1_pin_m_route_t *val);
+typedef enum {
+  LSM9DS1_ACTIVE_LOW    = 0,
+  LSM9DS1_ACTIVE_HIGH   = 1,
+} lsm9ds1_polarity_t;
+int32_t lsm9ds1_pin_polarity_set(lsm9ds1_ctx_t *ctx_mag,
+                                 lsm9ds1_ctx_t *ctx_imu,
+                                 lsm9ds1_polarity_t val);
+int32_t lsm9ds1_pin_polarity_get(lsm9ds1_ctx_t *ctx_mag,
+                                 lsm9ds1_ctx_t *ctx_imu,
+                                 lsm9ds1_polarity_t *val);
+
+typedef struct {
+  uint8_t xlie_xl             : 1;
+  uint8_t xhie_xl             : 1;
+  uint8_t ylie_xl             : 1;
+  uint8_t yhie_xl             : 1;
+  uint8_t zlie_xl             : 1;
+  uint8_t zhie_xl             : 1;
+} lsm9ds1_xl_trshld_en_t;
+int32_t lsm9ds1_xl_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_xl_trshld_en_t val);
+int32_t lsm9ds1_xl_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_xl_trshld_en_t *val);
+
+int32_t lsm9ds1_xl_trshld_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_xl_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm9ds1_xl_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_xl_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t xl_g             : 1;
+  uint8_t xh_g             : 1;
+  uint8_t yl_g             : 1;
+  uint8_t yh_g             : 1;
+  uint8_t zl_g             : 1;
+  uint8_t zh_g             : 1;
+  uint8_t ia_g             : 1;
+} lsm9ds1_gy_trshld_src_t;
+int32_t lsm9ds1_gy_trshld_src_get(lsm9ds1_ctx_t *ctx,
+                                  lsm9ds1_gy_trshld_src_t *val);
+
+typedef struct {
+  uint8_t xl_xl             : 1;
+  uint8_t xh_xl             : 1;
+  uint8_t yl_xl             : 1;
+  uint8_t yh_xl             : 1;
+  uint8_t zl_xl             : 1;
+  uint8_t zh_xl             : 1;
+  uint8_t ia_xl             : 1;
+} lsm9ds1_xl_trshld_src_t;
+int32_t lsm9ds1_xl_trshld_src_get(lsm9ds1_ctx_t *ctx,
+                                         lsm9ds1_xl_trshld_src_t *val);
+
+typedef struct {
+  uint8_t xlie_g             : 1;
+  uint8_t xhie_g             : 1;
+  uint8_t ylie_g             : 1;
+  uint8_t yhie_g             : 1;
+  uint8_t zlie_g             : 1;
+  uint8_t zhie_g             : 1;
+} lsm9ds1_gy_trshld_en_t;
+int32_t lsm9ds1_gy_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_gy_trshld_en_t val);
+int32_t lsm9ds1_gy_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_gy_trshld_en_t *val);
+
+typedef enum {
+  LSM9DS1_RESET_MODE = 0,
+  LSM9DS1_DECREMENT_MODE = 1,
+} lsm9ds1_dcrm_g_t;
+int32_t lsm9ds1_gy_trshld_mode_set(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_dcrm_g_t val);
+int32_t lsm9ds1_gy_trshld_mode_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_dcrm_g_t *val);
+
+int32_t lsm9ds1_gy_trshld_x_set(lsm9ds1_ctx_t *ctx, uint16_t val);
+int32_t lsm9ds1_gy_trshld_x_get(lsm9ds1_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm9ds1_gy_trshld_y_set(lsm9ds1_ctx_t *ctx, uint16_t val);
+int32_t lsm9ds1_gy_trshld_y_get(lsm9ds1_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm9ds1_gy_trshld_z_set(lsm9ds1_ctx_t *ctx, uint16_t val);
+int32_t lsm9ds1_gy_trshld_z_get(lsm9ds1_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm9ds1_gy_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_gy_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t zien             : 1;
+  uint8_t yien             : 1;
+  uint8_t xien             : 1;
+} lsm9ds1_mag_trshld_axis_t;
+int32_t lsm9ds1_mag_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+                                    lsm9ds1_mag_trshld_axis_t val);
+int32_t lsm9ds1_mag_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+                                    lsm9ds1_mag_trshld_axis_t *val);
+typedef struct {
+  uint8_t _int              : 1;
+  uint8_t nth_z             : 1;
+  uint8_t nth_y             : 1;
+  uint8_t nth_x             : 1;
+  uint8_t pth_z             : 1;
+  uint8_t pth_y             : 1;
+  uint8_t pth_x             : 1;
+} lsm9ds1_mag_trshld_src_t;
+int32_t lsm9ds1_mag_trshld_src_get(lsm9ds1_ctx_t *ctx,
+                                   lsm9ds1_mag_trshld_src_t *val);
+
+int32_t lsm9ds1_mag_trshld_set(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_mag_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_act_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_act_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM9DS1_GYRO_POWER_DOWN = 0,
+  LSM9DS1_GYRO_SLEEP = 1,
+} lsm9ds1_act_mode_t;
+int32_t lsm9ds1_act_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t val);
+int32_t lsm9ds1_act_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t *val);
+
+int32_t lsm9ds1_act_duration_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_act_duration_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM9DS1_ACTIVITY    = 0,
+  LSM9DS1_INACTIVITY  = 1,
+} lsm9ds1_inact_t;
+int32_t lsm9ds1_act_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_inact_t *val);
+
+typedef enum {
+  LSM9DS1_POS_MOVE_RECO_DISABLE   = 0x00,
+  LSM9DS1_6D_MOVE_RECO            = 0x01,
+  LSM9DS1_4D_MOVE_RECO            = 0x05,
+  LSM9DS1_6D_POS_RECO             = 0x03,
+  LSM9DS1_4D_POS_RECO             = 0x07,
+} lsm9ds1_6d_mode_t;
+int32_t lsm9ds1_6d_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t val);
+int32_t lsm9ds1_6d_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t *val);
+
+int32_t lsm9ds1_6d_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_6d_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+
+typedef struct {
+  uint8_t xl_xl             : 1;
+  uint8_t xh_xl             : 1;
+  uint8_t yl_xl             : 1;
+  uint8_t yh_xl             : 1;
+  uint8_t zl_xl             : 1;
+  uint8_t zh_xl             : 1;
+  uint8_t ia_xl             : 1;
+} lsm9ds1_6d_src_t;
+int32_t lsm9ds1_6d_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_src_t *val);
+
+int32_t lsm9ds1_fifo_stop_on_wtm_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_fifo_stop_on_wtm_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM9DS1_FIFO_OFF                = 0x00,
+  LSM9DS1_BYPASS_MODE             = 0x10,
+  LSM9DS1_FIFO_MODE               = 0x11,
+  LSM9DS1_STREAM_TO_FIFO_MODE     = 0x13,
+  LSM9DS1_BYPASS_TO_STREAM_MODE   = 0x14,
+  LSM9DS1_STREAM_MODE             = 0x16,
+} lsm9ds1_fifo_md_t;
+int32_t lsm9ds1_fifo_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t val);
+int32_t lsm9ds1_fifo_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t *val);
+
+int32_t lsm9ds1_fifo_temp_batch_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_fifo_temp_batch_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_fifo_watermark_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_fifo_watermark_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_fifo_full_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_fifo_data_level_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_fifo_ovr_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_fifo_wtm_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_xl_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_xl_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_gy_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_gy_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm9ds1_mag_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_mag_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSM9DS1_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/stts751_STdC/driver/stts751_reg.c
+++ b/sensor/stmemsc/stts751_STdC/driver/stts751_reg.c
@@ -1,0 +1,713 @@
+/*
+ ******************************************************************************
+ * @file    stts751_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   STTS751 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+
+#include "stts751_reg.h"
+
+/**
+  * @defgroup  STTS751
+  * @brief     This file provides a set of functions needed to drive the
+  *            stts751 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  STTS751_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_read_reg(stts751_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_write_reg(stts751_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    STTS751_Sensitivity
+  * @brief       These functions convert raw-data into engineering units and
+  *              vice-versa .
+  * @{
+  *
+  */
+
+float stts751_from_lsb_to_celsius(int16_t lsb)
+{
+  return ((float)lsb) / 256.0f;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup STTS751_Sensitivity_Reverse
+  * @brief    This conversion is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 10.8] -> " Explicit cast of composite
+  *                                         expression "
+  *
+  * @{
+  *
+  */
+
+int16_t stts751_from_celsius_to_lsb(float celsius)
+{
+  return (int16_t)(celsius * 256.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  STTS751_Data_Generation
+  * @brief     This section groups all the functions concerning
+  *            data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature sensor data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the sensor data rate
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_temp_data_rate_set(stts751_ctx_t *ctx, stts751_odr_t val)
+{
+  stts751_configuration_t configuration;
+  stts751_conversion_rate_t conversion_rate;
+  uint8_t dummy_value = 0xAA;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_CONVERSION_RATE,
+                         (uint8_t*)&conversion_rate, 1);
+  if (ret == 0) {
+    conversion_rate.conv = (uint8_t)val & 0x0FU;
+    ret = stts751_write_reg(ctx, STTS751_CONVERSION_RATE,
+                            (uint8_t*)&conversion_rate, 1);
+  }
+  if (ret == 0) {
+    ret = stts751_read_reg(ctx, STTS751_CONFIGURATION,
+                           (uint8_t*)&configuration, 1);
+  }
+  if (ret == 0) {
+    configuration.stop = ((uint8_t)val & 0x80U) >> 7;
+    ret = stts751_write_reg(ctx, STTS751_CONFIGURATION,
+                            (uint8_t*)&configuration, 1);
+  }
+  if ((ret == 0) && (val == STTS751_TEMP_ODR_ONE_SHOT)) {
+    ret = stts751_write_reg(ctx, STTS751_ONE_SHOT, &dummy_value, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the sensor data rate
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_temp_data_rate_get(stts751_ctx_t *ctx, stts751_odr_t *val)
+{
+  stts751_conversion_rate_t conversion_rate;
+  stts751_configuration_t configuration;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_CONVERSION_RATE,
+                         (uint8_t*)&conversion_rate, 1);
+  if (ret == 0) {
+    ret = stts751_read_reg(ctx, STTS751_CONFIGURATION,
+                           (uint8_t*)&configuration, 1);
+  }
+  switch ( (configuration.stop << 7) + conversion_rate.conv) {
+    case STTS751_TEMP_ODR_OFF:
+      *val = STTS751_TEMP_ODR_OFF;
+      break;
+    case STTS751_TEMP_ODR_ONE_SHOT:
+      *val = STTS751_TEMP_ODR_ONE_SHOT;
+      break;
+    case STTS751_TEMP_ODR_62mHz5:
+      *val = STTS751_TEMP_ODR_62mHz5;
+      break;
+    case STTS751_TEMP_ODR_125mHz:
+      *val = STTS751_TEMP_ODR_125mHz;
+      break;
+     case STTS751_TEMP_ODR_250mHz:
+      *val = STTS751_TEMP_ODR_250mHz;
+      break;
+    case STTS751_TEMP_ODR_500mHz:
+      *val = STTS751_TEMP_ODR_500mHz;
+      break;
+    case STTS751_TEMP_ODR_1Hz:
+      *val = STTS751_TEMP_ODR_1Hz;
+      break;
+    case STTS751_TEMP_ODR_2Hz:
+      *val = STTS751_TEMP_ODR_2Hz;
+      break;
+     case STTS751_TEMP_ODR_4Hz:
+      *val = STTS751_TEMP_ODR_4Hz;
+      break;
+    case STTS751_TEMP_ODR_8Hz:
+      *val = STTS751_TEMP_ODR_8Hz;
+      break;
+    case STTS751_TEMP_ODR_16Hz:
+      *val = STTS751_TEMP_ODR_16Hz;
+      break;
+    case STTS751_TEMP_ODR_32Hz:
+      *val = STTS751_TEMP_ODR_32Hz;
+      break;
+    default:
+      *val = STTS751_TEMP_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor resolution selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tres in reg CONFIGURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_resolution_set(stts751_ctx_t *ctx, stts751_tres_t val)
+{
+  stts751_configuration_t reg;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_CONFIGURATION,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tres = (uint8_t) val;
+    ret = stts751_write_reg(ctx, STTS751_CONFIGURATION,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief Temperature sensor resolution selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tres in reg CONFIGURATION
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_resolution_get(stts751_ctx_t *ctx, stts751_tres_t *val)
+{
+  stts751_configuration_t reg;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_CONFIGURATION,(uint8_t*) &reg, 1);
+
+  switch (reg.tres) {
+    case STTS751_9bit:
+      *val = STTS751_9bit;
+      break;
+    case STTS751_10bit:
+      *val = STTS751_10bit;
+      break;
+    case STTS751_11bit:
+      *val = STTS751_11bit;
+      break;
+    case STTS751_12bit:
+      *val = STTS751_12bit;
+      break;
+    default:
+      *val = STTS751_9bit;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_status_reg_get(stts751_ctx_t *ctx, stts751_status_t *val)
+{
+  int32_t ret;
+  ret = stts751_read_reg(ctx, STTS751_STATUS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Temperature sensor "conversion on-going" flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of busy in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_flag_busy_get(stts751_ctx_t *ctx, uint8_t *val)
+{
+  stts751_status_t reg;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_STATUS, (uint8_t*)&reg, 1);
+  *val = reg.busy;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  STTS751_Data_Output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data output register (r). L and H registers
+  *         together express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_temperature_raw_get(stts751_ctx_t *ctx, int16_t *buff)
+{
+  uint16_t temperature;
+  uint8_t temperature_low;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_TEMPERATURE_HIGH,
+                         (uint8_t*)&temperature, 1);
+  if (ret == 0) {
+    ret = stts751_read_reg(ctx, STTS751_TEMPERATURE_LOW,
+                           &temperature_low, 1);
+
+    temperature  = (temperature << 8) + temperature_low;
+    *buff = (int16_t)temperature;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  STTS751_Interrupt_Pins
+  * @brief     This section groups all the functions that manage event pin
+  * @{
+  *
+  */
+
+/**
+  * @brief  Route interrupt signal threshold on event pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      set mask1 bit in register CONFIGURATION.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_pin_event_route_set(stts751_ctx_t *ctx, uint8_t val)
+{
+  stts751_configuration_t reg;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_CONFIGURATION,(uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.mask1 = val;
+    ret = stts751_write_reg(ctx, STTS751_CONFIGURATION, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route interrupt signal threshold on event pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get mask1 bit in register CONFIGURATION.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_pin_event_route_get(stts751_ctx_t *ctx, uint8_t *val)
+{
+  stts751_configuration_t reg;
+  int32_t ret;
+  ret = stts751_read_reg(ctx, STTS751_CONFIGURATION, (uint8_t*)&reg, 1);
+  *val = reg.mask1;
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  STTS751_Interrupt_on_threshold
+  * @brief     This section groups all the functions that manage interrupt
+  *            on threshold event
+  * @{
+  *
+  */
+
+/**
+  * @brief  high temperature theshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_high_temperature_threshold_set(stts751_ctx_t *ctx,
+                                               int16_t buff)
+{
+  uint8_t *temperature_ptr;
+  int32_t ret;
+
+  temperature_ptr = (uint8_t*)&buff;
+  ret = stts751_write_reg(ctx, STTS751_TEMPERATURE_HIGH_LIMIT_LOW,
+                          (uint8_t*)temperature_ptr, 1);
+
+  if (ret == 0) {
+    temperature_ptr++;
+    ret = stts751_write_reg(ctx, STTS751_TEMPERATURE_HIGH_LIMIT_HIGH,
+                            (uint8_t*)temperature_ptr, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  high temperature theshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_high_temperature_threshold_get(stts751_ctx_t *ctx,
+                                               int16_t *buff)
+{
+  uint16_t temperature;
+  uint8_t temperature_low;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_TEMPERATURE_HIGH_LIMIT_HIGH,
+                         (uint8_t*)&temperature, 1);
+  if (ret == 0) {
+    ret = stts751_read_reg(ctx, STTS751_TEMPERATURE_HIGH_LIMIT_LOW,
+                           &temperature_low, 1);
+
+    temperature  = (temperature << 8) + temperature_low;
+    *buff = (int16_t)temperature;
+  }
+  return ret;
+}
+
+/**
+  * @brief  low temperature theshold.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_low_temperature_threshold_set(stts751_ctx_t *ctx,
+                                              int16_t buff)
+{
+
+  uint8_t *temperature_ptr;
+  int32_t ret;
+
+  temperature_ptr = (uint8_t*)&buff;
+  ret = stts751_write_reg(ctx, STTS751_TEMPERATURE_LOW_LIMIT_LOW,
+                          (uint8_t*)temperature_ptr, 1);
+
+  if (ret == 0) {
+    temperature_ptr++;
+    ret = stts751_write_reg(ctx, STTS751_TEMPERATURE_LOW_LIMIT_HIGH,
+                            (uint8_t*)temperature_ptr, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  low temperature theshold.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_low_temperature_threshold_get(stts751_ctx_t *ctx,
+                                              int16_t *buff)
+{
+  uint16_t temperature;
+  uint8_t temperature_low;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_TEMPERATURE_LOW_LIMIT_HIGH,
+                         (uint8_t*)&temperature, 1);
+  if (ret == 0) {
+    ret = stts751_read_reg(ctx, STTS751_TEMPERATURE_LOW_LIMIT_LOW,
+                           &temperature_low, 1);
+
+    temperature  = (temperature << 8) + temperature_low;
+    *buff = (int16_t)temperature;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+
+  /**
+  * @defgroup  STTS751 over temperature alarm
+  * @brief     This section groups all the functions that manage
+  *            over temperature alarm functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Thermal Limit. 1 LSB = 1 degC (max 127 degC min -127 degC ).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reg THERM_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_ota_thermal_limit_set(stts751_ctx_t *ctx, int8_t val)
+{
+  int32_t ret;
+  ret = stts751_write_reg(ctx, STTS751_THERM_LIMIT, (uint8_t*)&val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Thermal Limit. 1 LSB = 1 degC (max 127 degC min -127 degC ).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of reg THERM_LIMIT
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_ota_thermal_limit_get(stts751_ctx_t *ctx, int8_t *val)
+{
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_THERM_LIMIT, (uint8_t*)val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Thermal hysteresis. 1 LSB = 1 degC.[set]
+  *         max 127 degC min -127 degC.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reg THERM_HYSTERESIS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_ota_thermal_hyst_set(stts751_ctx_t *ctx, int8_t val)
+{
+  int32_t ret;
+
+  ret = stts751_write_reg(ctx, STTS751_THERM_HYSTERESIS, (uint8_t*)&val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Thermal hysteresis. 1 LSB = 1 degC.[get]
+  *         max 127 degC min -127 degC.
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of reg THERM_HYSTERESIS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_ota_thermal_hyst_get(stts751_ctx_t *ctx, int8_t *val)
+{
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_THERM_HYSTERESIS, (uint8_t*)val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  STTS751_Common
+  * @brief     This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  SMBus timeout.At power-up, the STTS751 is configured with an
+  *         SMBus timeout of 25 to 35 milliseconds.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      set timeout bit in register SMBUS_TIMEOUT.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_smbus_timeout_set(stts751_ctx_t *ctx, uint8_t val)
+{
+  stts751_smbus_timeout_t reg;
+  int32_t ret;
+
+  ret = stts751_read_reg(ctx, STTS751_SMBUS_TIMEOUT,(uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.timeout = val;
+    ret = stts751_write_reg(ctx, STTS751_SMBUS_TIMEOUT, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SMBus timeout.At power-up, the STTS751 is configured with an
+  *         SMBus timeout of 25 to 35 milliseconds.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get timeout bit in register SMBUS_TIMEOUT.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_smbus_timeout_get(stts751_ctx_t *ctx, uint8_t *val)
+{
+  stts751_smbus_timeout_t reg;
+  int32_t ret;
+  ret = stts751_read_reg(ctx, STTS751_SMBUS_TIMEOUT, (uint8_t*)&reg, 1);
+  *val = reg.timeout;
+  return ret;
+}
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t stts751_device_id_get(stts751_ctx_t *ctx, stts751_id_t *buff)
+{
+  int32_t ret;
+  ret = stts751_read_reg(ctx, STTS751_PRODUCT_ID,
+                         (uint8_t*)&buff->product_id, 1);
+  if (ret == 0){
+  ret = stts751_read_reg(ctx, STTS751_MANUFACTURER_ID,
+                         (uint8_t*)&buff->manufacturer_id, 1);
+  }
+  if (ret == 0){
+  ret = stts751_read_reg(ctx, STTS751_REVISION_ID,
+                         (uint8_t*)&buff->revision_id, 1);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/stts751_STdC/driver/stts751_reg.h
+++ b/sensor/stmemsc/stts751_STdC/driver/stts751_reg.h
@@ -1,0 +1,325 @@
+/*
+ ******************************************************************************
+ * @file    stts751_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          stts751_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STTS751_REGS_H
+#define STTS751_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup STTS751
+  * @{
+  *
+  */
+
+/** @defgroup STTS751_sensors_common_types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    These unions are useful to represent different sensors data type.
+  *           These unions are not need by the driver.
+  *
+  *           REMOVING the unions you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  int16_t i16bit[3];
+  uint8_t u8bit[6];
+} axis3bit16_t;
+
+typedef union{
+  int16_t i16bit;
+  uint8_t u8bit[2];
+} axis1bit16_t;
+
+typedef union{
+  int32_t i32bit[3];
+  uint8_t u8bit[12];
+} axis3bit32_t;
+
+typedef union{
+  int32_t i32bit;
+  uint8_t u8bit[4];
+} axis1bit32_t;
+
+/**
+  * @}
+  *
+  */
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+#endif /* MEMS_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @addtogroup  STTS751_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stts751_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stts751_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stts751_write_ptr  write_reg;
+  stts751_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stts751_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup STTS751_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format **/
+#define STTS751_0xxxx_ADD_7K5  0x91U
+#define STTS751_0xxxx_ADD_12K  0x93U
+#define STTS751_0xxxx_ADD_20K  0x71U
+#define STTS751_0xxxx_ADD_33K  0x73U
+
+#define STTS751_1xxxx_ADD_7K5  0x95U
+#define STTS751_1xxxx_ADD_12K  0x97U
+#define STTS751_1xxxx_ADD_20K  0x75U
+#define STTS751_1xxxx_ADD_33K  0x77U
+
+/** Device Identification **/
+/* Product ID */
+#define STTS751_ID_0xxxx       0x00U
+#define STTS751_ID_1xxxx       0x01U
+/* Manufacturer ID */
+#define STTS751_ID_MAN         0x53U
+/* Revision number */
+#define STTS751_REV            0x01U
+
+/**
+  * @}
+  *
+  */
+
+#define STTS751_TEMPERATURE_HIGH            0x00U
+#define STTS751_STATUS                      0x01U
+typedef struct {
+  uint8_t thrm                       : 1;
+  uint8_t not_used_01                : 4;
+  uint8_t t_low                      : 1;
+  uint8_t t_high                     : 1;
+  uint8_t busy                       : 1;
+} stts751_status_t;
+
+#define STTS751_TEMPERATURE_LOW             0x02U
+#define STTS751_CONFIGURATION               0x03U
+typedef struct {
+  uint8_t not_used_01                : 2;
+  uint8_t tres                       : 2;
+  uint8_t not_used_02                : 2;
+  uint8_t stop                       : 1;
+  uint8_t mask1                      : 1;
+} stts751_configuration_t;
+
+#define STTS751_CONVERSION_RATE             0x04U
+typedef struct {
+  uint8_t conv                       : 4;
+  uint8_t not_used_01                : 4;
+} stts751_conversion_rate_t;
+
+#define STTS751_TEMPERATURE_HIGH_LIMIT_HIGH 0x05U
+#define STTS751_TEMPERATURE_HIGH_LIMIT_LOW  0x06U
+#define STTS751_TEMPERATURE_LOW_LIMIT_HIGH  0x07U
+#define STTS751_TEMPERATURE_LOW_LIMIT_LOW   0x08U
+#define STTS751_ONE_SHOT                    0x0FU
+#define STTS751_THERM_LIMIT                 0x20U
+#define STTS751_THERM_HYSTERESIS            0x21U
+#define STTS751_SMBUS_TIMEOUT               0x22U
+typedef struct {
+  uint8_t not_used_01                : 7;
+  uint8_t timeout                    : 1;
+} stts751_smbus_timeout_t;
+
+#define STTS751_PRODUCT_ID                  0xFDU
+#define STTS751_MANUFACTURER_ID             0xFEU
+#define STTS751_REVISION_ID                 0xFFU
+
+/**
+  * @defgroup STTS751_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  stts751_status_t                       status;
+  stts751_configuration_t                configuration;
+  stts751_conversion_rate_t              conversion_rate;
+  stts751_smbus_timeout_t                smbus_timeout;
+  bitwise_t                              bitwise;
+  uint8_t                                byte;
+} stts751_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t stts751_read_reg(stts751_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t stts751_write_reg(stts751_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float stts751_from_lsb_to_celsius(int16_t lsb);
+extern int16_t stts751_from_celsius_to_lsb(float celsius);
+
+typedef enum {
+  STTS751_TEMP_ODR_OFF        = 0x80,
+  STTS751_TEMP_ODR_ONE_SHOT   = 0x90,
+  STTS751_TEMP_ODR_62mHz5     = 0x00,
+  STTS751_TEMP_ODR_125mHz     = 0x01,
+  STTS751_TEMP_ODR_250mHz     = 0x02,
+  STTS751_TEMP_ODR_500mHz     = 0x03,
+  STTS751_TEMP_ODR_1Hz        = 0x04,
+  STTS751_TEMP_ODR_2Hz        = 0x05,
+  STTS751_TEMP_ODR_4Hz        = 0x06,
+  STTS751_TEMP_ODR_8Hz        = 0x07,
+  STTS751_TEMP_ODR_16Hz       = 0x08, /* 9, 10, or 11-bit resolutions only */
+  STTS751_TEMP_ODR_32Hz       = 0x09, /* 9 or 10-bit resolutions only */
+} stts751_odr_t;
+int32_t stts751_temp_data_rate_set(stts751_ctx_t *ctx, stts751_odr_t val);
+int32_t stts751_temp_data_rate_get(stts751_ctx_t *ctx, stts751_odr_t *val);
+
+typedef enum {
+  STTS751_9bit      = 2,
+  STTS751_10bit     = 0,
+  STTS751_11bit     = 1,
+  STTS751_12bit     = 3,
+} stts751_tres_t;
+int32_t stts751_resolution_set(stts751_ctx_t *ctx, stts751_tres_t val);
+int32_t stts751_resolution_get(stts751_ctx_t *ctx, stts751_tres_t *val);
+
+int32_t stts751_status_reg_get(stts751_ctx_t *ctx, stts751_status_t *val);
+
+int32_t stts751_flag_busy_get(stts751_ctx_t *ctx, uint8_t *val);
+
+int32_t stts751_temperature_raw_get(stts751_ctx_t *ctx, int16_t *buff);
+
+int32_t stts751_pin_event_route_set(stts751_ctx_t *ctx, uint8_t val);
+int32_t stts751_pin_event_route_get(stts751_ctx_t *ctx, uint8_t *val);
+
+
+int32_t stts751_high_temperature_threshold_set(stts751_ctx_t *ctx,
+                                               int16_t buff);
+int32_t stts751_high_temperature_threshold_get(stts751_ctx_t *ctx,
+                                               int16_t *buff);
+
+int32_t stts751_low_temperature_threshold_set(stts751_ctx_t *ctx,
+                                              int16_t buff);
+int32_t stts751_low_temperature_threshold_get(stts751_ctx_t *ctx,
+                                              int16_t *buff);
+
+int32_t stts751_ota_thermal_limit_set(stts751_ctx_t *ctx, int8_t val);
+int32_t stts751_ota_thermal_limit_get(stts751_ctx_t *ctx, int8_t *val);
+
+int32_t stts751_ota_thermal_hyst_set(stts751_ctx_t *ctx, int8_t val);
+int32_t stts751_ota_thermal_hyst_get(stts751_ctx_t *ctx, int8_t *val);
+
+int32_t stts751_smbus_timeout_set(stts751_ctx_t *ctx, uint8_t val);
+int32_t stts751_smbus_timeout_get(stts751_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t product_id;
+  uint8_t manufacturer_id;
+  uint8_t revision_id;
+} stts751_id_t;
+int32_t stts751_device_id_get(stts751_ctx_t *ctx, stts751_id_t *buff);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*STTS751_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
(NOTE: it replaces #14111)

This package contains platform independent drivers written in C
language for STMicroelectronics sensors. The aim of this package
is to provide a common, clean and stable interface to access sensor
registers.

Origin: ST Microelectronics
License: BSD-3-Clause
URL: https://www.st.com/en/embedded-software/c-driver-mems.html
Commit: v1.00
Purpose: provide a common and stable i/f to access sensor registers
Maintained-by: ST Microelectronics

Signed-off-by: Armando Visconti <armando.visconti@st.com>