### PR TITLE
sensor/stmemsc: Align stmemsc i/f to v1.02

### DIFF
--- a/sensor/stmemsc/CMakeLists.txt
+++ b/sensor/stmemsc/CMakeLists.txt
@@ -6,8 +6,10 @@
 
 set(stmems_pids
   a3g4250d
+  ais2dw12
   ais328dq
   ais3624dq
+  asm330lhh
   h3lis331dl
   hts221
   i3g4250d
@@ -16,12 +18,16 @@ set(stmems_pids
   iis2mdc
   iis328dq
   iis3dhhc
+  iis3dwb
   ism303dac
+  ism330dhcx
   ism330dlc
   l20g20is
+  l3gd20h
   lis2de12
   lis2dh12
   lis2ds12
+  lis2dtw12
   lis2dw12
   lis2hh12
   lis2mdl
@@ -33,14 +39,18 @@ set(stmems_pids
   lps22hb
   lps22hh
   lps25hb
+  lps27hhw
   lps33hw
+  lps33w
   lsm303agr
   lsm303ah
   lsm6ds3
+  lsm6ds3tr_c
   lsm6dsl
   lsm6dsm
   lsm6dso
   lsm6dsox
+  lsm6dsr
   lsm9ds1
   stts751
   )

--- a/sensor/stmemsc/README
+++ b/sensor/stmemsc/README
@@ -6,7 +6,7 @@ Origin:
    https://www.st.com/en/embedded-software/c-driver-mems.html
 
 Status:
-   version v1.00
+   version v1.02
 
 Purpose:
    ST Microelectronics standard C platform-independent drivers for MEMS
@@ -34,9 +34,9 @@ Description:
    int platform_wr(void *handle, u8_t reg, u8_t *bufp, u16_t len);
    int platform_rd(void *handle, u8_t reg, u8_t *bufp, u16_t len);
 
-   xyz_ctx_t xyz_ctx = {
-       .read_reg = (xyz_read_ptr) platform_rd,
-       .write_reg = (xyz_write_ptr) platform_wr,
+   stmdev_ctx_t stmdev_ctx = {
+       .read_reg = (stmdev_read_ptr) platform_rd,
+       .write_reg = (stmdev_write_ptr) platform_wr,
    };
 
 Dependencies:
@@ -46,7 +46,7 @@ URL:
    https://www.st.com/en/embedded-software/c-driver-mems.html
 
 commit:
-   version v1.00
+   version v1.02
 
 Maintained-by:
    ST Microelectronics

--- a/sensor/stmemsc/_resources/FIFO_decompression_utility/fifo_utility.c
+++ b/sensor/stmemsc/_resources/FIFO_decompression_utility/fifo_utility.c
@@ -1,0 +1,923 @@
+/*
+ ******************************************************************************
+ * @file    fifo_utility.c
+ * @author  Sensor Solutions Software Team
+ * @brief   Utility for managing data compression in smart FIFO.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Includes ------------------------------------------------------------------*/
+#include <math.h>
+#include "fifo_utility.h"
+
+/**
+  * @defgroup  FIFO utility
+  * @brief     This file provides a set of functions needed to  manage data
+  *            compression in smart FIFO.
+  * @{
+  *
+  */
+
+/* Private constants  --------------------------------------------------------*/
+#define ODR_XL_MASK              (0x0FU)
+#define ODR_XL_SHIFT             (0x00U)
+#define BDR_XL_MASK              (0x0FU)
+#define BDR_XL_SHIFT             (0x00U)
+
+#define ODR_GY_MASK              (0xF0U)
+#define ODR_GY_SHIFT             (0x04U)
+#define BDR_GY_MASK              (0xF0U)
+#define BDR_GY_SHIFT             (0x04U)
+
+#define BDR_VSENS_MASK           (0x0FU)
+#define BDR_VSENS_SHIFT          (0x00U)
+
+#define TAG_COUNTER_MASK         (0x06U)
+#define TAG_SENSOR_MASK          (0xF8U)
+#define TAG_COUNTER_SHIFT        (0x01U)
+#define TAG_SENSOR_SHIFT         (0x03U)
+
+#define TAG_GY                   (0x01U)
+#define TAG_XL                   (0x02U)
+#define TAG_TEMP                 (0x03U)
+#define TAG_TS                   (0x04U)
+#define TAG_ODRCHG               (0x05U)
+#define TAG_XL_UNCOMPRESSED_T_2  (0x06U)
+#define TAG_XL_UNCOMPRESSED_T_1  (0x07U)
+#define TAG_XL_COMPRESSED_2X     (0x08U)
+#define TAG_XL_COMPRESSED_3X     (0x09U)
+#define TAG_GY_UNCOMPRESSED_T_2  (0x0AU)
+#define TAG_GY_UNCOMPRESSED_T_1  (0x0BU)
+#define TAG_GY_COMPRESSED_2X     (0x0CU)
+#define TAG_GY_COMPRESSED_3X     (0x0DU)
+#define TAG_EXT_SENS_0           (0x0EU)
+#define TAG_EXT_SENS_1           (0x0FU)
+#define TAG_EXT_SENS_2           (0x10U)
+#define TAG_EXT_SENS_3           (0x11U)
+#define TAG_STEP_COUNTER         (0x12U)
+#define TAG_GAME_RV              (0x13U)
+#define TAG_GEOM_RV              (0x14U)
+#define TAG_NORM_RV              (0x15U)
+#define TAG_GYRO_BIAS            (0x16U)
+#define TAG_GRAVITIY             (0x17U)
+#define TAG_MAG_CAL              (0x18U)
+#define TAG_EXT_SENS_NACK        (0x19U)
+
+#define TAG_VALID_LIMIT          (0x19U)
+
+#define TIMESTAMP_FREQ          (40000U)
+
+/* Private typedef -----------------------------------------------------------*/
+typedef enum {
+  ST_FIFO_COMPRESSION_NC,
+  ST_FIFO_COMPRESSION_NC_T_1,
+  ST_FIFO_COMPRESSION_NC_T_2,
+  ST_FIFO_COMPRESSION_2X,
+  ST_FIFO_COMPRESSION_3X
+} st_fifo_compression_type;
+
+/* Private functions ---------------------------------------------------------*/
+/*  Functions declare in this section are defined at the end of this file.    */
+static uint8_t has_even_parity(uint8_t x);
+static st_fifo_sensor_type get_sensor_type(uint8_t tag);
+static st_fifo_compression_type get_compression_type(uint8_t tag);
+static uint8_t is_tag_valid(uint8_t tag);
+static void get_diff_2x(int16_t diff[6], uint8_t input[6]);
+static void get_diff_3x(int16_t diff[9], uint8_t input[6]);
+static void byte_cpy(uint8_t *destination, uint8_t *source, uint32_t len);
+
+/* Private variables ---------------------------------------------------------*/
+static uint8_t tag_counter_old     = 0x00U;
+static float_t bdr_xl              = 0.0f;
+static float_t bdr_gy              = 0.0f;
+static float_t bdr_vsens           = 0.0f;
+static float_t bdr_xl_old          = 0.0f;
+static float_t bdr_gy_old          = 0.0f;
+static float_t bdr_max             = 0.0f;
+static uint32_t timestamp          = 0;
+static uint32_t last_timestamp_xl  = 0;
+static uint32_t last_timestamp_gy  = 0;
+static uint8_t bdr_chg_xl_flag     = 0;
+static uint8_t bdr_chg_gy_flag     = 0;
+static int16_t last_data_xl[3]     = {0};
+static int16_t last_data_gy[3]     = {0};
+
+/**
+  * @defgroup  FIFO_pubblic_functions
+  * @brief     This section provide a set of usefull APIs for managing data
+  *            compression in smart FIFO.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Initialize the FIFO utility library.
+  *
+  * @param  bdr_xl_in         batch data rate for accelerometer sensor in Hz,
+  *                           pass 0 Hz if odrchg_en is set to 1 or timestamp
+  *                           is stored in FIFO.
+  * @param  bdr_gy_in         batch data rate for gyro sensor in Hz,
+  *                           pass 0 Hz if odrchg_en is set to 1 or timestamp
+  *                           is stored in FIFO.
+  * @param  bdr_vsens_in      batch data rate for virtual sensor in Hz,
+  *                           pass 0 Hz if odrchg_en is set to 1 or timestamp
+  *                           is stored in FIFO.
+  *
+  * @retval st_fifo_status    ST_FIFO_OK /  ST_FIFO_ERR
+  *
+  */
+st_fifo_status st_fifo_init(float_t    bdr_xl_in,
+                            float_t    bdr_gy_in,
+                            float_t    bdr_vsens_in)
+{
+  uint32_t i;
+  st_fifo_status ret = ST_FIFO_ERR;
+
+  if ( (bdr_xl_in < 0.0f) || (bdr_gy_in < 0.0f) || (bdr_vsens_in < 0.0f) ) {
+    ret = ST_FIFO_ERR;
+  }
+  else {
+
+    tag_counter_old = 0x00U;
+    bdr_xl = bdr_xl_in;
+    bdr_gy = bdr_gy_in;
+    bdr_vsens = bdr_vsens_in;
+    bdr_xl_old = bdr_xl_in;
+    bdr_gy_old = bdr_gy_in;
+    bdr_max = ( ( bdr_xl  > bdr_gy )    ? bdr_xl  : bdr_gy );
+    bdr_max = ( ( bdr_max > bdr_vsens ) ? bdr_max : bdr_vsens );
+    timestamp = 0;
+    bdr_chg_xl_flag = 0;
+    bdr_chg_gy_flag = 0;
+    last_timestamp_xl = 0;
+    last_timestamp_gy = 0;
+
+    for (i = 0; i < 3U; i++) {
+      last_data_xl[i] = 0;
+      last_data_gy[i] = 0;
+
+      ret = ST_FIFO_OK;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decompress a compressed raw FIFO stream.
+  *
+  * @param  fifo_out_slot     decoded output stream.(ptr)
+  * @param  fifo_raw_slot     compressed raw input data stream.(ptr)
+  * @param  out_slot_size     decoded stream size.(ptr)
+  * @param  stream_size       raw input stream size.
+  *
+  * @retval st_fifo_status    ST_FIFO_OK /  ST_FIFO_ERR
+  *
+  */
+st_fifo_status st_fifo_decompress(st_fifo_out_slot *fifo_out_slot,
+                                  st_fifo_raw_slot *fifo_raw_slot,
+                                  uint16_t *out_slot_size,
+                                  uint16_t stream_size)
+{
+  uint16_t j = 0;
+  int16_t data[3];
+  uint8_t tag;
+  uint8_t tag_counter;
+  uint8_t diff_tag_counter;
+  uint8_t bdr_acc_cfg;
+  uint8_t bdr_gyr_cfg;
+  uint8_t bdr_vsens_cfg;
+  uint32_t last_timestamp;
+  int16_t diff[9];
+
+  float_t bdr_acc_vect[]  = {    0,   13    ,  26,   52,  104,
+                               208,  416    , 833, 1666, 3333,
+                              6666,    1.625,   0,    0,    0,
+                                 0 };
+  
+  float_t bdr_gyr_vect[] = {   0,   13,   26,   52, 104, 208, 416,
+                             833, 1666, 3333, 6666,   0,   0,   0,
+                               0,    0};
+  
+  float_t bdr_vsens_vect[] = { 0, 13, 26, 52, 104    , 208, 416,
+                               0,  0,  0,  0,   1.625,   0,   0,
+                               0,  0};
+
+  for (uint16_t i = 0; i < stream_size; i++) {
+
+    tag = (fifo_raw_slot[i].fifo_data_out[0] & TAG_SENSOR_MASK);
+    tag = tag >> TAG_SENSOR_SHIFT;
+
+    tag_counter = (fifo_raw_slot[i].fifo_data_out[0] & TAG_COUNTER_MASK);
+    tag_counter = tag_counter >> TAG_COUNTER_SHIFT;
+
+    if ((has_even_parity(fifo_raw_slot[i].fifo_data_out[0]) == 0U) ||
+        (is_tag_valid(tag) == 0U)){
+      continue;
+    }
+
+    if ((tag_counter != (tag_counter_old)) && (bdr_max != 0.0f) ) {
+
+      if (tag_counter < tag_counter_old){
+        diff_tag_counter = tag_counter + 4U - tag_counter_old;
+      }
+      else{
+        diff_tag_counter = tag_counter - tag_counter_old;
+      }
+
+      timestamp += (TIMESTAMP_FREQ / (uint32_t)bdr_max) * diff_tag_counter;
+    }
+
+    if (tag == TAG_ODRCHG) {
+
+      bdr_acc_cfg = (fifo_raw_slot[i].fifo_data_out[6] & BDR_XL_MASK);
+      bdr_acc_cfg = bdr_acc_cfg >> BDR_XL_SHIFT;
+
+      bdr_gyr_cfg = (fifo_raw_slot[i].fifo_data_out[6] & BDR_GY_MASK);
+      bdr_gyr_cfg = bdr_gyr_cfg >> BDR_GY_SHIFT;
+
+      bdr_vsens_cfg =(fifo_raw_slot[i].fifo_data_out[3] & BDR_VSENS_MASK);
+      bdr_vsens_cfg = bdr_vsens_cfg >> BDR_VSENS_SHIFT;
+
+      bdr_xl_old = bdr_xl;
+      bdr_gy_old = bdr_gy;
+
+      bdr_xl = bdr_acc_vect[bdr_acc_cfg];
+      bdr_gy = bdr_gyr_vect[bdr_gyr_cfg];
+      bdr_vsens = bdr_vsens_vect[bdr_vsens_cfg];
+      bdr_max = ((bdr_xl > bdr_gy) ? bdr_xl : bdr_gy);
+      bdr_max = ((bdr_max > bdr_vsens) ? bdr_max : bdr_vsens);
+
+      bdr_chg_xl_flag = 1;
+      bdr_chg_gy_flag = 1;
+
+      } else if (tag == TAG_TS) {
+
+        byte_cpy( (uint8_t*)&timestamp, &fifo_raw_slot[i].fifo_data_out[1], 4);
+
+      } else {
+
+      st_fifo_compression_type compression_type = get_compression_type(tag);
+      st_fifo_sensor_type sensor_type = get_sensor_type(tag);
+
+      switch (compression_type){
+        case ST_FIFO_COMPRESSION_NC:
+          if (tag == TAG_STEP_COUNTER){
+            byte_cpy((uint8_t*)&fifo_out_slot[j].timestamp,
+                     &fifo_raw_slot[i].fifo_data_out[3], 4);
+          }
+          else{
+            fifo_out_slot[j].timestamp = timestamp;
+          }
+
+          fifo_out_slot[j].sensor_tag = sensor_type;
+          byte_cpy(fifo_out_slot[j].raw_data,
+                   &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+          if (sensor_type == ST_FIFO_ACCELEROMETER) {
+            byte_cpy((uint8_t*)last_data_xl, fifo_out_slot[j].raw_data, 6);
+            last_timestamp_xl = timestamp;
+            bdr_chg_xl_flag = 0;
+          }
+
+          if (sensor_type == ST_FIFO_GYROSCOPE) {
+            byte_cpy((uint8_t*)last_data_gy, fifo_out_slot[j].raw_data, 6);
+            last_timestamp_gy = timestamp;
+            bdr_chg_gy_flag = 0;
+          }
+
+          j++;
+          break;
+        case ST_FIFO_COMPRESSION_NC_T_1:
+          fifo_out_slot[j].sensor_tag = get_sensor_type(tag);
+          byte_cpy(fifo_out_slot[j].raw_data,
+                   &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+          if (sensor_type == ST_FIFO_ACCELEROMETER) {
+
+
+            if (bdr_chg_xl_flag != 0U){
+              last_timestamp = (last_timestamp_xl +
+                                (TIMESTAMP_FREQ / (uint32_t)bdr_xl_old));
+            }
+            else{
+              last_timestamp = ((uint32_t)timestamp -
+                                ((uint32_t)TIMESTAMP_FREQ / (uint32_t)bdr_xl));
+            }
+
+            fifo_out_slot[j].timestamp = last_timestamp;
+            byte_cpy((uint8_t*)last_data_xl,
+                     (uint8_t*) fifo_out_slot[j].raw_data, 6);
+            last_timestamp_xl = last_timestamp;
+          }
+
+          if (sensor_type == ST_FIFO_GYROSCOPE) {
+
+
+            if (bdr_chg_gy_flag != 0U){
+              last_timestamp = (last_timestamp_gy +
+                                (TIMESTAMP_FREQ / (uint32_t)bdr_gy_old));
+            }
+            else{
+              last_timestamp = (timestamp -
+                                (TIMESTAMP_FREQ / (uint32_t)bdr_gy));
+            }
+
+            fifo_out_slot[j].timestamp = last_timestamp;
+            byte_cpy((uint8_t*)last_data_gy, fifo_out_slot[j].raw_data, 6);
+            last_timestamp_gy = last_timestamp;
+          }
+
+          j++;
+          break;
+        case ST_FIFO_COMPRESSION_NC_T_2:
+          fifo_out_slot[j].sensor_tag = get_sensor_type(tag);
+          byte_cpy(fifo_out_slot[j].raw_data,
+                   &fifo_raw_slot[i].fifo_data_out[1], 6);
+
+          if (sensor_type == ST_FIFO_ACCELEROMETER) {
+            if (bdr_chg_xl_flag != 0U){
+              last_timestamp = (last_timestamp_xl +
+                                (TIMESTAMP_FREQ / (uint32_t)bdr_xl_old));
+            }
+            else{
+              last_timestamp = (timestamp -
+                                ((2U * TIMESTAMP_FREQ) / (uint32_t) bdr_xl));
+            }
+
+            fifo_out_slot[j].timestamp = last_timestamp;
+            byte_cpy((uint8_t*)last_data_xl, fifo_out_slot[j].raw_data, 6);
+            last_timestamp_xl = last_timestamp;
+          }
+          if (sensor_type == ST_FIFO_GYROSCOPE) {
+
+            if (bdr_chg_gy_flag != 0U){
+              last_timestamp = (last_timestamp_gy +
+                                (TIMESTAMP_FREQ / (uint32_t)bdr_gy_old));
+            }
+            else{
+              last_timestamp = (timestamp -
+                                (2U * TIMESTAMP_FREQ / (uint32_t)bdr_gy));
+            }
+
+            fifo_out_slot[j].timestamp = last_timestamp;
+            byte_cpy((uint8_t*)last_data_gy,
+                     (uint8_t*)fifo_out_slot[j].raw_data, 6);
+            last_timestamp_gy = last_timestamp;
+          }
+
+          j++;
+          break;
+        case ST_FIFO_COMPRESSION_2X:
+          get_diff_2x(diff, &fifo_raw_slot[i].fifo_data_out[1]);
+
+          fifo_out_slot[j].sensor_tag = sensor_type;
+
+          if (sensor_type == ST_FIFO_ACCELEROMETER) {
+            data[0] = last_data_xl[0] + diff[0];
+            data[1] = last_data_xl[1] + diff[1];
+            data[2] = last_data_xl[2] + diff[2];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            fifo_out_slot[j].timestamp =
+                        (timestamp - (2U * TIMESTAMP_FREQ / (uint32_t)bdr_xl));
+
+            byte_cpy((uint8_t*)last_data_xl, fifo_out_slot[j].raw_data, 6);
+          }
+
+          if (sensor_type == ST_FIFO_GYROSCOPE) {
+            data[0] = last_data_gy[0] + diff[0];
+            data[1] = last_data_gy[1] + diff[1];
+            data[2] = last_data_gy[2] + diff[2];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            fifo_out_slot[j].timestamp =
+                        (timestamp - (2U * TIMESTAMP_FREQ / (uint32_t)bdr_gy));
+
+            byte_cpy((uint8_t*)last_data_gy, fifo_out_slot[j].raw_data, 6);
+          }
+
+          j++;
+
+          fifo_out_slot[j].sensor_tag = sensor_type;
+
+          if (sensor_type == ST_FIFO_ACCELEROMETER) {
+            last_timestamp = (timestamp - (TIMESTAMP_FREQ / (uint32_t)bdr_xl));
+            data[0] = last_data_xl[0] + diff[3];
+            data[1] = last_data_xl[1] + diff[4];
+            data[2] = last_data_xl[2] + diff[5];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            fifo_out_slot[j].timestamp = last_timestamp;
+            byte_cpy((uint8_t*)last_data_xl, fifo_out_slot[j].raw_data, 6);
+            last_timestamp_xl = last_timestamp;
+          }
+
+          if (sensor_type == ST_FIFO_GYROSCOPE) {
+            last_timestamp = (timestamp - (TIMESTAMP_FREQ / (uint32_t)bdr_gy));
+            data[0] = last_data_gy[0] + diff[3];
+            data[1] = last_data_gy[1] + diff[4];
+            data[2] = last_data_gy[2] + diff[5];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            fifo_out_slot[j].timestamp = last_timestamp;
+            byte_cpy((uint8_t*)last_data_gy, fifo_out_slot[j].raw_data, 6);
+            last_timestamp_gy = last_timestamp;
+          }
+
+          j++;
+          break;
+        default: //(compression_type == ST_FIFO_COMPRESSION_3X)
+
+          get_diff_3x(diff, &fifo_raw_slot[i].fifo_data_out[1]);
+
+          fifo_out_slot[j].sensor_tag = sensor_type;
+
+          if (sensor_type == ST_FIFO_ACCELEROMETER) {
+            data[0] = last_data_xl[0] + diff[0];
+            data[1] = last_data_xl[1] + diff[1];
+            data[2] = last_data_xl[2] + diff[2];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            fifo_out_slot[j].timestamp =
+                        (timestamp - (2U * TIMESTAMP_FREQ / (uint32_t)bdr_xl));
+            byte_cpy((uint8_t*)last_data_xl, fifo_out_slot[j].raw_data, 6);
+          }
+
+          if (sensor_type == ST_FIFO_GYROSCOPE) {
+            data[0] = last_data_gy[0] + diff[0];
+            data[1] = last_data_gy[1] + diff[1];
+            data[2] = last_data_gy[2] + diff[2];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            fifo_out_slot[j].timestamp =
+                        (timestamp - (2U * TIMESTAMP_FREQ / (uint32_t)bdr_gy));
+            byte_cpy((uint8_t*)last_data_gy,
+                     (uint8_t*)fifo_out_slot[j].raw_data, 6);
+          }
+
+          j++;
+
+          fifo_out_slot[j].sensor_tag = sensor_type;
+
+          if (sensor_type == ST_FIFO_ACCELEROMETER) {
+            data[0] = last_data_xl[0] + diff[3];
+            data[1] = last_data_xl[1] + diff[4];
+            data[2] = last_data_xl[2] + diff[5];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            fifo_out_slot[j].timestamp =
+                             (timestamp -(TIMESTAMP_FREQ / (uint32_t)bdr_xl));
+            byte_cpy((uint8_t*)last_data_xl, fifo_out_slot[j].raw_data, 6);
+          }
+
+          if (sensor_type == ST_FIFO_GYROSCOPE) {
+            data[0] = last_data_gy[0] + diff[3];
+            data[1] = last_data_gy[1] + diff[4];
+            data[2] = last_data_gy[2] + diff[5];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            fifo_out_slot[j].timestamp =
+                             (timestamp - (TIMESTAMP_FREQ / (uint32_t)bdr_gy));
+            byte_cpy((uint8_t*)last_data_gy, fifo_out_slot[j].raw_data, 6);
+          }
+
+          j++;
+
+          fifo_out_slot[j].timestamp = timestamp;
+          fifo_out_slot[j].sensor_tag = sensor_type;
+
+          if (sensor_type == ST_FIFO_ACCELEROMETER) {
+            data[0] = last_data_xl[0] + diff[6];
+            data[1] = last_data_xl[1] + diff[7];
+            data[2] = last_data_xl[2] + diff[8];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            byte_cpy((uint8_t*)last_data_xl, fifo_out_slot[j].raw_data, 6);
+            last_timestamp_xl = timestamp;
+          }
+
+          if (sensor_type == ST_FIFO_GYROSCOPE) {
+            data[0] = last_data_gy[0] + diff[6];
+            data[1] = last_data_gy[1] + diff[7];
+            data[2] = last_data_gy[2] + diff[8];
+            byte_cpy(fifo_out_slot[j].raw_data,(uint8_t*)data, 6);
+            byte_cpy((uint8_t*)last_data_gy, fifo_out_slot[j].raw_data, 6);
+            last_timestamp_gy = timestamp;
+          }
+
+          j++;
+          break;
+        }
+
+        *out_slot_size = j;
+      }
+
+    tag_counter_old = tag_counter;
+  }
+
+  return ST_FIFO_OK;
+}
+
+/**
+  * @brief  Sort FIFO stream from older to newer timestamp.
+  *
+  * @param  fifo_out_slot     decoded output stream.(ptr)
+  * @param  out_slot_size     decoded srteam size.
+  *
+  */
+void st_fifo_sort(st_fifo_out_slot *fifo_out_slot, uint16_t out_slot_size)
+{
+
+  int32_t j, i;
+  st_fifo_out_slot temp;
+
+  for (i = 1; i < (int32_t)out_slot_size; i++) {
+
+    byte_cpy((uint8_t*)&temp, (uint8_t*)&fifo_out_slot[i],
+             sizeof(st_fifo_out_slot));
+
+    j = i - 1;
+
+    while ((j >= 0) && (fifo_out_slot[j].timestamp > temp.timestamp)) {
+      byte_cpy((uint8_t*)&fifo_out_slot[j + 1], (uint8_t*)&fifo_out_slot[j],
+               sizeof(st_fifo_out_slot));
+      j--;
+    }
+
+    byte_cpy((uint8_t*)&fifo_out_slot[j + 1], (uint8_t*)&temp,
+             sizeof(st_fifo_out_slot));
+  }
+
+}
+
+/**
+  * @brief  Return the number of a sensor tag occurrency in a
+  *         decoded FIFO stream.
+  *
+  * @param  fifo_out_slot     decoded output stream.(ptr)
+  * @param  out_slot_size     decoded srteam size.
+  * @param  sensor_type       The name of the sensor that is need
+  *                           to count occurrences.
+  *
+  * @retval uint16_t          the number of a sensor tag occurrency in a
+  *                           decoded FIFO stream.
+  *
+  */
+uint16_t  st_fifo_get_sensor_occurrence(st_fifo_out_slot *fifo_out_slot,
+                                        uint16_t out_slot_size,
+                                        st_fifo_sensor_type sensor_type)
+{
+  uint16_t occurrence = 0;
+
+  for (uint16_t i = 0; i < out_slot_size; i++) {
+
+    if (fifo_out_slot[i].sensor_tag == sensor_type){
+      occurrence++;
+    }
+
+  }
+
+  return occurrence;
+}
+
+/**
+  * @brief  This function extracts all the data of a specific sensor
+  *         from a decoded FIFO stream.
+  *
+  * @param  sensor_out_slot   data of a specific sensor.(ptr)
+  * @param  fifo_out_slot     decoded output stream.(ptr)
+  * @param  out_slot_size     decoded srteam size.
+  * @param  sensor_type       The name of the sensor that is need
+  *                           to extract data.
+  *
+  */
+void st_fifo_extract_sensor(st_fifo_out_slot *sensor_out_slot,
+                            st_fifo_out_slot *fifo_out_slot,
+                            uint16_t  out_slot_size,
+                            st_fifo_sensor_type sensor_type)
+{
+  uint16_t temp_i = 0;
+
+  for (uint16_t i = 0; i < out_slot_size; i++) {
+
+    if (fifo_out_slot[i].sensor_tag == sensor_type) {
+
+      byte_cpy((uint8_t*)&sensor_out_slot[temp_i], (uint8_t*)&fifo_out_slot[i],
+               sizeof(st_fifo_out_slot));
+
+      temp_i++;
+    }
+
+  }
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  FIFO private functions
+  * @brief     This section provide a set of private low-level functions
+  *            used by pubblic APIs.
+  * @{
+  *
+  */
+
+/**
+  * @brief  This function indicate if a raw tag is valid or not.
+  *
+  * @param  tag               tag to be analyzed.
+  *
+  * @retval uint8_t           valid(1) / invalid(0) tag.
+  *
+  */
+static uint8_t is_tag_valid(uint8_t tag)
+{
+  uint8_t ret;
+
+  if (tag > TAG_VALID_LIMIT){
+    ret = 0;
+  }
+  else{
+    ret = 1;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  This function convert a raw tag in a sensor type
+  *
+  * @param  tag                    tag to be analyzed.
+  *
+  * @retval st_fifo_sensor_type    Sensor type.
+  *
+  */
+static st_fifo_sensor_type get_sensor_type(uint8_t tag)
+{
+  st_fifo_sensor_type ret;
+  switch (tag) {
+    case TAG_GY:
+    ret = ST_FIFO_GYROSCOPE;
+    break;
+    case TAG_XL:
+    ret =  ST_FIFO_ACCELEROMETER;
+    break;
+    case TAG_TEMP:
+    ret =  ST_FIFO_TEMPERATURE;
+    break;
+    case TAG_EXT_SENS_0:
+    ret =  ST_FIFO_EXT_SENSOR0;
+    break;
+    case TAG_EXT_SENS_1:
+    ret =  ST_FIFO_EXT_SENSOR1;
+    break;
+    case TAG_EXT_SENS_2:
+    ret =  ST_FIFO_EXT_SENSOR2;
+    break;
+    case TAG_EXT_SENS_3:
+    ret =  ST_FIFO_EXT_SENSOR3;
+    break;
+    case TAG_STEP_COUNTER:
+    ret =  ST_FIFO_STEP_COUNTER;
+    break;
+    case TAG_XL_UNCOMPRESSED_T_2:
+    ret =  ST_FIFO_ACCELEROMETER;
+    break;
+    case TAG_XL_UNCOMPRESSED_T_1:
+    ret =  ST_FIFO_ACCELEROMETER;
+    break;
+    case TAG_XL_COMPRESSED_2X:
+    ret =  ST_FIFO_ACCELEROMETER;
+    break;
+    case TAG_XL_COMPRESSED_3X:
+    ret =  ST_FIFO_ACCELEROMETER;
+    break;
+    case TAG_GY_UNCOMPRESSED_T_2:
+    ret =  ST_FIFO_GYROSCOPE;
+    break;
+    case TAG_GY_UNCOMPRESSED_T_1:
+    ret =  ST_FIFO_GYROSCOPE;
+    break;
+    case TAG_GY_COMPRESSED_2X:
+    ret =  ST_FIFO_GYROSCOPE;
+    break;
+    case TAG_GY_COMPRESSED_3X:
+    ret =  ST_FIFO_GYROSCOPE;
+    break;
+    case TAG_GAME_RV:
+    ret =  ST_FIFO_6X_GAME_RV;
+    break;
+    case TAG_GEOM_RV:
+    ret =  ST_FIFO_6X_GEOM_RV;
+    break;
+    case TAG_NORM_RV:
+    ret =  ST_FIFO_9X_RV;
+    break;
+    case TAG_GYRO_BIAS:
+    ret =  ST_FIFO_GYRO_BIAS;
+    break;
+    case TAG_GRAVITIY:
+    ret =  ST_FIFO_GRAVITY;
+    break;
+    case TAG_MAG_CAL:
+    ret =  ST_FIFO_MAGNETOMETER_CALIB;
+    break;
+    case TAG_EXT_SENS_NACK:
+    ret =  ST_FIFO_EXT_SENSOR_NACK;
+    break;
+    default:
+    ret =  ST_FIFO_NONE;
+    break;
+
+  }
+  return ret;
+}
+
+/**
+  * @brief  This function convert a raw tag in a type of compression
+  *
+  * @param  tag                         tag to be analyzed.
+  *
+  * @retval st_fifo_compression_type    Compression type.
+  *
+  */
+static st_fifo_compression_type get_compression_type(uint8_t tag)
+{
+  st_fifo_compression_type ret;
+  switch (tag) {
+    case TAG_GY:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+    case TAG_XL:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+    case TAG_TEMP:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+    case TAG_EXT_SENS_0:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+    case TAG_EXT_SENS_1:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+    case TAG_EXT_SENS_2:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+    case TAG_EXT_SENS_3:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+    case TAG_STEP_COUNTER:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+    case TAG_XL_UNCOMPRESSED_T_2:
+    ret =  ST_FIFO_COMPRESSION_NC_T_2;
+    break;
+    case TAG_XL_UNCOMPRESSED_T_1:
+    ret =  ST_FIFO_COMPRESSION_NC_T_1;
+    break;
+    case TAG_XL_COMPRESSED_2X:
+    ret =  ST_FIFO_COMPRESSION_2X;
+    break;
+    case TAG_XL_COMPRESSED_3X:
+    ret =  ST_FIFO_COMPRESSION_3X;
+    break;
+    case TAG_GY_UNCOMPRESSED_T_2:
+    ret =  ST_FIFO_COMPRESSION_NC_T_2;
+    break;
+    case TAG_GY_UNCOMPRESSED_T_1:
+    ret =  ST_FIFO_COMPRESSION_NC_T_1;
+    break;
+    case TAG_GY_COMPRESSED_2X:
+    ret =  ST_FIFO_COMPRESSION_2X;
+    break;
+    case TAG_GY_COMPRESSED_3X:
+    ret =  ST_FIFO_COMPRESSION_3X;
+    break;
+    default:
+    ret =  ST_FIFO_COMPRESSION_NC;
+    break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  This function check the parity of a byte.
+  *
+  * @param  x                 Byte to be analyzed.
+  *
+  * @retval uint8_t           Sensor type defined in st_fifo_compression_type.
+  *
+  */
+static uint8_t has_even_parity(uint8_t x)
+{
+  uint8_t count = 0x00, i, b = 0x01;
+  uint8_t ret = 1;
+
+  for (i = 0U; i < 8U; i++) {
+    if( ( x & (b << i) ) == 0x01U){
+      count++;
+    }
+  }
+
+  if ((count & 0x01U) == 0x01U) {
+    ret = 0;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Convert raw data FIFO into compressed data (2x).
+  *
+  * @param  diff[6]           Compressed data (2x).
+  * @param  input[6]          FIFO raw word without tag.
+  *
+  */
+static void get_diff_2x(int16_t diff[6], uint8_t input[6])
+{
+  uint8_t i;
+  for (i = 0; i < 6U; i++){
+    if ( input[i] < 128U ){
+      diff[i] = (int16_t)input[i];
+    }
+    else {
+      diff[i] = ((int16_t)input[i] - 256);
+    }
+  }
+}
+
+/**
+  * @brief  Convert raw data FIFO into compressed data (3x).
+  *
+  * @param  diff[6]           Compressed data (3x).
+  * @param  input[6]          fifo raw word without tag.
+  *
+  */
+static void get_diff_3x(int16_t diff[9], uint8_t input[6])
+{
+  uint32_t decode_temp;
+
+  for (uint8_t i = 0; i < 3U; i++) {
+
+    byte_cpy((uint8_t*)&decode_temp, &input[2U * i], 2);
+
+    for (uint8_t j = 0; j < 3U; j++) {
+
+      decode_temp &= ( (uint32_t)0x1FU << (5U * j) );
+      decode_temp = decode_temp >> (5U * j);
+
+      int16_t temp = (int16_t)decode_temp;
+
+      diff[j + (3U * i)] = (temp < 16) ? temp : (temp - 32);
+    }
+  }
+}
+
+/**
+  * @brief  Copy source buffer in destination buffer.
+  *
+  * @param  destination      Destination buffer.(ptr)
+  * @param  source           Source buffer.(ptr)
+  *
+  */
+static void byte_cpy(uint8_t *destination, uint8_t *source, uint32_t len)
+{
+  uint32_t i;
+
+  for ( i = 0; i < len; i++ ){
+    destination[i] =  source[i];
+  }
+
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */

--- a/sensor/stmemsc/_resources/FIFO_decompression_utility/fifo_utility.h
+++ b/sensor/stmemsc/_resources/FIFO_decompression_utility/fifo_utility.h
@@ -1,0 +1,151 @@
+/*
+ ******************************************************************************
+ * @file    fifo_utility.h
+ * @author  Sensor Solutions Software Team
+ * @brief   This file contains all the functions prototypes for the
+ *          fifo_utility.c.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef ST_FIFO_H
+#define ST_FIFO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+
+/** @addtogroup FIFO utility
+  * @{
+  *
+  */
+
+/** @defgroup FIFO_pubblic_definitions
+  * @{
+  *
+  */
+
+typedef enum {
+  ST_FIFO_OK = 0,
+  ST_FIFO_ERR
+} st_fifo_status;
+
+typedef enum {
+  ST_FIFO_GYROSCOPE,
+  ST_FIFO_ACCELEROMETER,
+  ST_FIFO_TEMPERATURE,
+  ST_FIFO_EXT_SENSOR0,
+  ST_FIFO_EXT_SENSOR1,
+  ST_FIFO_EXT_SENSOR2,
+  ST_FIFO_EXT_SENSOR3,
+  ST_FIFO_STEP_COUNTER,
+  ST_FIFO_6X_GAME_RV,
+  ST_FIFO_6X_GEOM_RV,
+  ST_FIFO_9X_RV,
+  ST_FIFO_GYRO_BIAS,
+  ST_FIFO_GRAVITY,
+  ST_FIFO_MAGNETOMETER_CALIB,
+  ST_FIFO_EXT_SENSOR_NACK,
+  ST_FIFO_NONE
+} st_fifo_sensor_type;
+
+typedef struct {
+  uint8_t fifo_data_out[7]; /* output fifo registers */
+} st_fifo_raw_slot;
+
+typedef struct {
+  uint32_t timestamp;
+  st_fifo_sensor_type sensor_tag;
+  uint8_t raw_data[6];
+} st_fifo_out_slot;
+
+/**
+  * @defgroup axisXbitXX_t
+  * @brief    This union is useful to represent different sensors data type.
+  *           This union are not need by the driver.
+  *
+  *           REMOVING the union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union {
+  int16_t data[3];       /* 3 axes mems */
+  int16_t temp;          /* temperature sensor */
+  uint16_t steps;        /* step counter */
+  uint16_t quat[3];      /* quaternion 3 axes format [x,y,z] */
+  uint8_t nack;          /* ext sensor nack index */
+  uint8_t raw_data[6];   /* raw data */
+} sensor_data_t;
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+st_fifo_status st_fifo_init(float_t bdr_xl, float_t bdr_gy, float_t bdr_vsens);
+
+st_fifo_status st_fifo_decompress(st_fifo_out_slot *fifo_out_slot,
+                                  st_fifo_raw_slot *fifo_raw_slot,
+                                  uint16_t *out_slot_size,
+                                  uint16_t stream_size);
+
+void st_fifo_sort(st_fifo_out_slot *fifo_out_slot, uint16_t out_slot_size);
+
+uint16_t st_fifo_get_sensor_occurrence(st_fifo_out_slot *fifo_out_slot,
+                                       uint16_t out_slot_size,
+                                       st_fifo_sensor_type sensor_type);
+
+void st_fifo_extract_sensor(st_fifo_out_slot *sensor_out_slot,
+                            st_fifo_out_slot *fifo_out_slot,
+                            uint16_t out_slot_size,
+                            st_fifo_sensor_type sensor_type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ST_FIFO_H */
+
+/**
+  * @}
+  *
+  */

--- a/sensor/stmemsc/a3g4250d_STdC/driver/a3g4250d_reg.c
+++ b/sensor/stmemsc/a3g4250d_STdC/driver/a3g4250d_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "a3g4250d_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t a3g4250d_read_reg(a3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t a3g4250d_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t a3g4250d_read_reg(a3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t a3g4250d_write_reg(a3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t a3g4250d_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -132,7 +115,7 @@ float_t a3g4250d_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_data_rate_set(a3g4250d_ctx_t *ctx, a3g4250d_dr_t val)
+int32_t a3g4250d_data_rate_set(stmdev_ctx_t *ctx, a3g4250d_dr_t val)
 {
   a3g4250d_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -155,7 +138,7 @@ int32_t a3g4250d_data_rate_set(a3g4250d_ctx_t *ctx, a3g4250d_dr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_data_rate_get(a3g4250d_ctx_t *ctx, a3g4250d_dr_t *val)
+int32_t a3g4250d_data_rate_get(stmdev_ctx_t *ctx, a3g4250d_dr_t *val)
 {
   a3g4250d_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -197,7 +180,7 @@ int32_t a3g4250d_data_rate_get(a3g4250d_ctx_t *ctx, a3g4250d_dr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_status_reg_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_status_reg_get(stmdev_ctx_t *ctx,
                                 a3g4250d_status_reg_t *val)
 {
   int32_t ret;
@@ -213,7 +196,7 @@ int32_t a3g4250d_status_reg_get(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_flag_data_ready_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_status_reg_t status_reg;
   int32_t ret;
@@ -243,7 +226,7 @@ int32_t a3g4250d_flag_data_ready_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_temperature_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
+int32_t a3g4250d_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = a3g4250d_read_reg(ctx, A3G4250D_OUT_TEMP, buff, 1);
@@ -259,7 +242,7 @@ int32_t a3g4250d_temperature_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_angular_rate_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
+int32_t a3g4250d_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  a3g4250d_read_reg(ctx, A3G4250D_OUT_X_L, buff, 6);
@@ -286,7 +269,7 @@ int32_t a3g4250d_angular_rate_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
   * @retval          Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_device_id_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
+int32_t a3g4250d_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = a3g4250d_read_reg(ctx, A3G4250D_WHO_AM_I, buff, 1);
@@ -301,7 +284,7 @@ int32_t a3g4250d_device_id_get(a3g4250d_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_self_test_set(a3g4250d_ctx_t *ctx, a3g4250d_st_t val)
+int32_t a3g4250d_self_test_set(stmdev_ctx_t *ctx, a3g4250d_st_t val)
 {
   a3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -322,7 +305,7 @@ int32_t a3g4250d_self_test_set(a3g4250d_ctx_t *ctx, a3g4250d_st_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_self_test_get(a3g4250d_ctx_t *ctx, a3g4250d_st_t *val)
+int32_t a3g4250d_self_test_get(stmdev_ctx_t *ctx, a3g4250d_st_t *val)
 {
   a3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -355,7 +338,7 @@ int32_t a3g4250d_self_test_get(a3g4250d_ctx_t *ctx, a3g4250d_st_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_data_format_set(a3g4250d_ctx_t *ctx, a3g4250d_ble_t val)
+int32_t a3g4250d_data_format_set(stmdev_ctx_t *ctx, a3g4250d_ble_t val)
 {
   a3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -376,7 +359,7 @@ int32_t a3g4250d_data_format_set(a3g4250d_ctx_t *ctx, a3g4250d_ble_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_data_format_get(a3g4250d_ctx_t *ctx, a3g4250d_ble_t *val)
+int32_t a3g4250d_data_format_get(stmdev_ctx_t *ctx, a3g4250d_ble_t *val)
 {
   a3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -404,7 +387,7 @@ int32_t a3g4250d_data_format_get(a3g4250d_ctx_t *ctx, a3g4250d_ble_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_boot_set(a3g4250d_ctx_t *ctx, uint8_t val)
+int32_t a3g4250d_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   a3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -426,7 +409,7 @@ int32_t a3g4250d_boot_set(a3g4250d_ctx_t *ctx, uint8_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_boot_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -458,7 +441,7 @@ int32_t a3g4250d_boot_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_lp_bandwidth_set(a3g4250d_ctx_t *ctx, a3g4250d_bw_t val)
+int32_t a3g4250d_lp_bandwidth_set(stmdev_ctx_t *ctx, a3g4250d_bw_t val)
 {
   a3g4250d_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -480,7 +463,7 @@ int32_t a3g4250d_lp_bandwidth_set(a3g4250d_ctx_t *ctx, a3g4250d_bw_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_lp_bandwidth_get(a3g4250d_ctx_t *ctx, a3g4250d_bw_t *val)
+int32_t a3g4250d_lp_bandwidth_get(stmdev_ctx_t *ctx, a3g4250d_bw_t *val)
 {
   a3g4250d_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -516,7 +499,7 @@ int32_t a3g4250d_lp_bandwidth_get(a3g4250d_ctx_t *ctx, a3g4250d_bw_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_hp_bandwidth_set(a3g4250d_ctx_t *ctx, a3g4250d_hpcf_t val)
+int32_t a3g4250d_hp_bandwidth_set(stmdev_ctx_t *ctx, a3g4250d_hpcf_t val)
 {
   a3g4250d_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -538,7 +521,7 @@ int32_t a3g4250d_hp_bandwidth_set(a3g4250d_ctx_t *ctx, a3g4250d_hpcf_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_hp_bandwidth_get(a3g4250d_ctx_t *ctx, a3g4250d_hpcf_t *val)
+int32_t a3g4250d_hp_bandwidth_get(stmdev_ctx_t *ctx, a3g4250d_hpcf_t *val)
 {
   a3g4250d_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -592,7 +575,7 @@ int32_t a3g4250d_hp_bandwidth_get(a3g4250d_ctx_t *ctx, a3g4250d_hpcf_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_hp_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t val)
+int32_t a3g4250d_hp_mode_set(stmdev_ctx_t *ctx, a3g4250d_hpm_t val)
 {
   a3g4250d_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -614,7 +597,7 @@ int32_t a3g4250d_hp_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_hp_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t *val)
+int32_t a3g4250d_hp_mode_get(stmdev_ctx_t *ctx, a3g4250d_hpm_t *val)
 {
   a3g4250d_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -650,7 +633,7 @@ int32_t a3g4250d_hp_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_filter_path_set(a3g4250d_ctx_t *ctx, a3g4250d_out_sel_t val)
+int32_t a3g4250d_filter_path_set(stmdev_ctx_t *ctx, a3g4250d_out_sel_t val)
 {
   a3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -673,7 +656,7 @@ int32_t a3g4250d_filter_path_set(a3g4250d_ctx_t *ctx, a3g4250d_out_sel_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_filter_path_get(a3g4250d_ctx_t *ctx, a3g4250d_out_sel_t *val)
+int32_t a3g4250d_filter_path_get(stmdev_ctx_t *ctx, a3g4250d_out_sel_t *val)
 {
   a3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -709,7 +692,7 @@ int32_t a3g4250d_filter_path_get(a3g4250d_ctx_t *ctx, a3g4250d_out_sel_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_filter_path_internal_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_filter_path_internal_set(stmdev_ctx_t *ctx,
                                           a3g4250d_int1_sel_t val)
 {
   a3g4250d_ctrl_reg5_t ctrl_reg5;
@@ -733,7 +716,7 @@ int32_t a3g4250d_filter_path_internal_set(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_filter_path_internal_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_filter_path_internal_get(stmdev_ctx_t *ctx,
                                           a3g4250d_int1_sel_t *val)
 {
   a3g4250d_ctrl_reg5_t ctrl_reg5;
@@ -770,7 +753,7 @@ int32_t a3g4250d_filter_path_internal_get(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_hp_reference_value_set(a3g4250d_ctx_t *ctx, uint8_t val)
+int32_t a3g4250d_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   a3g4250d_reference_t reference;
   int32_t ret;
@@ -792,7 +775,7 @@ int32_t a3g4250d_hp_reference_value_set(a3g4250d_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_hp_reference_value_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_reference_t reference;
   int32_t ret;
@@ -824,7 +807,7 @@ int32_t a3g4250d_hp_reference_value_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_spi_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_sim_t val)
+int32_t a3g4250d_spi_mode_set(stmdev_ctx_t *ctx, a3g4250d_sim_t val)
 {
   a3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -846,7 +829,7 @@ int32_t a3g4250d_spi_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_spi_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_sim_t *val)
+int32_t a3g4250d_spi_mode_get(stmdev_ctx_t *ctx, a3g4250d_sim_t *val)
 {
   a3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -889,7 +872,7 @@ int32_t a3g4250d_spi_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_pin_int1_route_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     a3g4250d_int1_route_t val)
 {
   a3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -914,7 +897,7 @@ int32_t a3g4250d_pin_int1_route_set(a3g4250d_ctx_t *ctx,
   *
   */
 
-int32_t a3g4250d_pin_int1_route_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     a3g4250d_int1_route_t *val)
 {
   a3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -934,7 +917,7 @@ int32_t a3g4250d_pin_int1_route_get(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_pin_int2_route_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     a3g4250d_int2_route_t val)
 {
   a3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -960,7 +943,7 @@ int32_t a3g4250d_pin_int2_route_set(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_pin_int2_route_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     a3g4250d_int2_route_t *val)
 {
   a3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -983,7 +966,7 @@ int32_t a3g4250d_pin_int2_route_get(a3g4250d_ctx_t *ctx,
   *
   */
 
-int32_t a3g4250d_pin_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t val)
+int32_t a3g4250d_pin_mode_set(stmdev_ctx_t *ctx, a3g4250d_pp_od_t val)
 {
   a3g4250d_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1005,7 +988,7 @@ int32_t a3g4250d_pin_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_pin_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t *val)
+int32_t a3g4250d_pin_mode_get(stmdev_ctx_t *ctx, a3g4250d_pp_od_t *val)
 {
   a3g4250d_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1035,7 +1018,7 @@ int32_t a3g4250d_pin_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_pin_polarity_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_polarity_set(stmdev_ctx_t *ctx,
                                   a3g4250d_h_lactive_t val)
 {
   a3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -1058,7 +1041,7 @@ int32_t a3g4250d_pin_polarity_set(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_pin_polarity_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_polarity_get(stmdev_ctx_t *ctx,
                                   a3g4250d_h_lactive_t *val)
 {
   a3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -1089,7 +1072,7 @@ int32_t a3g4250d_pin_polarity_get(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_notification_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_notification_set(stmdev_ctx_t *ctx,
                                       a3g4250d_lir_t val)
 {
   a3g4250d_int1_cfg_t int1_cfg;
@@ -1112,7 +1095,7 @@ int32_t a3g4250d_int_notification_set(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_notification_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_notification_get(stmdev_ctx_t *ctx,
                                       a3g4250d_lir_t *val)
 {
   a3g4250d_int1_cfg_t int1_cfg;
@@ -1156,7 +1139,7 @@ int32_t a3g4250d_int_notification_get(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_on_threshold_conf_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                            a3g4250d_int1_cfg_t *val)
 {
   int32_t ret;
@@ -1172,7 +1155,7 @@ int32_t a3g4250d_int_on_threshold_conf_set(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_on_threshold_conf_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                            a3g4250d_int1_cfg_t *val)
 {
   int32_t ret;
@@ -1187,7 +1170,7 @@ int32_t a3g4250d_int_on_threshold_conf_get(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_on_threshold_mode_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                            a3g4250d_and_or_t val)
 {
   a3g4250d_int1_cfg_t int1_cfg;
@@ -1210,7 +1193,7 @@ int32_t a3g4250d_int_on_threshold_mode_set(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_on_threshold_mode_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                            a3g4250d_and_or_t *val)
 {
   a3g4250d_int1_cfg_t int1_cfg;
@@ -1239,7 +1222,7 @@ int32_t a3g4250d_int_on_threshold_mode_get(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_on_threshold_src_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_src_get(stmdev_ctx_t *ctx,
                                           a3g4250d_int1_src_t *val)
 {
   int32_t ret;
@@ -1255,7 +1238,7 @@ int32_t a3g4250d_int_on_threshold_src_get(a3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_x_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
+int32_t a3g4250d_int_x_treshold_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   a3g4250d_int1_tsh_xh_t int1_tsh_xh;
   a3g4250d_int1_tsh_xl_t int1_tsh_xl;
@@ -1288,7 +1271,7 @@ int32_t a3g4250d_int_x_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_x_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
+int32_t a3g4250d_int_x_treshold_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   a3g4250d_int1_tsh_xh_t int1_tsh_xh;
   a3g4250d_int1_tsh_xl_t int1_tsh_xl;
@@ -1315,7 +1298,7 @@ int32_t a3g4250d_int_x_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_y_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
+int32_t a3g4250d_int_y_treshold_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   a3g4250d_int1_tsh_yh_t int1_tsh_yh;
   a3g4250d_int1_tsh_yl_t int1_tsh_yl;
@@ -1348,7 +1331,7 @@ int32_t a3g4250d_int_y_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_y_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
+int32_t a3g4250d_int_y_treshold_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   a3g4250d_int1_tsh_yh_t int1_tsh_yh;
   a3g4250d_int1_tsh_yl_t int1_tsh_yl;
@@ -1375,7 +1358,7 @@ int32_t a3g4250d_int_y_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_z_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
+int32_t a3g4250d_int_z_treshold_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   a3g4250d_int1_tsh_zh_t int1_tsh_zh;
   a3g4250d_int1_tsh_zl_t int1_tsh_zl;
@@ -1408,7 +1391,7 @@ int32_t a3g4250d_int_z_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_z_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
+int32_t a3g4250d_int_z_treshold_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   a3g4250d_int1_tsh_zh_t int1_tsh_zh;
   a3g4250d_int1_tsh_zl_t int1_tsh_zl;
@@ -1435,7 +1418,7 @@ int32_t a3g4250d_int_z_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_on_threshold_dur_set(a3g4250d_ctx_t *ctx, uint8_t val)
+int32_t a3g4250d_int_on_threshold_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   a3g4250d_int1_duration_t int1_duration;
   int32_t ret;
@@ -1464,7 +1447,7 @@ int32_t a3g4250d_int_on_threshold_dur_set(a3g4250d_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_int_on_threshold_dur_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_int_on_threshold_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_int1_duration_t int1_duration;
   int32_t ret;
@@ -1496,7 +1479,7 @@ int32_t a3g4250d_int_on_threshold_dur_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_enable_set(a3g4250d_ctx_t *ctx, uint8_t val)
+int32_t a3g4250d_fifo_enable_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   a3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1518,7 +1501,7 @@ int32_t a3g4250d_fifo_enable_set(a3g4250d_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_enable_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_fifo_enable_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1537,7 +1520,7 @@ int32_t a3g4250d_fifo_enable_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_watermark_set(a3g4250d_ctx_t *ctx, uint8_t val)
+int32_t a3g4250d_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   a3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1561,7 +1544,7 @@ int32_t a3g4250d_fifo_watermark_set(a3g4250d_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_watermark_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1581,7 +1564,7 @@ int32_t a3g4250d_fifo_watermark_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t val)
+int32_t a3g4250d_fifo_mode_set(stmdev_ctx_t *ctx, a3g4250d_fifo_mode_t val)
 {
   a3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1605,7 +1588,7 @@ int32_t a3g4250d_fifo_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t *val)
+int32_t a3g4250d_fifo_mode_get(stmdev_ctx_t *ctx, a3g4250d_fifo_mode_t *val)
 {
   a3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1639,7 +1622,7 @@ int32_t a3g4250d_fifo_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_data_level_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1659,7 +1642,7 @@ int32_t a3g4250d_fifo_data_level_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_empty_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1679,7 +1662,7 @@ int32_t a3g4250d_fifo_empty_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t a3g4250d_fifo_ovr_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1702,7 +1685,7 @@ int32_t a3g4250d_fifo_ovr_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val)
   *
   */
 
-int32_t a3g4250d_fifo_wtm_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t a3g4250d_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   a3g4250d_fifo_src_reg_t fifo_src_reg;
   int32_t ret;

--- a/sensor/stmemsc/a3g4250d_STdC/driver/a3g4250d_reg.h
+++ b/sensor/stmemsc/a3g4250d_STdC/driver/a3g4250d_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef A3G4250D_REGS_H
 #define A3G4250D_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup A3G4250D_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,35 +57,62 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/**
-  * @defgroup a3g4250d_interface
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
   * @{
   *
   */
 
-typedef int32_t (*a3g4250d_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*a3g4250d_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  a3g4250d_write_ptr  write_reg;
-  a3g4250d_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} a3g4250d_ctx_t;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
 
 /**
   * @defgroup a3g4250d_Infos
@@ -346,22 +320,22 @@ typedef union{
   *
   */
 
-int32_t a3g4250d_read_reg(a3g4250d_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t a3g4250d_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t a3g4250d_write_reg(a3g4250d_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t a3g4250d_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t a3g4250d_from_fs245dps_to_mdps(int16_t lsb);
 extern float_t a3g4250d_from_lsb_to_celsius(int16_t lsb);
 
-int32_t a3g4250d_axis_x_data_set(a3g4250d_ctx_t *ctx, uint8_t val);
-int32_t a3g4250d_axis_x_data_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t a3g4250d_axis_y_data_set(a3g4250d_ctx_t *ctx, uint8_t val);
-int32_t a3g4250d_axis_y_data_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t a3g4250d_axis_z_data_set(a3g4250d_ctx_t *ctx, uint8_t val);
-int32_t a3g4250d_axis_z_data_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   A3G4250D_ODR_OFF     = 0x00,
@@ -371,37 +345,37 @@ typedef enum {
   A3G4250D_ODR_400Hz   = 0x2F,
   A3G4250D_ODR_800Hz   = 0x3F,
 } a3g4250d_dr_t;
-int32_t a3g4250d_data_rate_set(a3g4250d_ctx_t *ctx, a3g4250d_dr_t val);
-int32_t a3g4250d_data_rate_get(a3g4250d_ctx_t *ctx, a3g4250d_dr_t *val);
+int32_t a3g4250d_data_rate_set(stmdev_ctx_t *ctx, a3g4250d_dr_t val);
+int32_t a3g4250d_data_rate_get(stmdev_ctx_t *ctx, a3g4250d_dr_t *val);
 
-int32_t a3g4250d_status_reg_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_status_reg_get(stmdev_ctx_t *ctx,
                                 a3g4250d_status_reg_t *val);
 
-int32_t a3g4250d_flag_data_ready_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t a3g4250d_temperature_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff);
+int32_t a3g4250d_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t a3g4250d_angular_rate_raw_get(a3g4250d_ctx_t *ctx, uint8_t *buff);
+int32_t a3g4250d_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t a3g4250d_device_id_get(a3g4250d_ctx_t *ctx, uint8_t *buff);
+int32_t a3g4250d_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   A3G4250D_GY_ST_DISABLE    = 0,
   A3G4250D_GY_ST_POSITIVE   = 1,
   A3G4250D_GY_ST_NEGATIVE   = 3,
 } a3g4250d_st_t;
-int32_t a3g4250d_self_test_set(a3g4250d_ctx_t *ctx, a3g4250d_st_t val);
-int32_t a3g4250d_self_test_get(a3g4250d_ctx_t *ctx, a3g4250d_st_t *val);
+int32_t a3g4250d_self_test_set(stmdev_ctx_t *ctx, a3g4250d_st_t val);
+int32_t a3g4250d_self_test_get(stmdev_ctx_t *ctx, a3g4250d_st_t *val);
 
 typedef enum {
   A3G4250D_AUX_LSB_AT_LOW_ADD   = 0,
   A3G4250D_AUX_MSB_AT_LOW_ADD   = 1,
 } a3g4250d_ble_t;
-int32_t a3g4250d_data_format_set(a3g4250d_ctx_t *ctx, a3g4250d_ble_t val);
-int32_t a3g4250d_data_format_get(a3g4250d_ctx_t *ctx, a3g4250d_ble_t *val);
+int32_t a3g4250d_data_format_set(stmdev_ctx_t *ctx, a3g4250d_ble_t val);
+int32_t a3g4250d_data_format_get(stmdev_ctx_t *ctx, a3g4250d_ble_t *val);
 
-int32_t a3g4250d_boot_set(a3g4250d_ctx_t *ctx, uint8_t val);
-int32_t a3g4250d_boot_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   A3G4250D_CUT_OFF_LOW        = 0,
@@ -409,8 +383,8 @@ typedef enum {
   A3G4250D_CUT_OFF_HIGH       = 2,
   A3G4250D_CUT_OFF_VERY_HIGH  = 3,
 } a3g4250d_bw_t;
-int32_t a3g4250d_lp_bandwidth_set(a3g4250d_ctx_t *ctx, a3g4250d_bw_t val);
-int32_t a3g4250d_lp_bandwidth_get(a3g4250d_ctx_t *ctx, a3g4250d_bw_t *val);
+int32_t a3g4250d_lp_bandwidth_set(stmdev_ctx_t *ctx, a3g4250d_bw_t val);
+int32_t a3g4250d_lp_bandwidth_get(stmdev_ctx_t *ctx, a3g4250d_bw_t *val);
 
 typedef enum {
   A3G4250D_HP_LEVEL_0   = 0,
@@ -424,9 +398,9 @@ typedef enum {
   A3G4250D_HP_LEVEL_8   = 8,
   A3G4250D_HP_LEVEL_9   = 9,
 } a3g4250d_hpcf_t;
-int32_t a3g4250d_hp_bandwidth_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                   a3g4250d_hpcf_t val);
-int32_t a3g4250d_hp_bandwidth_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                   a3g4250d_hpcf_t *val);
 
 typedef enum {
@@ -435,8 +409,8 @@ typedef enum {
   A3G4250D_HP_NORMAL_MODE           = 2,
   A3G4250D_HP_AUTO_RESET_ON_INT     = 3,
 } a3g4250d_hpm_t;
-int32_t a3g4250d_hp_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t val);
-int32_t a3g4250d_hp_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_hpm_t *val);
+int32_t a3g4250d_hp_mode_set(stmdev_ctx_t *ctx, a3g4250d_hpm_t val);
+int32_t a3g4250d_hp_mode_get(stmdev_ctx_t *ctx, a3g4250d_hpm_t *val);
 
 typedef enum {
   A3G4250D_ONLY_LPF1_ON_OUT     = 0,
@@ -444,9 +418,9 @@ typedef enum {
   A3G4250D_LPF1_LPF2_ON_OUT     = 2,
   A3G4250D_LPF1_HP_LPF2_ON_OUT  = 6,
 } a3g4250d_out_sel_t;
-int32_t a3g4250d_filter_path_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_filter_path_set(stmdev_ctx_t *ctx,
                                  a3g4250d_out_sel_t val);
-int32_t a3g4250d_filter_path_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_filter_path_get(stmdev_ctx_t *ctx,
                                  a3g4250d_out_sel_t *val);
 
 typedef enum {
@@ -455,28 +429,28 @@ typedef enum {
   A3G4250D_LPF1_LPF2_ON_INT     = 2,
   A3G4250D_LPF1_HP_LPF2_ON_INT  = 6,
 } a3g4250d_int1_sel_t;
-int32_t a3g4250d_filter_path_internal_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_filter_path_internal_set(stmdev_ctx_t *ctx,
                                           a3g4250d_int1_sel_t val);
-int32_t a3g4250d_filter_path_internal_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_filter_path_internal_get(stmdev_ctx_t *ctx,
                                           a3g4250d_int1_sel_t *val);
 
-int32_t a3g4250d_hp_reference_value_set(a3g4250d_ctx_t *ctx, uint8_t val);
-int32_t a3g4250d_hp_reference_value_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   A3G4250D_SPI_4_WIRE  = 0,
   A3G4250D_SPI_3_WIRE  = 1,
 } a3g4250d_sim_t;
-int32_t a3g4250d_spi_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_sim_t val);
-int32_t a3g4250d_spi_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_sim_t *val);
+int32_t a3g4250d_spi_mode_set(stmdev_ctx_t *ctx, a3g4250d_sim_t val);
+int32_t a3g4250d_spi_mode_get(stmdev_ctx_t *ctx, a3g4250d_sim_t *val);
 
 typedef struct {
   uint8_t i1_int1             : 1;
   uint8_t i1_boot             : 1;
 } a3g4250d_int1_route_t;
-int32_t a3g4250d_pin_int1_route_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     a3g4250d_int1_route_t val);
-int32_t a3g4250d_pin_int1_route_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     a3g4250d_int1_route_t *val);
 
 typedef struct {
@@ -485,86 +459,86 @@ typedef struct {
   uint8_t i2_wtm               : 1;
   uint8_t i2_drdy              : 1;
 } a3g4250d_int2_route_t;
-int32_t a3g4250d_pin_int2_route_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     a3g4250d_int2_route_t val);
-int32_t a3g4250d_pin_int2_route_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     a3g4250d_int2_route_t *val);
 
 typedef enum {
   A3G4250D_PUSH_PULL   = 0,
   A3G4250D_OPEN_DRAIN  = 1,
 } a3g4250d_pp_od_t;
-int32_t a3g4250d_pin_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t val);
-int32_t a3g4250d_pin_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_pp_od_t *val);
+int32_t a3g4250d_pin_mode_set(stmdev_ctx_t *ctx, a3g4250d_pp_od_t val);
+int32_t a3g4250d_pin_mode_get(stmdev_ctx_t *ctx, a3g4250d_pp_od_t *val);
 
 typedef enum {
   A3G4250D_ACTIVE_HIGH  = 0,
   A3G4250D_ACTIVE_LOW   = 1,
 } a3g4250d_h_lactive_t;
-int32_t a3g4250d_pin_polarity_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_polarity_set(stmdev_ctx_t *ctx,
                                   a3g4250d_h_lactive_t val);
-int32_t a3g4250d_pin_polarity_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_pin_polarity_get(stmdev_ctx_t *ctx,
                                   a3g4250d_h_lactive_t *val);
 
 typedef enum {
   A3G4250D_INT_PULSED   = 0,
   A3G4250D_INT_LATCHED  = 1,
 } a3g4250d_lir_t;
-int32_t a3g4250d_int_notification_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_notification_set(stmdev_ctx_t *ctx,
                                       a3g4250d_lir_t val);
-int32_t a3g4250d_int_notification_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_notification_get(stmdev_ctx_t *ctx,
                                       a3g4250d_lir_t *val);
 
-int32_t a3g4250d_int_on_threshold_conf_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                            a3g4250d_int1_cfg_t *val);
-int32_t a3g4250d_int_on_threshold_conf_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                            a3g4250d_int1_cfg_t *val);
 
 typedef enum {
   A3G4250D_INT1_ON_TH_AND  = 1,
   A3G4250D_INT1_ON_TH_OR   = 0,
 } a3g4250d_and_or_t;
-int32_t a3g4250d_int_on_threshold_mode_set(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                            a3g4250d_and_or_t val);
-int32_t a3g4250d_int_on_threshold_mode_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                            a3g4250d_and_or_t *val);
 
-int32_t a3g4250d_int_on_threshold_src_get(a3g4250d_ctx_t *ctx,
+int32_t a3g4250d_int_on_threshold_src_get(stmdev_ctx_t *ctx,
                                           a3g4250d_int1_src_t *val);
 
-int32_t a3g4250d_int_x_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val);
-int32_t a3g4250d_int_x_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val);
+int32_t a3g4250d_int_x_treshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t a3g4250d_int_x_treshold_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t a3g4250d_int_y_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val);
-int32_t a3g4250d_int_y_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val);
+int32_t a3g4250d_int_y_treshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t a3g4250d_int_y_treshold_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t a3g4250d_int_z_treshold_set(a3g4250d_ctx_t *ctx, uint16_t val);
-int32_t a3g4250d_int_z_treshold_get(a3g4250d_ctx_t *ctx, uint16_t *val);
+int32_t a3g4250d_int_z_treshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t a3g4250d_int_z_treshold_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t a3g4250d_int_on_threshold_dur_set(a3g4250d_ctx_t *ctx, uint8_t val);
-int32_t a3g4250d_int_on_threshold_dur_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_int_on_threshold_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_int_on_threshold_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t a3g4250d_fifo_enable_set(a3g4250d_ctx_t *ctx, uint8_t val);
-int32_t a3g4250d_fifo_enable_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_fifo_enable_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_fifo_enable_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t a3g4250d_fifo_watermark_set(a3g4250d_ctx_t *ctx, uint8_t val);
-int32_t a3g4250d_fifo_watermark_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t a3g4250d_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   A3G4250D_FIFO_BYPASS_MODE     = 0x00,
   A3G4250D_FIFO_MODE            = 0x01,
   A3G4250D_FIFO_STREAM_MODE     = 0x02,
 } a3g4250d_fifo_mode_t;
-int32_t a3g4250d_fifo_mode_set(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t val);
-int32_t a3g4250d_fifo_mode_get(a3g4250d_ctx_t *ctx, a3g4250d_fifo_mode_t *val);
+int32_t a3g4250d_fifo_mode_set(stmdev_ctx_t *ctx, a3g4250d_fifo_mode_t val);
+int32_t a3g4250d_fifo_mode_get(stmdev_ctx_t *ctx, a3g4250d_fifo_mode_t *val);
 
-int32_t a3g4250d_fifo_data_level_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t a3g4250d_fifo_empty_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t a3g4250d_fifo_ovr_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t a3g4250d_fifo_wtm_flag_get(a3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t a3g4250d_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/ais2dw12_STdC/driver/ais2dw12_reg.c
+++ b/sensor/stmemsc/ais2dw12_STdC/driver/ais2dw12_reg.c
@@ -1,0 +1,2278 @@
+/*
+ ******************************************************************************
+ * @file    ais2dw12_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   AIS2DW12 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "ais2dw12_reg.h"
+
+/**
+  * @defgroup  AIS2DW12
+  * @brief     This file provides a set of functions needed to drive the
+  *            ais2dw12 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    AIS2DW12_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t ais2dw12_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t ais2dw12_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t ais2dw12_from_fs2_12bit_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t ais2dw12_from_fs4_12bit_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t ais2dw12_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 16.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Data_Generation
+  * @brief     This section groups all the functions concerning
+  *            data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select accelerometer operating modes.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of op_mode / pw_mode in reg CTRL1
+  *                  and low_noise in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_power_mode_set(stmdev_ctx_t *ctx, ais2dw12_mode_t val)
+{
+  ais2dw12_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ctrl1.op_mode = ( (uint8_t) val & 0x0CU ) >> 2;
+    ctrl1.pw_mode = (uint8_t) val & 0x03U ;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select accelerometer operating modes.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of op_mode / pw_mode in reg CTRL1
+  *                  and low_noise in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_power_mode_get(stmdev_ctx_t *ctx, ais2dw12_mode_t *val)
+{
+  ais2dw12_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  switch ( (ctrl1.op_mode << 2) + ctrl1.pw_mode) {
+    case AIS2DW12_PWR_MD_4:
+      *val = AIS2DW12_PWR_MD_4;
+      break;
+    case AIS2DW12_PWR_MD_3:
+      *val = AIS2DW12_PWR_MD_3;
+      break;
+    case AIS2DW12_PWR_MD_2:
+      *val = AIS2DW12_PWR_MD_2;
+      break;
+    case AIS2DW12_PWR_MD_12bit:
+      *val = AIS2DW12_PWR_MD_12bit;
+      break;
+    case AIS2DW12_SINGLE_PWR_MD_4:
+      *val = AIS2DW12_SINGLE_PWR_MD_4;
+      break;
+    case AIS2DW12_SINGLE_PWR_MD_3:
+      *val = AIS2DW12_SINGLE_PWR_MD_3;
+      break;
+    case AIS2DW12_SINGLE_PWR_MD_2:
+      *val = AIS2DW12_SINGLE_PWR_MD_2;
+      break;
+    case AIS2DW12_SINGLE_PWR_MD_12bit:
+      *val = AIS2DW12_SINGLE_PWR_MD_12bit;
+      break;
+    default:
+      *val = AIS2DW12_PWR_MD_4;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_data_rate_set(stmdev_ctx_t *ctx, ais2dw12_odr_t val)
+{
+  ais2dw12_ctrl1_t ctrl1;
+  ais2dw12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ctrl1.odr = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  }
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &ctrl3, 1);
+  }
+  if (ret == 0) {
+    ctrl3.slp_mode = ( (uint8_t) val & 0x30U ) >> 4;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr in reg CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_data_rate_get(stmdev_ctx_t *ctx, ais2dw12_odr_t *val)
+{
+  ais2dw12_ctrl1_t ctrl1;
+  ais2dw12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &ctrl3, 1);
+
+    switch ((ctrl3.slp_mode << 4) + ctrl1.odr) {
+      case AIS2DW12_XL_ODR_OFF:
+        *val = AIS2DW12_XL_ODR_OFF;
+        break;
+      case AIS2DW12_XL_ODR_12Hz5:
+        *val = AIS2DW12_XL_ODR_12Hz5;
+        break;
+      case AIS2DW12_XL_ODR_25Hz:
+        *val = AIS2DW12_XL_ODR_25Hz;
+        break;
+       case AIS2DW12_XL_ODR_50Hz:
+        *val = AIS2DW12_XL_ODR_50Hz;
+        break;
+      case AIS2DW12_XL_ODR_100Hz:
+        *val = AIS2DW12_XL_ODR_100Hz;
+        break;
+      case AIS2DW12_XL_SET_SW_TRIG:
+        *val = AIS2DW12_XL_SET_SW_TRIG;
+        break;
+      case AIS2DW12_XL_SET_PIN_TRIG:
+        *val = AIS2DW12_XL_SET_PIN_TRIG;
+        break;
+      default:
+        *val = AIS2DW12_XL_ODR_OFF;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_full_scale_set(stmdev_ctx_t *ctx, ais2dw12_fs_t val)
+{
+  ais2dw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fs = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_full_scale_get(stmdev_ctx_t *ctx, ais2dw12_fs_t *val)
+{
+  ais2dw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+
+  switch (reg.fs) {
+    case AIS2DW12_2g:
+      *val = AIS2DW12_2g;
+      break;
+    case AIS2DW12_4g:
+      *val = AIS2DW12_4g;
+      break;
+    default:
+      *val = AIS2DW12_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS to
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_status_reg_get(stmdev_ctx_t *ctx, ais2dw12_status_t *val)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_STATUS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_status_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_STATUS,(uint8_t*) &reg, 1);
+  *val = reg.drdy;
+
+  return ret;
+}
+/**
+  * @brief   Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers STATUS_DUP, WAKE_UP_SRC,
+  *                  TAP_SRC, SIXD_SRC, ALL_INT_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_all_sources_get(stmdev_ctx_t *ctx,
+                                 ais2dw12_all_sources_t *val)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_STATUS_DUP, (uint8_t*) val, 5);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_write_reg(ctx, AIS2DW12_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_write_reg(ctx, AIS2DW12_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_write_reg(ctx, AIS2DW12_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR,
+  *         Y_OFS_USR, Z_OFS_USR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_w in
+  *                               reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_offset_weight_set(stmdev_ctx_t *ctx,
+                                   ais2dw12_usr_off_w_t val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.usr_off_w = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR,
+  *         Y_OFS_USR, Z_OFS_USR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of usr_off_w in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_offset_weight_get(stmdev_ctx_t *ctx,
+                                   ais2dw12_usr_off_w_t *val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  switch (reg.usr_off_w) {
+    case AIS2DW12_LSb_977ug:
+      *val = AIS2DW12_LSb_977ug;
+      break;
+    case AIS2DW12_LSb_15mg6:
+      *val = AIS2DW12_LSb_15mg6;
+      break;
+    default:
+      *val = AIS2DW12_LSb_977ug;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Data_Output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data output register (r). L and H registers
+  *         together express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_OUT_T_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as
+  *         a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Common
+  * @brief     This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.if_add_inc = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during multiple
+  *         byte access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_reset in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.soft_reset = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_reset in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.soft_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.boot = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor self-test enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_self_test_set(stmdev_ctx_t *ctx, ais2dw12_st_t val)
+{
+  ais2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.st = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor self-test enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_self_test_get(stmdev_ctx_t *ctx, ais2dw12_st_t *val)
+{
+  ais2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.st) {
+    case AIS2DW12_XL_ST_DISABLE:
+      *val = AIS2DW12_XL_ST_DISABLE;
+      break;
+    case AIS2DW12_XL_ST_POSITIVE:
+      *val = AIS2DW12_XL_ST_POSITIVE;
+      break;
+    case AIS2DW12_XL_ST_NEGATIVE:
+      *val = AIS2DW12_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = AIS2DW12_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_pulsed in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                     ais2dw12_drdy_pulsed_t val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.drdy_pulsed = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of drdy_pulsed in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                     ais2dw12_drdy_pulsed_t *val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+
+  switch (reg.drdy_pulsed) {
+    case AIS2DW12_DRDY_LATCHED:
+      *val = AIS2DW12_DRDY_LATCHED;
+      break;
+    case AIS2DW12_DRDY_PULSED:
+      *val = AIS2DW12_DRDY_PULSED;
+      break;
+    default:
+      *val = AIS2DW12_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Filters
+  * @brief     This section group all the functions concerning the filters
+  *            configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer filtering path for outputs.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_filter_path_set(stmdev_ctx_t *ctx, ais2dw12_fds_t val)
+{
+  ais2dw12_ctrl6_t ctrl6;
+  ais2dw12_ctrl7_t ctrl_reg7;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  if (ret == 0) {
+    ctrl6.fds = ( (uint8_t) val & 0x10U ) >> 4;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  }
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &ctrl_reg7, 1);
+  }
+  if (ret == 0) {
+    ctrl_reg7.usr_off_on_out = (uint8_t) val & 0x01U;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &ctrl_reg7, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer filtering path for outputs.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fds in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_filter_path_get(stmdev_ctx_t *ctx, ais2dw12_fds_t *val)
+{
+  ais2dw12_ctrl6_t ctrl6;
+  ais2dw12_ctrl7_t ctrl_reg7;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  if (ret == 0) {
+   ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &ctrl_reg7, 1);
+
+    switch ((ctrl6.fds << 4 ) + ctrl_reg7.usr_off_on_out) {
+      case AIS2DW12_LPF_ON_OUT:
+        *val = AIS2DW12_LPF_ON_OUT;
+        break;
+      case AIS2DW12_USER_OFFSET_ON_OUT:
+        *val = AIS2DW12_USER_OFFSET_ON_OUT;
+        break;
+      case AIS2DW12_HIGH_PASS_ON_OUT:
+        *val = AIS2DW12_HIGH_PASS_ON_OUT;
+        break;
+      default:
+        *val = AIS2DW12_LPF_ON_OUT;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer cutoff filter frequency. Valid for low and high
+  *          pass filter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bw_filt in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_filter_bandwidth_set(stmdev_ctx_t *ctx,
+                                         ais2dw12_bw_filt_t val)
+{
+  ais2dw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bw_filt = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer cutoff filter frequency. Valid for low and
+  *          high pass filter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of bw_filt in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_filter_bandwidth_get(stmdev_ctx_t *ctx,
+                                         ais2dw12_bw_filt_t *val)
+{
+  ais2dw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL6,(uint8_t*) &reg, 1);
+
+  switch (reg.bw_filt) {
+    case AIS2DW12_ODR_DIV_2:
+      *val = AIS2DW12_ODR_DIV_2;
+      break;
+    case AIS2DW12_ODR_DIV_4:
+      *val = AIS2DW12_ODR_DIV_4;
+      break;
+    case AIS2DW12_ODR_DIV_10:
+      *val = AIS2DW12_ODR_DIV_10;
+      break;
+    case AIS2DW12_ODR_DIV_20:
+      *val = AIS2DW12_ODR_DIV_20;
+      break;
+    default:
+      *val = AIS2DW12_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_ref_mode in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.hp_ref_mode = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_ref_mode in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  *val = reg.hp_ref_mode;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   AIS2DW12_Serial_Interface
+  * @brief      This section groups all the functions concerning main serial
+  *             interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_spi_mode_set(stmdev_ctx_t *ctx, ais2dw12_sim_t val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sim = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_spi_mode_get(stmdev_ctx_t *ctx, ais2dw12_sim_t *val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.sim) {
+    case AIS2DW12_SPI_4_WIRE:
+      *val = AIS2DW12_SPI_4_WIRE;
+      break;
+    case AIS2DW12_SPI_3_WIRE:
+      *val = AIS2DW12_SPI_3_WIRE;
+      break;
+    default:
+      *val = AIS2DW12_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_disable in
+  *                                 reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_i2c_interface_set(stmdev_ctx_t *ctx,
+                                   ais2dw12_i2c_disable_t val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i2c_disable = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_disable in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_i2c_interface_get(stmdev_ctx_t *ctx,
+                                   ais2dw12_i2c_disable_t *val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.i2c_disable) {
+    case AIS2DW12_I2C_ENABLE:
+      *val = AIS2DW12_I2C_ENABLE;
+      break;
+    case AIS2DW12_I2C_DISABLE:
+      *val = AIS2DW12_I2C_DISABLE;
+      break;
+    default:
+      *val = AIS2DW12_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disconnect CS pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of cs_pu_disc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_cs_mode_set(stmdev_ctx_t *ctx, ais2dw12_cs_pu_disc_t val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.cs_pu_disc = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disconnect CS pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of cs_pu_disc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_cs_mode_get(stmdev_ctx_t *ctx, ais2dw12_cs_pu_disc_t *val)
+{
+  ais2dw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.cs_pu_disc) {
+    case AIS2DW12_PULL_UP_CONNECT:
+      *val = AIS2DW12_PULL_UP_CONNECT;
+      break;
+    case AIS2DW12_PULL_UP_DISCONNECT:
+      *val = AIS2DW12_PULL_UP_DISCONNECT;
+      break;
+    default:
+      *val = AIS2DW12_PULL_UP_CONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Interrupt_Pins
+  * @brief     This section groups all the functions that manage interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of h_lactive in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_pin_polarity_set(stmdev_ctx_t *ctx,
+                                  ais2dw12_h_lactive_t val)
+{
+  ais2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.h_lactive = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of h_lactive in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_pin_polarity_get(stmdev_ctx_t *ctx,
+                                  ais2dw12_h_lactive_t *val)
+{
+  ais2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.h_lactive) {
+    case AIS2DW12_ACTIVE_HIGH:
+      *val = AIS2DW12_ACTIVE_HIGH;
+      break;
+    case AIS2DW12_ACTIVE_LOW:
+      *val = AIS2DW12_ACTIVE_LOW;
+      break;
+    default:
+      *val = AIS2DW12_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_int_notification_set(stmdev_ctx_t *ctx,
+                                      ais2dw12_lir_t val)
+{
+  ais2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lir = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_int_notification_get(stmdev_ctx_t *ctx,
+                                      ais2dw12_lir_t *val)
+{
+  ais2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.lir) {
+    case AIS2DW12_INT_PULSED:
+      *val = AIS2DW12_INT_PULSED;
+      break;
+    case AIS2DW12_INT_LATCHED:
+      *val = AIS2DW12_INT_LATCHED;
+      break;
+    default:
+      *val = AIS2DW12_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pp_od in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_pin_mode_set(stmdev_ctx_t *ctx, ais2dw12_pp_od_t val)
+{
+  ais2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.pp_od = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pp_od in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_pin_mode_get(stmdev_ctx_t *ctx, ais2dw12_pp_od_t *val)
+{
+  ais2dw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.pp_od) {
+    case AIS2DW12_PUSH_PULL:
+      *val = AIS2DW12_PUSH_PULL;
+      break;
+    case AIS2DW12_OPEN_DRAIN:
+      *val = AIS2DW12_OPEN_DRAIN;
+      break;
+    default:
+      *val = AIS2DW12_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL4_INT1_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                    ais2dw12_ctrl4_int1_t *val)
+{
+  ais2dw12_ctrl5_int2_t ctrl5_int2_pad_ctrl;
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL5_INT2,
+                          (uint8_t*)&ctrl5_int2_pad_ctrl, 1);
+
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+  if (ret == 0) {
+    if ((val->int1_ff |
+         val->int1_wu |
+         val->int1_6d |
+         ctrl5_int2_pad_ctrl.int2_sleep_state |
+         ctrl5_int2_pad_ctrl.int2_sleep_chg ) != PROPERTY_DISABLE){
+      reg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      reg.interrupts_enable = PROPERTY_DISABLE;
+    }
+
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL4_INT1,
+                                (uint8_t*) val, 1);
+  } if (ret == 0) {
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL4_INT1_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                    ais2dw12_ctrl4_int1_t *val)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL4_INT1,
+                          (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief   Select the signal that need to route on int2 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL5_INT2_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                    ais2dw12_ctrl5_int2_t *val)
+{
+  ais2dw12_ctrl4_int1_t ctrl4_int1_pad_ctrl;
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL4_INT1,
+                          (uint8_t*) &ctrl4_int1_pad_ctrl, 1);
+
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+  if (ret == 0) {
+    if ((ctrl4_int1_pad_ctrl.int1_ff |
+         ctrl4_int1_pad_ctrl.int1_wu |
+         ctrl4_int1_pad_ctrl.int1_6d |
+         val->int2_sleep_state | val->int2_sleep_chg ) != PROPERTY_DISABLE) {
+        reg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      reg.interrupts_enable = PROPERTY_DISABLE;
+    }
+
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL5_INT2,
+                             (uint8_t*) val, 1);
+  }
+  if (ret == 0) {
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL5_INT2_PAD_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                    ais2dw12_ctrl5_int2_t *val)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL5_INT2,
+                          (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.int2_on_int1 = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  *val = reg.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Wake_Up_Event
+  * @brief     This section groups all the functions that manage the Wake
+  *            Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wk_ths = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  *val = reg.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wake_dur = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  *val = reg.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Data sent to wake-up interrupt function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_wu in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_wkup_feed_data_set(stmdev_ctx_t *ctx,
+                                    ais2dw12_usr_off_on_wu_t val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.usr_off_on_wu = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data sent to wake-up interrupt function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of usr_off_on_wu in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_wkup_feed_data_get(stmdev_ctx_t *ctx,
+                                    ais2dw12_usr_off_on_wu_t *val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+
+  switch (reg.usr_off_on_wu) {
+    case AIS2DW12_HP_FEED:
+      *val = AIS2DW12_HP_FEED;
+      break;
+    case AIS2DW12_USER_OFFSET_FEED:
+      *val = AIS2DW12_USER_OFFSET_FEED;
+      break;
+    default:
+      *val = AIS2DW12_HP_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   AIS2DW12_Activity/Inactivity_Detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Config activity / inactivity or
+  *         stationary / motion detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_on / stationary in
+  *                  reg WAKE_UP_THS / WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_act_mode_set(stmdev_ctx_t *ctx, ais2dw12_sleep_on_t val)
+{
+  ais2dw12_wake_up_ths_t wake_up_ths;
+  ais2dw12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  }
+  if (ret == 0) {
+    wake_up_ths.sleep_on = (uint8_t) val & 0x01U;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  }
+  if (ret == 0) {
+    wake_up_dur.stationary = ((uint8_t)val & 0x02U) >> 1;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Config activity / inactivity or
+  *         stationary / motion detection. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sleep_on in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_act_mode_get(stmdev_ctx_t *ctx, ais2dw12_sleep_on_t *val)
+{
+  ais2dw12_wake_up_ths_t wake_up_ths;
+  ais2dw12_wake_up_dur_t wake_up_dur;;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+
+    switch ((wake_up_dur.stationary << 1) + wake_up_ths.sleep_on){
+      case AIS2DW12_NO_DETECTION:
+        *val = AIS2DW12_NO_DETECTION;
+        break;
+      case AIS2DW12_DETECT_ACT_INACT:
+        *val = AIS2DW12_DETECT_ACT_INACT;
+        break;
+      case AIS2DW12_DETECT_STAT_MOTION:
+        *val = AIS2DW12_DETECT_STAT_MOTION;
+        break;
+      default:
+        *val = AIS2DW12_NO_DETECTION;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sleep_dur = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  *val = reg.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   AIS2DW12_Six_Position_Detection(6D/4D)
+  * @brief      This section groups all the functions concerning six
+  *             position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 6d_ths in reg SIXD_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_sixd_ths_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_SIXD_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg._6d_ths = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_SIXD_THS,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 6d_ths in reg SIXD_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_sixd_ths_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_SIXD_THS,(uint8_t*) &reg, 1);
+  *val = reg._6d_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4d_en in reg SIXD_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_sixd_ths_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_SIXD_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg._4d_en = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_SIXD_THS,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4d_en in reg SIXD_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_sixd_ths_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_SIXD_THS,(uint8_t*) &reg, 1);
+  *val = reg._4d_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Read the 6D tap source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from SIXD_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_6d_src_get(stmdev_ctx_t *ctx, ais2dw12_sixd_src_t *val)
+{
+  int32_t ret;
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_SIXD_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+/**
+  * @brief  Data sent to 6D interrupt function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpass_on6d in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_6d_feed_data_set(stmdev_ctx_t *ctx,
+                                  ais2dw12_lpass_on6d_t val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lpass_on6d = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data sent to 6D interrupt function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lpass_on6d in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_6d_feed_data_get(stmdev_ctx_t *ctx,
+                                  ais2dw12_lpass_on6d_t *val)
+{
+  ais2dw12_ctrl7_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_CTRL7,(uint8_t*) &reg, 1);
+
+  switch (reg.lpass_on6d) {
+    case AIS2DW12_ODR_DIV_2_FEED:
+      *val = AIS2DW12_ODR_DIV_2_FEED;
+      break;
+    case AIS2DW12_LPF2_FEED:
+      *val = AIS2DW12_LPF2_FEED;
+      break;
+    default:
+      *val = AIS2DW12_ODR_DIV_2_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Free_Fall
+  * @brief     This section group all the functions concerning
+  *            the free fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in reg
+  *                  WAKE_UP_DUR /F REE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_wake_up_dur_t wake_up_dur;
+  ais2dw12_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+  }
+  if(ret == 0) {
+    wake_up_dur.ff_dur = ( (uint8_t) val & 0x20U) >> 5;
+    free_fall.ff_dur = (uint8_t) val & 0x1FU;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  }
+  if(ret == 0) {
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in
+  *                  reg WAKE_UP_DUR /F REE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_wake_up_dur_t wake_up_dur;
+  ais2dw12_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  if (ret == 0) {
+    ret = ais2dw12_read_reg(ctx, AIS2DW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+    *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_ths in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_ff_threshold_set(stmdev_ctx_t *ctx, ais2dw12_ff_ths_t val)
+{
+  ais2dw12_free_fall_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FREE_FALL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.ff_ths = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_FREE_FALL,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ff_ths in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_ff_threshold_get(stmdev_ctx_t *ctx,
+                                  ais2dw12_ff_ths_t *val)
+{
+  ais2dw12_free_fall_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FREE_FALL,(uint8_t*) &reg, 1);
+
+  switch (reg.ff_ths) {
+    case AIS2DW12_FF_TSH_5LSb_FS2g:
+      *val = AIS2DW12_FF_TSH_5LSb_FS2g;
+      break;
+    case AIS2DW12_FF_TSH_7LSb_FS2g:
+      *val = AIS2DW12_FF_TSH_7LSb_FS2g;
+      break;
+    case AIS2DW12_FF_TSH_8LSb_FS2g:
+      *val = AIS2DW12_FF_TSH_8LSb_FS2g;
+      break;
+    case AIS2DW12_FF_TSH_10LSb_FS2g:
+      *val = AIS2DW12_FF_TSH_10LSb_FS2g;
+      break;
+    case AIS2DW12_FF_TSH_11LSb_FS2g:
+      *val = AIS2DW12_FF_TSH_11LSb_FS2g;
+      break;
+    case AIS2DW12_FF_TSH_13LSb_FS2g:
+      *val = AIS2DW12_FF_TSH_13LSb_FS2g;
+      break;
+    case AIS2DW12_FF_TSH_15LSb_FS2g:
+      *val = AIS2DW12_FF_TSH_15LSb_FS2g;
+      break;
+    case AIS2DW12_FF_TSH_16LSb_FS2g:
+      *val = AIS2DW12_FF_TSH_16LSb_FS2g;
+      break;
+    default:
+      *val = AIS2DW12_FF_TSH_5LSb_FS2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  AIS2DW12_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ais2dw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fth = val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  *val = reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fmode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_fifo_mode_set(stmdev_ctx_t *ctx, ais2dw12_fmode_t val)
+{
+  ais2dw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fmode = (uint8_t) val;
+    ret = ais2dw12_write_reg(ctx, AIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fmode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_fifo_mode_get(stmdev_ctx_t *ctx, ais2dw12_fmode_t *val)
+{
+  ais2dw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+
+  switch (reg.fmode) {
+    case AIS2DW12_BYPASS_MODE:
+      *val = AIS2DW12_BYPASS_MODE;
+      break;
+    case AIS2DW12_FIFO_MODE:
+      *val = AIS2DW12_FIFO_MODE;
+      break;
+    case AIS2DW12_STREAM_TO_FIFO_MODE:
+      *val = AIS2DW12_STREAM_TO_FIFO_MODE;
+      break;
+    case AIS2DW12_BYPASS_TO_STREAM_MODE:
+      *val = AIS2DW12_BYPASS_TO_STREAM_MODE;
+      break;
+    case AIS2DW12_STREAM_MODE:
+      *val = AIS2DW12_STREAM_MODE;
+      break;
+    default:
+      *val = AIS2DW12_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of unread samples stored in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of diff in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.diff;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_ovr in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.fifo_ovr;
+
+  return ret;
+}
+/**
+  * @brief  FIFO threshold status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_fth in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ais2dw12_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ais2dw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = ais2dw12_read_reg(ctx, AIS2DW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.fifo_fth;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ais2dw12_STdC/driver/ais2dw12_reg.h
+++ b/sensor/stmemsc/ais2dw12_STdC/driver/ais2dw12_reg.h
@@ -1,0 +1,641 @@
+/*
+ ******************************************************************************
+ * @file    ais2dw12_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          ais2dw12_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef AIS2DW12_REGS_H
+#define AIS2DW12_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup AIS2DW12
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup AIS2DW12_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define AIS2DW12_I2C_ADD_L   0x31U
+#define AIS2DW12_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define AIS2DW12_ID            0x44U
+
+/**
+  * @}
+  *
+  */
+
+#define AIS2DW12_OUT_T_L                     0x0DU
+#define AIS2DW12_OUT_T_H                     0x0EU
+#define AIS2DW12_WHO_AM_I                    0x0FU
+#define AIS2DW12_CTRL1                       0x20U
+typedef struct {
+  uint8_t pw_mode                    : 2;
+  uint8_t op_mode                    : 2;
+  uint8_t odr                        : 4;
+} ais2dw12_ctrl1_t;
+
+#define AIS2DW12_CTRL2                       0x21U
+typedef struct {
+  uint8_t sim                        : 1;
+  uint8_t i2c_disable                : 1;
+  uint8_t if_add_inc                 : 1;
+  uint8_t bdu                        : 1;
+  uint8_t cs_pu_disc                 : 1;
+  uint8_t not_used_01                : 1;
+  uint8_t soft_reset                 : 1;
+  uint8_t boot                       : 1;
+} ais2dw12_ctrl2_t;
+
+#define AIS2DW12_CTRL3                       0x22U
+typedef struct {
+  uint8_t slp_mode                   : 2;  /* slp_mode_sel + slp_mode_1 */
+  uint8_t not_used_01                : 1;
+  uint8_t h_lactive                  : 1;
+  uint8_t lir                        : 1;
+  uint8_t pp_od                      : 1;
+  uint8_t st                         : 2;
+} ais2dw12_ctrl3_t;
+
+#define AIS2DW12_CTRL4_INT1                  0x23U
+typedef struct {
+  uint8_t int1_drdy                  : 1;
+  uint8_t int1_fth                   : 1;
+  uint8_t int1_diff5                 : 1;
+  uint8_t not_used_01                : 1;
+  uint8_t int1_ff                    : 1;
+  uint8_t int1_wu                    : 1;
+  uint8_t not_used_02                : 1;
+  uint8_t int1_6d                    : 1;
+} ais2dw12_ctrl4_int1_t;
+
+#define AIS2DW12_CTRL5_INT2                  0x24U
+typedef struct {
+  uint8_t int2_drdy                  : 1;
+  uint8_t int2_fth                   : 1;
+  uint8_t int2_diff5                 : 1;
+  uint8_t int2_ovr                   : 1;
+  uint8_t int2_drdy_t                : 1;
+  uint8_t int2_boot                  : 1;
+  uint8_t int2_sleep_chg             : 1;
+  uint8_t int2_sleep_state           : 1;
+} ais2dw12_ctrl5_int2_t;
+
+#define AIS2DW12_CTRL6                       0x25U
+typedef struct {
+  uint8_t not_used_01                : 3;
+  uint8_t fds                        : 1;
+  uint8_t fs                         : 2;
+  uint8_t bw_filt                    : 2;
+} ais2dw12_ctrl6_t;
+
+#define AIS2DW12_OUT_T                       0x26U
+#define AIS2DW12_STATUS                      0x27U
+typedef struct {
+  uint8_t drdy                       : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t not_used_01                : 2;
+  uint8_t sleep_state                : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t fifo_ths                   : 1;
+} ais2dw12_status_t;
+
+#define AIS2DW12_OUT_X_L                     0x28U
+#define AIS2DW12_OUT_X_H                     0x29U
+#define AIS2DW12_OUT_Y_L                     0x2AU
+#define AIS2DW12_OUT_Y_H                     0x2BU
+#define AIS2DW12_OUT_Z_L                     0x2CU
+#define AIS2DW12_OUT_Z_H                     0x2DU
+#define AIS2DW12_FIFO_CTRL                   0x2EU
+typedef struct {
+  uint8_t fth                        : 5;
+  uint8_t fmode                      : 3;
+} ais2dw12_fifo_ctrl_t;
+
+#define AIS2DW12_FIFO_SAMPLES                0x2FU
+typedef struct {
+  uint8_t diff                       : 6;
+  uint8_t fifo_ovr                   : 1;
+  uint8_t fifo_fth                   : 1;
+} ais2dw12_fifo_samples_t;
+
+#define AIS2DW12_SIXD_THS                    0x30U
+typedef struct {
+  uint8_t not_used_01                 : 5;
+  uint8_t _6d_ths                     : 2;
+  uint8_t _4d_en                      : 1;
+} ais2dw12_sixd_ths_t;
+
+#define AIS2DW12_WAKE_UP_THS                 0x34U
+typedef struct {
+  uint8_t wk_ths                     : 6;
+  uint8_t sleep_on                   : 1;
+  uint8_t not_used_01                : 1;
+} ais2dw12_wake_up_ths_t;
+
+#define AIS2DW12_WAKE_UP_DUR                 0x35U
+typedef struct {
+  uint8_t sleep_dur                  : 4;
+  uint8_t stationary                 : 1;
+  uint8_t wake_dur                   : 2;
+  uint8_t ff_dur                     : 1;
+} ais2dw12_wake_up_dur_t;
+
+#define AIS2DW12_FREE_FALL                   0x36U
+typedef struct {
+  uint8_t ff_ths                     : 3;
+  uint8_t ff_dur                     : 5;
+} ais2dw12_free_fall_t;
+
+#define AIS2DW12_STATUS_DUP                  0x37U
+typedef struct {
+  uint8_t drdy                       : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t not_used_01                : 2;
+  uint8_t sleep_state_ia             : 1;
+  uint8_t drdy_t                     : 1;
+  uint8_t ovr                        : 1;
+} ais2dw12_status_dup_t;
+
+#define AIS2DW12_WAKE_UP_SRC                 0x38U
+typedef struct {
+  uint8_t z_wu                       : 1;
+  uint8_t y_wu                       : 1;
+  uint8_t x_wu                       : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t sleep_state_ia             : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t not_used_01                : 2;
+} ais2dw12_wake_up_src_t;
+
+#define AIS2DW12_SIXD_SRC                    0x3AU
+typedef struct {
+  uint8_t xl                         : 1;
+  uint8_t xh                         : 1;
+  uint8_t yl                         : 1;
+  uint8_t yh                         : 1;
+  uint8_t zl                         : 1;
+  uint8_t zh                         : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t not_used_01                : 1;
+} ais2dw12_sixd_src_t;
+
+#define AIS2DW12_ALL_INT_SRC                 0x3BU
+typedef struct {
+  uint8_t ff_ia                      : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t not_used_01                : 2;
+  uint8_t _6d_ia                     : 1;
+  uint8_t sleep_change_ia            : 1;
+  uint8_t not_used_02                : 2;
+} ais2dw12_all_int_src_t;
+
+#define AIS2DW12_X_OFS_USR                   0x3CU
+#define AIS2DW12_Y_OFS_USR                   0x3DU
+#define AIS2DW12_Z_OFS_USR                   0x3EU
+#define AIS2DW12_CTRL7                       0x3FU
+typedef struct {
+  uint8_t lpass_on6d                 : 1;
+  uint8_t hp_ref_mode                : 1;
+  uint8_t usr_off_w                  : 1;
+  uint8_t usr_off_on_wu              : 1;
+  uint8_t usr_off_on_out             : 1;
+  uint8_t interrupts_enable          : 1;
+  uint8_t int2_on_int1               : 1;
+  uint8_t drdy_pulsed                : 1;
+} ais2dw12_ctrl7_t;
+
+/**
+  * @defgroup AIS2DW12_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  ais2dw12_ctrl1_t                   ctrl1;
+  ais2dw12_ctrl2_t                   ctrl2;
+  ais2dw12_ctrl3_t                   ctrl3;
+  ais2dw12_ctrl4_int1_t              ctrl4_int1;
+  ais2dw12_ctrl5_int2_t              ctrl5_int2;
+  ais2dw12_ctrl6_t                   ctrl6;
+  ais2dw12_status_t                  status;
+  ais2dw12_fifo_ctrl_t               fifo_ctrl;
+  ais2dw12_fifo_samples_t            fifo_samples;
+  ais2dw12_sixd_ths_t                sixd_ths;
+  ais2dw12_wake_up_ths_t             wake_up_ths;
+  ais2dw12_wake_up_dur_t             wake_up_dur;
+  ais2dw12_free_fall_t               free_fall;
+  ais2dw12_status_dup_t              status_dup;
+  ais2dw12_wake_up_src_t             wake_up_src;
+  ais2dw12_sixd_src_t                sixd_src;
+  ais2dw12_all_int_src_t             all_int_src;
+  ais2dw12_ctrl7_t                   ctrl7;
+  bitwise_t                          bitwise;
+  uint8_t                            byte;
+} ais2dw12_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t ais2dw12_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t ais2dw12_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t ais2dw12_from_fs2_to_mg(int16_t lsb);
+extern float_t ais2dw12_from_fs4_to_mg(int16_t lsb);
+extern float_t ais2dw12_from_fs2_12bit_to_mg(int16_t lsb);
+extern float_t ais2dw12_from_fs4_12bit_to_mg(int16_t lsb);
+
+extern float_t ais2dw12_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  AIS2DW12_PWR_MD_4                           = 0x03,
+  AIS2DW12_PWR_MD_3                           = 0x02,
+  AIS2DW12_PWR_MD_2                           = 0x01,
+  AIS2DW12_PWR_MD_12bit                       = 0x00,
+  AIS2DW12_SINGLE_PWR_MD_4                    = 0x0B,
+  AIS2DW12_SINGLE_PWR_MD_3                    = 0x0A,
+  AIS2DW12_SINGLE_PWR_MD_2                    = 0x09,
+  AIS2DW12_SINGLE_PWR_MD_12bit                = 0x08,
+} ais2dw12_mode_t;
+int32_t ais2dw12_power_mode_set(stmdev_ctx_t *ctx, ais2dw12_mode_t val);
+int32_t ais2dw12_power_mode_get(stmdev_ctx_t *ctx, ais2dw12_mode_t *val);
+
+typedef enum {
+  AIS2DW12_XL_ODR_OFF            = 0x00,
+  AIS2DW12_XL_ODR_1Hz6           = 0x01,
+  AIS2DW12_XL_ODR_12Hz5          = 0x02,
+  AIS2DW12_XL_ODR_25Hz           = 0x03,
+  AIS2DW12_XL_ODR_50Hz           = 0x04,
+  AIS2DW12_XL_ODR_100Hz          = 0x05,
+  AIS2DW12_XL_SET_SW_TRIG        = 0x12,  /* Use this only in SINGLE mode */
+  AIS2DW12_XL_SET_PIN_TRIG       = 0x22,  /* Use this only in SINGLE mode */
+} ais2dw12_odr_t;
+int32_t ais2dw12_data_rate_set(stmdev_ctx_t *ctx, ais2dw12_odr_t val);
+int32_t ais2dw12_data_rate_get(stmdev_ctx_t *ctx, ais2dw12_odr_t *val);
+
+int32_t ais2dw12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS2DW12_2g     = 0,
+  AIS2DW12_4g     = 1,
+} ais2dw12_fs_t;
+int32_t ais2dw12_full_scale_set(stmdev_ctx_t *ctx, ais2dw12_fs_t val);
+int32_t ais2dw12_full_scale_get(stmdev_ctx_t *ctx, ais2dw12_fs_t *val);
+
+int32_t ais2dw12_status_reg_get(stmdev_ctx_t *ctx, ais2dw12_status_t *val);
+
+int32_t ais2dw12_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct{
+  ais2dw12_status_dup_t   status_dup;
+  ais2dw12_wake_up_src_t  wake_up_src;
+  ais2dw12_sixd_src_t     sixd_src;
+  ais2dw12_all_int_src_t  all_int_src;
+} ais2dw12_all_sources_t;
+int32_t ais2dw12_all_sources_get(stmdev_ctx_t *ctx,
+                                 ais2dw12_all_sources_t *val);
+
+int32_t ais2dw12_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ais2dw12_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais2dw12_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ais2dw12_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais2dw12_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ais2dw12_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  AIS2DW12_LSb_977ug    = 0,
+  AIS2DW12_LSb_15mg6    = 1,
+} ais2dw12_usr_off_w_t;
+int32_t ais2dw12_offset_weight_set(stmdev_ctx_t *ctx,
+                                      ais2dw12_usr_off_w_t val);
+int32_t ais2dw12_offset_weight_get(stmdev_ctx_t *ctx,
+                                      ais2dw12_usr_off_w_t *val);
+
+int32_t ais2dw12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais2dw12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais2dw12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ais2dw12_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS2DW12_XL_ST_DISABLE      = 0,
+  AIS2DW12_XL_ST_POSITIVE     = 1,
+  AIS2DW12_XL_ST_NEGATIVE     = 2,
+} ais2dw12_st_t;
+int32_t ais2dw12_self_test_set(stmdev_ctx_t *ctx, ais2dw12_st_t val);
+int32_t ais2dw12_self_test_get(stmdev_ctx_t *ctx, ais2dw12_st_t *val);
+
+typedef enum {
+  AIS2DW12_DRDY_LATCHED   = 0,
+  AIS2DW12_DRDY_PULSED    = 1,
+} ais2dw12_drdy_pulsed_t;
+int32_t ais2dw12_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                     ais2dw12_drdy_pulsed_t val);
+int32_t ais2dw12_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                     ais2dw12_drdy_pulsed_t *val);
+
+typedef enum {
+  AIS2DW12_LPF_ON_OUT         = 0x00,
+  AIS2DW12_USER_OFFSET_ON_OUT  = 0x01,
+  AIS2DW12_HIGH_PASS_ON_OUT    = 0x10,
+} ais2dw12_fds_t;
+int32_t ais2dw12_filter_path_set(stmdev_ctx_t *ctx, ais2dw12_fds_t val);
+int32_t ais2dw12_filter_path_get(stmdev_ctx_t *ctx, ais2dw12_fds_t *val);
+
+typedef enum {
+  AIS2DW12_ODR_DIV_2     = 0,
+  AIS2DW12_ODR_DIV_4     = 1,
+  AIS2DW12_ODR_DIV_10    = 2,
+  AIS2DW12_ODR_DIV_20    = 3,
+} ais2dw12_bw_filt_t;
+int32_t ais2dw12_filter_bandwidth_set(stmdev_ctx_t *ctx,
+                                         ais2dw12_bw_filt_t val);
+int32_t ais2dw12_filter_bandwidth_get(stmdev_ctx_t *ctx,
+                                         ais2dw12_bw_filt_t *val);
+
+int32_t ais2dw12_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS2DW12_SPI_4_WIRE   = 0,
+  AIS2DW12_SPI_3_WIRE   = 1,
+} ais2dw12_sim_t;
+int32_t ais2dw12_spi_mode_set(stmdev_ctx_t *ctx, ais2dw12_sim_t val);
+int32_t ais2dw12_spi_mode_get(stmdev_ctx_t *ctx, ais2dw12_sim_t *val);
+
+typedef enum {
+  AIS2DW12_I2C_ENABLE    = 0,
+  AIS2DW12_I2C_DISABLE   = 1,
+} ais2dw12_i2c_disable_t;
+int32_t ais2dw12_i2c_interface_set(stmdev_ctx_t *ctx,
+                                   ais2dw12_i2c_disable_t val);
+int32_t ais2dw12_i2c_interface_get(stmdev_ctx_t *ctx,
+                                   ais2dw12_i2c_disable_t *val);
+
+typedef enum {
+  AIS2DW12_PULL_UP_CONNECT     = 0,
+  AIS2DW12_PULL_UP_DISCONNECT  = 1,
+} ais2dw12_cs_pu_disc_t;
+int32_t ais2dw12_cs_mode_set(stmdev_ctx_t *ctx, ais2dw12_cs_pu_disc_t val);
+int32_t ais2dw12_cs_mode_get(stmdev_ctx_t *ctx, ais2dw12_cs_pu_disc_t *val);
+
+typedef enum {
+  AIS2DW12_ACTIVE_HIGH  = 0,
+  AIS2DW12_ACTIVE_LOW   = 1,
+} ais2dw12_h_lactive_t;
+int32_t ais2dw12_pin_polarity_set(stmdev_ctx_t *ctx,
+                                  ais2dw12_h_lactive_t val);
+int32_t ais2dw12_pin_polarity_get(stmdev_ctx_t *ctx,
+                                  ais2dw12_h_lactive_t *val);
+
+typedef enum {
+  AIS2DW12_INT_PULSED   = 0,
+  AIS2DW12_INT_LATCHED  = 1,
+} ais2dw12_lir_t;
+int32_t ais2dw12_int_notification_set(stmdev_ctx_t *ctx,
+                                      ais2dw12_lir_t val);
+int32_t ais2dw12_int_notification_get(stmdev_ctx_t *ctx,
+                                      ais2dw12_lir_t *val);
+
+typedef enum {
+  AIS2DW12_PUSH_PULL   = 0,
+  AIS2DW12_OPEN_DRAIN  = 1,
+} ais2dw12_pp_od_t;
+int32_t ais2dw12_pin_mode_set(stmdev_ctx_t *ctx, ais2dw12_pp_od_t val);
+int32_t ais2dw12_pin_mode_get(stmdev_ctx_t *ctx, ais2dw12_pp_od_t *val);
+
+int32_t ais2dw12_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                    ais2dw12_ctrl4_int1_t *val);
+int32_t ais2dw12_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                    ais2dw12_ctrl4_int1_t *val);
+
+int32_t ais2dw12_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                    ais2dw12_ctrl5_int2_t *val);
+int32_t ais2dw12_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                    ais2dw12_ctrl5_int2_t *val);
+
+int32_t ais2dw12_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS2DW12_HP_FEED           = 0,
+  AIS2DW12_USER_OFFSET_FEED  = 1,
+} ais2dw12_usr_off_on_wu_t;
+int32_t ais2dw12_wkup_feed_data_set(stmdev_ctx_t *ctx,
+                                    ais2dw12_usr_off_on_wu_t val);
+int32_t ais2dw12_wkup_feed_data_get(stmdev_ctx_t *ctx,
+                                    ais2dw12_usr_off_on_wu_t *val);
+
+typedef enum {
+  AIS2DW12_NO_DETECTION        = 0,
+  AIS2DW12_DETECT_ACT_INACT    = 1,
+  AIS2DW12_DETECT_STAT_MOTION  = 3,
+} ais2dw12_sleep_on_t;
+int32_t ais2dw12_act_mode_set(stmdev_ctx_t *ctx, ais2dw12_sleep_on_t val);
+int32_t ais2dw12_act_mode_get(stmdev_ctx_t *ctx, ais2dw12_sleep_on_t *val);
+
+int32_t ais2dw12_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_6d_src_get(stmdev_ctx_t *ctx, ais2dw12_sixd_src_t *val);
+
+typedef enum {
+  AIS2DW12_ODR_DIV_2_FEED   = 0,
+  AIS2DW12_LPF2_FEED        = 1,
+} ais2dw12_lpass_on6d_t;
+int32_t ais2dw12_6d_feed_data_set(stmdev_ctx_t *ctx,
+                                  ais2dw12_lpass_on6d_t val);
+int32_t ais2dw12_6d_feed_data_get(stmdev_ctx_t *ctx,
+                                  ais2dw12_lpass_on6d_t *val);
+
+int32_t ais2dw12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS2DW12_FF_TSH_5LSb_FS2g  = 0,
+  AIS2DW12_FF_TSH_7LSb_FS2g  = 1,
+  AIS2DW12_FF_TSH_8LSb_FS2g  = 2,
+  AIS2DW12_FF_TSH_10LSb_FS2g = 3,
+  AIS2DW12_FF_TSH_11LSb_FS2g = 4,
+  AIS2DW12_FF_TSH_13LSb_FS2g = 5,
+  AIS2DW12_FF_TSH_15LSb_FS2g = 6,
+  AIS2DW12_FF_TSH_16LSb_FS2g = 7,
+} ais2dw12_ff_ths_t;
+int32_t ais2dw12_ff_threshold_set(stmdev_ctx_t *ctx,
+                                  ais2dw12_ff_ths_t val);
+int32_t ais2dw12_ff_threshold_get(stmdev_ctx_t *ctx,
+                                  ais2dw12_ff_ths_t *val);
+
+int32_t ais2dw12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais2dw12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  AIS2DW12_BYPASS_MODE             = 0,
+  AIS2DW12_FIFO_MODE               = 1,
+  AIS2DW12_STREAM_TO_FIFO_MODE     = 3,
+  AIS2DW12_BYPASS_TO_STREAM_MODE   = 4,
+  AIS2DW12_STREAM_MODE             = 6,
+} ais2dw12_fmode_t;
+int32_t ais2dw12_fifo_mode_set(stmdev_ctx_t *ctx, ais2dw12_fmode_t val);
+int32_t ais2dw12_fifo_mode_get(stmdev_ctx_t *ctx, ais2dw12_fmode_t *val);
+
+int32_t ais2dw12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ais2dw12_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*AIS2DW12_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ais328dq_STdC/driver/ais328dq_reg.c
+++ b/sensor/stmemsc/ais328dq_STdC/driver/ais328dq_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "ais328dq_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t ais328dq_read_reg(ais328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t ais328dq_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t ais328dq_read_reg(ais328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t ais328dq_write_reg(ais328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t ais328dq_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                             uint16_t len)
 {
   int32_t ret;
@@ -136,7 +119,7 @@ float ais328dq_from_fs8_to_mg(int16_t lsb)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t ais328dq_axis_x_data_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -157,7 +140,7 @@ int32_t ais328dq_axis_x_data_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t ais328dq_axis_x_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -175,7 +158,7 @@ int32_t ais328dq_axis_x_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t ais328dq_axis_y_data_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -196,7 +179,7 @@ int32_t ais328dq_axis_y_data_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t ais328dq_axis_y_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -214,7 +197,7 @@ int32_t ais328dq_axis_y_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t ais328dq_axis_z_data_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -235,7 +218,7 @@ int32_t ais328dq_axis_z_data_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t ais328dq_axis_z_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -253,7 +236,7 @@ int32_t ais328dq_axis_z_data_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of dr in reg CTRL_REG1
   *
   */
-int32_t ais328dq_data_rate_set(ais328dq_ctx_t *ctx, ais328dq_dr_t val)
+int32_t ais328dq_data_rate_set(stmdev_ctx_t *ctx, ais328dq_dr_t val)
 {
   ais328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -276,7 +259,7 @@ int32_t ais328dq_data_rate_set(ais328dq_ctx_t *ctx, ais328dq_dr_t val)
   * @param  val         Get the values of dr in reg CTRL_REG1
   *
   */
-int32_t ais328dq_data_rate_get(ais328dq_ctx_t *ctx, ais328dq_dr_t *val)
+int32_t ais328dq_data_rate_get(stmdev_ctx_t *ctx, ais328dq_dr_t *val)
 {
   ais328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -331,7 +314,7 @@ int32_t ais328dq_data_rate_get(ais328dq_ctx_t *ctx, ais328dq_dr_t *val)
   * @param  val         change the values of hpm in reg CTRL_REG2
   *
   */
-int32_t ais328dq_reference_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_reference_mode_set(stmdev_ctx_t *ctx,
                                      ais328dq_hpm_t val)
 {
   ais328dq_ctrl_reg2_t ctrl_reg2;
@@ -353,7 +336,7 @@ int32_t ais328dq_reference_mode_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of hpm in reg CTRL_REG2
   *
   */
-int32_t ais328dq_reference_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_reference_mode_get(stmdev_ctx_t *ctx,
                                      ais328dq_hpm_t *val)
 {
   ais328dq_ctrl_reg2_t ctrl_reg2;
@@ -384,7 +367,7 @@ int32_t ais328dq_reference_mode_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of fs in reg CTRL_REG4
   *
   */
-int32_t ais328dq_full_scale_set(ais328dq_ctx_t *ctx, ais328dq_fs_t val)
+int32_t ais328dq_full_scale_set(stmdev_ctx_t *ctx, ais328dq_fs_t val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -405,7 +388,7 @@ int32_t ais328dq_full_scale_set(ais328dq_ctx_t *ctx, ais328dq_fs_t val)
   * @param  val         Get the values of fs in reg CTRL_REG4
   *
   */
-int32_t ais328dq_full_scale_get(ais328dq_ctx_t *ctx, ais328dq_fs_t *val)
+int32_t ais328dq_full_scale_get(stmdev_ctx_t *ctx, ais328dq_fs_t *val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -438,7 +421,7 @@ int32_t ais328dq_full_scale_get(ais328dq_ctx_t *ctx, ais328dq_fs_t *val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t ais328dq_block_data_update_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -459,7 +442,7 @@ int32_t ais328dq_block_data_update_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t ais328dq_block_data_update_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -477,7 +460,7 @@ int32_t ais328dq_block_data_update_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         registers STATUS_REG
   *
   */
-int32_t ais328dq_status_reg_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_status_reg_get(stmdev_ctx_t *ctx,
                                  ais328dq_status_reg_t *val)
 {
   int32_t ret;
@@ -492,7 +475,7 @@ int32_t ais328dq_status_reg_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of zyxda in reg STATUS_REG
   *
   */
-int32_t ais328dq_flag_data_ready_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_status_reg_t status_reg;
   int32_t ret;
@@ -524,7 +507,7 @@ int32_t ais328dq_flag_data_ready_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t ais328dq_acceleration_raw_get(ais328dq_ctx_t *ctx, uint8_t *buff)
+int32_t ais328dq_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ais328dq_read_reg(ctx, AIS328DQ_OUT_X_L, buff, 6);
@@ -550,7 +533,7 @@ int32_t ais328dq_acceleration_raw_get(ais328dq_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t ais328dq_device_id_get(ais328dq_ctx_t *ctx, uint8_t *buff)
+int32_t ais328dq_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ais328dq_read_reg(ctx, AIS328DQ_WHO_AM_I, buff, 1);
@@ -564,7 +547,7 @@ int32_t ais328dq_device_id_get(ais328dq_ctx_t *ctx, uint8_t *buff)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t ais328dq_boot_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -585,7 +568,7 @@ int32_t ais328dq_boot_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t ais328dq_boot_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -603,7 +586,7 @@ int32_t ais328dq_boot_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of st in reg CTRL_REG4
   *
   */
-int32_t ais328dq_self_test_set(ais328dq_ctx_t *ctx, ais328dq_st_t val)
+int32_t ais328dq_self_test_set(stmdev_ctx_t *ctx, ais328dq_st_t val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -624,7 +607,7 @@ int32_t ais328dq_self_test_set(ais328dq_ctx_t *ctx, ais328dq_st_t val)
   * @param  val         Get the values of st in reg CTRL_REG4
   *
   */
-int32_t ais328dq_self_test_get(ais328dq_ctx_t *ctx, ais328dq_st_t *val)
+int32_t ais328dq_self_test_get(stmdev_ctx_t *ctx, ais328dq_st_t *val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -657,7 +640,7 @@ int32_t ais328dq_self_test_get(ais328dq_ctx_t *ctx, ais328dq_st_t *val)
   * @param  val         change the values of ble in reg CTRL_REG4
   *
   */
-int32_t ais328dq_data_format_set(ais328dq_ctx_t *ctx, ais328dq_ble_t val)
+int32_t ais328dq_data_format_set(stmdev_ctx_t *ctx, ais328dq_ble_t val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -678,7 +661,7 @@ int32_t ais328dq_data_format_set(ais328dq_ctx_t *ctx, ais328dq_ble_t val)
   * @param  val         Get the values of ble in reg CTRL_REG4
   *
   */
-int32_t ais328dq_data_format_get(ais328dq_ctx_t *ctx, ais328dq_ble_t *val)
+int32_t ais328dq_data_format_get(stmdev_ctx_t *ctx, ais328dq_ble_t *val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -721,7 +704,7 @@ int32_t ais328dq_data_format_get(ais328dq_ctx_t *ctx, ais328dq_ble_t *val)
   * @param  val         change the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t ais328dq_hp_bandwidth_set(ais328dq_ctx_t *ctx, ais328dq_hpcf_t val)
+int32_t ais328dq_hp_bandwidth_set(stmdev_ctx_t *ctx, ais328dq_hpcf_t val)
 {
   ais328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -742,7 +725,7 @@ int32_t ais328dq_hp_bandwidth_set(ais328dq_ctx_t *ctx, ais328dq_hpcf_t val)
   * @param  val         Get the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t ais328dq_hp_bandwidth_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    ais328dq_hpcf_t *val)
 {
   ais328dq_ctrl_reg2_t ctrl_reg2;
@@ -779,7 +762,7 @@ int32_t ais328dq_hp_bandwidth_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of hpen in reg CTRL_REG2
   *
   */
-int32_t ais328dq_hp_path_set(ais328dq_ctx_t *ctx, ais328dq_hpen_t val)
+int32_t ais328dq_hp_path_set(stmdev_ctx_t *ctx, ais328dq_hpen_t val)
 {
   ais328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -801,7 +784,7 @@ int32_t ais328dq_hp_path_set(ais328dq_ctx_t *ctx, ais328dq_hpen_t val)
   * @param  val         Get the values of hpen in reg CTRL_REG2
   *
   */
-int32_t ais328dq_hp_path_get(ais328dq_ctx_t *ctx, ais328dq_hpen_t *val)
+int32_t ais328dq_hp_path_get(stmdev_ctx_t *ctx, ais328dq_hpen_t *val)
 {
   ais328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -852,7 +835,7 @@ int32_t ais328dq_hp_path_get(ais328dq_ctx_t *ctx, ais328dq_hpen_t *val)
   * @param  ctx         read / write interface definitions(ptr)
   *
   */
-int32_t ais328dq_hp_reset_get(ais328dq_ctx_t *ctx)
+int32_t ais328dq_hp_reset_get(stmdev_ctx_t *ctx)
 {
   uint8_t dummy;
   int32_t ret;
@@ -868,7 +851,7 @@ int32_t ais328dq_hp_reset_get(ais328dq_ctx_t *ctx)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t ais328dq_hp_reference_value_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
   ret = ais328dq_write_reg(ctx, AIS328DQ_REFERENCE, (uint8_t*)&val, 1);
@@ -882,7 +865,7 @@ int32_t ais328dq_hp_reference_value_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t ais328dq_hp_reference_value_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
   ret = ais328dq_read_reg(ctx, AIS328DQ_REFERENCE, val, 1);
@@ -909,7 +892,7 @@ int32_t ais328dq_hp_reference_value_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of sim in reg CTRL_REG4
   *
   */
-int32_t ais328dq_spi_mode_set(ais328dq_ctx_t *ctx, ais328dq_sim_t val)
+int32_t ais328dq_spi_mode_set(stmdev_ctx_t *ctx, ais328dq_sim_t val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -930,7 +913,7 @@ int32_t ais328dq_spi_mode_set(ais328dq_ctx_t *ctx, ais328dq_sim_t val)
   * @param  val         Get the values of sim in reg CTRL_REG4
   *
   */
-int32_t ais328dq_spi_mode_get(ais328dq_ctx_t *ctx, ais328dq_sim_t *val)
+int32_t ais328dq_spi_mode_get(stmdev_ctx_t *ctx, ais328dq_sim_t *val)
 {
   ais328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -973,7 +956,7 @@ int32_t ais328dq_spi_mode_get(ais328dq_ctx_t *ctx, ais328dq_sim_t *val)
   * @param  val         change the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t ais328dq_pin_int1_route_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      ais328dq_i1_cfg_t val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
@@ -995,7 +978,7 @@ int32_t ais328dq_pin_int1_route_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t ais328dq_pin_int1_route_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      ais328dq_i1_cfg_t *val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
@@ -1033,7 +1016,7 @@ int32_t ais328dq_pin_int1_route_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t ais328dq_int1_notification_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_notification_set(stmdev_ctx_t *ctx,
                                         ais328dq_lir1_t val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
@@ -1056,7 +1039,7 @@ int32_t ais328dq_int1_notification_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t ais328dq_int1_notification_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_notification_get(stmdev_ctx_t *ctx,
                                         ais328dq_lir1_t *val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
@@ -1087,7 +1070,7 @@ int32_t ais328dq_int1_notification_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t ais328dq_pin_int2_route_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      ais328dq_i2_cfg_t val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
@@ -1109,7 +1092,7 @@ int32_t ais328dq_pin_int2_route_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t ais328dq_pin_int2_route_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      ais328dq_i2_cfg_t *val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
@@ -1147,7 +1130,7 @@ int32_t ais328dq_pin_int2_route_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t ais328dq_int2_notification_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_notification_set(stmdev_ctx_t *ctx,
                                         ais328dq_lir2_t val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
@@ -1170,7 +1153,7 @@ int32_t ais328dq_int2_notification_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t ais328dq_int2_notification_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_notification_get(stmdev_ctx_t *ctx,
                                         ais328dq_lir2_t *val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
@@ -1201,7 +1184,7 @@ int32_t ais328dq_int2_notification_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t ais328dq_pin_mode_set(ais328dq_ctx_t *ctx, ais328dq_pp_od_t val)
+int32_t ais328dq_pin_mode_set(stmdev_ctx_t *ctx, ais328dq_pp_od_t val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1222,7 +1205,7 @@ int32_t ais328dq_pin_mode_set(ais328dq_ctx_t *ctx, ais328dq_pp_od_t val)
   * @param  val         Get the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t ais328dq_pin_mode_get(ais328dq_ctx_t *ctx, ais328dq_pp_od_t *val)
+int32_t ais328dq_pin_mode_get(stmdev_ctx_t *ctx, ais328dq_pp_od_t *val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1252,7 +1235,7 @@ int32_t ais328dq_pin_mode_get(ais328dq_ctx_t *ctx, ais328dq_pp_od_t *val)
   * @param  val         change the values of ihl in reg CTRL_REG3
   *
   */
-int32_t ais328dq_pin_polarity_set(ais328dq_ctx_t *ctx, ais328dq_ihl_t val)
+int32_t ais328dq_pin_polarity_set(stmdev_ctx_t *ctx, ais328dq_ihl_t val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1273,7 +1256,7 @@ int32_t ais328dq_pin_polarity_set(ais328dq_ctx_t *ctx, ais328dq_ihl_t val)
   * @param  val         Get the values of ihl in reg CTRL_REG3
   *
   */
-int32_t ais328dq_pin_polarity_get(ais328dq_ctx_t *ctx, ais328dq_ihl_t *val)
+int32_t ais328dq_pin_polarity_get(stmdev_ctx_t *ctx, ais328dq_ihl_t *val)
 {
   ais328dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1316,8 +1299,8 @@ int32_t ais328dq_pin_polarity_get(ais328dq_ctx_t *ctx, ais328dq_ihl_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t ais328dq_int1_on_threshold_conf_set(ais328dq_ctx_t *ctx,
-                                              int1_on_th_conf_t val)
+int32_t ais328dq_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                              ais328dq_int1_on_th_conf_t val)
 {
   ais328dq_int1_cfg_t int1_cfg;
   int32_t ret;
@@ -1343,8 +1326,8 @@ int32_t ais328dq_int1_on_threshold_conf_set(ais328dq_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t ais328dq_int1_on_threshold_conf_get(ais328dq_ctx_t *ctx,
-                                             int1_on_th_conf_t *val)
+int32_t ais328dq_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             ais328dq_int1_on_th_conf_t *val)
 {
   ais328dq_int1_cfg_t int1_cfg;
   int32_t ret;
@@ -1367,7 +1350,7 @@ int32_t ais328dq_int1_on_threshold_conf_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT1_CFG
   *
   */
-int32_t ais328dq_int1_on_threshold_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              ais328dq_int1_aoi_t val)
 {
   ais328dq_int1_cfg_t int1_cfg;
@@ -1389,7 +1372,7 @@ int32_t ais328dq_int1_on_threshold_mode_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT1_CFG
   *
   */
-int32_t ais328dq_int1_on_threshold_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              ais328dq_int1_aoi_t *val)
 {
   ais328dq_int1_cfg_t int1_cfg;
@@ -1420,7 +1403,7 @@ int32_t ais328dq_int1_on_threshold_mode_get(ais328dq_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t ais328dq_int1_src_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_src_get(stmdev_ctx_t *ctx,
                                ais328dq_int1_src_t *val)
 {
   int32_t ret;
@@ -1435,7 +1418,7 @@ int32_t ais328dq_int1_src_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t ais328dq_int1_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1456,7 +1439,7 @@ int32_t ais328dq_int1_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t ais328dq_int1_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1474,7 +1457,7 @@ int32_t ais328dq_int1_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t ais328dq_int1_dur_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_int1_duration_t int1_duration;
   int32_t ret;
@@ -1496,7 +1479,7 @@ int32_t ais328dq_int1_dur_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t ais328dq_int1_dur_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_int1_duration_t int1_duration;
   int32_t ret;
@@ -1515,8 +1498,8 @@ int32_t ais328dq_int1_dur_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t ais328dq_int2_on_threshold_conf_set(ais328dq_ctx_t *ctx,
-                                              int2_on_th_conf_t val)
+int32_t ais328dq_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                              ais328dq_int2_on_th_conf_t val)
 {
   ais328dq_int2_cfg_t int2_cfg;
   int32_t ret;
@@ -1543,8 +1526,8 @@ int32_t ais328dq_int2_on_threshold_conf_set(ais328dq_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t ais328dq_int2_on_threshold_conf_get(ais328dq_ctx_t *ctx,
-                                              int2_on_th_conf_t *val)
+int32_t ais328dq_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                              ais328dq_int2_on_th_conf_t *val)
 {
   ais328dq_int2_cfg_t int2_cfg;
   int32_t ret;
@@ -1567,7 +1550,7 @@ int32_t ais328dq_int2_on_threshold_conf_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT2_CFG
   *
   */
-int32_t ais328dq_int2_on_threshold_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              ais328dq_int2_aoi_t val)
 {
   ais328dq_int2_cfg_t int2_cfg;
@@ -1589,7 +1572,7 @@ int32_t ais328dq_int2_on_threshold_mode_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT2_CFG
   *
   */
-int32_t ais328dq_int2_on_threshold_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              ais328dq_int2_aoi_t *val)
 {
   ais328dq_int2_cfg_t int2_cfg;
@@ -1620,7 +1603,7 @@ int32_t ais328dq_int2_on_threshold_mode_get(ais328dq_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t ais328dq_int2_src_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_src_get(stmdev_ctx_t *ctx,
                                ais328dq_int2_src_t *val)
 {
   int32_t ret;
@@ -1635,7 +1618,7 @@ int32_t ais328dq_int2_src_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t ais328dq_int2_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1656,7 +1639,7 @@ int32_t ais328dq_int2_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t ais328dq_int2_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1674,7 +1657,7 @@ int32_t ais328dq_int2_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t ais328dq_int2_dur_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_int2_duration_t int2_duration;
   int32_t ret;
@@ -1696,7 +1679,7 @@ int32_t ais328dq_int2_dur_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t ais328dq_int2_dur_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_int2_duration_t int2_duration;
   int32_t ret;
@@ -1728,7 +1711,7 @@ int32_t ais328dq_int2_dur_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t ais328dq_wkup_to_sleep_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1749,7 +1732,7 @@ int32_t ais328dq_wkup_to_sleep_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t ais328dq_wkup_to_sleep_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1780,7 +1763,7 @@ int32_t ais328dq_wkup_to_sleep_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of 6d in reg INT1_CFG
   *
   */
-int32_t ais328dq_int1_6d_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_6d_mode_set(stmdev_ctx_t *ctx,
                                    ais328dq_int1_6d_t val)
 {
   ais328dq_int1_cfg_t int1_cfg;
@@ -1802,7 +1785,7 @@ int32_t ais328dq_int1_6d_mode_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of 6d in reg INT1_CFG
   *
   */
-int32_t ais328dq_int1_6d_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_6d_mode_get(stmdev_ctx_t *ctx,
                                    ais328dq_int1_6d_t *val)
 {
   ais328dq_int1_cfg_t int1_cfg;
@@ -1836,7 +1819,7 @@ int32_t ais328dq_int1_6d_mode_get(ais328dq_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t ais328dq_int1_6d_src_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_6d_src_get(stmdev_ctx_t *ctx,
                                   ais328dq_int1_src_t *val)
 {
   int32_t ret;
@@ -1851,7 +1834,7 @@ int32_t ais328dq_int1_6d_src_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t ais328dq_int1_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_int1_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1871,7 +1854,7 @@ int32_t ais328dq_int1_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t ais328dq_int1_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_int1_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1889,7 +1872,7 @@ int32_t ais328dq_int1_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of 6d in reg INT2_CFG
   *
   */
-int32_t ais328dq_int2_6d_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_6d_mode_set(stmdev_ctx_t *ctx,
                                    ais328dq_int2_6d_t val)
 {
   ais328dq_int2_cfg_t int2_cfg;
@@ -1912,7 +1895,7 @@ int32_t ais328dq_int2_6d_mode_set(ais328dq_ctx_t *ctx,
   * @param  val         Get the values of 6d in reg INT2_CFG
   *
   */
-int32_t ais328dq_int2_6d_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_6d_mode_get(stmdev_ctx_t *ctx,
                                    ais328dq_int2_6d_t *val)
 {
   ais328dq_int2_cfg_t int2_cfg;
@@ -1946,7 +1929,7 @@ int32_t ais328dq_int2_6d_mode_get(ais328dq_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t ais328dq_int2_6d_src_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_6d_src_get(stmdev_ctx_t *ctx,
                                   ais328dq_int2_src_t *val)
 {
   int32_t ret;
@@ -1961,7 +1944,7 @@ int32_t ais328dq_int2_6d_src_get(ais328dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t ais328dq_int2_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
+int32_t ais328dq_int2_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais328dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1982,7 +1965,7 @@ int32_t ais328dq_int2_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t ais328dq_int2_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val)
+int32_t ais328dq_int2_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais328dq_int2_ths_t int2_ths;
   int32_t ret;

--- a/sensor/stmemsc/ais328dq_STdC/driver/ais328dq_reg.h
+++ b/sensor/stmemsc/ais328dq_STdC/driver/ais328dq_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup AIS328DQ_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  AIS328DQ_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,22 +65,54 @@ typedef struct{
   *
   */
 
-typedef int32_t (*ais328dq_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*ais328dq_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  ais328dq_write_ptr  write_reg;
-  ais328dq_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} ais328dq_ctx_t;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
 
 /** @defgroup AIS328DQ_Infos
   * @{
@@ -356,23 +327,23 @@ typedef union{
   *
   */
 
-int32_t ais328dq_read_reg(ais328dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t ais328dq_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
-int32_t ais328dq_write_reg(ais328dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t ais328dq_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                             uint16_t len);
 
 extern float ais328dq_from_fs2_to_mg(int16_t lsb);
 extern float ais328dq_from_fs4_to_mg(int16_t lsb);
 extern float ais328dq_from_fs8_to_mg(int16_t lsb);
 
-int32_t ais328dq_axis_x_data_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_axis_x_data_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais328dq_axis_y_data_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_axis_y_data_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais328dq_axis_z_data_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_axis_z_data_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS328DQ_ODR_OFF   = 0x00,
@@ -386,16 +357,16 @@ typedef enum {
   AIS328DQ_ODR_400Hz = 0x21,
   AIS328DQ_ODR_1kHz  = 0x31,
 } ais328dq_dr_t;
-int32_t ais328dq_data_rate_set(ais328dq_ctx_t *ctx, ais328dq_dr_t val);
-int32_t ais328dq_data_rate_get(ais328dq_ctx_t *ctx, ais328dq_dr_t *val);
+int32_t ais328dq_data_rate_set(stmdev_ctx_t *ctx, ais328dq_dr_t val);
+int32_t ais328dq_data_rate_get(stmdev_ctx_t *ctx, ais328dq_dr_t *val);
 
 typedef enum {
   AIS328DQ_NORMAL_MODE      = 0,
   AIS328DQ_REF_MODE_ENABLE  = 1,
 } ais328dq_hpm_t;
-int32_t ais328dq_reference_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_reference_mode_set(stmdev_ctx_t *ctx,
                                      ais328dq_hpm_t val);
-int32_t ais328dq_reference_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_reference_mode_get(stmdev_ctx_t *ctx,
                                      ais328dq_hpm_t *val);
 
 typedef enum {
@@ -403,39 +374,39 @@ typedef enum {
   AIS328DQ_4g  = 1,
   AIS328DQ_8g  = 3,
 } ais328dq_fs_t;
-int32_t ais328dq_full_scale_set(ais328dq_ctx_t *ctx, ais328dq_fs_t val);
-int32_t ais328dq_full_scale_get(ais328dq_ctx_t *ctx, ais328dq_fs_t *val);
+int32_t ais328dq_full_scale_set(stmdev_ctx_t *ctx, ais328dq_fs_t val);
+int32_t ais328dq_full_scale_get(stmdev_ctx_t *ctx, ais328dq_fs_t *val);
 
-int32_t ais328dq_block_data_update_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_block_data_update_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais328dq_status_reg_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_status_reg_get(stmdev_ctx_t *ctx,
                                  ais328dq_status_reg_t *val);
 
-int32_t ais328dq_flag_data_ready_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_flag_data_ready_get(stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t ais328dq_acceleration_raw_get(ais328dq_ctx_t *ctx, uint8_t *buff);
+int32_t ais328dq_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ais328dq_device_id_get(ais328dq_ctx_t *ctx, uint8_t *buff);
+int32_t ais328dq_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ais328dq_boot_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_boot_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS328DQ_ST_DISABLE   = 0,
   AIS328DQ_ST_POSITIVE  = 1,
   AIS328DQ_ST_NEGATIVE  = 5,
 } ais328dq_st_t;
-int32_t ais328dq_self_test_set(ais328dq_ctx_t *ctx, ais328dq_st_t val);
-int32_t ais328dq_self_test_get(ais328dq_ctx_t *ctx, ais328dq_st_t *val);
+int32_t ais328dq_self_test_set(stmdev_ctx_t *ctx, ais328dq_st_t val);
+int32_t ais328dq_self_test_get(stmdev_ctx_t *ctx, ais328dq_st_t *val);
 
 typedef enum {
   AIS328DQ_LSB_AT_LOW_ADD  = 0,
   AIS328DQ_MSB_AT_LOW_ADD  = 1,
 } ais328dq_ble_t;
-int32_t ais328dq_data_format_set(ais328dq_ctx_t *ctx, ais328dq_ble_t val);
-int32_t ais328dq_data_format_get(ais328dq_ctx_t *ctx, ais328dq_ble_t *val);
+int32_t ais328dq_data_format_set(stmdev_ctx_t *ctx, ais328dq_ble_t val);
+int32_t ais328dq_data_format_get(stmdev_ctx_t *ctx, ais328dq_ble_t *val);
 
 typedef enum {
   AIS328DQ_CUT_OFF_8Hz   = 0,
@@ -443,9 +414,9 @@ typedef enum {
   AIS328DQ_CUT_OFF_32Hz  = 2,
   AIS328DQ_CUT_OFF_64Hz  = 3,
 } ais328dq_hpcf_t;
-int32_t ais328dq_hp_bandwidth_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                    ais328dq_hpcf_t val);
-int32_t ais328dq_hp_bandwidth_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    ais328dq_hpcf_t *val);
 
 typedef enum {
@@ -458,20 +429,20 @@ typedef enum {
   AIS328DQ_HP_ON_INT2_OUT        = 6,
   AIS328DQ_HP_ON_INT1_OUT        = 5,
 } ais328dq_hpen_t;
-int32_t ais328dq_hp_path_set(ais328dq_ctx_t *ctx, ais328dq_hpen_t val);
-int32_t ais328dq_hp_path_get(ais328dq_ctx_t *ctx, ais328dq_hpen_t *val);
+int32_t ais328dq_hp_path_set(stmdev_ctx_t *ctx, ais328dq_hpen_t val);
+int32_t ais328dq_hp_path_get(stmdev_ctx_t *ctx, ais328dq_hpen_t *val);
 
-int32_t ais328dq_hp_reset_get(ais328dq_ctx_t *ctx);
+int32_t ais328dq_hp_reset_get(stmdev_ctx_t *ctx);
 
-int32_t ais328dq_hp_reference_value_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_hp_reference_value_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS328DQ_SPI_4_WIRE  = 0,
   AIS328DQ_SPI_3_WIRE  = 1,
 } ais328dq_sim_t;
-int32_t ais328dq_spi_mode_set(ais328dq_ctx_t *ctx, ais328dq_sim_t val);
-int32_t ais328dq_spi_mode_get(ais328dq_ctx_t *ctx, ais328dq_sim_t *val);
+int32_t ais328dq_spi_mode_set(stmdev_ctx_t *ctx, ais328dq_sim_t val);
+int32_t ais328dq_spi_mode_get(stmdev_ctx_t *ctx, ais328dq_sim_t *val);
 
 typedef enum {
   AIS328DQ_PAD1_INT1_SRC           = 0,
@@ -479,18 +450,18 @@ typedef enum {
   AIS328DQ_PAD1_DRDY               = 2,
   AIS328DQ_PAD1_BOOT               = 3,
 } ais328dq_i1_cfg_t;
-int32_t ais328dq_pin_int1_route_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      ais328dq_i1_cfg_t val);
-int32_t ais328dq_pin_int1_route_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      ais328dq_i1_cfg_t *val);
 
 typedef enum {
   AIS328DQ_INT1_PULSED   = 0,
   AIS328DQ_INT1_LATCHED  = 1,
 } ais328dq_lir1_t;
-int32_t ais328dq_int1_notification_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_notification_set(stmdev_ctx_t *ctx,
                                         ais328dq_lir1_t val);
-int32_t ais328dq_int1_notification_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_notification_get(stmdev_ctx_t *ctx,
                                         ais328dq_lir1_t *val);
 
 typedef enum {
@@ -499,34 +470,34 @@ typedef enum {
   AIS328DQ_PAD2_DRDY               = 2,
   AIS328DQ_PAD2_BOOT               = 3,
 } ais328dq_i2_cfg_t;
-int32_t ais328dq_pin_int2_route_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      ais328dq_i2_cfg_t val);
-int32_t ais328dq_pin_int2_route_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      ais328dq_i2_cfg_t *val);
 
 typedef enum {
   AIS328DQ_INT2_PULSED   = 0,
   AIS328DQ_INT2_LATCHED  = 1,
 } ais328dq_lir2_t;
-int32_t ais328dq_int2_notification_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_notification_set(stmdev_ctx_t *ctx,
                                         ais328dq_lir2_t val);
-int32_t ais328dq_int2_notification_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_notification_get(stmdev_ctx_t *ctx,
                                         ais328dq_lir2_t *val);
 
 typedef enum {
   AIS328DQ_PUSH_PULL   = 0,
   AIS328DQ_OPEN_DRAIN  = 1,
 } ais328dq_pp_od_t;
-int32_t ais328dq_pin_mode_set(ais328dq_ctx_t *ctx, ais328dq_pp_od_t val);
-int32_t ais328dq_pin_mode_get(ais328dq_ctx_t *ctx, ais328dq_pp_od_t *val);
+int32_t ais328dq_pin_mode_set(stmdev_ctx_t *ctx, ais328dq_pp_od_t val);
+int32_t ais328dq_pin_mode_get(stmdev_ctx_t *ctx, ais328dq_pp_od_t *val);
 
 typedef enum {
   AIS328DQ_ACTIVE_HIGH  = 0,
   AIS328DQ_ACTIVE_LOW   = 1,
 } ais328dq_ihl_t;
-int32_t ais328dq_pin_polarity_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_polarity_set(stmdev_ctx_t *ctx,
                                    ais328dq_ihl_t val);
-int32_t ais328dq_pin_polarity_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_pin_polarity_get(stmdev_ctx_t *ctx,
                                    ais328dq_ihl_t *val);
 
 typedef struct {
@@ -536,29 +507,29 @@ typedef struct {
   uint8_t int1_yhie             : 1;
   uint8_t int1_zlie             : 1;
   uint8_t int1_zhie             : 1;
-} int1_on_th_conf_t;
-int32_t ais328dq_int1_on_threshold_conf_set(ais328dq_ctx_t *ctx,
-                                             int1_on_th_conf_t val);
-int32_t ais328dq_int1_on_threshold_conf_get(ais328dq_ctx_t *ctx,
-                                             int1_on_th_conf_t *val);
+} ais328dq_int1_on_th_conf_t;
+int32_t ais328dq_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                             ais328dq_int1_on_th_conf_t val);
+int32_t ais328dq_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             ais328dq_int1_on_th_conf_t *val);
 
 typedef enum {
   AIS328DQ_INT1_ON_THRESHOLD_OR   = 0,
   AIS328DQ_INT1_ON_THRESHOLD_AND  = 1,
 } ais328dq_int1_aoi_t;
-int32_t ais328dq_int1_on_threshold_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              ais328dq_int1_aoi_t val);
-int32_t ais328dq_int1_on_threshold_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              ais328dq_int1_aoi_t *val);
 
-int32_t ais328dq_int1_src_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_src_get(stmdev_ctx_t *ctx,
                                ais328dq_int1_src_t *val);
 
-int32_t ais328dq_int1_treshold_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_int1_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais328dq_int1_dur_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_int1_dur_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t int2_xlie             : 1;
@@ -567,64 +538,64 @@ typedef struct {
   uint8_t int2_yhie             : 1;
   uint8_t int2_zlie             : 1;
   uint8_t int2_zhie             : 1;
-} int2_on_th_conf_t;
-int32_t ais328dq_int2_on_threshold_conf_set(ais328dq_ctx_t *ctx,
-                                             int2_on_th_conf_t val);
-int32_t ais328dq_int2_on_threshold_conf_get(ais328dq_ctx_t *ctx,
-                                             int2_on_th_conf_t *val);
+} ais328dq_int2_on_th_conf_t;
+int32_t ais328dq_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                             ais328dq_int2_on_th_conf_t val);
+int32_t ais328dq_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             ais328dq_int2_on_th_conf_t *val);
 
 typedef enum {
   AIS328DQ_INT2_ON_THRESHOLD_OR   = 0,
   AIS328DQ_INT2_ON_THRESHOLD_AND  = 1,
 } ais328dq_int2_aoi_t;
-int32_t ais328dq_int2_on_threshold_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              ais328dq_int2_aoi_t val);
-int32_t ais328dq_int2_on_threshold_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              ais328dq_int2_aoi_t *val);
 
-int32_t ais328dq_int2_src_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_src_get(stmdev_ctx_t *ctx,
                                ais328dq_int2_src_t *val);
 
-int32_t ais328dq_int2_treshold_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_int2_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais328dq_int2_dur_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_int2_dur_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais328dq_wkup_to_sleep_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_wkup_to_sleep_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS328DQ_6D_INT1_DISABLE   = 0,
   AIS328DQ_6D_INT1_MOVEMENT  = 1,
   AIS328DQ_6D_INT1_POSITION  = 3,
 } ais328dq_int1_6d_t;
-int32_t ais328dq_int1_6d_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_6d_mode_set(stmdev_ctx_t *ctx,
                                    ais328dq_int1_6d_t val);
-int32_t ais328dq_int1_6d_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_6d_mode_get(stmdev_ctx_t *ctx,
                                    ais328dq_int1_6d_t *val);
 
-int32_t ais328dq_int1_6d_src_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int1_6d_src_get(stmdev_ctx_t *ctx,
                                   ais328dq_int1_src_t *val);
 
-int32_t ais328dq_int1_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_int1_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_int1_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int1_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS328DQ_6D_INT2_DISABLE   = 0,
   AIS328DQ_6D_INT2_MOVEMENT  = 1,
   AIS328DQ_6D_INT2_POSITION  = 3,
 } ais328dq_int2_6d_t;
-int32_t ais328dq_int2_6d_mode_set(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_6d_mode_set(stmdev_ctx_t *ctx,
                                    ais328dq_int2_6d_t val);
-int32_t ais328dq_int2_6d_mode_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_6d_mode_get(stmdev_ctx_t *ctx,
                                    ais328dq_int2_6d_t *val);
 
-int32_t ais328dq_int2_6d_src_get(ais328dq_ctx_t *ctx,
+int32_t ais328dq_int2_6d_src_get(stmdev_ctx_t *ctx,
                                   ais328dq_int2_src_t *val);
 
-int32_t ais328dq_int2_6d_treshold_set(ais328dq_ctx_t *ctx, uint8_t val);
-int32_t ais328dq_int2_6d_treshold_get(ais328dq_ctx_t *ctx, uint8_t *val);
+int32_t ais328dq_int2_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais328dq_int2_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/ais3624dq_STdC/driver/ais3624dq_reg.c
+++ b/sensor/stmemsc/ais3624dq_STdC/driver/ais3624dq_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "ais3624dq_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t ais3624dq_read_reg(ais3624dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t ais3624dq_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t ais3624dq_read_reg(ais3624dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t ais3624dq_write_reg(ais3624dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t ais3624dq_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                             uint16_t len)
 {
   int32_t ret;
@@ -136,7 +119,7 @@ float ais3624dq_from_fs24_to_mg(int16_t lsb)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t ais3624dq_axis_x_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -157,7 +140,7 @@ int32_t ais3624dq_axis_x_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t ais3624dq_axis_x_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -175,7 +158,7 @@ int32_t ais3624dq_axis_x_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t ais3624dq_axis_y_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -196,7 +179,7 @@ int32_t ais3624dq_axis_y_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t ais3624dq_axis_y_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -214,7 +197,7 @@ int32_t ais3624dq_axis_y_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t ais3624dq_axis_z_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -235,7 +218,7 @@ int32_t ais3624dq_axis_z_data_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t ais3624dq_axis_z_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -253,7 +236,7 @@ int32_t ais3624dq_axis_z_data_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of dr in reg CTRL_REG1
   *
   */
-int32_t ais3624dq_data_rate_set(ais3624dq_ctx_t *ctx, ais3624dq_dr_t val)
+int32_t ais3624dq_data_rate_set(stmdev_ctx_t *ctx, ais3624dq_dr_t val)
 {
   ais3624dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -276,7 +259,7 @@ int32_t ais3624dq_data_rate_set(ais3624dq_ctx_t *ctx, ais3624dq_dr_t val)
   * @param  val         Get the values of dr in reg CTRL_REG1
   *
   */
-int32_t ais3624dq_data_rate_get(ais3624dq_ctx_t *ctx, ais3624dq_dr_t *val)
+int32_t ais3624dq_data_rate_get(stmdev_ctx_t *ctx, ais3624dq_dr_t *val)
 {
   ais3624dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -331,7 +314,7 @@ int32_t ais3624dq_data_rate_get(ais3624dq_ctx_t *ctx, ais3624dq_dr_t *val)
   * @param  val         change the values of hpm in reg CTRL_REG2
   *
   */
-int32_t ais3624dq_reference_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_reference_mode_set(stmdev_ctx_t *ctx,
                                      ais3624dq_hpm_t val)
 {
   ais3624dq_ctrl_reg2_t ctrl_reg2;
@@ -353,7 +336,7 @@ int32_t ais3624dq_reference_mode_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of hpm in reg CTRL_REG2
   *
   */
-int32_t ais3624dq_reference_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_reference_mode_get(stmdev_ctx_t *ctx,
                                      ais3624dq_hpm_t *val)
 {
   ais3624dq_ctrl_reg2_t ctrl_reg2;
@@ -384,7 +367,7 @@ int32_t ais3624dq_reference_mode_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of fs in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_full_scale_set(ais3624dq_ctx_t *ctx, ais3624dq_fs_t val)
+int32_t ais3624dq_full_scale_set(stmdev_ctx_t *ctx, ais3624dq_fs_t val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -405,7 +388,7 @@ int32_t ais3624dq_full_scale_set(ais3624dq_ctx_t *ctx, ais3624dq_fs_t val)
   * @param  val         Get the values of fs in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_full_scale_get(ais3624dq_ctx_t *ctx, ais3624dq_fs_t *val)
+int32_t ais3624dq_full_scale_get(stmdev_ctx_t *ctx, ais3624dq_fs_t *val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -438,7 +421,7 @@ int32_t ais3624dq_full_scale_get(ais3624dq_ctx_t *ctx, ais3624dq_fs_t *val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_block_data_update_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -459,7 +442,7 @@ int32_t ais3624dq_block_data_update_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_block_data_update_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -477,7 +460,7 @@ int32_t ais3624dq_block_data_update_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         registers STATUS_REG
   *
   */
-int32_t ais3624dq_status_reg_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_status_reg_get(stmdev_ctx_t *ctx,
                                  ais3624dq_status_reg_t *val)
 {
   int32_t ret;
@@ -492,7 +475,7 @@ int32_t ais3624dq_status_reg_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of zyxda in reg STATUS_REG
   *
   */
-int32_t ais3624dq_flag_data_ready_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_status_reg_t status_reg;
   int32_t ret;
@@ -524,7 +507,7 @@ int32_t ais3624dq_flag_data_ready_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t ais3624dq_acceleration_raw_get(ais3624dq_ctx_t *ctx, uint8_t *buff)
+int32_t ais3624dq_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ais3624dq_read_reg(ctx, AIS3624DQ_OUT_X_L, buff, 6);
@@ -550,7 +533,7 @@ int32_t ais3624dq_acceleration_raw_get(ais3624dq_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t ais3624dq_device_id_get(ais3624dq_ctx_t *ctx, uint8_t *buff)
+int32_t ais3624dq_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ais3624dq_read_reg(ctx, AIS3624DQ_WHO_AM_I, buff, 1);
@@ -564,7 +547,7 @@ int32_t ais3624dq_device_id_get(ais3624dq_ctx_t *ctx, uint8_t *buff)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t ais3624dq_boot_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -585,7 +568,7 @@ int32_t ais3624dq_boot_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t ais3624dq_boot_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -603,7 +586,7 @@ int32_t ais3624dq_boot_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of st in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_self_test_set(ais3624dq_ctx_t *ctx, ais3624dq_st_t val)
+int32_t ais3624dq_self_test_set(stmdev_ctx_t *ctx, ais3624dq_st_t val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -624,7 +607,7 @@ int32_t ais3624dq_self_test_set(ais3624dq_ctx_t *ctx, ais3624dq_st_t val)
   * @param  val         Get the values of st in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_self_test_get(ais3624dq_ctx_t *ctx, ais3624dq_st_t *val)
+int32_t ais3624dq_self_test_get(stmdev_ctx_t *ctx, ais3624dq_st_t *val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -657,7 +640,7 @@ int32_t ais3624dq_self_test_get(ais3624dq_ctx_t *ctx, ais3624dq_st_t *val)
   * @param  val         change the values of ble in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_data_format_set(ais3624dq_ctx_t *ctx, ais3624dq_ble_t val)
+int32_t ais3624dq_data_format_set(stmdev_ctx_t *ctx, ais3624dq_ble_t val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -678,7 +661,7 @@ int32_t ais3624dq_data_format_set(ais3624dq_ctx_t *ctx, ais3624dq_ble_t val)
   * @param  val         Get the values of ble in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_data_format_get(ais3624dq_ctx_t *ctx, ais3624dq_ble_t *val)
+int32_t ais3624dq_data_format_get(stmdev_ctx_t *ctx, ais3624dq_ble_t *val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -721,7 +704,7 @@ int32_t ais3624dq_data_format_get(ais3624dq_ctx_t *ctx, ais3624dq_ble_t *val)
   * @param  val         change the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t ais3624dq_hp_bandwidth_set(ais3624dq_ctx_t *ctx, ais3624dq_hpcf_t val)
+int32_t ais3624dq_hp_bandwidth_set(stmdev_ctx_t *ctx, ais3624dq_hpcf_t val)
 {
   ais3624dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -742,7 +725,7 @@ int32_t ais3624dq_hp_bandwidth_set(ais3624dq_ctx_t *ctx, ais3624dq_hpcf_t val)
   * @param  val         Get the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t ais3624dq_hp_bandwidth_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    ais3624dq_hpcf_t *val)
 {
   ais3624dq_ctrl_reg2_t ctrl_reg2;
@@ -779,7 +762,7 @@ int32_t ais3624dq_hp_bandwidth_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of hpen in reg CTRL_REG2
   *
   */
-int32_t ais3624dq_hp_path_set(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t val)
+int32_t ais3624dq_hp_path_set(stmdev_ctx_t *ctx, ais3624dq_hpen_t val)
 {
   ais3624dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -801,7 +784,7 @@ int32_t ais3624dq_hp_path_set(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t val)
   * @param  val         Get the values of hpen in reg CTRL_REG2
   *
   */
-int32_t ais3624dq_hp_path_get(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t *val)
+int32_t ais3624dq_hp_path_get(stmdev_ctx_t *ctx, ais3624dq_hpen_t *val)
 {
   ais3624dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -852,7 +835,7 @@ int32_t ais3624dq_hp_path_get(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t *val)
   * @param  ctx         read / write interface definitions(ptr)
   *
   */
-int32_t ais3624dq_hp_reset_get(ais3624dq_ctx_t *ctx)
+int32_t ais3624dq_hp_reset_get(stmdev_ctx_t *ctx)
 {
   uint8_t dummy;
   int32_t ret;
@@ -868,7 +851,7 @@ int32_t ais3624dq_hp_reset_get(ais3624dq_ctx_t *ctx)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t ais3624dq_hp_reference_value_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
   ret = ais3624dq_write_reg(ctx, AIS3624DQ_REFERENCE, (uint8_t*)&val, 1);
@@ -882,7 +865,7 @@ int32_t ais3624dq_hp_reference_value_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t ais3624dq_hp_reference_value_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
   ret = ais3624dq_read_reg(ctx, AIS3624DQ_REFERENCE, val, 1);
@@ -909,7 +892,7 @@ int32_t ais3624dq_hp_reference_value_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of sim in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_spi_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_sim_t val)
+int32_t ais3624dq_spi_mode_set(stmdev_ctx_t *ctx, ais3624dq_sim_t val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -930,7 +913,7 @@ int32_t ais3624dq_spi_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_sim_t val)
   * @param  val         Get the values of sim in reg CTRL_REG4
   *
   */
-int32_t ais3624dq_spi_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_sim_t *val)
+int32_t ais3624dq_spi_mode_get(stmdev_ctx_t *ctx, ais3624dq_sim_t *val)
 {
   ais3624dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -973,7 +956,7 @@ int32_t ais3624dq_spi_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_sim_t *val)
   * @param  val         change the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_pin_int1_route_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      ais3624dq_i1_cfg_t val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
@@ -995,7 +978,7 @@ int32_t ais3624dq_pin_int1_route_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_pin_int1_route_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      ais3624dq_i1_cfg_t *val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
@@ -1033,7 +1016,7 @@ int32_t ais3624dq_pin_int1_route_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_int1_notification_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_notification_set(stmdev_ctx_t *ctx,
                                         ais3624dq_lir1_t val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
@@ -1056,7 +1039,7 @@ int32_t ais3624dq_int1_notification_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_int1_notification_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_notification_get(stmdev_ctx_t *ctx,
                                         ais3624dq_lir1_t *val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
@@ -1087,7 +1070,7 @@ int32_t ais3624dq_int1_notification_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_pin_int2_route_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      ais3624dq_i2_cfg_t val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
@@ -1109,7 +1092,7 @@ int32_t ais3624dq_pin_int2_route_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_pin_int2_route_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      ais3624dq_i2_cfg_t *val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
@@ -1147,7 +1130,7 @@ int32_t ais3624dq_pin_int2_route_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_int2_notification_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_notification_set(stmdev_ctx_t *ctx,
                                         ais3624dq_lir2_t val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
@@ -1170,7 +1153,7 @@ int32_t ais3624dq_int2_notification_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_int2_notification_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_notification_get(stmdev_ctx_t *ctx,
                                         ais3624dq_lir2_t *val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
@@ -1201,7 +1184,7 @@ int32_t ais3624dq_int2_notification_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_pin_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t val)
+int32_t ais3624dq_pin_mode_set(stmdev_ctx_t *ctx, ais3624dq_pp_od_t val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1222,7 +1205,7 @@ int32_t ais3624dq_pin_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t val)
   * @param  val         Get the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_pin_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t *val)
+int32_t ais3624dq_pin_mode_get(stmdev_ctx_t *ctx, ais3624dq_pp_od_t *val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1252,7 +1235,7 @@ int32_t ais3624dq_pin_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t *val)
   * @param  val         change the values of ihl in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_pin_polarity_set(ais3624dq_ctx_t *ctx, ais3624dq_ihl_t val)
+int32_t ais3624dq_pin_polarity_set(stmdev_ctx_t *ctx, ais3624dq_ihl_t val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1273,7 +1256,7 @@ int32_t ais3624dq_pin_polarity_set(ais3624dq_ctx_t *ctx, ais3624dq_ihl_t val)
   * @param  val         Get the values of ihl in reg CTRL_REG3
   *
   */
-int32_t ais3624dq_pin_polarity_get(ais3624dq_ctx_t *ctx, ais3624dq_ihl_t *val)
+int32_t ais3624dq_pin_polarity_get(stmdev_ctx_t *ctx, ais3624dq_ihl_t *val)
 {
   ais3624dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1316,8 +1299,8 @@ int32_t ais3624dq_pin_polarity_get(ais3624dq_ctx_t *ctx, ais3624dq_ihl_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t ais3624dq_int1_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
-                                              int1_on_th_conf_t val)
+int32_t ais3624dq_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                              ais3624dq_int1_on_th_conf_t val)
 {
   ais3624dq_int1_cfg_t int1_cfg;
   int32_t ret;
@@ -1343,8 +1326,8 @@ int32_t ais3624dq_int1_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t ais3624dq_int1_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
-                                             int1_on_th_conf_t *val)
+int32_t ais3624dq_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             ais3624dq_int1_on_th_conf_t *val)
 {
   ais3624dq_int1_cfg_t int1_cfg;
   int32_t ret;
@@ -1367,7 +1350,7 @@ int32_t ais3624dq_int1_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT1_CFG
   *
   */
-int32_t ais3624dq_int1_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              ais3624dq_int1_aoi_t val)
 {
   ais3624dq_int1_cfg_t int1_cfg;
@@ -1389,7 +1372,7 @@ int32_t ais3624dq_int1_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT1_CFG
   *
   */
-int32_t ais3624dq_int1_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              ais3624dq_int1_aoi_t *val)
 {
   ais3624dq_int1_cfg_t int1_cfg;
@@ -1420,7 +1403,7 @@ int32_t ais3624dq_int1_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t ais3624dq_int1_src_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_src_get(stmdev_ctx_t *ctx,
                                ais3624dq_int1_src_t *val)
 {
   int32_t ret;
@@ -1435,7 +1418,7 @@ int32_t ais3624dq_int1_src_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t ais3624dq_int1_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1456,7 +1439,7 @@ int32_t ais3624dq_int1_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t ais3624dq_int1_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1474,7 +1457,7 @@ int32_t ais3624dq_int1_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t ais3624dq_int1_dur_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_int1_duration_t int1_duration;
   int32_t ret;
@@ -1496,7 +1479,7 @@ int32_t ais3624dq_int1_dur_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t ais3624dq_int1_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_int1_duration_t int1_duration;
   int32_t ret;
@@ -1515,8 +1498,8 @@ int32_t ais3624dq_int1_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t ais3624dq_int2_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
-                                              int2_on_th_conf_t val)
+int32_t ais3624dq_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                              ais3624dq_int2_on_th_conf_t val)
 {
   ais3624dq_int2_cfg_t int2_cfg;
   int32_t ret;
@@ -1543,8 +1526,8 @@ int32_t ais3624dq_int2_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t ais3624dq_int2_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
-                                              int2_on_th_conf_t *val)
+int32_t ais3624dq_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                              ais3624dq_int2_on_th_conf_t *val)
 {
   ais3624dq_int2_cfg_t int2_cfg;
   int32_t ret;
@@ -1567,7 +1550,7 @@ int32_t ais3624dq_int2_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT2_CFG
   *
   */
-int32_t ais3624dq_int2_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              ais3624dq_int2_aoi_t val)
 {
   ais3624dq_int2_cfg_t int2_cfg;
@@ -1589,7 +1572,7 @@ int32_t ais3624dq_int2_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT2_CFG
   *
   */
-int32_t ais3624dq_int2_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              ais3624dq_int2_aoi_t *val)
 {
   ais3624dq_int2_cfg_t int2_cfg;
@@ -1620,7 +1603,7 @@ int32_t ais3624dq_int2_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t ais3624dq_int2_src_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_src_get(stmdev_ctx_t *ctx,
                                ais3624dq_int2_src_t *val)
 {
   int32_t ret;
@@ -1635,7 +1618,7 @@ int32_t ais3624dq_int2_src_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t ais3624dq_int2_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1656,7 +1639,7 @@ int32_t ais3624dq_int2_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t ais3624dq_int2_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1674,7 +1657,7 @@ int32_t ais3624dq_int2_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t ais3624dq_int2_dur_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_int2_duration_t int2_duration;
   int32_t ret;
@@ -1696,7 +1679,7 @@ int32_t ais3624dq_int2_dur_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t ais3624dq_int2_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_int2_duration_t int2_duration;
   int32_t ret;
@@ -1728,7 +1711,7 @@ int32_t ais3624dq_int2_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t ais3624dq_wkup_to_sleep_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1749,7 +1732,7 @@ int32_t ais3624dq_wkup_to_sleep_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t ais3624dq_wkup_to_sleep_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1780,7 +1763,7 @@ int32_t ais3624dq_wkup_to_sleep_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of 6d in reg INT1_CFG
   *
   */
-int32_t ais3624dq_int1_6d_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_6d_mode_set(stmdev_ctx_t *ctx,
                                    ais3624dq_int1_6d_t val)
 {
   ais3624dq_int1_cfg_t int1_cfg;
@@ -1802,7 +1785,7 @@ int32_t ais3624dq_int1_6d_mode_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of 6d in reg INT1_CFG
   *
   */
-int32_t ais3624dq_int1_6d_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_6d_mode_get(stmdev_ctx_t *ctx,
                                    ais3624dq_int1_6d_t *val)
 {
   ais3624dq_int1_cfg_t int1_cfg;
@@ -1836,7 +1819,7 @@ int32_t ais3624dq_int1_6d_mode_get(ais3624dq_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t ais3624dq_int1_6d_src_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_6d_src_get(stmdev_ctx_t *ctx,
                                   ais3624dq_int1_src_t *val)
 {
   int32_t ret;
@@ -1851,7 +1834,7 @@ int32_t ais3624dq_int1_6d_src_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t ais3624dq_int1_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_int1_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1871,7 +1854,7 @@ int32_t ais3624dq_int1_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t ais3624dq_int1_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_int1_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1889,7 +1872,7 @@ int32_t ais3624dq_int1_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of 6d in reg INT2_CFG
   *
   */
-int32_t ais3624dq_int2_6d_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_6d_mode_set(stmdev_ctx_t *ctx,
                                    ais3624dq_int2_6d_t val)
 {
   ais3624dq_int2_cfg_t int2_cfg;
@@ -1912,7 +1895,7 @@ int32_t ais3624dq_int2_6d_mode_set(ais3624dq_ctx_t *ctx,
   * @param  val         Get the values of 6d in reg INT2_CFG
   *
   */
-int32_t ais3624dq_int2_6d_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_6d_mode_get(stmdev_ctx_t *ctx,
                                    ais3624dq_int2_6d_t *val)
 {
   ais3624dq_int2_cfg_t int2_cfg;
@@ -1946,7 +1929,7 @@ int32_t ais3624dq_int2_6d_mode_get(ais3624dq_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t ais3624dq_int2_6d_src_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_6d_src_get(stmdev_ctx_t *ctx,
                                   ais3624dq_int2_src_t *val)
 {
   int32_t ret;
@@ -1961,7 +1944,7 @@ int32_t ais3624dq_int2_6d_src_get(ais3624dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t ais3624dq_int2_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
+int32_t ais3624dq_int2_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ais3624dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1982,7 +1965,7 @@ int32_t ais3624dq_int2_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t ais3624dq_int2_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val)
+int32_t ais3624dq_int2_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ais3624dq_int2_ths_t int2_ths;
   int32_t ret;

--- a/sensor/stmemsc/ais3624dq_STdC/driver/ais3624dq_reg.h
+++ b/sensor/stmemsc/ais3624dq_STdC/driver/ais3624dq_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup AIS3624DQ_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  AIS3624DQ_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*ais3624dq_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*ais3624dq_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  ais3624dq_write_ptr  write_reg;
-  ais3624dq_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} ais3624dq_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -355,23 +327,23 @@ typedef union{
   *
   */
 
-int32_t ais3624dq_read_reg(ais3624dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t ais3624dq_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
-int32_t ais3624dq_write_reg(ais3624dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t ais3624dq_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                             uint16_t len);
 
 extern float ais3624dq_from_fs6_to_mg(int16_t lsb);
 extern float ais3624dq_from_fs12_to_mg(int16_t lsb);
 extern float ais3624dq_from_fs24_to_mg(int16_t lsb);
 
-int32_t ais3624dq_axis_x_data_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_axis_x_data_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais3624dq_axis_y_data_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_axis_y_data_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais3624dq_axis_z_data_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_axis_z_data_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS3624DQ_ODR_OFF   = 0x00,
@@ -385,16 +357,16 @@ typedef enum {
   AIS3624DQ_ODR_400Hz = 0x21,
   AIS3624DQ_ODR_1kHz  = 0x31,
 } ais3624dq_dr_t;
-int32_t ais3624dq_data_rate_set(ais3624dq_ctx_t *ctx, ais3624dq_dr_t val);
-int32_t ais3624dq_data_rate_get(ais3624dq_ctx_t *ctx, ais3624dq_dr_t *val);
+int32_t ais3624dq_data_rate_set(stmdev_ctx_t *ctx, ais3624dq_dr_t val);
+int32_t ais3624dq_data_rate_get(stmdev_ctx_t *ctx, ais3624dq_dr_t *val);
 
 typedef enum {
   AIS3624DQ_NORMAL_MODE      = 0,
   AIS3624DQ_REF_MODE_ENABLE  = 1,
 } ais3624dq_hpm_t;
-int32_t ais3624dq_reference_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_reference_mode_set(stmdev_ctx_t *ctx,
                                      ais3624dq_hpm_t val);
-int32_t ais3624dq_reference_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_reference_mode_get(stmdev_ctx_t *ctx,
                                      ais3624dq_hpm_t *val);
 
 typedef enum {
@@ -402,39 +374,39 @@ typedef enum {
   AIS3624DQ_12g  = 1,
   AIS3624DQ_24g  = 3,
 } ais3624dq_fs_t;
-int32_t ais3624dq_full_scale_set(ais3624dq_ctx_t *ctx, ais3624dq_fs_t val);
-int32_t ais3624dq_full_scale_get(ais3624dq_ctx_t *ctx, ais3624dq_fs_t *val);
+int32_t ais3624dq_full_scale_set(stmdev_ctx_t *ctx, ais3624dq_fs_t val);
+int32_t ais3624dq_full_scale_get(stmdev_ctx_t *ctx, ais3624dq_fs_t *val);
 
-int32_t ais3624dq_block_data_update_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_block_data_update_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais3624dq_status_reg_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_status_reg_get(stmdev_ctx_t *ctx,
                                  ais3624dq_status_reg_t *val);
 
-int32_t ais3624dq_flag_data_ready_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_flag_data_ready_get(stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t ais3624dq_acceleration_raw_get(ais3624dq_ctx_t *ctx, uint8_t *buff);
+int32_t ais3624dq_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ais3624dq_device_id_get(ais3624dq_ctx_t *ctx, uint8_t *buff);
+int32_t ais3624dq_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ais3624dq_boot_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_boot_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS3624DQ_ST_DISABLE   = 0,
   AIS3624DQ_ST_POSITIVE  = 1,
   AIS3624DQ_ST_NEGATIVE  = 5,
 } ais3624dq_st_t;
-int32_t ais3624dq_self_test_set(ais3624dq_ctx_t *ctx, ais3624dq_st_t val);
-int32_t ais3624dq_self_test_get(ais3624dq_ctx_t *ctx, ais3624dq_st_t *val);
+int32_t ais3624dq_self_test_set(stmdev_ctx_t *ctx, ais3624dq_st_t val);
+int32_t ais3624dq_self_test_get(stmdev_ctx_t *ctx, ais3624dq_st_t *val);
 
 typedef enum {
   AIS3624DQ_LSB_AT_LOW_ADD  = 0,
   AIS3624DQ_MSB_AT_LOW_ADD  = 1,
 } ais3624dq_ble_t;
-int32_t ais3624dq_data_format_set(ais3624dq_ctx_t *ctx, ais3624dq_ble_t val);
-int32_t ais3624dq_data_format_get(ais3624dq_ctx_t *ctx, ais3624dq_ble_t *val);
+int32_t ais3624dq_data_format_set(stmdev_ctx_t *ctx, ais3624dq_ble_t val);
+int32_t ais3624dq_data_format_get(stmdev_ctx_t *ctx, ais3624dq_ble_t *val);
 
 typedef enum {
   AIS3624DQ_CUT_OFF_8Hz   = 0,
@@ -442,9 +414,9 @@ typedef enum {
   AIS3624DQ_CUT_OFF_32Hz  = 2,
   AIS3624DQ_CUT_OFF_64Hz  = 3,
 } ais3624dq_hpcf_t;
-int32_t ais3624dq_hp_bandwidth_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                    ais3624dq_hpcf_t val);
-int32_t ais3624dq_hp_bandwidth_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    ais3624dq_hpcf_t *val);
 
 typedef enum {
@@ -457,20 +429,20 @@ typedef enum {
   AIS3624DQ_HP_ON_INT2_OUT        = 6,
   AIS3624DQ_HP_ON_INT1_OUT        = 5,
 } ais3624dq_hpen_t;
-int32_t ais3624dq_hp_path_set(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t val);
-int32_t ais3624dq_hp_path_get(ais3624dq_ctx_t *ctx, ais3624dq_hpen_t *val);
+int32_t ais3624dq_hp_path_set(stmdev_ctx_t *ctx, ais3624dq_hpen_t val);
+int32_t ais3624dq_hp_path_get(stmdev_ctx_t *ctx, ais3624dq_hpen_t *val);
 
-int32_t ais3624dq_hp_reset_get(ais3624dq_ctx_t *ctx);
+int32_t ais3624dq_hp_reset_get(stmdev_ctx_t *ctx);
 
-int32_t ais3624dq_hp_reference_value_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_hp_reference_value_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS3624DQ_SPI_4_WIRE  = 0,
   AIS3624DQ_SPI_3_WIRE  = 1,
 } ais3624dq_sim_t;
-int32_t ais3624dq_spi_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_sim_t val);
-int32_t ais3624dq_spi_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_sim_t *val);
+int32_t ais3624dq_spi_mode_set(stmdev_ctx_t *ctx, ais3624dq_sim_t val);
+int32_t ais3624dq_spi_mode_get(stmdev_ctx_t *ctx, ais3624dq_sim_t *val);
 
 typedef enum {
   AIS3624DQ_PAD1_INT1_SRC           = 0,
@@ -478,18 +450,18 @@ typedef enum {
   AIS3624DQ_PAD1_DRDY               = 2,
   AIS3624DQ_PAD1_BOOT               = 3,
 } ais3624dq_i1_cfg_t;
-int32_t ais3624dq_pin_int1_route_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      ais3624dq_i1_cfg_t val);
-int32_t ais3624dq_pin_int1_route_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      ais3624dq_i1_cfg_t *val);
 
 typedef enum {
   AIS3624DQ_INT1_PULSED   = 0,
   AIS3624DQ_INT1_LATCHED  = 1,
 } ais3624dq_lir1_t;
-int32_t ais3624dq_int1_notification_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_notification_set(stmdev_ctx_t *ctx,
                                         ais3624dq_lir1_t val);
-int32_t ais3624dq_int1_notification_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_notification_get(stmdev_ctx_t *ctx,
                                         ais3624dq_lir1_t *val);
 
 typedef enum {
@@ -498,34 +470,34 @@ typedef enum {
   AIS3624DQ_PAD2_DRDY               = 2,
   AIS3624DQ_PAD2_BOOT               = 3,
 } ais3624dq_i2_cfg_t;
-int32_t ais3624dq_pin_int2_route_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      ais3624dq_i2_cfg_t val);
-int32_t ais3624dq_pin_int2_route_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      ais3624dq_i2_cfg_t *val);
 
 typedef enum {
   AIS3624DQ_INT2_PULSED   = 0,
   AIS3624DQ_INT2_LATCHED  = 1,
 } ais3624dq_lir2_t;
-int32_t ais3624dq_int2_notification_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_notification_set(stmdev_ctx_t *ctx,
                                         ais3624dq_lir2_t val);
-int32_t ais3624dq_int2_notification_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_notification_get(stmdev_ctx_t *ctx,
                                         ais3624dq_lir2_t *val);
 
 typedef enum {
   AIS3624DQ_PUSH_PULL   = 0,
   AIS3624DQ_OPEN_DRAIN  = 1,
 } ais3624dq_pp_od_t;
-int32_t ais3624dq_pin_mode_set(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t val);
-int32_t ais3624dq_pin_mode_get(ais3624dq_ctx_t *ctx, ais3624dq_pp_od_t *val);
+int32_t ais3624dq_pin_mode_set(stmdev_ctx_t *ctx, ais3624dq_pp_od_t val);
+int32_t ais3624dq_pin_mode_get(stmdev_ctx_t *ctx, ais3624dq_pp_od_t *val);
 
 typedef enum {
   AIS3624DQ_ACTIVE_HIGH  = 0,
   AIS3624DQ_ACTIVE_LOW   = 1,
 } ais3624dq_ihl_t;
-int32_t ais3624dq_pin_polarity_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_polarity_set(stmdev_ctx_t *ctx,
                                    ais3624dq_ihl_t val);
-int32_t ais3624dq_pin_polarity_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_pin_polarity_get(stmdev_ctx_t *ctx,
                                    ais3624dq_ihl_t *val);
 
 typedef struct {
@@ -535,29 +507,29 @@ typedef struct {
   uint8_t int1_yhie             : 1;
   uint8_t int1_zlie             : 1;
   uint8_t int1_zhie             : 1;
-} int1_on_th_conf_t;
-int32_t ais3624dq_int1_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
-                                             int1_on_th_conf_t val);
-int32_t ais3624dq_int1_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
-                                             int1_on_th_conf_t *val);
+} ais3624dq_int1_on_th_conf_t;
+int32_t ais3624dq_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                             ais3624dq_int1_on_th_conf_t val);
+int32_t ais3624dq_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             ais3624dq_int1_on_th_conf_t *val);
 
 typedef enum {
   AIS3624DQ_INT1_ON_THRESHOLD_OR   = 0,
   AIS3624DQ_INT1_ON_THRESHOLD_AND  = 1,
 } ais3624dq_int1_aoi_t;
-int32_t ais3624dq_int1_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              ais3624dq_int1_aoi_t val);
-int32_t ais3624dq_int1_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              ais3624dq_int1_aoi_t *val);
 
-int32_t ais3624dq_int1_src_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_src_get(stmdev_ctx_t *ctx,
                                ais3624dq_int1_src_t *val);
 
-int32_t ais3624dq_int1_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_int1_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais3624dq_int1_dur_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_int1_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t int2_xlie             : 1;
@@ -566,64 +538,64 @@ typedef struct {
   uint8_t int2_yhie             : 1;
   uint8_t int2_zlie             : 1;
   uint8_t int2_zhie             : 1;
-} int2_on_th_conf_t;
-int32_t ais3624dq_int2_on_threshold_conf_set(ais3624dq_ctx_t *ctx,
-                                             int2_on_th_conf_t val);
-int32_t ais3624dq_int2_on_threshold_conf_get(ais3624dq_ctx_t *ctx,
-                                             int2_on_th_conf_t *val);
+} ais3624dq_int2_on_th_conf_t;
+int32_t ais3624dq_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                             ais3624dq_int2_on_th_conf_t val);
+int32_t ais3624dq_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             ais3624dq_int2_on_th_conf_t *val);
 
 typedef enum {
   AIS3624DQ_INT2_ON_THRESHOLD_OR   = 0,
   AIS3624DQ_INT2_ON_THRESHOLD_AND  = 1,
 } ais3624dq_int2_aoi_t;
-int32_t ais3624dq_int2_on_threshold_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              ais3624dq_int2_aoi_t val);
-int32_t ais3624dq_int2_on_threshold_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              ais3624dq_int2_aoi_t *val);
 
-int32_t ais3624dq_int2_src_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_src_get(stmdev_ctx_t *ctx,
                                ais3624dq_int2_src_t *val);
 
-int32_t ais3624dq_int2_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_int2_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais3624dq_int2_dur_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_int2_dur_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ais3624dq_wkup_to_sleep_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_wkup_to_sleep_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS3624DQ_6D_INT1_DISABLE   = 0,
   AIS3624DQ_6D_INT1_MOVEMENT  = 1,
   AIS3624DQ_6D_INT1_POSITION  = 3,
 } ais3624dq_int1_6d_t;
-int32_t ais3624dq_int1_6d_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_6d_mode_set(stmdev_ctx_t *ctx,
                                    ais3624dq_int1_6d_t val);
-int32_t ais3624dq_int1_6d_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_6d_mode_get(stmdev_ctx_t *ctx,
                                    ais3624dq_int1_6d_t *val);
 
-int32_t ais3624dq_int1_6d_src_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int1_6d_src_get(stmdev_ctx_t *ctx,
                                   ais3624dq_int1_src_t *val);
 
-int32_t ais3624dq_int1_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_int1_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_int1_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int1_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   AIS3624DQ_6D_INT2_DISABLE   = 0,
   AIS3624DQ_6D_INT2_MOVEMENT  = 1,
   AIS3624DQ_6D_INT2_POSITION  = 3,
 } ais3624dq_int2_6d_t;
-int32_t ais3624dq_int2_6d_mode_set(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_6d_mode_set(stmdev_ctx_t *ctx,
                                    ais3624dq_int2_6d_t val);
-int32_t ais3624dq_int2_6d_mode_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_6d_mode_get(stmdev_ctx_t *ctx,
                                    ais3624dq_int2_6d_t *val);
 
-int32_t ais3624dq_int2_6d_src_get(ais3624dq_ctx_t *ctx,
+int32_t ais3624dq_int2_6d_src_get(stmdev_ctx_t *ctx,
                                   ais3624dq_int2_src_t *val);
 
-int32_t ais3624dq_int2_6d_treshold_set(ais3624dq_ctx_t *ctx, uint8_t val);
-int32_t ais3624dq_int2_6d_treshold_get(ais3624dq_ctx_t *ctx, uint8_t *val);
+int32_t ais3624dq_int2_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ais3624dq_int2_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.c
+++ b/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "asm330lhh_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t asm330lhh_read_reg(asm330lhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t asm330lhh_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t asm330lhh_read_reg(asm330lhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t asm330lhh_write_reg(asm330lhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t asm330lhh_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                             uint16_t len)
 {
   int32_t ret;
@@ -182,7 +165,7 @@ float_t asm330lhh_from_lsb_to_nsec(int32_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_full_scale_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_full_scale_set(stmdev_ctx_t *ctx,
                                     asm330lhh_fs_xl_t val)
 {
   asm330lhh_ctrl1_xl_t ctrl1_xl;
@@ -205,7 +188,7 @@ int32_t asm330lhh_xl_full_scale_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_full_scale_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_full_scale_get(stmdev_ctx_t *ctx,
                                     asm330lhh_fs_xl_t *val)
 {
   asm330lhh_ctrl1_xl_t ctrl1_xl;
@@ -240,7 +223,7 @@ int32_t asm330lhh_xl_full_scale_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_data_rate_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_data_rate_set(stmdev_ctx_t *ctx,
                                    asm330lhh_odr_xl_t val)
 {
   asm330lhh_ctrl1_xl_t ctrl1_xl;
@@ -263,7 +246,7 @@ int32_t asm330lhh_xl_data_rate_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_data_rate_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_data_rate_get(stmdev_ctx_t *ctx,
                                    asm330lhh_odr_xl_t *val)
 {
   asm330lhh_ctrl1_xl_t ctrl1_xl;
@@ -322,7 +305,7 @@ int32_t asm330lhh_xl_data_rate_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_full_scale_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_full_scale_set(stmdev_ctx_t *ctx,
                                     asm330lhh_fs_g_t val)
 {
   asm330lhh_ctrl2_g_t ctrl2_g;
@@ -344,7 +327,7 @@ int32_t asm330lhh_gy_full_scale_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_full_scale_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_full_scale_get(stmdev_ctx_t *ctx,
                                     asm330lhh_fs_g_t *val)
 {
   asm330lhh_ctrl2_g_t ctrl2_g;
@@ -385,7 +368,7 @@ int32_t asm330lhh_gy_full_scale_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_data_rate_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_data_rate_set(stmdev_ctx_t *ctx,
                                    asm330lhh_odr_g_t val)
 {
   asm330lhh_ctrl2_g_t ctrl2_g;
@@ -407,7 +390,7 @@ int32_t asm330lhh_gy_data_rate_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_data_rate_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_data_rate_get(stmdev_ctx_t *ctx,
                                    asm330lhh_odr_g_t *val)
 {
   asm330lhh_ctrl2_g_t ctrl2_g;
@@ -463,7 +446,7 @@ int32_t asm330lhh_gy_data_rate_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_block_data_update_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -484,7 +467,7 @@ int32_t asm330lhh_block_data_update_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_block_data_update_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -504,7 +487,7 @@ int32_t asm330lhh_block_data_update_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_offset_weight_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                      asm330lhh_usr_off_w_t val)
 {
   asm330lhh_ctrl6_g_t ctrl6_c;
@@ -527,7 +510,7 @@ int32_t asm330lhh_xl_offset_weight_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_offset_weight_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                        asm330lhh_usr_off_w_t *val)
 {
   asm330lhh_ctrl6_g_t ctrl6_c;
@@ -559,7 +542,7 @@ int32_t asm330lhh_xl_offset_weight_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_all_sources_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_all_sources_get(stmdev_ctx_t *ctx,
                                   asm330lhh_all_sources_t *val)
 {
   int32_t ret;
@@ -594,7 +577,7 @@ int32_t asm330lhh_all_sources_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_status_reg_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_status_reg_get(stmdev_ctx_t *ctx,
                                  asm330lhh_status_reg_t *val)
 {
   int32_t ret;
@@ -610,7 +593,7 @@ int32_t asm330lhh_status_reg_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_status_reg_t status_reg;
   int32_t ret;
@@ -630,7 +613,7 @@ int32_t asm330lhh_xl_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_status_reg_t status_reg;
   int32_t ret;
@@ -650,7 +633,7 @@ int32_t asm330lhh_gy_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_temp_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_status_reg_t status_reg;
   int32_t ret;
@@ -672,7 +655,7 @@ int32_t asm330lhh_temp_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_x_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_write_reg(ctx, ASM330LHH_X_OFS_USR, buff, 1);
@@ -689,7 +672,7 @@ int32_t asm330lhh_xl_usr_offset_x_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_x_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_X_OFS_USR, buff, 1);
@@ -706,7 +689,7 @@ int32_t asm330lhh_xl_usr_offset_x_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_y_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_write_reg(ctx, ASM330LHH_Y_OFS_USR, buff, 1);
@@ -723,7 +706,7 @@ int32_t asm330lhh_xl_usr_offset_y_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_y_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_Y_OFS_USR, buff, 1);
@@ -740,7 +723,7 @@ int32_t asm330lhh_xl_usr_offset_y_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_z_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_write_reg(ctx, ASM330LHH_Z_OFS_USR, buff, 1);
@@ -757,7 +740,7 @@ int32_t asm330lhh_xl_usr_offset_z_set(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_z_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_Z_OFS_USR, buff, 1);
@@ -772,7 +755,7 @@ int32_t asm330lhh_xl_usr_offset_z_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -793,7 +776,7 @@ int32_t asm330lhh_xl_usr_offset_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -825,7 +808,7 @@ int32_t asm330lhh_xl_usr_offset_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_timestamp_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -847,7 +830,7 @@ int32_t asm330lhh_timestamp_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_timestamp_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -868,7 +851,7 @@ int32_t asm330lhh_timestamp_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_timestamp_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_TIMESTAMP0, buff, 4);
@@ -895,7 +878,7 @@ int32_t asm330lhh_timestamp_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_rounding_mode_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_rounding_mode_set(stmdev_ctx_t *ctx,
                                     asm330lhh_rounding_t val)
 {
   asm330lhh_ctrl5_c_t ctrl5_c;
@@ -917,7 +900,7 @@ int32_t asm330lhh_rounding_mode_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_rounding_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_rounding_mode_get(stmdev_ctx_t *ctx,
                                     asm330lhh_rounding_t *val)
 {
   asm330lhh_ctrl5_c_t ctrl5_c;
@@ -954,7 +937,7 @@ int32_t asm330lhh_rounding_mode_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_temperature_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_OUT_TEMP_L, buff, 2);
@@ -970,7 +953,7 @@ int32_t asm330lhh_temperature_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_angular_rate_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_OUTX_L_G, buff, 6);
@@ -986,7 +969,7 @@ int32_t asm330lhh_angular_rate_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_acceleration_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_OUTX_L_A, buff, 6);
@@ -1001,7 +984,7 @@ int32_t asm330lhh_acceleration_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_out_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_FIFO_DATA_OUT_X_L, buff, 6);
@@ -1030,7 +1013,7 @@ int32_t asm330lhh_fifo_out_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_odr_cal_reg_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_internal_freq_fine_t internal_freq_fine;
   int32_t ret;
@@ -1055,7 +1038,7 @@ int32_t asm330lhh_odr_cal_reg_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_odr_cal_reg_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_internal_freq_fine_t internal_freq_fine;
   int32_t ret;
@@ -1076,7 +1059,7 @@ int32_t asm330lhh_odr_cal_reg_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_data_ready_mode_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_data_ready_mode_set(stmdev_ctx_t *ctx,
                                       asm330lhh_dataready_pulsed_t val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
@@ -1101,7 +1084,7 @@ int32_t asm330lhh_data_ready_mode_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_data_ready_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_data_ready_mode_get(stmdev_ctx_t *ctx,
                                       asm330lhh_dataready_pulsed_t *val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
@@ -1131,7 +1114,7 @@ int32_t asm330lhh_data_ready_mode_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_device_id_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
+int32_t asm330lhh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = asm330lhh_read_reg(ctx, ASM330LHH_WHO_AM_I, buff, 1);
@@ -1146,7 +1129,7 @@ int32_t asm330lhh_device_id_get(asm330lhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_reset_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1167,7 +1150,7 @@ int32_t asm330lhh_reset_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_reset_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1187,7 +1170,7 @@ int32_t asm330lhh_reset_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_auto_increment_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1209,7 +1192,7 @@ int32_t asm330lhh_auto_increment_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_auto_increment_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1228,7 +1211,7 @@ int32_t asm330lhh_auto_increment_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_boot_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1249,7 +1232,7 @@ int32_t asm330lhh_boot_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_boot_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1270,7 +1253,7 @@ int32_t asm330lhh_boot_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_self_test_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_self_test_set(stmdev_ctx_t *ctx,
                                    asm330lhh_st_xl_t val)
 {
   asm330lhh_ctrl5_c_t ctrl5_c;
@@ -1292,7 +1275,7 @@ int32_t asm330lhh_xl_self_test_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_self_test_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_self_test_get(stmdev_ctx_t *ctx,
                                    asm330lhh_st_xl_t *val)
 {
   asm330lhh_ctrl5_c_t ctrl5_c;
@@ -1325,7 +1308,7 @@ int32_t asm330lhh_xl_self_test_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_self_test_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_self_test_set(stmdev_ctx_t *ctx,
                                    asm330lhh_st_g_t val)
 {
   asm330lhh_ctrl5_c_t ctrl5_c;
@@ -1347,7 +1330,7 @@ int32_t asm330lhh_gy_self_test_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_self_test_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_self_test_get(stmdev_ctx_t *ctx,
                                    asm330lhh_st_g_t *val)
 {
   asm330lhh_ctrl5_c_t ctrl5_c;
@@ -1393,7 +1376,7 @@ int32_t asm330lhh_gy_self_test_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_filter_lp2_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -1415,7 +1398,7 @@ int32_t asm330lhh_xl_filter_lp2_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_filter_lp2_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -1435,7 +1418,7 @@ int32_t asm330lhh_xl_filter_lp2_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_filter_lp1_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_gy_filter_lp1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1457,7 +1440,7 @@ int32_t asm330lhh_gy_filter_lp1_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_filter_lp1_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_gy_filter_lp1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1477,7 +1460,7 @@ int32_t asm330lhh_gy_filter_lp1_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_filter_settling_mask_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1499,7 +1482,7 @@ int32_t asm330lhh_filter_settling_mask_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_filter_settling_mask_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_filter_settling_mask_get(stmdev_ctx_t *ctx,
                                            uint8_t *val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
@@ -1519,7 +1502,7 @@ int32_t asm330lhh_filter_settling_mask_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_lp1_bandwidth_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                        asm330lhh_ftype_t val)
 {
   asm330lhh_ctrl6_g_t ctrl6_c;
@@ -1541,7 +1524,7 @@ int32_t asm330lhh_gy_lp1_bandwidth_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_lp1_bandwidth_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                        asm330lhh_ftype_t *val)
 {
   asm330lhh_ctrl6_g_t ctrl6_c;
@@ -1589,7 +1572,7 @@ int32_t asm330lhh_gy_lp1_bandwidth_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_lp2_on_6d_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_xl_lp2_on_6d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1611,7 +1594,7 @@ int32_t asm330lhh_xl_lp2_on_6d_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_lp2_on_6d_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_xl_lp2_on_6d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1631,7 +1614,7 @@ int32_t asm330lhh_xl_lp2_on_6d_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_hp_path_on_out_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
                                         asm330lhh_hp_slope_xl_en_t val)
 {
   asm330lhh_ctrl8_xl_t ctrl8_xl;
@@ -1657,7 +1640,7 @@ int32_t asm330lhh_xl_hp_path_on_out_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_hp_path_on_out_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
                                         asm330lhh_hp_slope_xl_en_t *val)
 {
   asm330lhh_ctrl8_xl_t ctrl8_xl;
@@ -1752,7 +1735,7 @@ int32_t asm330lhh_xl_hp_path_on_out_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_fast_settling_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1776,7 +1759,7 @@ int32_t asm330lhh_xl_fast_settling_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_fast_settling_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1796,7 +1779,7 @@ int32_t asm330lhh_xl_fast_settling_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_hp_path_internal_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                           asm330lhh_slope_fds_t val)
 {
   asm330lhh_int_cfg0_t int_cfg0;
@@ -1820,7 +1803,7 @@ int32_t asm330lhh_xl_hp_path_internal_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_hp_path_internal_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                           asm330lhh_slope_fds_t *val)
 {
   asm330lhh_int_cfg0_t int_cfg0;
@@ -1850,7 +1833,7 @@ int32_t asm330lhh_xl_hp_path_internal_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_hp_path_internal_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_hp_path_internal_set(stmdev_ctx_t *ctx,
                                           asm330lhh_hpm_g_t val)
 {
   asm330lhh_ctrl7_g_t ctrl7_g;
@@ -1874,7 +1857,7 @@ int32_t asm330lhh_gy_hp_path_internal_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_hp_path_internal_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_hp_path_internal_get(stmdev_ctx_t *ctx,
                                           asm330lhh_hpm_g_t *val)
 {
   asm330lhh_ctrl7_g_t ctrl7_g;
@@ -1926,7 +1909,7 @@ int32_t asm330lhh_gy_hp_path_internal_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_sdo_sa0_mode_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                    asm330lhh_sdo_pu_en_t val)
 {
   asm330lhh_pin_ctrl_t pin_ctrl;
@@ -1948,7 +1931,7 @@ int32_t asm330lhh_sdo_sa0_mode_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_sdo_sa0_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                    asm330lhh_sdo_pu_en_t *val)
 {
   asm330lhh_pin_ctrl_t pin_ctrl;
@@ -1978,7 +1961,7 @@ int32_t asm330lhh_sdo_sa0_mode_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_spi_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_sim_t val)
+int32_t asm330lhh_spi_mode_set(stmdev_ctx_t *ctx, asm330lhh_sim_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1999,7 +1982,7 @@ int32_t asm330lhh_spi_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_spi_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_sim_t *val)
+int32_t asm330lhh_spi_mode_get(stmdev_ctx_t *ctx, asm330lhh_sim_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2028,7 +2011,7 @@ int32_t asm330lhh_spi_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_i2c_interface_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_i2c_interface_set(stmdev_ctx_t *ctx,
                                     asm330lhh_i2c_disable_t val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
@@ -2050,7 +2033,7 @@ int32_t asm330lhh_i2c_interface_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_i2c_interface_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_i2c_interface_get(stmdev_ctx_t *ctx,
                                     asm330lhh_i2c_disable_t *val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
@@ -2094,7 +2077,7 @@ int32_t asm330lhh_i2c_interface_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_int1_route_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      asm330lhh_pin_int1_route_t *val)
 {
   asm330lhh_int_cfg1_t tap_cfg2;
@@ -2143,7 +2126,7 @@ int32_t asm330lhh_pin_int1_route_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_int1_route_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      asm330lhh_pin_int1_route_t *val)
 {
   int32_t ret;
@@ -2167,7 +2150,7 @@ int32_t asm330lhh_pin_int1_route_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_int2_route_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      asm330lhh_pin_int2_route_t *val)
 {
   asm330lhh_int_cfg1_t tap_cfg2;
@@ -2217,7 +2200,7 @@ int32_t asm330lhh_pin_int2_route_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_int2_route_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      asm330lhh_pin_int2_route_t *val)
 {
   int32_t ret;
@@ -2239,7 +2222,7 @@ int32_t asm330lhh_pin_int2_route_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t val)
+int32_t asm330lhh_pin_mode_set(stmdev_ctx_t *ctx, asm330lhh_pp_od_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2260,7 +2243,7 @@ int32_t asm330lhh_pin_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t *val)
+int32_t asm330lhh_pin_mode_get(stmdev_ctx_t *ctx, asm330lhh_pp_od_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2289,7 +2272,7 @@ int32_t asm330lhh_pin_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_polarity_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_polarity_set(stmdev_ctx_t *ctx,
                                    asm330lhh_h_lactive_t val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
@@ -2311,7 +2294,7 @@ int32_t asm330lhh_pin_polarity_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_pin_polarity_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_polarity_get(stmdev_ctx_t *ctx,
                                    asm330lhh_h_lactive_t *val)
 {
   asm330lhh_ctrl3_c_t ctrl3_c;
@@ -2341,7 +2324,7 @@ int32_t asm330lhh_pin_polarity_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_all_on_int1_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2362,7 +2345,7 @@ int32_t asm330lhh_all_on_int1_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_all_on_int1_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2381,7 +2364,7 @@ int32_t asm330lhh_all_on_int1_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_int_notification_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_int_notification_set(stmdev_ctx_t *ctx,
                                        asm330lhh_lir_t val)
 {
   asm330lhh_int_cfg0_t int_cfg0;
@@ -2405,7 +2388,7 @@ int32_t asm330lhh_int_notification_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_int_notification_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_int_notification_get(stmdev_ctx_t *ctx,
                                        asm330lhh_lir_t *val)
 {
   asm330lhh_int_cfg0_t int_cfg0;
@@ -2451,7 +2434,7 @@ int32_t asm330lhh_int_notification_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_wkup_ths_weight_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_wkup_ths_weight_set(stmdev_ctx_t *ctx,
                                       asm330lhh_wake_ths_w_t val)
 {
   asm330lhh_wake_up_dur_t wake_up_dur;
@@ -2477,7 +2460,7 @@ int32_t asm330lhh_wkup_ths_weight_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_wkup_ths_weight_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_wkup_ths_weight_get(stmdev_ctx_t *ctx,
                                       asm330lhh_wake_ths_w_t *val)
 {
   asm330lhh_wake_up_dur_t wake_up_dur;
@@ -2509,7 +2492,7 @@ int32_t asm330lhh_wkup_ths_weight_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_wkup_threshold_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2533,7 +2516,7 @@ int32_t asm330lhh_wkup_threshold_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_wkup_threshold_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2553,7 +2536,7 @@ int32_t asm330lhh_wkup_threshold_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_on_wkup_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2576,7 +2559,7 @@ int32_t asm330lhh_xl_usr_offset_on_wkup_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_xl_usr_offset_on_wkup_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx,
                                             uint8_t *val)
 {
   asm330lhh_wake_up_ths_t wake_up_ths;
@@ -2597,7 +2580,7 @@ int32_t asm330lhh_xl_usr_offset_on_wkup_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_wkup_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2620,7 +2603,7 @@ int32_t asm330lhh_wkup_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_wkup_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2653,7 +2636,7 @@ int32_t asm330lhh_wkup_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_sleep_mode_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2674,7 +2657,7 @@ int32_t asm330lhh_gy_sleep_mode_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_gy_sleep_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2695,7 +2678,7 @@ int32_t asm330lhh_gy_sleep_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_act_pin_notification_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_act_pin_notification_set(stmdev_ctx_t *ctx,
                                            asm330lhh_sleep_status_on_int_t val)
 {
   asm330lhh_int_cfg0_t int_cfg0;
@@ -2720,7 +2703,7 @@ int32_t asm330lhh_act_pin_notification_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_act_pin_notification_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_act_pin_notification_get(stmdev_ctx_t *ctx,
                                        asm330lhh_sleep_status_on_int_t *val)
 {
   asm330lhh_int_cfg0_t int_cfg0;
@@ -2749,7 +2732,7 @@ int32_t asm330lhh_act_pin_notification_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_act_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_inact_en_t val)
+int32_t asm330lhh_act_mode_set(stmdev_ctx_t *ctx, asm330lhh_inact_en_t val)
 {
   asm330lhh_int_cfg1_t tap_cfg2;
   int32_t ret;
@@ -2770,7 +2753,7 @@ int32_t asm330lhh_act_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_inact_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_act_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_act_mode_get(stmdev_ctx_t *ctx,
                                asm330lhh_inact_en_t *val)
 {
   asm330lhh_int_cfg1_t tap_cfg2;
@@ -2806,7 +2789,7 @@ int32_t asm330lhh_act_mode_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_act_sleep_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2829,7 +2812,7 @@ int32_t asm330lhh_act_sleep_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_act_sleep_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2862,7 +2845,7 @@ int32_t asm330lhh_act_sleep_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_6d_threshold_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_6d_threshold_set(stmdev_ctx_t *ctx,
                                    asm330lhh_sixd_ths_t val)
 {
   asm330lhh_ths_6d_t tap_ths_6d;
@@ -2886,7 +2869,7 @@ int32_t asm330lhh_6d_threshold_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_6d_threshold_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_6d_threshold_get(stmdev_ctx_t *ctx,
                                    asm330lhh_sixd_ths_t *val)
 {
   asm330lhh_ths_6d_t tap_ths_6d;
@@ -2923,7 +2906,7 @@ int32_t asm330lhh_6d_threshold_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_4d_mode_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -2946,7 +2929,7 @@ int32_t asm330lhh_4d_mode_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_4d_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -2979,7 +2962,7 @@ int32_t asm330lhh_4d_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_ff_threshold_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_ff_threshold_set(stmdev_ctx_t *ctx,
                                    asm330lhh_ff_ths_t val)
 {
   asm330lhh_free_fall_t free_fall;
@@ -3002,7 +2985,7 @@ int32_t asm330lhh_ff_threshold_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_ff_threshold_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_ff_threshold_get(stmdev_ctx_t *ctx,
                                    asm330lhh_ff_ths_t *val)
 {
   asm330lhh_free_fall_t free_fall;
@@ -3050,7 +3033,7 @@ int32_t asm330lhh_ff_threshold_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_ff_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_wake_up_dur_t wake_up_dur;
   asm330lhh_free_fall_t free_fall;
@@ -3083,7 +3066,7 @@ int32_t asm330lhh_ff_dur_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_ff_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_wake_up_dur_t wake_up_dur;
   asm330lhh_free_fall_t free_fall;
@@ -3122,7 +3105,7 @@ int32_t asm330lhh_ff_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_watermark_set(asm330lhh_ctx_t *ctx, uint16_t val)
+int32_t asm330lhh_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   asm330lhh_fifo_ctrl1_t fifo_ctrl1;
   asm330lhh_fifo_ctrl2_t fifo_ctrl2;
@@ -3151,7 +3134,7 @@ int32_t asm330lhh_fifo_watermark_set(asm330lhh_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_watermark_get(asm330lhh_ctx_t *ctx, uint16_t *val)
+int32_t asm330lhh_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   asm330lhh_fifo_ctrl1_t fifo_ctrl1;
   asm330lhh_fifo_ctrl2_t fifo_ctrl2;
@@ -3177,7 +3160,7 @@ int32_t asm330lhh_fifo_watermark_get(asm330lhh_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
                                                 uint8_t val)
 {
   asm330lhh_fifo_ctrl2_t fifo_ctrl2;
@@ -3202,7 +3185,7 @@ int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_virtual_sens_odr_chg_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
                                                 uint8_t *val)
 {
   asm330lhh_fifo_ctrl2_t fifo_ctrl2;
@@ -3224,7 +3207,7 @@ int32_t asm330lhh_fifo_virtual_sens_odr_chg_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_stop_on_wtm_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3248,7 +3231,7 @@ int32_t asm330lhh_fifo_stop_on_wtm_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_stop_on_wtm_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3269,7 +3252,7 @@ int32_t asm330lhh_fifo_stop_on_wtm_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_xl_batch_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                     asm330lhh_bdr_xl_t val)
 {
   asm330lhh_fifo_ctrl3_t fifo_ctrl3;
@@ -3294,7 +3277,7 @@ int32_t asm330lhh_fifo_xl_batch_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_xl_batch_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                     asm330lhh_bdr_xl_t *val)
 {
   asm330lhh_fifo_ctrl3_t fifo_ctrl3;
@@ -3356,7 +3339,7 @@ int32_t asm330lhh_fifo_xl_batch_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_gy_batch_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                     asm330lhh_bdr_gy_t val)
 {
   asm330lhh_fifo_ctrl3_t fifo_ctrl3;
@@ -3381,7 +3364,7 @@ int32_t asm330lhh_fifo_gy_batch_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_gy_batch_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                     asm330lhh_bdr_gy_t *val)
 {
   asm330lhh_fifo_ctrl3_t fifo_ctrl3;
@@ -3442,7 +3425,7 @@ int32_t asm330lhh_fifo_gy_batch_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_mode_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_mode_set(stmdev_ctx_t *ctx,
                                 asm330lhh_fifo_mode_t val)
 {
   asm330lhh_fifo_ctrl4_t fifo_ctrl4;
@@ -3466,7 +3449,7 @@ int32_t asm330lhh_fifo_mode_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_mode_get(stmdev_ctx_t *ctx,
                                 asm330lhh_fifo_mode_t *val)
 {
   asm330lhh_fifo_ctrl4_t fifo_ctrl4;
@@ -3510,7 +3493,7 @@ int32_t asm330lhh_fifo_mode_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_temp_batch_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_temp_batch_set(stmdev_ctx_t *ctx,
                                       asm330lhh_odr_t_batch_t val)
 {
   asm330lhh_fifo_ctrl4_t fifo_ctrl4;
@@ -3535,7 +3518,7 @@ int32_t asm330lhh_fifo_temp_batch_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_temp_batch_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_temp_batch_get(stmdev_ctx_t *ctx,
                                       asm330lhh_odr_t_batch_t *val)
 {
   asm330lhh_fifo_ctrl4_t fifo_ctrl4;
@@ -3574,7 +3557,7 @@ int32_t asm330lhh_fifo_temp_batch_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_timestamp_decimation_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
                                                 asm330lhh_odr_ts_batch_t val)
 {
   asm330lhh_fifo_ctrl4_t fifo_ctrl4;
@@ -3601,7 +3584,7 @@ int32_t asm330lhh_fifo_timestamp_decimation_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_timestamp_decimation_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
                                                 asm330lhh_odr_ts_batch_t *val)
 {
   asm330lhh_fifo_ctrl4_t fifo_ctrl4;
@@ -3640,7 +3623,7 @@ int32_t asm330lhh_fifo_timestamp_decimation_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_cnt_event_batch_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_cnt_event_batch_set(stmdev_ctx_t *ctx,
                                            asm330lhh_trig_counter_bdr_t val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
@@ -3666,7 +3649,7 @@ int32_t asm330lhh_fifo_cnt_event_batch_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_cnt_event_batch_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_cnt_event_batch_get(stmdev_ctx_t *ctx,
                                            asm330lhh_trig_counter_bdr_t *val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
@@ -3698,7 +3681,7 @@ int32_t asm330lhh_fifo_cnt_event_batch_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_rst_batch_counter_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
@@ -3722,7 +3705,7 @@ int32_t asm330lhh_rst_batch_counter_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_rst_batch_counter_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
@@ -3743,7 +3726,7 @@ int32_t asm330lhh_rst_batch_counter_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_batch_counter_threshold_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_batch_counter_threshold_set(stmdev_ctx_t *ctx,
                                               uint16_t val)
 {
   asm330lhh_counter_bdr_reg2_t counter_bdr_reg1;
@@ -3773,7 +3756,7 @@ int32_t asm330lhh_batch_counter_threshold_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_batch_counter_threshold_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_batch_counter_threshold_get(stmdev_ctx_t *ctx,
                                               uint16_t *val)
 {
   asm330lhh_counter_bdr_reg1_t counter_bdr_reg1;
@@ -3801,7 +3784,7 @@ int32_t asm330lhh_batch_counter_threshold_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_data_level_get(asm330lhh_ctx_t *ctx, uint16_t *val)
+int32_t asm330lhh_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   asm330lhh_fifo_status1_t fifo_status1;
   asm330lhh_fifo_status2_t fifo_status2;
@@ -3827,7 +3810,7 @@ int32_t asm330lhh_fifo_data_level_get(asm330lhh_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_status_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_status_get(stmdev_ctx_t *ctx,
                                   asm330lhh_fifo_status2_t *val)
 {
   int32_t ret;
@@ -3843,7 +3826,7 @@ int32_t asm330lhh_fifo_status_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_full_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_fifo_status2_t fifo_status2;
   int32_t ret;
@@ -3864,7 +3847,7 @@ int32_t asm330lhh_fifo_full_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_ovr_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_fifo_status2_t fifo_status2;
   int32_t ret;
@@ -3884,7 +3867,7 @@ int32_t asm330lhh_fifo_ovr_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_wtm_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_fifo_status2_t fifo_status2;
   int32_t ret;
@@ -3904,7 +3887,7 @@ int32_t asm330lhh_fifo_wtm_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_fifo_sensor_tag_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
                                       asm330lhh_fifo_tag_t *val)
 {
   asm330lhh_fifo_data_out_tag_t fifo_data_out_tag;
@@ -3957,7 +3940,7 @@ int32_t asm330lhh_fifo_sensor_tag_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_den_mode_t val)
+int32_t asm330lhh_den_mode_set(stmdev_ctx_t *ctx, asm330lhh_den_mode_t val)
 {
   asm330lhh_ctrl6_g_t ctrl6_c;
   int32_t ret;
@@ -3978,7 +3961,7 @@ int32_t asm330lhh_den_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_den_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_mode_get(stmdev_ctx_t *ctx,
                                asm330lhh_den_mode_t *val)
 {
   asm330lhh_ctrl6_g_t ctrl6_c;
@@ -4017,7 +4000,7 @@ int32_t asm330lhh_den_mode_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_polarity_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_polarity_set(stmdev_ctx_t *ctx,
                                    asm330lhh_den_lh_t val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
@@ -4040,7 +4023,7 @@ int32_t asm330lhh_den_polarity_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_polarity_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_polarity_get(stmdev_ctx_t *ctx,
                                    asm330lhh_den_lh_t *val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
@@ -4070,7 +4053,7 @@ int32_t asm330lhh_den_polarity_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_enable_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_enable_set(stmdev_ctx_t *ctx,
                                  asm330lhh_den_xl_g_t val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
@@ -4093,7 +4076,7 @@ int32_t asm330lhh_den_enable_set(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_enable_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_enable_get(stmdev_ctx_t *ctx,
                                  asm330lhh_den_xl_g_t *val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
@@ -4126,7 +4109,7 @@ int32_t asm330lhh_den_enable_get(asm330lhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mark_axis_x_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4148,7 +4131,7 @@ int32_t asm330lhh_den_mark_axis_x_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mark_axis_x_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4167,7 +4150,7 @@ int32_t asm330lhh_den_mark_axis_x_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mark_axis_y_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4189,7 +4172,7 @@ int32_t asm330lhh_den_mark_axis_y_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mark_axis_y_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4208,7 +4191,7 @@ int32_t asm330lhh_den_mark_axis_y_get(asm330lhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mark_axis_z_set(asm330lhh_ctx_t *ctx, uint8_t val)
+int32_t asm330lhh_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4229,7 +4212,7 @@ int32_t asm330lhh_den_mark_axis_z_set(asm330lhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t asm330lhh_den_mark_axis_z_get(asm330lhh_ctx_t *ctx, uint8_t *val)
+int32_t asm330lhh_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   asm330lhh_ctrl9_xl_t ctrl9_xl;
   int32_t ret;

--- a/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.h
+++ b/sensor/stmemsc/asm330lhh_STdC/driver/asm330lhh_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup ASM330LHH_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  ASM330LHH Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*asm330lhh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*asm330lhh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  asm330lhh_write_ptr  write_reg;
-  asm330lhh_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} asm330lhh_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -569,9 +541,9 @@ typedef union{
   *
   */
 
-int32_t asm330lhh_read_reg(asm330lhh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t asm330lhh_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t asm330lhh_write_reg(asm330lhh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t asm330lhh_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float_t asm330lhh_from_fs2g_to_mg(int16_t lsb);
@@ -593,8 +565,8 @@ typedef enum {
   ASM330LHH_4g   = 2,
   ASM330LHH_8g   = 3,
 } asm330lhh_fs_xl_t;
-int32_t asm330lhh_xl_full_scale_set(asm330lhh_ctx_t *ctx, asm330lhh_fs_xl_t val);
-int32_t asm330lhh_xl_full_scale_get(asm330lhh_ctx_t *ctx, asm330lhh_fs_xl_t *val);
+int32_t asm330lhh_xl_full_scale_set(stmdev_ctx_t *ctx, asm330lhh_fs_xl_t val);
+int32_t asm330lhh_xl_full_scale_get(stmdev_ctx_t *ctx, asm330lhh_fs_xl_t *val);
 
 typedef enum {
   ASM330LHH_XL_ODR_OFF    = 0,
@@ -610,8 +582,8 @@ typedef enum {
   ASM330LHH_XL_ODR_6667Hz = 10,
   ASM330LHH_XL_ODR_6Hz5   = 11, /* (low power only) */
 } asm330lhh_odr_xl_t;
-int32_t asm330lhh_xl_data_rate_set(asm330lhh_ctx_t *ctx, asm330lhh_odr_xl_t val);
-int32_t asm330lhh_xl_data_rate_get(asm330lhh_ctx_t *ctx, asm330lhh_odr_xl_t *val);
+int32_t asm330lhh_xl_data_rate_set(stmdev_ctx_t *ctx, asm330lhh_odr_xl_t val);
+int32_t asm330lhh_xl_data_rate_get(stmdev_ctx_t *ctx, asm330lhh_odr_xl_t *val);
 
 typedef enum {
   ASM330LHH_125dps = 2,
@@ -621,8 +593,8 @@ typedef enum {
   ASM330LHH_2000dps = 12,
   ASM330LHH_4000dps = 1,
 } asm330lhh_fs_g_t;
-int32_t asm330lhh_gy_full_scale_set(asm330lhh_ctx_t *ctx, asm330lhh_fs_g_t val);
-int32_t asm330lhh_gy_full_scale_get(asm330lhh_ctx_t *ctx, asm330lhh_fs_g_t *val);
+int32_t asm330lhh_gy_full_scale_set(stmdev_ctx_t *ctx, asm330lhh_fs_g_t val);
+int32_t asm330lhh_gy_full_scale_get(stmdev_ctx_t *ctx, asm330lhh_fs_g_t *val);
 
 typedef enum {
   ASM330LHH_GY_ODR_OFF    = 0,
@@ -637,21 +609,21 @@ typedef enum {
   ASM330LHH_GY_ODR_3333Hz = 9,
   ASM330LHH_GY_ODR_6667Hz = 10,
 } asm330lhh_odr_g_t;
-int32_t asm330lhh_gy_data_rate_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_data_rate_set(stmdev_ctx_t *ctx,
                                  asm330lhh_odr_g_t val);
-int32_t asm330lhh_gy_data_rate_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_data_rate_get(stmdev_ctx_t *ctx,
                                  asm330lhh_odr_g_t *val);
 
-int32_t asm330lhh_block_data_update_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_block_data_update_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_LSb_1mg  = 0,
   ASM330LHH_LSb_16mg = 1,
 } asm330lhh_usr_off_w_t;
-int32_t asm330lhh_xl_offset_weight_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                      asm330lhh_usr_off_w_t val);
-int32_t asm330lhh_xl_offset_weight_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                      asm330lhh_usr_off_w_t *val);
 
 typedef struct {
@@ -661,34 +633,34 @@ typedef struct {
   asm330lhh_d6d_src_t           d6d_src;
   asm330lhh_status_reg_t        status_reg;
   } asm330lhh_all_sources_t;
-int32_t asm330lhh_all_sources_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_all_sources_get(stmdev_ctx_t *ctx,
                                 asm330lhh_all_sources_t *val);
 
-int32_t asm330lhh_status_reg_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_status_reg_get(stmdev_ctx_t *ctx,
                                  asm330lhh_status_reg_t *val);
 
-int32_t asm330lhh_xl_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_gy_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_temp_flag_data_ready_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_xl_usr_offset_x_set(asm330lhh_ctx_t *ctx, uint8_t *buff);
-int32_t asm330lhh_xl_usr_offset_x_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_xl_usr_offset_y_set(asm330lhh_ctx_t *ctx, uint8_t *buff);
-int32_t asm330lhh_xl_usr_offset_y_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_xl_usr_offset_z_set(asm330lhh_ctx_t *ctx, uint8_t *buff);
-int32_t asm330lhh_xl_usr_offset_z_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_xl_usr_offset_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_xl_usr_offset_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_timestamp_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_timestamp_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_timestamp_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   ASM330LHH_NO_ROUND      = 0,
@@ -696,66 +668,66 @@ typedef enum {
   ASM330LHH_ROUND_GY      = 2,
   ASM330LHH_ROUND_GY_XL   = 3,
 } asm330lhh_rounding_t;
-int32_t asm330lhh_rounding_mode_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_rounding_mode_set(stmdev_ctx_t *ctx,
                                   asm330lhh_rounding_t val);
-int32_t asm330lhh_rounding_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_rounding_mode_get(stmdev_ctx_t *ctx,
                                   asm330lhh_rounding_t *val);
 
-int32_t asm330lhh_temperature_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_angular_rate_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_acceleration_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_fifo_out_raw_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_odr_cal_reg_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_odr_cal_reg_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_DRDY_LATCHED = 0,
   ASM330LHH_DRDY_PULSED  = 1,
 } asm330lhh_dataready_pulsed_t;
-int32_t asm330lhh_data_ready_mode_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_data_ready_mode_set(stmdev_ctx_t *ctx,
                                     asm330lhh_dataready_pulsed_t val);
-int32_t asm330lhh_data_ready_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_data_ready_mode_get(stmdev_ctx_t *ctx,
                                     asm330lhh_dataready_pulsed_t *val);
 
-int32_t asm330lhh_device_id_get(asm330lhh_ctx_t *ctx, uint8_t *buff);
+int32_t asm330lhh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t asm330lhh_reset_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_reset_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_auto_increment_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_auto_increment_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_boot_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_boot_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_XL_ST_DISABLE  = 0,
   ASM330LHH_XL_ST_POSITIVE = 1,
   ASM330LHH_XL_ST_NEGATIVE = 2,
 } asm330lhh_st_xl_t;
-int32_t asm330lhh_xl_self_test_set(asm330lhh_ctx_t *ctx, asm330lhh_st_xl_t val);
-int32_t asm330lhh_xl_self_test_get(asm330lhh_ctx_t *ctx, asm330lhh_st_xl_t *val);
+int32_t asm330lhh_xl_self_test_set(stmdev_ctx_t *ctx, asm330lhh_st_xl_t val);
+int32_t asm330lhh_xl_self_test_get(stmdev_ctx_t *ctx, asm330lhh_st_xl_t *val);
 
 typedef enum {
   ASM330LHH_GY_ST_DISABLE  = 0,
   ASM330LHH_GY_ST_POSITIVE = 1,
   ASM330LHH_GY_ST_NEGATIVE = 3,
 } asm330lhh_st_g_t;
-int32_t asm330lhh_gy_self_test_set(asm330lhh_ctx_t *ctx, asm330lhh_st_g_t val);
-int32_t asm330lhh_gy_self_test_get(asm330lhh_ctx_t *ctx, asm330lhh_st_g_t *val);
+int32_t asm330lhh_gy_self_test_set(stmdev_ctx_t *ctx, asm330lhh_st_g_t val);
+int32_t asm330lhh_gy_self_test_get(stmdev_ctx_t *ctx, asm330lhh_st_g_t *val);
 
-int32_t asm330lhh_xl_filter_lp2_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_xl_filter_lp2_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_gy_filter_lp1_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_gy_filter_lp1_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_gy_filter_lp1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_gy_filter_lp1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_filter_settling_mask_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_filter_settling_mask_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_ULTRA_LIGHT  = 0,
@@ -767,11 +739,11 @@ typedef enum {
   ASM330LHH_AGGRESSIVE   = 6,
   ASM330LHH_XTREME       = 7,
 } asm330lhh_ftype_t;
-int32_t asm330lhh_gy_lp1_bandwidth_set(asm330lhh_ctx_t *ctx, asm330lhh_ftype_t val);
-int32_t asm330lhh_gy_lp1_bandwidth_get(asm330lhh_ctx_t *ctx, asm330lhh_ftype_t *val);
+int32_t asm330lhh_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx, asm330lhh_ftype_t val);
+int32_t asm330lhh_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx, asm330lhh_ftype_t *val);
 
-int32_t asm330lhh_xl_lp2_on_6d_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_xl_lp2_on_6d_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_xl_lp2_on_6d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_lp2_on_6d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_HP_PATH_DISABLE_ON_OUT    = 0x00,
@@ -798,21 +770,21 @@ typedef enum {
   ASM330LHH_LP_ODR_DIV_400            = 0x06,
   ASM330LHH_LP_ODR_DIV_800            = 0x07,
 } asm330lhh_hp_slope_xl_en_t;
-int32_t asm330lhh_xl_hp_path_on_out_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
                                       asm330lhh_hp_slope_xl_en_t val);
-int32_t asm330lhh_xl_hp_path_on_out_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
                                       asm330lhh_hp_slope_xl_en_t *val);
 
-int32_t asm330lhh_xl_fast_settling_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_xl_fast_settling_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_USE_SLOPE = 0,
   ASM330LHH_USE_HPF   = 1,
 } asm330lhh_slope_fds_t;
-int32_t asm330lhh_xl_hp_path_internal_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         asm330lhh_slope_fds_t val);
-int32_t asm330lhh_xl_hp_path_internal_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         asm330lhh_slope_fds_t *val);
 
 typedef enum {
@@ -822,106 +794,106 @@ typedef enum {
   ASM330LHH_HP_FILTER_260mHz   = 0x82,
   ASM330LHH_HP_FILTER_1Hz04    = 0x83,
 } asm330lhh_hpm_g_t;
-int32_t asm330lhh_gy_hp_path_internal_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         asm330lhh_hpm_g_t val);
-int32_t asm330lhh_gy_hp_path_internal_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_gy_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         asm330lhh_hpm_g_t *val);
 
 typedef enum {
   ASM330LHH_PULL_UP_DISC       = 0,
   ASM330LHH_PULL_UP_CONNECT    = 1,
 } asm330lhh_sdo_pu_en_t;
-int32_t asm330lhh_sdo_sa0_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_sdo_pu_en_t val);
-int32_t asm330lhh_sdo_sa0_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_sdo_pu_en_t *val);
+int32_t asm330lhh_sdo_sa0_mode_set(stmdev_ctx_t *ctx, asm330lhh_sdo_pu_en_t val);
+int32_t asm330lhh_sdo_sa0_mode_get(stmdev_ctx_t *ctx, asm330lhh_sdo_pu_en_t *val);
 
 typedef enum {
   ASM330LHH_SPI_4_WIRE = 0,
   ASM330LHH_SPI_3_WIRE = 1,
 } asm330lhh_sim_t;
-int32_t asm330lhh_spi_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_sim_t val);
-int32_t asm330lhh_spi_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_sim_t *val);
+int32_t asm330lhh_spi_mode_set(stmdev_ctx_t *ctx, asm330lhh_sim_t val);
+int32_t asm330lhh_spi_mode_get(stmdev_ctx_t *ctx, asm330lhh_sim_t *val);
 
 typedef enum {
   ASM330LHH_I2C_ENABLE  = 0,
   ASM330LHH_I2C_DISABLE = 1,
 } asm330lhh_i2c_disable_t;
-int32_t asm330lhh_i2c_interface_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_i2c_interface_set(stmdev_ctx_t *ctx,
                                   asm330lhh_i2c_disable_t val);
-int32_t asm330lhh_i2c_interface_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_i2c_interface_get(stmdev_ctx_t *ctx,
                                   asm330lhh_i2c_disable_t *val);
 
 typedef struct {
     asm330lhh_int1_ctrl_t          int1_ctrl;
     asm330lhh_md1_cfg_t            md1_cfg;
 } asm330lhh_pin_int1_route_t;
-int32_t asm330lhh_pin_int1_route_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    asm330lhh_pin_int1_route_t *val);
-int32_t asm330lhh_pin_int1_route_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    asm330lhh_pin_int1_route_t *val);
 
 typedef struct {
   asm330lhh_int2_ctrl_t          int2_ctrl;
   asm330lhh_md2_cfg_t            md2_cfg;
 } asm330lhh_pin_int2_route_t;
-int32_t asm330lhh_pin_int2_route_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    asm330lhh_pin_int2_route_t *val);
-int32_t asm330lhh_pin_int2_route_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_pin_int2_route_get(stmdev_ctx_t *ctx,
                                    asm330lhh_pin_int2_route_t *val);
 
 typedef enum {
   ASM330LHH_PUSH_PULL   = 0,
   ASM330LHH_OPEN_DRAIN  = 1,
 } asm330lhh_pp_od_t;
-int32_t asm330lhh_pin_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t val);
-int32_t asm330lhh_pin_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_pp_od_t *val);
+int32_t asm330lhh_pin_mode_set(stmdev_ctx_t *ctx, asm330lhh_pp_od_t val);
+int32_t asm330lhh_pin_mode_get(stmdev_ctx_t *ctx, asm330lhh_pp_od_t *val);
 
 typedef enum {
   ASM330LHH_ACTIVE_HIGH = 0,
   ASM330LHH_ACTIVE_LOW  = 1,
 } asm330lhh_h_lactive_t;
-int32_t asm330lhh_pin_polarity_set(asm330lhh_ctx_t *ctx, asm330lhh_h_lactive_t val);
-int32_t asm330lhh_pin_polarity_get(asm330lhh_ctx_t *ctx, asm330lhh_h_lactive_t *val);
+int32_t asm330lhh_pin_polarity_set(stmdev_ctx_t *ctx, asm330lhh_h_lactive_t val);
+int32_t asm330lhh_pin_polarity_get(stmdev_ctx_t *ctx, asm330lhh_h_lactive_t *val);
 
-int32_t asm330lhh_all_on_int1_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_all_on_int1_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_ALL_INT_PULSED            = 0,
   ASM330LHH_ALL_INT_LATCHED           = 3,
 } asm330lhh_lir_t;
-int32_t asm330lhh_int_notification_set(asm330lhh_ctx_t *ctx, asm330lhh_lir_t val);
-int32_t asm330lhh_int_notification_get(asm330lhh_ctx_t *ctx, asm330lhh_lir_t *val);
+int32_t asm330lhh_int_notification_set(stmdev_ctx_t *ctx, asm330lhh_lir_t val);
+int32_t asm330lhh_int_notification_get(stmdev_ctx_t *ctx, asm330lhh_lir_t *val);
 
 typedef enum {
   ASM330LHH_LSb_FS_DIV_64       = 0,
   ASM330LHH_LSb_FS_DIV_256      = 1,
 } asm330lhh_wake_ths_w_t;
-int32_t asm330lhh_wkup_ths_weight_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_wkup_ths_weight_set(stmdev_ctx_t *ctx,
                                     asm330lhh_wake_ths_w_t val);
-int32_t asm330lhh_wkup_ths_weight_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_wkup_ths_weight_get(stmdev_ctx_t *ctx,
                                     asm330lhh_wake_ths_w_t *val);
 
-int32_t asm330lhh_wkup_threshold_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_wkup_threshold_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_xl_usr_offset_on_wkup_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx,
                                           uint8_t val);
-int32_t asm330lhh_xl_usr_offset_on_wkup_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx,
                                           uint8_t *val);
 
-int32_t asm330lhh_wkup_dur_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_wkup_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_gy_sleep_mode_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_gy_sleep_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_DRIVE_SLEEP_CHG_EVENT = 0,
   ASM330LHH_DRIVE_SLEEP_STATUS    = 1,
 } asm330lhh_sleep_status_on_int_t;
-int32_t asm330lhh_act_pin_notification_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_act_pin_notification_set(stmdev_ctx_t *ctx,
                                          asm330lhh_sleep_status_on_int_t val);
-int32_t asm330lhh_act_pin_notification_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_act_pin_notification_get(stmdev_ctx_t *ctx,
                                          asm330lhh_sleep_status_on_int_t *val);
 
 typedef enum {
@@ -930,13 +902,13 @@ typedef enum {
   ASM330LHH_XL_12Hz5_GY_SLEEP           = 2,
   ASM330LHH_XL_12Hz5_GY_PD              = 3,
 } asm330lhh_inact_en_t;
-int32_t asm330lhh_act_mode_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_act_mode_set(stmdev_ctx_t *ctx,
                              asm330lhh_inact_en_t val);
-int32_t asm330lhh_act_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_act_mode_get(stmdev_ctx_t *ctx,
                              asm330lhh_inact_en_t *val);
 
-int32_t asm330lhh_act_sleep_dur_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_act_sleep_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_DEG_80  = 0,
@@ -944,13 +916,13 @@ typedef enum {
   ASM330LHH_DEG_60  = 2,
   ASM330LHH_DEG_50  = 3,
 } asm330lhh_sixd_ths_t;
-int32_t asm330lhh_6d_threshold_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_6d_threshold_set(stmdev_ctx_t *ctx,
                                  asm330lhh_sixd_ths_t val);
-int32_t asm330lhh_6d_threshold_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_6d_threshold_get(stmdev_ctx_t *ctx,
                                  asm330lhh_sixd_ths_t *val);
 
-int32_t asm330lhh_4d_mode_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_4d_mode_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_FF_TSH_156mg = 0,
@@ -962,24 +934,24 @@ typedef enum {
   ASM330LHH_FF_TSH_469mg = 6,
   ASM330LHH_FF_TSH_500mg = 7,
 } asm330lhh_ff_ths_t;
-int32_t asm330lhh_ff_threshold_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_ff_threshold_set(stmdev_ctx_t *ctx,
                                  asm330lhh_ff_ths_t val);
-int32_t asm330lhh_ff_threshold_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_ff_threshold_get(stmdev_ctx_t *ctx,
                                  asm330lhh_ff_ths_t *val);
 
-int32_t asm330lhh_ff_dur_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_ff_dur_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_fifo_watermark_set(asm330lhh_ctx_t *ctx, uint16_t val);
-int32_t asm330lhh_fifo_watermark_get(asm330lhh_ctx_t *ctx, uint16_t *val);
+int32_t asm330lhh_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t asm330lhh_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
                                               uint8_t val);
-int32_t asm330lhh_fifo_virtual_sens_odr_chg_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
-int32_t asm330lhh_fifo_stop_on_wtm_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_fifo_stop_on_wtm_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_XL_NOT_BATCHED        =  0,
@@ -995,8 +967,8 @@ typedef enum {
   ASM330LHH_XL_BATCHED_AT_6667Hz  = 10,
   ASM330LHH_XL_BATCHED_AT_6Hz5    = 11,
 } asm330lhh_bdr_xl_t;
-int32_t asm330lhh_fifo_xl_batch_set(asm330lhh_ctx_t *ctx, asm330lhh_bdr_xl_t val);
-int32_t asm330lhh_fifo_xl_batch_get(asm330lhh_ctx_t *ctx, asm330lhh_bdr_xl_t *val);
+int32_t asm330lhh_fifo_xl_batch_set(stmdev_ctx_t *ctx, asm330lhh_bdr_xl_t val);
+int32_t asm330lhh_fifo_xl_batch_get(stmdev_ctx_t *ctx, asm330lhh_bdr_xl_t *val);
 
 typedef enum {
   ASM330LHH_GY_NOT_BATCHED         = 0,
@@ -1012,8 +984,8 @@ typedef enum {
   ASM330LHH_GY_BATCHED_AT_6667Hz   = 10,
   ASM330LHH_GY_BATCHED_6Hz5        = 11,
 } asm330lhh_bdr_gy_t;
-int32_t asm330lhh_fifo_gy_batch_set(asm330lhh_ctx_t *ctx, asm330lhh_bdr_gy_t val);
-int32_t asm330lhh_fifo_gy_batch_get(asm330lhh_ctx_t *ctx, asm330lhh_bdr_gy_t *val);
+int32_t asm330lhh_fifo_gy_batch_set(stmdev_ctx_t *ctx, asm330lhh_bdr_gy_t val);
+int32_t asm330lhh_fifo_gy_batch_get(stmdev_ctx_t *ctx, asm330lhh_bdr_gy_t *val);
 
 typedef enum {
   ASM330LHH_BYPASS_MODE             = 0,
@@ -1023,8 +995,8 @@ typedef enum {
   ASM330LHH_STREAM_MODE             = 6,
   ASM330LHH_BYPASS_TO_FIFO_MODE     = 7,
 } asm330lhh_fifo_mode_t;
-int32_t asm330lhh_fifo_mode_set(asm330lhh_ctx_t *ctx, asm330lhh_fifo_mode_t val);
-int32_t asm330lhh_fifo_mode_get(asm330lhh_ctx_t *ctx, asm330lhh_fifo_mode_t *val);
+int32_t asm330lhh_fifo_mode_set(stmdev_ctx_t *ctx, asm330lhh_fifo_mode_t val);
+int32_t asm330lhh_fifo_mode_get(stmdev_ctx_t *ctx, asm330lhh_fifo_mode_t *val);
 
 typedef enum {
   ASM330LHH_TEMP_NOT_BATCHED        = 0,
@@ -1032,9 +1004,9 @@ typedef enum {
   ASM330LHH_TEMP_BATCHED_AT_12Hz5   = 2,
   ASM330LHH_TEMP_BATCHED_AT_1Hz6    = 3,
 } asm330lhh_odr_t_batch_t;
-int32_t asm330lhh_fifo_temp_batch_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_temp_batch_set(stmdev_ctx_t *ctx,
                                     asm330lhh_odr_t_batch_t val);
-int32_t asm330lhh_fifo_temp_batch_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_temp_batch_get(stmdev_ctx_t *ctx,
                                     asm330lhh_odr_t_batch_t *val);
 
 typedef enum {
@@ -1043,38 +1015,38 @@ typedef enum {
   ASM330LHH_DEC_8         = 2,
   ASM330LHH_DEC_32        = 3,
 } asm330lhh_odr_ts_batch_t;
-int32_t asm330lhh_fifo_timestamp_decimation_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
                                               asm330lhh_odr_ts_batch_t val);
-int32_t asm330lhh_fifo_timestamp_decimation_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
                                               asm330lhh_odr_ts_batch_t *val);
 
 typedef enum {
   ASM330LHH_XL_BATCH_EVENT   = 0,
   ASM330LHH_GYRO_BATCH_EVENT = 1,
 } asm330lhh_trig_counter_bdr_t;
-int32_t asm330lhh_fifo_cnt_event_batch_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_cnt_event_batch_set(stmdev_ctx_t *ctx,
                                          asm330lhh_trig_counter_bdr_t val);
-int32_t asm330lhh_fifo_cnt_event_batch_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_cnt_event_batch_get(stmdev_ctx_t *ctx,
                                          asm330lhh_trig_counter_bdr_t *val);
 
-int32_t asm330lhh_rst_batch_counter_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_rst_batch_counter_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_batch_counter_threshold_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_batch_counter_threshold_set(stmdev_ctx_t *ctx,
                                             uint16_t val);
-int32_t asm330lhh_batch_counter_threshold_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_batch_counter_threshold_get(stmdev_ctx_t *ctx,
                                             uint16_t *val);
 
-int32_t asm330lhh_fifo_data_level_get(asm330lhh_ctx_t *ctx, uint16_t *val);
+int32_t asm330lhh_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t asm330lhh_fifo_status_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_status_get(stmdev_ctx_t *ctx,
                                 asm330lhh_fifo_status2_t *val);
 
-int32_t asm330lhh_fifo_full_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_fifo_ovr_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_fifo_wtm_flag_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ASM330LHH_GYRO_NC_TAG    = 1,
@@ -1083,7 +1055,7 @@ typedef enum {
   ASM330LHH_TIMESTAMP_TAG,
   ASM330LHH_CFG_CHANGE_TAG,
 } asm330lhh_fifo_tag_t;
-int32_t asm330lhh_fifo_sensor_tag_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
                                     asm330lhh_fifo_tag_t *val);
 
 typedef enum {
@@ -1093,18 +1065,18 @@ typedef enum {
   ASM330LHH_LEVEL_TRIGGER  = 2,
   ASM330LHH_EDGE_TRIGGER   = 4,
 } asm330lhh_den_mode_t;
-int32_t asm330lhh_den_mode_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_mode_set(stmdev_ctx_t *ctx,
                              asm330lhh_den_mode_t val);
-int32_t asm330lhh_den_mode_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_mode_get(stmdev_ctx_t *ctx,
                              asm330lhh_den_mode_t *val);
 
 typedef enum {
   ASM330LHH_DEN_ACT_LOW  = 0,
   ASM330LHH_DEN_ACT_HIGH = 1,
 } asm330lhh_den_lh_t;
-int32_t asm330lhh_den_polarity_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_polarity_set(stmdev_ctx_t *ctx,
                                  asm330lhh_den_lh_t val);
-int32_t asm330lhh_den_polarity_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_polarity_get(stmdev_ctx_t *ctx,
                                  asm330lhh_den_lh_t *val);
 
 typedef enum {
@@ -1112,19 +1084,19 @@ typedef enum {
   ASM330LHH_STAMP_IN_XL_DATA     = 1,
   ASM330LHH_STAMP_IN_GY_XL_DATA  = 2,
 } asm330lhh_den_xl_g_t;
-int32_t asm330lhh_den_enable_set(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_enable_set(stmdev_ctx_t *ctx,
                                asm330lhh_den_xl_g_t val);
-int32_t asm330lhh_den_enable_get(asm330lhh_ctx_t *ctx,
+int32_t asm330lhh_den_enable_get(stmdev_ctx_t *ctx,
                                asm330lhh_den_xl_g_t *val);
 
-int32_t asm330lhh_den_mark_axis_x_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_den_mark_axis_x_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_den_mark_axis_y_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_den_mark_axis_y_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t asm330lhh_den_mark_axis_z_set(asm330lhh_ctx_t *ctx, uint8_t val);
-int32_t asm330lhh_den_mark_axis_z_get(asm330lhh_ctx_t *ctx, uint8_t *val);
+int32_t asm330lhh_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t asm330lhh_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/h3lis331dl_STdC/driver/h3lis331dl_reg.c
+++ b/sensor/stmemsc/h3lis331dl_STdC/driver/h3lis331dl_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "h3lis331dl_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t h3lis331dl_read_reg(h3lis331dl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t h3lis331dl_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t h3lis331dl_read_reg(h3lis331dl_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t h3lis331dl_write_reg(h3lis331dl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t h3lis331dl_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                             uint16_t len)
 {
   int32_t ret;
@@ -136,7 +119,7 @@ float h3lis331dl_from_fs400_to_mg(int16_t lsb)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t h3lis331dl_axis_x_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -158,7 +141,7 @@ int32_t h3lis331dl_axis_x_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t h3lis331dl_axis_x_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -177,7 +160,7 @@ int32_t h3lis331dl_axis_x_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t h3lis331dl_axis_y_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -199,7 +182,7 @@ int32_t h3lis331dl_axis_y_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t h3lis331dl_axis_y_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -218,7 +201,7 @@ int32_t h3lis331dl_axis_y_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t h3lis331dl_axis_z_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -240,7 +223,7 @@ int32_t h3lis331dl_axis_z_data_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t h3lis331dl_axis_z_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -259,7 +242,7 @@ int32_t h3lis331dl_axis_z_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of dr in reg CTRL_REG1
   *
   */
-int32_t h3lis331dl_data_rate_set(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t val)
+int32_t h3lis331dl_data_rate_set(stmdev_ctx_t *ctx, h3lis331dl_dr_t val)
 {
   h3lis331dl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -282,7 +265,7 @@ int32_t h3lis331dl_data_rate_set(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t val)
   * @param  val         Get the values of dr in reg CTRL_REG1
   *
   */
-int32_t h3lis331dl_data_rate_get(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t *val)
+int32_t h3lis331dl_data_rate_get(stmdev_ctx_t *ctx, h3lis331dl_dr_t *val)
 {
   h3lis331dl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -337,7 +320,7 @@ int32_t h3lis331dl_data_rate_get(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t *val)
   * @param  val         change the values of hpm in reg CTRL_REG2
   *
   */
-int32_t h3lis331dl_reference_mode_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_reference_mode_set(stmdev_ctx_t *ctx,
                                      h3lis331dl_hpm_t val)
 {
   h3lis331dl_ctrl_reg2_t ctrl_reg2;
@@ -360,7 +343,7 @@ int32_t h3lis331dl_reference_mode_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of hpm in reg CTRL_REG2
   *
   */
-int32_t h3lis331dl_reference_mode_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_reference_mode_get(stmdev_ctx_t *ctx,
                                      h3lis331dl_hpm_t *val)
 {
   h3lis331dl_ctrl_reg2_t ctrl_reg2;
@@ -391,7 +374,7 @@ int32_t h3lis331dl_reference_mode_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of fs in reg CTRL_REG4
   *
   */
-int32_t h3lis331dl_full_scale_set(h3lis331dl_ctx_t *ctx, h3lis331dl_fs_t val)
+int32_t h3lis331dl_full_scale_set(stmdev_ctx_t *ctx, h3lis331dl_fs_t val)
 {
   h3lis331dl_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -413,7 +396,7 @@ int32_t h3lis331dl_full_scale_set(h3lis331dl_ctx_t *ctx, h3lis331dl_fs_t val)
   * @param  val         Get the values of fs in reg CTRL_REG4
   *
   */
-int32_t h3lis331dl_full_scale_get(h3lis331dl_ctx_t *ctx, h3lis331dl_fs_t *val)
+int32_t h3lis331dl_full_scale_get(stmdev_ctx_t *ctx, h3lis331dl_fs_t *val)
 {
   h3lis331dl_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -447,7 +430,7 @@ int32_t h3lis331dl_full_scale_get(h3lis331dl_ctx_t *ctx, h3lis331dl_fs_t *val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t h3lis331dl_block_data_update_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -469,7 +452,7 @@ int32_t h3lis331dl_block_data_update_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t h3lis331dl_block_data_update_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -488,7 +471,7 @@ int32_t h3lis331dl_block_data_update_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         registers STATUS_REG
   *
   */
-int32_t h3lis331dl_status_reg_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_status_reg_get(stmdev_ctx_t *ctx,
                                  h3lis331dl_status_reg_t *val)
 {
   int32_t ret;
@@ -504,7 +487,7 @@ int32_t h3lis331dl_status_reg_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of zyxda in reg STATUS_REG
   *
   */
-int32_t h3lis331dl_flag_data_ready_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_status_reg_t status_reg;
   int32_t ret;
@@ -536,7 +519,7 @@ int32_t h3lis331dl_flag_data_ready_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t h3lis331dl_acceleration_raw_get(h3lis331dl_ctx_t *ctx, uint8_t *buff)
+int32_t h3lis331dl_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = h3lis331dl_read_reg(ctx, H3LIS331DL_OUT_X_L, buff, 6);
@@ -562,7 +545,7 @@ int32_t h3lis331dl_acceleration_raw_get(h3lis331dl_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t h3lis331dl_device_id_get(h3lis331dl_ctx_t *ctx, uint8_t *buff)
+int32_t h3lis331dl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = h3lis331dl_read_reg(ctx, H3LIS331DL_WHO_AM_I, buff, 1);
@@ -576,7 +559,7 @@ int32_t h3lis331dl_device_id_get(h3lis331dl_ctx_t *ctx, uint8_t *buff)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t h3lis331dl_boot_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -598,7 +581,7 @@ int32_t h3lis331dl_boot_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t h3lis331dl_boot_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -617,7 +600,7 @@ int32_t h3lis331dl_boot_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of ble in reg CTRL_REG4
   *
   */
-int32_t h3lis331dl_data_format_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_data_format_set(stmdev_ctx_t *ctx,
                                    h3lis331dl_ble_t val)
 {
   h3lis331dl_ctrl_reg4_t ctrl_reg4;
@@ -640,7 +623,7 @@ int32_t h3lis331dl_data_format_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of ble in reg CTRL_REG4
   *
   */
-int32_t h3lis331dl_data_format_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_data_format_get(stmdev_ctx_t *ctx,
                                    h3lis331dl_ble_t *val)
 {
   h3lis331dl_ctrl_reg4_t ctrl_reg4;
@@ -685,7 +668,7 @@ int32_t h3lis331dl_data_format_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t h3lis331dl_hp_bandwidth_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                     h3lis331dl_hpcf_t val)
 {
   h3lis331dl_ctrl_reg2_t ctrl_reg2;
@@ -708,7 +691,7 @@ int32_t h3lis331dl_hp_bandwidth_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t h3lis331dl_hp_bandwidth_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    h3lis331dl_hpcf_t *val)
 {
   h3lis331dl_ctrl_reg2_t ctrl_reg2;
@@ -746,7 +729,7 @@ int32_t h3lis331dl_hp_bandwidth_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of hpen in reg CTRL_REG2
   *
   */
-int32_t h3lis331dl_hp_path_set(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t val)
+int32_t h3lis331dl_hp_path_set(stmdev_ctx_t *ctx, h3lis331dl_hpen_t val)
 {
   h3lis331dl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -769,7 +752,7 @@ int32_t h3lis331dl_hp_path_set(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t val)
   * @param  val         Get the values of hpen in reg CTRL_REG2
   *
   */
-int32_t h3lis331dl_hp_path_get(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t *val)
+int32_t h3lis331dl_hp_path_get(stmdev_ctx_t *ctx, h3lis331dl_hpen_t *val)
 {
   h3lis331dl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -821,7 +804,7 @@ int32_t h3lis331dl_hp_path_get(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t *val)
   * @param  ctx         read / write interface definitions(ptr)
   *
   */
-int32_t h3lis331dl_hp_reset_get(h3lis331dl_ctx_t *ctx)
+int32_t h3lis331dl_hp_reset_get(stmdev_ctx_t *ctx)
 {
   uint8_t dummy;
   int32_t ret;
@@ -837,7 +820,7 @@ int32_t h3lis331dl_hp_reset_get(h3lis331dl_ctx_t *ctx)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t h3lis331dl_hp_reference_value_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
   ret = h3lis331dl_write_reg(ctx, H3LIS331DL_REFERENCE, (uint8_t*)&val, 1);
@@ -851,7 +834,7 @@ int32_t h3lis331dl_hp_reference_value_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t h3lis331dl_hp_reference_value_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
   ret = h3lis331dl_read_reg(ctx, H3LIS331DL_REFERENCE, val, 1);
@@ -878,7 +861,7 @@ int32_t h3lis331dl_hp_reference_value_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of sim in reg CTRL_REG4
   *
   */
-int32_t h3lis331dl_spi_mode_set(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t val)
+int32_t h3lis331dl_spi_mode_set(stmdev_ctx_t *ctx, h3lis331dl_sim_t val)
 {
   h3lis331dl_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -900,7 +883,7 @@ int32_t h3lis331dl_spi_mode_set(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t val)
   * @param  val         Get the values of sim in reg CTRL_REG4
   *
   */
-int32_t h3lis331dl_spi_mode_get(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t *val)
+int32_t h3lis331dl_spi_mode_get(stmdev_ctx_t *ctx, h3lis331dl_sim_t *val)
 {
   h3lis331dl_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -944,7 +927,7 @@ int32_t h3lis331dl_spi_mode_get(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t *val)
   * @param  val         change the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_pin_int1_route_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      h3lis331dl_i1_cfg_t val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -967,7 +950,7 @@ int32_t h3lis331dl_pin_int1_route_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_pin_int1_route_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      h3lis331dl_i1_cfg_t *val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1006,7 +989,7 @@ int32_t h3lis331dl_pin_int1_route_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_int1_notification_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_notification_set(stmdev_ctx_t *ctx,
                                         h3lis331dl_lir1_t val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1030,7 +1013,7 @@ int32_t h3lis331dl_int1_notification_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_int1_notification_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_notification_get(stmdev_ctx_t *ctx,
                                         h3lis331dl_lir1_t *val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1062,7 +1045,7 @@ int32_t h3lis331dl_int1_notification_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_pin_int2_route_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      h3lis331dl_i2_cfg_t val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1085,7 +1068,7 @@ int32_t h3lis331dl_pin_int2_route_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_pin_int2_route_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      h3lis331dl_i2_cfg_t *val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1124,7 +1107,7 @@ int32_t h3lis331dl_pin_int2_route_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_int2_notification_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_notification_set(stmdev_ctx_t *ctx,
                                         h3lis331dl_lir2_t val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1148,7 +1131,7 @@ int32_t h3lis331dl_int2_notification_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_int2_notification_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_notification_get(stmdev_ctx_t *ctx,
                                         h3lis331dl_lir2_t *val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1180,7 +1163,7 @@ int32_t h3lis331dl_int2_notification_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_pin_mode_set(h3lis331dl_ctx_t *ctx, h3lis331dl_pp_od_t val)
+int32_t h3lis331dl_pin_mode_set(stmdev_ctx_t *ctx, h3lis331dl_pp_od_t val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1202,7 +1185,7 @@ int32_t h3lis331dl_pin_mode_set(h3lis331dl_ctx_t *ctx, h3lis331dl_pp_od_t val)
   * @param  val         Get the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_pin_mode_get(h3lis331dl_ctx_t *ctx, h3lis331dl_pp_od_t *val)
+int32_t h3lis331dl_pin_mode_get(stmdev_ctx_t *ctx, h3lis331dl_pp_od_t *val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1233,7 +1216,7 @@ int32_t h3lis331dl_pin_mode_get(h3lis331dl_ctx_t *ctx, h3lis331dl_pp_od_t *val)
   * @param  val         change the values of ihl in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_pin_polarity_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_polarity_set(stmdev_ctx_t *ctx,
                                     h3lis331dl_ihl_t val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1256,7 +1239,7 @@ int32_t h3lis331dl_pin_polarity_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of ihl in reg CTRL_REG3
   *
   */
-int32_t h3lis331dl_pin_polarity_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_polarity_get(stmdev_ctx_t *ctx,
                                     h3lis331dl_ihl_t *val)
 {
   h3lis331dl_ctrl_reg3_t ctrl_reg3;
@@ -1301,8 +1284,8 @@ int32_t h3lis331dl_pin_polarity_get(h3lis331dl_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t h3lis331dl_int1_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
-                                              int1_on_th_conf_t val)
+int32_t h3lis331dl_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                              h3lis331dl_int1_on_th_conf_t val)
 {
   h3lis331dl_int1_cfg_t int1_cfg;
   int32_t ret;
@@ -1328,8 +1311,8 @@ int32_t h3lis331dl_int1_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t h3lis331dl_int1_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
-                                             int1_on_th_conf_t *val)
+int32_t h3lis331dl_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             h3lis331dl_int1_on_th_conf_t *val)
 {
   h3lis331dl_int1_cfg_t int1_cfg;
   int32_t ret;
@@ -1352,7 +1335,7 @@ int32_t h3lis331dl_int1_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT1_CFG
   *
   */
-int32_t h3lis331dl_int1_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              h3lis331dl_int1_aoi_t val)
 {
   h3lis331dl_int1_cfg_t int1_cfg;
@@ -1374,7 +1357,7 @@ int32_t h3lis331dl_int1_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT1_CFG
   *
   */
-int32_t h3lis331dl_int1_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              h3lis331dl_int1_aoi_t *val)
 {
   h3lis331dl_int1_cfg_t int1_cfg;
@@ -1405,7 +1388,7 @@ int32_t h3lis331dl_int1_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t h3lis331dl_int1_src_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_src_get(stmdev_ctx_t *ctx,
                                h3lis331dl_int1_src_t *val)
 {
   int32_t ret;
@@ -1420,7 +1403,7 @@ int32_t h3lis331dl_int1_src_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t h3lis331dl_int1_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_int1_ths_t int1_ths;
   int32_t ret;
@@ -1441,7 +1424,7 @@ int32_t h3lis331dl_int1_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t h3lis331dl_int1_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_int1_ths_t int1_ths;
   int32_t ret;
@@ -1459,7 +1442,7 @@ int32_t h3lis331dl_int1_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t h3lis331dl_int1_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_int1_duration_t int1_duration;
   int32_t ret;
@@ -1481,7 +1464,7 @@ int32_t h3lis331dl_int1_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t h3lis331dl_int1_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_int1_duration_t int1_duration;
   int32_t ret;
@@ -1500,8 +1483,8 @@ int32_t h3lis331dl_int1_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t h3lis331dl_int2_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
-                                              int2_on_th_conf_t val)
+int32_t h3lis331dl_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                              h3lis331dl_int2_on_th_conf_t val)
 {
   h3lis331dl_int2_cfg_t int2_cfg;
   int32_t ret;
@@ -1528,8 +1511,8 @@ int32_t h3lis331dl_int2_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t h3lis331dl_int2_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
-                                              int2_on_th_conf_t *val)
+int32_t h3lis331dl_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                              h3lis331dl_int2_on_th_conf_t *val)
 {
   h3lis331dl_int2_cfg_t int2_cfg;
   int32_t ret;
@@ -1552,7 +1535,7 @@ int32_t h3lis331dl_int2_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT2_CFG
   *
   */
-int32_t h3lis331dl_int2_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              h3lis331dl_int2_aoi_t val)
 {
   h3lis331dl_int2_cfg_t int2_cfg;
@@ -1574,7 +1557,7 @@ int32_t h3lis331dl_int2_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT2_CFG
   *
   */
-int32_t h3lis331dl_int2_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              h3lis331dl_int2_aoi_t *val)
 {
   h3lis331dl_int2_cfg_t int2_cfg;
@@ -1605,7 +1588,7 @@ int32_t h3lis331dl_int2_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t h3lis331dl_int2_src_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_src_get(stmdev_ctx_t *ctx,
                                h3lis331dl_int2_src_t *val)
 {
   int32_t ret;
@@ -1620,7 +1603,7 @@ int32_t h3lis331dl_int2_src_get(h3lis331dl_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t h3lis331dl_int2_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_int2_ths_t int2_ths;
   int32_t ret;
@@ -1641,7 +1624,7 @@ int32_t h3lis331dl_int2_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t h3lis331dl_int2_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_int2_ths_t int2_ths;
   int32_t ret;
@@ -1659,7 +1642,7 @@ int32_t h3lis331dl_int2_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t h3lis331dl_int2_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_int2_duration_t int2_duration;
   int32_t ret;
@@ -1681,7 +1664,7 @@ int32_t h3lis331dl_int2_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t h3lis331dl_int2_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_int2_duration_t int2_duration;
   int32_t ret;
@@ -1713,7 +1696,7 @@ int32_t h3lis331dl_int2_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t h3lis331dl_wkup_to_sleep_set(h3lis331dl_ctx_t *ctx, uint8_t val)
+int32_t h3lis331dl_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   h3lis331dl_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1735,7 +1718,7 @@ int32_t h3lis331dl_wkup_to_sleep_set(h3lis331dl_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t h3lis331dl_wkup_to_sleep_get(h3lis331dl_ctx_t *ctx, uint8_t *val)
+int32_t h3lis331dl_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   h3lis331dl_ctrl_reg5_t ctrl_reg5;
   int32_t ret;

--- a/sensor/stmemsc/h3lis331dl_STdC/driver/h3lis331dl_reg.h
+++ b/sensor/stmemsc/h3lis331dl_STdC/driver/h3lis331dl_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup H3LIS331DL_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  H3LIS331DL_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*h3lis331dl_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*h3lis331dl_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  h3lis331dl_write_ptr  write_reg;
-  h3lis331dl_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} h3lis331dl_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -355,23 +327,23 @@ typedef union{
   *
   */
 
-int32_t h3lis331dl_read_reg(h3lis331dl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t h3lis331dl_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
-int32_t h3lis331dl_write_reg(h3lis331dl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t h3lis331dl_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                             uint16_t len);
 
 extern float h3lis331dl_from_fs100_to_mg(int16_t lsb);
 extern float h3lis331dl_from_fs200_to_mg(int16_t lsb);
 extern float h3lis331dl_from_fs400_to_mg(int16_t lsb);
 
-int32_t h3lis331dl_axis_x_data_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_axis_x_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t h3lis331dl_axis_y_data_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_axis_y_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t h3lis331dl_axis_z_data_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_axis_z_data_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   H3LIS331DL_ODR_OFF   = 0x00,
@@ -385,16 +357,16 @@ typedef enum {
   H3LIS331DL_ODR_400Hz = 0x21,
   H3LIS331DL_ODR_1kHz  = 0x31,
 } h3lis331dl_dr_t;
-int32_t h3lis331dl_data_rate_set(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t val);
-int32_t h3lis331dl_data_rate_get(h3lis331dl_ctx_t *ctx, h3lis331dl_dr_t *val);
+int32_t h3lis331dl_data_rate_set(stmdev_ctx_t *ctx, h3lis331dl_dr_t val);
+int32_t h3lis331dl_data_rate_get(stmdev_ctx_t *ctx, h3lis331dl_dr_t *val);
 
 typedef enum {
   H3LIS331DL_NORMAL_MODE      = 0,
   H3LIS331DL_REF_MODE_ENABLE  = 1,
 } h3lis331dl_hpm_t;
-int32_t h3lis331dl_reference_mode_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_reference_mode_set(stmdev_ctx_t *ctx,
                                      h3lis331dl_hpm_t val);
-int32_t h3lis331dl_reference_mode_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_reference_mode_get(stmdev_ctx_t *ctx,
                                      h3lis331dl_hpm_t *val);
 
 typedef enum {
@@ -402,34 +374,34 @@ typedef enum {
   H3LIS331DL_200g  = 1,
   H3LIS331DL_400g  = 3,
 } h3lis331dl_fs_t;
-int32_t h3lis331dl_full_scale_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_full_scale_set(stmdev_ctx_t *ctx,
                                   h3lis331dl_fs_t val);
-int32_t h3lis331dl_full_scale_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_full_scale_get(stmdev_ctx_t *ctx,
                                   h3lis331dl_fs_t *val);
 
-int32_t h3lis331dl_block_data_update_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_block_data_update_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t h3lis331dl_status_reg_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_status_reg_get(stmdev_ctx_t *ctx,
                                  h3lis331dl_status_reg_t *val);
 
-int32_t h3lis331dl_flag_data_ready_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_flag_data_ready_get(stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t h3lis331dl_acceleration_raw_get(h3lis331dl_ctx_t *ctx, uint8_t *buff);
+int32_t h3lis331dl_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t h3lis331dl_device_id_get(h3lis331dl_ctx_t *ctx, uint8_t *buff);
+int32_t h3lis331dl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t h3lis331dl_boot_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_boot_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   H3LIS331DL_LSB_AT_LOW_ADD  = 0,
   H3LIS331DL_MSB_AT_LOW_ADD  = 1,
 } h3lis331dl_ble_t;
-int32_t h3lis331dl_data_format_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_data_format_set(stmdev_ctx_t *ctx,
                                    h3lis331dl_ble_t val);
-int32_t h3lis331dl_data_format_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_data_format_get(stmdev_ctx_t *ctx,
                                    h3lis331dl_ble_t *val);
 
 typedef enum {
@@ -438,9 +410,9 @@ typedef enum {
   H3LIS331DL_CUT_OFF_32Hz  = 2,
   H3LIS331DL_CUT_OFF_64Hz  = 3,
 } h3lis331dl_hpcf_t;
-int32_t h3lis331dl_hp_bandwidth_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                    h3lis331dl_hpcf_t val);
-int32_t h3lis331dl_hp_bandwidth_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    h3lis331dl_hpcf_t *val);
 
 typedef enum {
@@ -453,20 +425,20 @@ typedef enum {
   H3LIS331DL_HP_ON_INT2_OUT        = 6,
   H3LIS331DL_HP_ON_INT1_OUT        = 5,
 } h3lis331dl_hpen_t;
-int32_t h3lis331dl_hp_path_set(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t val);
-int32_t h3lis331dl_hp_path_get(h3lis331dl_ctx_t *ctx, h3lis331dl_hpen_t *val);
+int32_t h3lis331dl_hp_path_set(stmdev_ctx_t *ctx, h3lis331dl_hpen_t val);
+int32_t h3lis331dl_hp_path_get(stmdev_ctx_t *ctx, h3lis331dl_hpen_t *val);
 
-int32_t h3lis331dl_hp_reset_get(h3lis331dl_ctx_t *ctx);
+int32_t h3lis331dl_hp_reset_get(stmdev_ctx_t *ctx);
 
-int32_t h3lis331dl_hp_reference_value_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_hp_reference_value_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   H3LIS331DL_SPI_4_WIRE  = 0,
   H3LIS331DL_SPI_3_WIRE  = 1,
 } h3lis331dl_sim_t;
-int32_t h3lis331dl_spi_mode_set(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t val);
-int32_t h3lis331dl_spi_mode_get(h3lis331dl_ctx_t *ctx, h3lis331dl_sim_t *val);
+int32_t h3lis331dl_spi_mode_set(stmdev_ctx_t *ctx, h3lis331dl_sim_t val);
+int32_t h3lis331dl_spi_mode_get(stmdev_ctx_t *ctx, h3lis331dl_sim_t *val);
 
 typedef enum {
   H3LIS331DL_PAD1_INT1_SRC           = 0,
@@ -474,18 +446,18 @@ typedef enum {
   H3LIS331DL_PAD1_DRDY               = 2,
   H3LIS331DL_PAD1_BOOT               = 3,
 } h3lis331dl_i1_cfg_t;
-int32_t h3lis331dl_pin_int1_route_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      h3lis331dl_i1_cfg_t val);
-int32_t h3lis331dl_pin_int1_route_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      h3lis331dl_i1_cfg_t *val);
 
 typedef enum {
   H3LIS331DL_INT1_PULSED   = 0,
   H3LIS331DL_INT1_LATCHED  = 1,
 } h3lis331dl_lir1_t;
-int32_t h3lis331dl_int1_notification_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_notification_set(stmdev_ctx_t *ctx,
                                         h3lis331dl_lir1_t val);
-int32_t h3lis331dl_int1_notification_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_notification_get(stmdev_ctx_t *ctx,
                                         h3lis331dl_lir1_t *val);
 
 typedef enum {
@@ -494,36 +466,36 @@ typedef enum {
   H3LIS331DL_PAD2_DRDY               = 2,
   H3LIS331DL_PAD2_BOOT               = 3,
 } h3lis331dl_i2_cfg_t;
-int32_t h3lis331dl_pin_int2_route_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      h3lis331dl_i2_cfg_t val);
-int32_t h3lis331dl_pin_int2_route_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      h3lis331dl_i2_cfg_t *val);
 
 typedef enum {
   H3LIS331DL_INT2_PULSED   = 0,
   H3LIS331DL_INT2_LATCHED  = 1,
 } h3lis331dl_lir2_t;
-int32_t h3lis331dl_int2_notification_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_notification_set(stmdev_ctx_t *ctx,
                                         h3lis331dl_lir2_t val);
-int32_t h3lis331dl_int2_notification_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_notification_get(stmdev_ctx_t *ctx,
                                         h3lis331dl_lir2_t *val);
 
 typedef enum {
   H3LIS331DL_PUSH_PULL   = 0,
   H3LIS331DL_OPEN_DRAIN  = 1,
 } h3lis331dl_pp_od_t;
-int32_t h3lis331dl_pin_mode_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_mode_set(stmdev_ctx_t *ctx,
                                 h3lis331dl_pp_od_t val);
-int32_t h3lis331dl_pin_mode_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_mode_get(stmdev_ctx_t *ctx,
                                 h3lis331dl_pp_od_t *val);
 
 typedef enum {
   H3LIS331DL_ACTIVE_HIGH  = 0,
   H3LIS331DL_ACTIVE_LOW   = 1,
 } h3lis331dl_ihl_t;
-int32_t h3lis331dl_pin_polarity_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_polarity_set(stmdev_ctx_t *ctx,
                                    h3lis331dl_ihl_t val);
-int32_t h3lis331dl_pin_polarity_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_pin_polarity_get(stmdev_ctx_t *ctx,
                                    h3lis331dl_ihl_t *val);
 
 typedef struct {
@@ -533,29 +505,29 @@ typedef struct {
   uint8_t int1_yhie             : 1;
   uint8_t int1_zlie             : 1;
   uint8_t int1_zhie             : 1;
-} int1_on_th_conf_t;
-int32_t h3lis331dl_int1_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
-                                             int1_on_th_conf_t val);
-int32_t h3lis331dl_int1_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
-                                             int1_on_th_conf_t *val);
+} h3lis331dl_int1_on_th_conf_t;
+int32_t h3lis331dl_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                             h3lis331dl_int1_on_th_conf_t val);
+int32_t h3lis331dl_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             h3lis331dl_int1_on_th_conf_t *val);
 
 typedef enum {
   H3LIS331DL_INT1_ON_THRESHOLD_OR   = 0,
   H3LIS331DL_INT1_ON_THRESHOLD_AND  = 1,
 } h3lis331dl_int1_aoi_t;
-int32_t h3lis331dl_int1_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              h3lis331dl_int1_aoi_t val);
-int32_t h3lis331dl_int1_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              h3lis331dl_int1_aoi_t *val);
 
-int32_t h3lis331dl_int1_src_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int1_src_get(stmdev_ctx_t *ctx,
                                h3lis331dl_int1_src_t *val);
 
-int32_t h3lis331dl_int1_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_int1_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t h3lis331dl_int1_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_int1_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t int2_xlie             : 1;
@@ -564,32 +536,32 @@ typedef struct {
   uint8_t int2_yhie             : 1;
   uint8_t int2_zlie             : 1;
   uint8_t int2_zhie             : 1;
-} int2_on_th_conf_t;
-int32_t h3lis331dl_int2_on_threshold_conf_set(h3lis331dl_ctx_t *ctx,
-                                             int2_on_th_conf_t val);
-int32_t h3lis331dl_int2_on_threshold_conf_get(h3lis331dl_ctx_t *ctx,
-                                             int2_on_th_conf_t *val);
+} h3lis331dl_int2_on_th_conf_t;
+int32_t h3lis331dl_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
+                                             h3lis331dl_int2_on_th_conf_t val);
+int32_t h3lis331dl_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
+                                             h3lis331dl_int2_on_th_conf_t *val);
 
 typedef enum {
   H3LIS331DL_INT2_ON_THRESHOLD_OR   = 0,
   H3LIS331DL_INT2_ON_THRESHOLD_AND  = 1,
 } h3lis331dl_int2_aoi_t;
-int32_t h3lis331dl_int2_on_threshold_mode_set(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              h3lis331dl_int2_aoi_t val);
-int32_t h3lis331dl_int2_on_threshold_mode_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              h3lis331dl_int2_aoi_t *val);
 
-int32_t h3lis331dl_int2_src_get(h3lis331dl_ctx_t *ctx,
+int32_t h3lis331dl_int2_src_get(stmdev_ctx_t *ctx,
                                h3lis331dl_int2_src_t *val);
 
-int32_t h3lis331dl_int2_treshold_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_int2_treshold_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t h3lis331dl_int2_dur_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_int2_dur_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t h3lis331dl_wkup_to_sleep_set(h3lis331dl_ctx_t *ctx, uint8_t val);
-int32_t h3lis331dl_wkup_to_sleep_get(h3lis331dl_ctx_t *ctx, uint8_t *val);
+int32_t h3lis331dl_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t h3lis331dl_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/hts221_STdC/driver/hts221_reg.c
+++ b/sensor/stmemsc/hts221_STdC/driver/hts221_reg.c
@@ -1,38 +1,21 @@
 /*
  ******************************************************************************
  * @file    hts221_reg.c
- * @author  MEMS Software Solution Team
+ * @author  Sensors Software Solution Team
  * @brief   HTS221 driver file
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 #include "hts221_reg.h"
 
@@ -62,7 +45,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_read_reg(hts221_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t hts221_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                         uint16_t len)
 {
   int32_t ret;
@@ -80,7 +63,7 @@ int32_t hts221_read_reg(hts221_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_write_reg(hts221_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t hts221_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -108,7 +91,7 @@ int32_t hts221_write_reg(hts221_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_humidity_avg_set(hts221_ctx_t *ctx, hts221_avgh_t val)
+int32_t hts221_humidity_avg_set(stmdev_ctx_t *ctx, hts221_avgh_t val)
 {
   hts221_av_conf_t reg;
   int32_t ret;
@@ -131,7 +114,7 @@ int32_t hts221_humidity_avg_set(hts221_ctx_t *ctx, hts221_avgh_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_humidity_avg_get(hts221_ctx_t *ctx, hts221_avgh_t *val)
+int32_t hts221_humidity_avg_get(stmdev_ctx_t *ctx, hts221_avgh_t *val)
 {
   hts221_av_conf_t reg;
   int32_t ret;
@@ -179,7 +162,7 @@ int32_t hts221_humidity_avg_get(hts221_ctx_t *ctx, hts221_avgh_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_temperature_avg_set(hts221_ctx_t *ctx, hts221_avgt_t val)
+int32_t hts221_temperature_avg_set(stmdev_ctx_t *ctx, hts221_avgt_t val)
 {
   hts221_av_conf_t reg;
   int32_t ret;
@@ -202,7 +185,7 @@ int32_t hts221_temperature_avg_set(hts221_ctx_t *ctx, hts221_avgt_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_temperature_avg_get(hts221_ctx_t *ctx, hts221_avgt_t *val)
+int32_t hts221_temperature_avg_get(stmdev_ctx_t *ctx, hts221_avgt_t *val)
 {
   hts221_av_conf_t reg;
   int32_t ret;
@@ -250,7 +233,7 @@ int32_t hts221_temperature_avg_get(hts221_ctx_t *ctx, hts221_avgt_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_data_rate_set(hts221_ctx_t *ctx, hts221_odr_t val)
+int32_t hts221_data_rate_set(stmdev_ctx_t *ctx, hts221_odr_t val)
 {
   hts221_ctrl_reg1_t reg;
   int32_t ret;
@@ -273,7 +256,7 @@ int32_t hts221_data_rate_set(hts221_ctx_t *ctx, hts221_odr_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_data_rate_get(hts221_ctx_t *ctx, hts221_odr_t *val)
+int32_t hts221_data_rate_get(stmdev_ctx_t *ctx, hts221_odr_t *val)
 {
   hts221_ctrl_reg1_t reg;
   int32_t ret;
@@ -309,7 +292,7 @@ int32_t hts221_data_rate_get(hts221_ctx_t *ctx, hts221_odr_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_block_data_update_set(hts221_ctx_t *ctx, uint8_t val)
+int32_t hts221_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   hts221_ctrl_reg1_t reg;
   int32_t ret;
@@ -332,7 +315,7 @@ int32_t hts221_block_data_update_set(hts221_ctx_t *ctx, uint8_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_block_data_update_get(hts221_ctx_t *ctx, uint8_t *val)
+int32_t hts221_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   hts221_ctrl_reg1_t reg;
   int32_t ret;
@@ -351,7 +334,7 @@ int32_t hts221_block_data_update_get(hts221_ctx_t *ctx, uint8_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_one_shoot_trigger_set(hts221_ctx_t *ctx, uint8_t val)
+int32_t hts221_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   hts221_ctrl_reg2_t reg;
   int32_t ret;
@@ -374,7 +357,7 @@ int32_t hts221_one_shoot_trigger_set(hts221_ctx_t *ctx, uint8_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_one_shoot_trigger_get(hts221_ctx_t *ctx, uint8_t *val)
+int32_t hts221_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   hts221_ctrl_reg2_t reg;
   int32_t ret;
@@ -393,7 +376,7 @@ int32_t hts221_one_shoot_trigger_get(hts221_ctx_t *ctx, uint8_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_temp_data_ready_get(hts221_ctx_t *ctx, uint8_t *val)
+int32_t hts221_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   hts221_status_reg_t reg;
   int32_t ret;
@@ -412,7 +395,7 @@ int32_t hts221_temp_data_ready_get(hts221_ctx_t *ctx, uint8_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_hum_data_ready_get(hts221_ctx_t *ctx, uint8_t *val)
+int32_t hts221_hum_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   hts221_status_reg_t reg;
   int32_t ret;
@@ -431,7 +414,7 @@ int32_t hts221_hum_data_ready_get(hts221_ctx_t *ctx, uint8_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_humidity_raw_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_humidity_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = hts221_read_reg(ctx, HTS221_HUMIDITY_OUT_L, buff, 2);
@@ -446,7 +429,7 @@ int32_t hts221_humidity_raw_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_temperature_raw_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = hts221_read_reg(ctx, HTS221_TEMP_OUT_L, buff, 2);
@@ -473,7 +456,7 @@ int32_t hts221_temperature_raw_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_device_id_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = hts221_read_reg(ctx, HTS221_WHO_AM_I, buff, 1);
@@ -488,7 +471,7 @@ int32_t hts221_device_id_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_power_on_set(hts221_ctx_t *ctx, uint8_t val)
+int32_t hts221_power_on_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   hts221_ctrl_reg1_t reg;
   int32_t ret;
@@ -510,7 +493,7 @@ int32_t hts221_power_on_set(hts221_ctx_t *ctx, uint8_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_power_on_get(hts221_ctx_t *ctx, uint8_t *val)
+int32_t hts221_power_on_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   hts221_ctrl_reg1_t reg;
   int32_t mm_error;
@@ -529,7 +512,7 @@ int32_t hts221_power_on_get(hts221_ctx_t *ctx, uint8_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_heater_set(hts221_ctx_t *ctx, uint8_t val)
+int32_t hts221_heater_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   hts221_ctrl_reg2_t reg;
   int32_t ret;
@@ -552,7 +535,7 @@ int32_t hts221_heater_set(hts221_ctx_t *ctx, uint8_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_heater_get(hts221_ctx_t *ctx, uint8_t *val)
+int32_t hts221_heater_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   hts221_ctrl_reg2_t reg;
   int32_t ret;
@@ -571,7 +554,7 @@ int32_t hts221_heater_get(hts221_ctx_t *ctx, uint8_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_boot_set(hts221_ctx_t *ctx, uint8_t val)
+int32_t hts221_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   hts221_ctrl_reg2_t reg;
   int32_t ret;
@@ -594,7 +577,7 @@ int32_t hts221_boot_set(hts221_ctx_t *ctx, uint8_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_boot_get(hts221_ctx_t *ctx, uint8_t *val)
+int32_t hts221_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   hts221_ctrl_reg2_t reg;
   int32_t ret;
@@ -613,7 +596,7 @@ int32_t hts221_boot_get(hts221_ctx_t *ctx, uint8_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_status_get(hts221_ctx_t *ctx, hts221_status_reg_t *val)
+int32_t hts221_status_get(stmdev_ctx_t *ctx, hts221_status_reg_t *val)
 {
   int32_t ret;
   ret = hts221_read_reg(ctx, HTS221_STATUS_REG, (uint8_t*) val, 1);
@@ -640,7 +623,7 @@ int32_t hts221_status_get(hts221_ctx_t *ctx, hts221_status_reg_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_drdy_on_int_set(hts221_ctx_t *ctx, uint8_t val)
+int32_t hts221_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   hts221_ctrl_reg3_t reg;
   int32_t ret;
@@ -663,7 +646,7 @@ int32_t hts221_drdy_on_int_set(hts221_ctx_t *ctx, uint8_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_drdy_on_int_get(hts221_ctx_t *ctx, uint8_t *val)
+int32_t hts221_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   hts221_ctrl_reg3_t reg;
   int32_t ret;
@@ -681,7 +664,7 @@ int32_t hts221_drdy_on_int_get(hts221_ctx_t *ctx, uint8_t *val)
   * @param  val     change the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t hts221_pin_mode_set(hts221_ctx_t *ctx, hts221_pp_od_t val)
+int32_t hts221_pin_mode_set(stmdev_ctx_t *ctx, hts221_pp_od_t val)
 {
   hts221_ctrl_reg3_t reg;
   int32_t ret;
@@ -704,7 +687,7 @@ int32_t hts221_pin_mode_set(hts221_ctx_t *ctx, hts221_pp_od_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_pin_mode_get(hts221_ctx_t *ctx, hts221_pp_od_t *val)
+int32_t hts221_pin_mode_get(stmdev_ctx_t *ctx, hts221_pp_od_t *val)
 {
   hts221_ctrl_reg3_t reg;
   int32_t ret;
@@ -734,7 +717,7 @@ int32_t hts221_pin_mode_get(hts221_ctx_t *ctx, hts221_pp_od_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_int_polarity_set(hts221_ctx_t *ctx, hts221_drdy_h_l_t val)
+int32_t hts221_int_polarity_set(stmdev_ctx_t *ctx, hts221_drdy_h_l_t val)
 {
   hts221_ctrl_reg3_t reg;
   int32_t ret;
@@ -757,7 +740,7 @@ int32_t hts221_int_polarity_set(hts221_ctx_t *ctx, hts221_drdy_h_l_t val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_int_polarity_get(hts221_ctx_t *ctx, hts221_drdy_h_l_t *val)
+int32_t hts221_int_polarity_get(stmdev_ctx_t *ctx, hts221_drdy_h_l_t *val)
 {
   hts221_ctrl_reg3_t reg;
   int32_t ret;
@@ -800,7 +783,7 @@ int32_t hts221_int_polarity_get(hts221_ctx_t *ctx, hts221_drdy_h_l_t *val)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_hum_rh_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_hum_rh_point_0_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -818,7 +801,7 @@ int32_t hts221_hum_rh_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_hum_rh_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_hum_rh_point_1_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -836,7 +819,7 @@ int32_t hts221_hum_rh_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_temp_deg_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_temp_deg_point_0_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   hts221_t1_t0_msb_t reg;
   uint8_t coeff_h, coeff_l;
@@ -861,7 +844,7 @@ int32_t hts221_temp_deg_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_temp_deg_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_temp_deg_point_1_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   hts221_t1_t0_msb_t reg;
   uint8_t coeff_h, coeff_l;
@@ -886,7 +869,7 @@ int32_t hts221_temp_deg_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_hum_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_hum_adc_point_0_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = hts221_read_reg(ctx, HTS221_H0_T0_OUT_L, buff, 2);
@@ -901,7 +884,7 @@ int32_t hts221_hum_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_hum_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_hum_adc_point_1_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = hts221_read_reg(ctx, HTS221_H1_T0_OUT_L, buff, 2);
@@ -916,7 +899,7 @@ int32_t hts221_hum_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_temp_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_temp_adc_point_0_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = hts221_read_reg(ctx, HTS221_T0_OUT_L, buff, 2);
@@ -931,7 +914,7 @@ int32_t hts221_temp_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff)
   * @retval         interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t hts221_temp_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff)
+int32_t hts221_temp_adc_point_1_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = hts221_read_reg(ctx, HTS221_T1_OUT_L, buff, 2);

--- a/sensor/stmemsc/hts221_STdC/driver/hts221_reg.h
+++ b/sensor/stmemsc/hts221_STdC/driver/hts221_reg.h
@@ -1,39 +1,22 @@
 /*
  ******************************************************************************
  * @file    hts221_reg.h
- * @author  MEMS Software Solution Team
+ * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
  *          hts221_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef HTS221_REGS_H
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup HTS221_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  HTS221_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*hts221_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*hts221_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  hts221_write_ptr  write_reg;
-  hts221_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} hts221_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -250,9 +222,9 @@ typedef union{
   *
   */
 
-int32_t hts221_read_reg(hts221_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t hts221_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                         uint16_t len);
-int32_t hts221_write_reg(hts221_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t hts221_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
 
 typedef enum {
@@ -266,8 +238,8 @@ typedef enum {
   HTS221_H_AVG_512  = 7,
   HTS221_H_AVG_ND   = 8,
 } hts221_avgh_t;
-int32_t hts221_humidity_avg_set(hts221_ctx_t *ctx, hts221_avgh_t val);
-int32_t hts221_humidity_avg_get(hts221_ctx_t *ctx, hts221_avgh_t *val);
+int32_t hts221_humidity_avg_set(stmdev_ctx_t *ctx, hts221_avgh_t val);
+int32_t hts221_humidity_avg_get(stmdev_ctx_t *ctx, hts221_avgh_t *val);
 
 typedef enum {
   HTS221_T_AVG_2   = 0,
@@ -280,8 +252,8 @@ typedef enum {
   HTS221_T_AVG_256 = 7,
   HTS221_T_AVG_ND  = 8,
 } hts221_avgt_t;
-int32_t hts221_temperature_avg_set(hts221_ctx_t *ctx, hts221_avgt_t val);
-int32_t hts221_temperature_avg_get(hts221_ctx_t *ctx, hts221_avgt_t *val);
+int32_t hts221_temperature_avg_set(stmdev_ctx_t *ctx, hts221_avgt_t val);
+int32_t hts221_temperature_avg_get(stmdev_ctx_t *ctx, hts221_avgt_t *val);
 
 typedef enum {
   HTS221_ONE_SHOT  = 0,
@@ -290,67 +262,67 @@ typedef enum {
   HTS221_ODR_12Hz5 = 3,
   HTS221_ODR_ND    = 4,
 } hts221_odr_t;
-int32_t hts221_data_rate_set(hts221_ctx_t *ctx, hts221_odr_t val);
-int32_t hts221_data_rate_get(hts221_ctx_t *ctx, hts221_odr_t *val);
+int32_t hts221_data_rate_set(stmdev_ctx_t *ctx, hts221_odr_t val);
+int32_t hts221_data_rate_get(stmdev_ctx_t *ctx, hts221_odr_t *val);
 
-int32_t hts221_block_data_update_set(hts221_ctx_t *ctx, uint8_t val);
-int32_t hts221_block_data_update_get(hts221_ctx_t *ctx, uint8_t *val);
+int32_t hts221_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t hts221_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t hts221_one_shoot_trigger_set(hts221_ctx_t *ctx, uint8_t val);
-int32_t hts221_one_shoot_trigger_get(hts221_ctx_t *ctx, uint8_t *val);
+int32_t hts221_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t hts221_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t hts221_temp_data_ready_get(hts221_ctx_t *ctx, uint8_t *val);
+int32_t hts221_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t hts221_hum_data_ready_get(hts221_ctx_t *ctx, uint8_t *val);
+int32_t hts221_hum_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t hts221_humidity_raw_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_humidity_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t hts221_temperature_raw_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t hts221_device_id_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t hts221_power_on_set(hts221_ctx_t *ctx, uint8_t val);
+int32_t hts221_power_on_set(stmdev_ctx_t *ctx, uint8_t val);
 
-int32_t hts221_power_on_get(hts221_ctx_t *ctx, uint8_t *val);
+int32_t hts221_power_on_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t hts221_heater_set(hts221_ctx_t *ctx, uint8_t val);
-int32_t hts221_heater_get(hts221_ctx_t *ctx, uint8_t *val);
+int32_t hts221_heater_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t hts221_heater_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t hts221_boot_set(hts221_ctx_t *ctx, uint8_t val);
-int32_t hts221_boot_get(hts221_ctx_t *ctx, uint8_t *val);
+int32_t hts221_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t hts221_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t hts221_status_get(hts221_ctx_t *ctx, hts221_status_reg_t *val);
+int32_t hts221_status_get(stmdev_ctx_t *ctx, hts221_status_reg_t *val);
 
-int32_t hts221_drdy_on_int_set(hts221_ctx_t *ctx, uint8_t val);
-int32_t hts221_drdy_on_int_get(hts221_ctx_t *ctx, uint8_t *val);
+int32_t hts221_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t hts221_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   HTS221_PUSH_PULL   = 0,
   HTS221_OPEN_DRAIN  = 1,
   HTS221_PIN_MODE_ND = 2,
 } hts221_pp_od_t;
-int32_t hts221_pin_mode_set(hts221_ctx_t *ctx, hts221_pp_od_t val);
-int32_t hts221_pin_mode_get(hts221_ctx_t *ctx, hts221_pp_od_t *val);
+int32_t hts221_pin_mode_set(stmdev_ctx_t *ctx, hts221_pp_od_t val);
+int32_t hts221_pin_mode_get(stmdev_ctx_t *ctx, hts221_pp_od_t *val);
 
 typedef enum {
   HTS221_ACTIVE_HIGH = 0,
   HTS221_ACTIVE_LOW  = 1,
   HTS221_ACTIVE_ND   = 2,
 } hts221_drdy_h_l_t;
-int32_t hts221_int_polarity_set(hts221_ctx_t *ctx, hts221_drdy_h_l_t val);
-int32_t hts221_int_polarity_get(hts221_ctx_t *ctx, hts221_drdy_h_l_t *val);
+int32_t hts221_int_polarity_set(stmdev_ctx_t *ctx, hts221_drdy_h_l_t val);
+int32_t hts221_int_polarity_get(stmdev_ctx_t *ctx, hts221_drdy_h_l_t *val);
 
-int32_t hts221_hum_rh_point_0_get(hts221_ctx_t *ctx, uint8_t *buff);
-int32_t hts221_hum_rh_point_1_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_hum_rh_point_0_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_hum_rh_point_1_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t hts221_temp_deg_point_0_get(hts221_ctx_t *ctx, uint8_t *buff);
-int32_t hts221_temp_deg_point_1_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_temp_deg_point_0_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_temp_deg_point_1_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t hts221_hum_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff);
-int32_t hts221_hum_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_hum_adc_point_0_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_hum_adc_point_1_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t hts221_temp_adc_point_0_get(hts221_ctx_t *ctx, uint8_t *buff);
-int32_t hts221_temp_adc_point_1_get(hts221_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_temp_adc_point_0_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t hts221_temp_adc_point_1_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 /**
   * @}

--- a/sensor/stmemsc/i3g4250d_STdC/driver/i3g4250d_reg.c
+++ b/sensor/stmemsc/i3g4250d_STdC/driver/i3g4250d_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "i3g4250d_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t i3g4250d_read_reg(i3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t i3g4250d_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t i3g4250d_read_reg(i3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t i3g4250d_write_reg(i3g4250d_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t i3g4250d_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -132,7 +115,7 @@ float_t i3g4250d_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_data_rate_set(i3g4250d_ctx_t *ctx, i3g4250d_dr_t val)
+int32_t i3g4250d_data_rate_set(stmdev_ctx_t *ctx, i3g4250d_dr_t val)
 {
   i3g4250d_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -155,7 +138,7 @@ int32_t i3g4250d_data_rate_set(i3g4250d_ctx_t *ctx, i3g4250d_dr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_data_rate_get(i3g4250d_ctx_t *ctx, i3g4250d_dr_t *val)
+int32_t i3g4250d_data_rate_get(stmdev_ctx_t *ctx, i3g4250d_dr_t *val)
 {
   i3g4250d_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -197,7 +180,7 @@ int32_t i3g4250d_data_rate_get(i3g4250d_ctx_t *ctx, i3g4250d_dr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_status_reg_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_status_reg_get(stmdev_ctx_t *ctx,
                                 i3g4250d_status_reg_t *val)
 {
   int32_t ret;
@@ -213,7 +196,7 @@ int32_t i3g4250d_status_reg_get(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_flag_data_ready_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_status_reg_t status_reg;
   int32_t ret;
@@ -243,7 +226,7 @@ int32_t i3g4250d_flag_data_ready_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_temperature_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
+int32_t i3g4250d_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = i3g4250d_read_reg(ctx, I3G4250D_OUT_TEMP, buff, 1);
@@ -259,7 +242,7 @@ int32_t i3g4250d_temperature_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_angular_rate_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
+int32_t i3g4250d_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  i3g4250d_read_reg(ctx, I3G4250D_OUT_X_L, buff, 6);
@@ -286,7 +269,7 @@ int32_t i3g4250d_angular_rate_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
   * @retval          Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_device_id_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
+int32_t i3g4250d_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = i3g4250d_read_reg(ctx, I3G4250D_WHO_AM_I, buff, 1);
@@ -301,7 +284,7 @@ int32_t i3g4250d_device_id_get(i3g4250d_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_self_test_set(i3g4250d_ctx_t *ctx, i3g4250d_st_t val)
+int32_t i3g4250d_self_test_set(stmdev_ctx_t *ctx, i3g4250d_st_t val)
 {
   i3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -322,7 +305,7 @@ int32_t i3g4250d_self_test_set(i3g4250d_ctx_t *ctx, i3g4250d_st_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_self_test_get(i3g4250d_ctx_t *ctx, i3g4250d_st_t *val)
+int32_t i3g4250d_self_test_get(stmdev_ctx_t *ctx, i3g4250d_st_t *val)
 {
   i3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -355,7 +338,7 @@ int32_t i3g4250d_self_test_get(i3g4250d_ctx_t *ctx, i3g4250d_st_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_data_format_set(i3g4250d_ctx_t *ctx, i3g4250d_ble_t val)
+int32_t i3g4250d_data_format_set(stmdev_ctx_t *ctx, i3g4250d_ble_t val)
 {
   i3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -376,7 +359,7 @@ int32_t i3g4250d_data_format_set(i3g4250d_ctx_t *ctx, i3g4250d_ble_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_data_format_get(i3g4250d_ctx_t *ctx, i3g4250d_ble_t *val)
+int32_t i3g4250d_data_format_get(stmdev_ctx_t *ctx, i3g4250d_ble_t *val)
 {
   i3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -404,7 +387,7 @@ int32_t i3g4250d_data_format_get(i3g4250d_ctx_t *ctx, i3g4250d_ble_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_boot_set(i3g4250d_ctx_t *ctx, uint8_t val)
+int32_t i3g4250d_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   i3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -426,7 +409,7 @@ int32_t i3g4250d_boot_set(i3g4250d_ctx_t *ctx, uint8_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_boot_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -458,7 +441,7 @@ int32_t i3g4250d_boot_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_lp_bandwidth_set(i3g4250d_ctx_t *ctx, i3g4250d_bw_t val)
+int32_t i3g4250d_lp_bandwidth_set(stmdev_ctx_t *ctx, i3g4250d_bw_t val)
 {
   i3g4250d_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -480,7 +463,7 @@ int32_t i3g4250d_lp_bandwidth_set(i3g4250d_ctx_t *ctx, i3g4250d_bw_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_lp_bandwidth_get(i3g4250d_ctx_t *ctx, i3g4250d_bw_t *val)
+int32_t i3g4250d_lp_bandwidth_get(stmdev_ctx_t *ctx, i3g4250d_bw_t *val)
 {
   i3g4250d_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -516,7 +499,7 @@ int32_t i3g4250d_lp_bandwidth_get(i3g4250d_ctx_t *ctx, i3g4250d_bw_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_hp_bandwidth_set(i3g4250d_ctx_t *ctx, i3g4250d_hpcf_t val)
+int32_t i3g4250d_hp_bandwidth_set(stmdev_ctx_t *ctx, i3g4250d_hpcf_t val)
 {
   i3g4250d_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -538,7 +521,7 @@ int32_t i3g4250d_hp_bandwidth_set(i3g4250d_ctx_t *ctx, i3g4250d_hpcf_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_hp_bandwidth_get(i3g4250d_ctx_t *ctx, i3g4250d_hpcf_t *val)
+int32_t i3g4250d_hp_bandwidth_get(stmdev_ctx_t *ctx, i3g4250d_hpcf_t *val)
 {
   i3g4250d_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -592,7 +575,7 @@ int32_t i3g4250d_hp_bandwidth_get(i3g4250d_ctx_t *ctx, i3g4250d_hpcf_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_hp_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t val)
+int32_t i3g4250d_hp_mode_set(stmdev_ctx_t *ctx, i3g4250d_hpm_t val)
 {
   i3g4250d_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -614,7 +597,7 @@ int32_t i3g4250d_hp_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_hp_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t *val)
+int32_t i3g4250d_hp_mode_get(stmdev_ctx_t *ctx, i3g4250d_hpm_t *val)
 {
   i3g4250d_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -650,7 +633,7 @@ int32_t i3g4250d_hp_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t *val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_filter_path_set(i3g4250d_ctx_t *ctx, i3g4250d_out_sel_t val)
+int32_t i3g4250d_filter_path_set(stmdev_ctx_t *ctx, i3g4250d_out_sel_t val)
 {
   i3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -673,7 +656,7 @@ int32_t i3g4250d_filter_path_set(i3g4250d_ctx_t *ctx, i3g4250d_out_sel_t val)
   * @retval         Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_filter_path_get(i3g4250d_ctx_t *ctx, i3g4250d_out_sel_t *val)
+int32_t i3g4250d_filter_path_get(stmdev_ctx_t *ctx, i3g4250d_out_sel_t *val)
 {
   i3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -709,7 +692,7 @@ int32_t i3g4250d_filter_path_get(i3g4250d_ctx_t *ctx, i3g4250d_out_sel_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_filter_path_internal_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_filter_path_internal_set(stmdev_ctx_t *ctx,
                                           i3g4250d_int1_sel_t val)
 {
   i3g4250d_ctrl_reg5_t ctrl_reg5;
@@ -733,7 +716,7 @@ int32_t i3g4250d_filter_path_internal_set(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_filter_path_internal_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_filter_path_internal_get(stmdev_ctx_t *ctx,
                                           i3g4250d_int1_sel_t *val)
 {
   i3g4250d_ctrl_reg5_t ctrl_reg5;
@@ -770,7 +753,7 @@ int32_t i3g4250d_filter_path_internal_get(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_hp_reference_value_set(i3g4250d_ctx_t *ctx, uint8_t val)
+int32_t i3g4250d_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   i3g4250d_reference_t reference;
   int32_t ret;
@@ -792,7 +775,7 @@ int32_t i3g4250d_hp_reference_value_set(i3g4250d_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_hp_reference_value_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_reference_t reference;
   int32_t ret;
@@ -824,7 +807,7 @@ int32_t i3g4250d_hp_reference_value_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_spi_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_sim_t val)
+int32_t i3g4250d_spi_mode_set(stmdev_ctx_t *ctx, i3g4250d_sim_t val)
 {
   i3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -846,7 +829,7 @@ int32_t i3g4250d_spi_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_spi_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_sim_t *val)
+int32_t i3g4250d_spi_mode_get(stmdev_ctx_t *ctx, i3g4250d_sim_t *val)
 {
   i3g4250d_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -889,7 +872,7 @@ int32_t i3g4250d_spi_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_pin_int1_route_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     i3g4250d_int1_route_t val)
 {
   i3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -914,7 +897,7 @@ int32_t i3g4250d_pin_int1_route_set(i3g4250d_ctx_t *ctx,
   *
   */
 
-int32_t i3g4250d_pin_int1_route_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     i3g4250d_int1_route_t *val)
 {
   i3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -934,7 +917,7 @@ int32_t i3g4250d_pin_int1_route_get(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_pin_int2_route_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     i3g4250d_int2_route_t val)
 {
   i3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -960,7 +943,7 @@ int32_t i3g4250d_pin_int2_route_set(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_pin_int2_route_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     i3g4250d_int2_route_t *val)
 {
   i3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -983,7 +966,7 @@ int32_t i3g4250d_pin_int2_route_get(i3g4250d_ctx_t *ctx,
   *
   */
 
-int32_t i3g4250d_pin_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t val)
+int32_t i3g4250d_pin_mode_set(stmdev_ctx_t *ctx, i3g4250d_pp_od_t val)
 {
   i3g4250d_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1005,7 +988,7 @@ int32_t i3g4250d_pin_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_pin_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t *val)
+int32_t i3g4250d_pin_mode_get(stmdev_ctx_t *ctx, i3g4250d_pp_od_t *val)
 {
   i3g4250d_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1035,7 +1018,7 @@ int32_t i3g4250d_pin_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_pin_polarity_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_polarity_set(stmdev_ctx_t *ctx,
                                   i3g4250d_h_lactive_t val)
 {
   i3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -1058,7 +1041,7 @@ int32_t i3g4250d_pin_polarity_set(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_pin_polarity_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_polarity_get(stmdev_ctx_t *ctx,
                                   i3g4250d_h_lactive_t *val)
 {
   i3g4250d_ctrl_reg3_t ctrl_reg3;
@@ -1089,7 +1072,7 @@ int32_t i3g4250d_pin_polarity_get(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_notification_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_notification_set(stmdev_ctx_t *ctx,
                                       i3g4250d_lir_t val)
 {
   i3g4250d_int1_cfg_t int1_cfg;
@@ -1112,7 +1095,7 @@ int32_t i3g4250d_int_notification_set(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_notification_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_notification_get(stmdev_ctx_t *ctx,
                                       i3g4250d_lir_t *val)
 {
   i3g4250d_int1_cfg_t int1_cfg;
@@ -1156,7 +1139,7 @@ int32_t i3g4250d_int_notification_get(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_on_threshold_conf_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                            i3g4250d_int1_cfg_t *val)
 {
   int32_t ret;
@@ -1172,7 +1155,7 @@ int32_t i3g4250d_int_on_threshold_conf_set(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_on_threshold_conf_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                            i3g4250d_int1_cfg_t *val)
 {
   int32_t ret;
@@ -1187,7 +1170,7 @@ int32_t i3g4250d_int_on_threshold_conf_get(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_on_threshold_mode_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                            i3g4250d_and_or_t val)
 {
   i3g4250d_int1_cfg_t int1_cfg;
@@ -1210,7 +1193,7 @@ int32_t i3g4250d_int_on_threshold_mode_set(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_on_threshold_mode_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                            i3g4250d_and_or_t *val)
 {
   i3g4250d_int1_cfg_t int1_cfg;
@@ -1239,7 +1222,7 @@ int32_t i3g4250d_int_on_threshold_mode_get(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_on_threshold_src_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_src_get(stmdev_ctx_t *ctx,
                                           i3g4250d_int1_src_t *val)
 {
   int32_t ret;
@@ -1255,7 +1238,7 @@ int32_t i3g4250d_int_on_threshold_src_get(i3g4250d_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_x_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
+int32_t i3g4250d_int_x_treshold_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   i3g4250d_int1_tsh_xh_t int1_tsh_xh;
   i3g4250d_int1_tsh_xl_t int1_tsh_xl;
@@ -1288,7 +1271,7 @@ int32_t i3g4250d_int_x_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_x_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
+int32_t i3g4250d_int_x_treshold_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   i3g4250d_int1_tsh_xh_t int1_tsh_xh;
   i3g4250d_int1_tsh_xl_t int1_tsh_xl;
@@ -1315,7 +1298,7 @@ int32_t i3g4250d_int_x_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_y_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
+int32_t i3g4250d_int_y_treshold_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   i3g4250d_int1_tsh_yh_t int1_tsh_yh;
   i3g4250d_int1_tsh_yl_t int1_tsh_yl;
@@ -1348,7 +1331,7 @@ int32_t i3g4250d_int_y_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_y_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
+int32_t i3g4250d_int_y_treshold_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   i3g4250d_int1_tsh_yh_t int1_tsh_yh;
   i3g4250d_int1_tsh_yl_t int1_tsh_yl;
@@ -1375,7 +1358,7 @@ int32_t i3g4250d_int_y_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_z_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
+int32_t i3g4250d_int_z_treshold_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   i3g4250d_int1_tsh_zh_t int1_tsh_zh;
   i3g4250d_int1_tsh_zl_t int1_tsh_zl;
@@ -1408,7 +1391,7 @@ int32_t i3g4250d_int_z_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_z_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
+int32_t i3g4250d_int_z_treshold_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   i3g4250d_int1_tsh_zh_t int1_tsh_zh;
   i3g4250d_int1_tsh_zl_t int1_tsh_zl;
@@ -1435,7 +1418,7 @@ int32_t i3g4250d_int_z_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_on_threshold_dur_set(i3g4250d_ctx_t *ctx, uint8_t val)
+int32_t i3g4250d_int_on_threshold_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   i3g4250d_int1_duration_t int1_duration;
   int32_t ret;
@@ -1464,7 +1447,7 @@ int32_t i3g4250d_int_on_threshold_dur_set(i3g4250d_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_int_on_threshold_dur_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_int_on_threshold_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_int1_duration_t int1_duration;
   int32_t ret;
@@ -1496,7 +1479,7 @@ int32_t i3g4250d_int_on_threshold_dur_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_enable_set(i3g4250d_ctx_t *ctx, uint8_t val)
+int32_t i3g4250d_fifo_enable_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   i3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1518,7 +1501,7 @@ int32_t i3g4250d_fifo_enable_set(i3g4250d_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_enable_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_fifo_enable_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1537,7 +1520,7 @@ int32_t i3g4250d_fifo_enable_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_watermark_set(i3g4250d_ctx_t *ctx, uint8_t val)
+int32_t i3g4250d_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   i3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1561,7 +1544,7 @@ int32_t i3g4250d_fifo_watermark_set(i3g4250d_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_watermark_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1581,7 +1564,7 @@ int32_t i3g4250d_fifo_watermark_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t val)
+int32_t i3g4250d_fifo_mode_set(stmdev_ctx_t *ctx, i3g4250d_fifo_mode_t val)
 {
   i3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1605,7 +1588,7 @@ int32_t i3g4250d_fifo_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t *val)
+int32_t i3g4250d_fifo_mode_get(stmdev_ctx_t *ctx, i3g4250d_fifo_mode_t *val)
 {
   i3g4250d_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1639,7 +1622,7 @@ int32_t i3g4250d_fifo_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_data_level_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1659,7 +1642,7 @@ int32_t i3g4250d_fifo_data_level_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_empty_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1679,7 +1662,7 @@ int32_t i3g4250d_fifo_empty_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t i3g4250d_fifo_ovr_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1702,7 +1685,7 @@ int32_t i3g4250d_fifo_ovr_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val)
   *
   */
 
-int32_t i3g4250d_fifo_wtm_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val)
+int32_t i3g4250d_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   i3g4250d_fifo_src_reg_t fifo_src_reg;
   int32_t ret;

--- a/sensor/stmemsc/i3g4250d_STdC/driver/i3g4250d_reg.h
+++ b/sensor/stmemsc/i3g4250d_STdC/driver/i3g4250d_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef I3G4250D_REGS_H
 #define I3G4250D_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup I3G4250D_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,29 +57,57 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
-/**
-  * @defgroup i3g4250d_interface
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
   * @{
   *
   */
 
-typedef int32_t (*i3g4250d_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*i3g4250d_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
-
 typedef struct {
-  /** Component mandatory fields **/
-  i3g4250d_write_ptr  write_reg;
-  i3g4250d_read_ptr   read_reg;
-  /** Customizable optional pointer **/
-  void *handle;
-} i3g4250d_ctx_t;
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -346,22 +321,22 @@ typedef union{
   *
   */
 
-int32_t i3g4250d_read_reg(i3g4250d_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t i3g4250d_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t i3g4250d_write_reg(i3g4250d_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t i3g4250d_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t i3g4250d_from_fs245dps_to_mdps(int16_t lsb);
 extern float_t i3g4250d_from_lsb_to_celsius(int16_t lsb);
 
-int32_t i3g4250d_axis_x_data_set(i3g4250d_ctx_t *ctx, uint8_t val);
-int32_t i3g4250d_axis_x_data_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t i3g4250d_axis_y_data_set(i3g4250d_ctx_t *ctx, uint8_t val);
-int32_t i3g4250d_axis_y_data_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t i3g4250d_axis_z_data_set(i3g4250d_ctx_t *ctx, uint8_t val);
-int32_t i3g4250d_axis_z_data_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   I3G4250D_ODR_OFF     = 0x00,
@@ -371,37 +346,37 @@ typedef enum {
   I3G4250D_ODR_400Hz   = 0x2F,
   I3G4250D_ODR_800Hz   = 0x3F,
 } i3g4250d_dr_t;
-int32_t i3g4250d_data_rate_set(i3g4250d_ctx_t *ctx, i3g4250d_dr_t val);
-int32_t i3g4250d_data_rate_get(i3g4250d_ctx_t *ctx, i3g4250d_dr_t *val);
+int32_t i3g4250d_data_rate_set(stmdev_ctx_t *ctx, i3g4250d_dr_t val);
+int32_t i3g4250d_data_rate_get(stmdev_ctx_t *ctx, i3g4250d_dr_t *val);
 
-int32_t i3g4250d_status_reg_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_status_reg_get(stmdev_ctx_t *ctx,
                                 i3g4250d_status_reg_t *val);
 
-int32_t i3g4250d_flag_data_ready_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t i3g4250d_temperature_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff);
+int32_t i3g4250d_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t i3g4250d_angular_rate_raw_get(i3g4250d_ctx_t *ctx, uint8_t *buff);
+int32_t i3g4250d_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t i3g4250d_device_id_get(i3g4250d_ctx_t *ctx, uint8_t *buff);
+int32_t i3g4250d_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   I3G4250D_GY_ST_DISABLE    = 0,
   I3G4250D_GY_ST_POSITIVE   = 1,
   I3G4250D_GY_ST_NEGATIVE   = 3,
 } i3g4250d_st_t;
-int32_t i3g4250d_self_test_set(i3g4250d_ctx_t *ctx, i3g4250d_st_t val);
-int32_t i3g4250d_self_test_get(i3g4250d_ctx_t *ctx, i3g4250d_st_t *val);
+int32_t i3g4250d_self_test_set(stmdev_ctx_t *ctx, i3g4250d_st_t val);
+int32_t i3g4250d_self_test_get(stmdev_ctx_t *ctx, i3g4250d_st_t *val);
 
 typedef enum {
   I3G4250D_AUX_LSB_AT_LOW_ADD   = 0,
   I3G4250D_AUX_MSB_AT_LOW_ADD   = 1,
 } i3g4250d_ble_t;
-int32_t i3g4250d_data_format_set(i3g4250d_ctx_t *ctx, i3g4250d_ble_t val);
-int32_t i3g4250d_data_format_get(i3g4250d_ctx_t *ctx, i3g4250d_ble_t *val);
+int32_t i3g4250d_data_format_set(stmdev_ctx_t *ctx, i3g4250d_ble_t val);
+int32_t i3g4250d_data_format_get(stmdev_ctx_t *ctx, i3g4250d_ble_t *val);
 
-int32_t i3g4250d_boot_set(i3g4250d_ctx_t *ctx, uint8_t val);
-int32_t i3g4250d_boot_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   I3G4250D_CUT_OFF_LOW        = 0,
@@ -409,8 +384,8 @@ typedef enum {
   I3G4250D_CUT_OFF_HIGH       = 2,
   I3G4250D_CUT_OFF_VERY_HIGH  = 3,
 } i3g4250d_bw_t;
-int32_t i3g4250d_lp_bandwidth_set(i3g4250d_ctx_t *ctx, i3g4250d_bw_t val);
-int32_t i3g4250d_lp_bandwidth_get(i3g4250d_ctx_t *ctx, i3g4250d_bw_t *val);
+int32_t i3g4250d_lp_bandwidth_set(stmdev_ctx_t *ctx, i3g4250d_bw_t val);
+int32_t i3g4250d_lp_bandwidth_get(stmdev_ctx_t *ctx, i3g4250d_bw_t *val);
 
 typedef enum {
   I3G4250D_HP_LEVEL_0   = 0,
@@ -424,9 +399,9 @@ typedef enum {
   I3G4250D_HP_LEVEL_8   = 8,
   I3G4250D_HP_LEVEL_9   = 9,
 } i3g4250d_hpcf_t;
-int32_t i3g4250d_hp_bandwidth_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                   i3g4250d_hpcf_t val);
-int32_t i3g4250d_hp_bandwidth_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                   i3g4250d_hpcf_t *val);
 
 typedef enum {
@@ -435,8 +410,8 @@ typedef enum {
   I3G4250D_HP_NORMAL_MODE           = 2,
   I3G4250D_HP_AUTO_RESET_ON_INT     = 3,
 } i3g4250d_hpm_t;
-int32_t i3g4250d_hp_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t val);
-int32_t i3g4250d_hp_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_hpm_t *val);
+int32_t i3g4250d_hp_mode_set(stmdev_ctx_t *ctx, i3g4250d_hpm_t val);
+int32_t i3g4250d_hp_mode_get(stmdev_ctx_t *ctx, i3g4250d_hpm_t *val);
 
 typedef enum {
   I3G4250D_ONLY_LPF1_ON_OUT     = 0,
@@ -444,9 +419,9 @@ typedef enum {
   I3G4250D_LPF1_LPF2_ON_OUT     = 2,
   I3G4250D_LPF1_HP_LPF2_ON_OUT  = 6,
 } i3g4250d_out_sel_t;
-int32_t i3g4250d_filter_path_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_filter_path_set(stmdev_ctx_t *ctx,
                                  i3g4250d_out_sel_t val);
-int32_t i3g4250d_filter_path_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_filter_path_get(stmdev_ctx_t *ctx,
                                  i3g4250d_out_sel_t *val);
 
 typedef enum {
@@ -455,28 +430,28 @@ typedef enum {
   I3G4250D_LPF1_LPF2_ON_INT     = 2,
   I3G4250D_LPF1_HP_LPF2_ON_INT  = 6,
 } i3g4250d_int1_sel_t;
-int32_t i3g4250d_filter_path_internal_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_filter_path_internal_set(stmdev_ctx_t *ctx,
                                           i3g4250d_int1_sel_t val);
-int32_t i3g4250d_filter_path_internal_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_filter_path_internal_get(stmdev_ctx_t *ctx,
                                           i3g4250d_int1_sel_t *val);
 
-int32_t i3g4250d_hp_reference_value_set(i3g4250d_ctx_t *ctx, uint8_t val);
-int32_t i3g4250d_hp_reference_value_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   I3G4250D_SPI_4_WIRE  = 0,
   I3G4250D_SPI_3_WIRE  = 1,
 } i3g4250d_sim_t;
-int32_t i3g4250d_spi_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_sim_t val);
-int32_t i3g4250d_spi_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_sim_t *val);
+int32_t i3g4250d_spi_mode_set(stmdev_ctx_t *ctx, i3g4250d_sim_t val);
+int32_t i3g4250d_spi_mode_get(stmdev_ctx_t *ctx, i3g4250d_sim_t *val);
 
 typedef struct {
   uint8_t i1_int1             : 1;
   uint8_t i1_boot             : 1;
 } i3g4250d_int1_route_t;
-int32_t i3g4250d_pin_int1_route_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     i3g4250d_int1_route_t val);
-int32_t i3g4250d_pin_int1_route_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     i3g4250d_int1_route_t *val);
 
 typedef struct {
@@ -485,86 +460,86 @@ typedef struct {
   uint8_t i2_wtm               : 1;
   uint8_t i2_drdy              : 1;
 } i3g4250d_int2_route_t;
-int32_t i3g4250d_pin_int2_route_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     i3g4250d_int2_route_t val);
-int32_t i3g4250d_pin_int2_route_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     i3g4250d_int2_route_t *val);
 
 typedef enum {
   I3G4250D_PUSH_PULL   = 0,
   I3G4250D_OPEN_DRAIN  = 1,
 } i3g4250d_pp_od_t;
-int32_t i3g4250d_pin_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t val);
-int32_t i3g4250d_pin_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_pp_od_t *val);
+int32_t i3g4250d_pin_mode_set(stmdev_ctx_t *ctx, i3g4250d_pp_od_t val);
+int32_t i3g4250d_pin_mode_get(stmdev_ctx_t *ctx, i3g4250d_pp_od_t *val);
 
 typedef enum {
   I3G4250D_ACTIVE_HIGH  = 0,
   I3G4250D_ACTIVE_LOW   = 1,
 } i3g4250d_h_lactive_t;
-int32_t i3g4250d_pin_polarity_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_polarity_set(stmdev_ctx_t *ctx,
                                   i3g4250d_h_lactive_t val);
-int32_t i3g4250d_pin_polarity_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_pin_polarity_get(stmdev_ctx_t *ctx,
                                   i3g4250d_h_lactive_t *val);
 
 typedef enum {
   I3G4250D_INT_PULSED   = 0,
   I3G4250D_INT_LATCHED  = 1,
 } i3g4250d_lir_t;
-int32_t i3g4250d_int_notification_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_notification_set(stmdev_ctx_t *ctx,
                                       i3g4250d_lir_t val);
-int32_t i3g4250d_int_notification_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_notification_get(stmdev_ctx_t *ctx,
                                       i3g4250d_lir_t *val);
 
-int32_t i3g4250d_int_on_threshold_conf_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                            i3g4250d_int1_cfg_t *val);
-int32_t i3g4250d_int_on_threshold_conf_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                            i3g4250d_int1_cfg_t *val);
 
 typedef enum {
   I3G4250D_INT1_ON_TH_AND  = 1,
   I3G4250D_INT1_ON_TH_OR   = 0,
 } i3g4250d_and_or_t;
-int32_t i3g4250d_int_on_threshold_mode_set(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                            i3g4250d_and_or_t val);
-int32_t i3g4250d_int_on_threshold_mode_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                            i3g4250d_and_or_t *val);
 
-int32_t i3g4250d_int_on_threshold_src_get(i3g4250d_ctx_t *ctx,
+int32_t i3g4250d_int_on_threshold_src_get(stmdev_ctx_t *ctx,
                                           i3g4250d_int1_src_t *val);
 
-int32_t i3g4250d_int_x_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val);
-int32_t i3g4250d_int_x_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val);
+int32_t i3g4250d_int_x_treshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t i3g4250d_int_x_treshold_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t i3g4250d_int_y_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val);
-int32_t i3g4250d_int_y_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val);
+int32_t i3g4250d_int_y_treshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t i3g4250d_int_y_treshold_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t i3g4250d_int_z_treshold_set(i3g4250d_ctx_t *ctx, uint16_t val);
-int32_t i3g4250d_int_z_treshold_get(i3g4250d_ctx_t *ctx, uint16_t *val);
+int32_t i3g4250d_int_z_treshold_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t i3g4250d_int_z_treshold_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t i3g4250d_int_on_threshold_dur_set(i3g4250d_ctx_t *ctx, uint8_t val);
-int32_t i3g4250d_int_on_threshold_dur_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_int_on_threshold_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_int_on_threshold_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t i3g4250d_fifo_enable_set(i3g4250d_ctx_t *ctx, uint8_t val);
-int32_t i3g4250d_fifo_enable_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_fifo_enable_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_fifo_enable_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t i3g4250d_fifo_watermark_set(i3g4250d_ctx_t *ctx, uint8_t val);
-int32_t i3g4250d_fifo_watermark_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t i3g4250d_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   I3G4250D_FIFO_BYPASS_MODE     = 0x00,
   I3G4250D_FIFO_MODE            = 0x01,
   I3G4250D_FIFO_STREAM_MODE     = 0x02,
 } i3g4250d_fifo_mode_t;
-int32_t i3g4250d_fifo_mode_set(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t val);
-int32_t i3g4250d_fifo_mode_get(i3g4250d_ctx_t *ctx, i3g4250d_fifo_mode_t *val);
+int32_t i3g4250d_fifo_mode_set(stmdev_ctx_t *ctx, i3g4250d_fifo_mode_t val);
+int32_t i3g4250d_fifo_mode_get(stmdev_ctx_t *ctx, i3g4250d_fifo_mode_t *val);
 
-int32_t i3g4250d_fifo_data_level_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t i3g4250d_fifo_empty_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t i3g4250d_fifo_ovr_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t i3g4250d_fifo_wtm_flag_get(i3g4250d_ctx_t *ctx, uint8_t *val);
+int32_t i3g4250d_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/iis2dh_STdC/driver/iis2dh_reg.c
+++ b/sensor/stmemsc/iis2dh_STdC/driver/iis2dh_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "iis2dh_reg.h"
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_read_reg(iis2dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis2dh_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                         uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t iis2dh_read_reg(iis2dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_write_reg(iis2dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis2dh_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -196,7 +179,7 @@ float iis2dh_from_lsb_lp_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_temp_status_reg_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dh_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_STATUS_REG_AUX, buff, 1);
@@ -210,7 +193,7 @@ int32_t iis2dh_temp_status_reg_get(iis2dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_temp_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -229,7 +212,7 @@ int32_t iis2dh_temp_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_temp_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -248,7 +231,7 @@ int32_t iis2dh_temp_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_temperature_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dh_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_OUT_TEMP_L, buff, 2);
@@ -262,7 +245,7 @@ int32_t iis2dh_temperature_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_temperature_meas_set(iis2dh_ctx_t *ctx, iis2dh_temp_en_t val)
+int32_t iis2dh_temperature_meas_set(stmdev_ctx_t *ctx, iis2dh_temp_en_t val)
 {
   iis2dh_temp_cfg_reg_t temp_cfg_reg;
   int32_t ret;
@@ -284,7 +267,7 @@ int32_t iis2dh_temperature_meas_set(iis2dh_ctx_t *ctx, iis2dh_temp_en_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_temperature_meas_get(iis2dh_ctx_t *ctx, iis2dh_temp_en_t *val)
+int32_t iis2dh_temperature_meas_get(stmdev_ctx_t *ctx, iis2dh_temp_en_t *val)
 {
   iis2dh_temp_cfg_reg_t temp_cfg_reg;
   int32_t ret;
@@ -313,7 +296,7 @@ int32_t iis2dh_temperature_meas_get(iis2dh_ctx_t *ctx, iis2dh_temp_en_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_operating_mode_set(iis2dh_ctx_t *ctx, iis2dh_op_md_t val)
+int32_t iis2dh_operating_mode_set(stmdev_ctx_t *ctx, iis2dh_op_md_t val)
 {
   iis2dh_ctrl_reg1_t ctrl_reg1;
   iis2dh_ctrl_reg4_t ctrl_reg4;
@@ -352,7 +335,7 @@ int32_t iis2dh_operating_mode_set(iis2dh_ctx_t *ctx, iis2dh_op_md_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_operating_mode_get(iis2dh_ctx_t *ctx, iis2dh_op_md_t *val)
+int32_t iis2dh_operating_mode_get(stmdev_ctx_t *ctx, iis2dh_op_md_t *val)
 {
   iis2dh_ctrl_reg1_t ctrl_reg1;
   iis2dh_ctrl_reg4_t ctrl_reg4;
@@ -380,7 +363,7 @@ int32_t iis2dh_operating_mode_get(iis2dh_ctx_t *ctx, iis2dh_op_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_data_rate_set(iis2dh_ctx_t *ctx, iis2dh_odr_t val)
+int32_t iis2dh_data_rate_set(stmdev_ctx_t *ctx, iis2dh_odr_t val)
 {
   iis2dh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -401,7 +384,7 @@ int32_t iis2dh_data_rate_set(iis2dh_ctx_t *ctx, iis2dh_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_data_rate_get(iis2dh_ctx_t *ctx, iis2dh_odr_t *val)
+int32_t iis2dh_data_rate_get(stmdev_ctx_t *ctx, iis2dh_odr_t *val)
 {
   iis2dh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -454,7 +437,7 @@ int32_t iis2dh_data_rate_get(iis2dh_ctx_t *ctx, iis2dh_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_high_pass_on_outputs_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -476,7 +459,7 @@ int32_t iis2dh_high_pass_on_outputs_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_high_pass_on_outputs_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -501,7 +484,7 @@ int32_t iis2dh_high_pass_on_outputs_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_high_pass_bandwidth_set(iis2dh_ctx_t *ctx, iis2dh_hpcf_t val)
+int32_t iis2dh_high_pass_bandwidth_set(stmdev_ctx_t *ctx, iis2dh_hpcf_t val)
 {
   iis2dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -528,7 +511,7 @@ int32_t iis2dh_high_pass_bandwidth_set(iis2dh_ctx_t *ctx, iis2dh_hpcf_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_high_pass_bandwidth_get(iis2dh_ctx_t *ctx, iis2dh_hpcf_t *val)
+int32_t iis2dh_high_pass_bandwidth_get(stmdev_ctx_t *ctx, iis2dh_hpcf_t *val)
 {
   iis2dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -562,7 +545,7 @@ int32_t iis2dh_high_pass_bandwidth_get(iis2dh_ctx_t *ctx, iis2dh_hpcf_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_high_pass_mode_set(iis2dh_ctx_t *ctx, iis2dh_hpm_t val)
+int32_t iis2dh_high_pass_mode_set(stmdev_ctx_t *ctx, iis2dh_hpm_t val)
 {
   iis2dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -583,7 +566,7 @@ int32_t iis2dh_high_pass_mode_set(iis2dh_ctx_t *ctx, iis2dh_hpm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_high_pass_mode_get(iis2dh_ctx_t *ctx, iis2dh_hpm_t *val)
+int32_t iis2dh_high_pass_mode_get(stmdev_ctx_t *ctx, iis2dh_hpm_t *val)
 {
   iis2dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -617,7 +600,7 @@ int32_t iis2dh_high_pass_mode_get(iis2dh_ctx_t *ctx, iis2dh_hpm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_full_scale_set(iis2dh_ctx_t *ctx, iis2dh_fs_t val)
+int32_t iis2dh_full_scale_set(stmdev_ctx_t *ctx, iis2dh_fs_t val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -638,7 +621,7 @@ int32_t iis2dh_full_scale_set(iis2dh_ctx_t *ctx, iis2dh_fs_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_full_scale_get(iis2dh_ctx_t *ctx, iis2dh_fs_t *val)
+int32_t iis2dh_full_scale_get(stmdev_ctx_t *ctx, iis2dh_fs_t *val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -672,7 +655,7 @@ int32_t iis2dh_full_scale_get(iis2dh_ctx_t *ctx, iis2dh_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_block_data_update_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -693,7 +676,7 @@ int32_t iis2dh_block_data_update_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_block_data_update_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -713,7 +696,7 @@ int32_t iis2dh_block_data_update_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_filter_reference_set(iis2dh_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dh_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dh_write_reg(ctx, IIS2DH_REFERENCE, buff, 1);
@@ -729,7 +712,7 @@ int32_t iis2dh_filter_reference_set(iis2dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_filter_reference_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dh_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_REFERENCE, buff, 1);
@@ -743,7 +726,7 @@ int32_t iis2dh_filter_reference_get(iis2dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_xl_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_status_reg_t status_reg;
   int32_t ret;
@@ -761,7 +744,7 @@ int32_t iis2dh_xl_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_xl_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_status_reg_t status_reg;
   int32_t ret;
@@ -779,7 +762,7 @@ int32_t iis2dh_xl_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_acceleration_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_OUT_X_L, buff, 6);
@@ -805,7 +788,7 @@ int32_t iis2dh_acceleration_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_device_id_get(iis2dh_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_WHO_AM_I, buff, 1);
@@ -819,7 +802,7 @@ int32_t iis2dh_device_id_get(iis2dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_self_test_set(iis2dh_ctx_t *ctx, iis2dh_st_t val)
+int32_t iis2dh_self_test_set(stmdev_ctx_t *ctx, iis2dh_st_t val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -840,7 +823,7 @@ int32_t iis2dh_self_test_set(iis2dh_ctx_t *ctx, iis2dh_st_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_self_test_get(iis2dh_ctx_t *ctx, iis2dh_st_t *val)
+int32_t iis2dh_self_test_get(stmdev_ctx_t *ctx, iis2dh_st_t *val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -871,7 +854,7 @@ int32_t iis2dh_self_test_get(iis2dh_ctx_t *ctx, iis2dh_st_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_data_format_set(iis2dh_ctx_t *ctx, iis2dh_ble_t val)
+int32_t iis2dh_data_format_set(stmdev_ctx_t *ctx, iis2dh_ble_t val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -892,7 +875,7 @@ int32_t iis2dh_data_format_set(iis2dh_ctx_t *ctx, iis2dh_ble_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_data_format_get(iis2dh_ctx_t *ctx, iis2dh_ble_t *val)
+int32_t iis2dh_data_format_get(stmdev_ctx_t *ctx, iis2dh_ble_t *val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -920,7 +903,7 @@ int32_t iis2dh_data_format_get(iis2dh_ctx_t *ctx, iis2dh_ble_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_boot_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -941,7 +924,7 @@ int32_t iis2dh_boot_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_boot_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -960,7 +943,7 @@ int32_t iis2dh_boot_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int_occurrencies_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_int_occurrencies_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_INT_COUNTER_REG, (uint8_t*) val, 1);
@@ -975,7 +958,7 @@ int32_t iis2dh_int_occurrencies_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_status_get(iis2dh_ctx_t *ctx, iis2dh_status_reg_t *val)
+int32_t iis2dh_status_get(stmdev_ctx_t *ctx, iis2dh_status_reg_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_STATUS_REG, (uint8_t*) val, 1);
@@ -1002,7 +985,7 @@ int32_t iis2dh_status_get(iis2dh_ctx_t *ctx, iis2dh_status_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val)
+int32_t iis2dh_int1_gen_conf_set(stmdev_ctx_t *ctx, iis2dh_int1_cfg_t *val)
 {
   int32_t ret;
   ret = iis2dh_write_reg(ctx, IIS2DH_INT1_CFG, (uint8_t*) val, 1);
@@ -1017,7 +1000,7 @@ int32_t iis2dh_int1_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val)
+int32_t iis2dh_int1_gen_conf_get(stmdev_ctx_t *ctx, iis2dh_int1_cfg_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_INT1_CFG, (uint8_t*) val, 1);
@@ -1032,7 +1015,7 @@ int32_t iis2dh_int1_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int1_src_t *val)
+int32_t iis2dh_int1_gen_source_get(stmdev_ctx_t *ctx, iis2dh_int1_src_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_INT1_SRC, (uint8_t*) val, 1);
@@ -1048,7 +1031,7 @@ int32_t iis2dh_int1_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int1_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_int1_ths_t int1_ths;
   int32_t ret;
@@ -1071,7 +1054,7 @@ int32_t iis2dh_int1_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_int1_ths_t int1_ths;
   int32_t ret;
@@ -1091,7 +1074,7 @@ int32_t iis2dh_int1_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_int1_duration_t int1_duration;
   int32_t ret;
@@ -1115,7 +1098,7 @@ int32_t iis2dh_int1_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_int1_duration_t int1_duration;
   int32_t ret;
@@ -1148,7 +1131,7 @@ int32_t iis2dh_int1_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val)
+int32_t iis2dh_int2_gen_conf_set(stmdev_ctx_t *ctx, iis2dh_int2_cfg_t *val)
 {
   int32_t ret;
   ret = iis2dh_write_reg(ctx, IIS2DH_INT2_CFG, (uint8_t*) val, 1);
@@ -1163,7 +1146,7 @@ int32_t iis2dh_int2_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val)
+int32_t iis2dh_int2_gen_conf_get(stmdev_ctx_t *ctx, iis2dh_int2_cfg_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_INT2_CFG, (uint8_t*) val, 1);
@@ -1177,7 +1160,7 @@ int32_t iis2dh_int2_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int2_src_t *val)
+int32_t iis2dh_int2_gen_source_get(stmdev_ctx_t *ctx, iis2dh_int2_src_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_INT2_SRC, (uint8_t*) val, 1);
@@ -1193,7 +1176,7 @@ int32_t iis2dh_int2_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int2_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_int2_ths_t int2_ths;
   int32_t ret;
@@ -1216,7 +1199,7 @@ int32_t iis2dh_int2_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_int2_ths_t int2_ths;
   int32_t ret;
@@ -1236,7 +1219,7 @@ int32_t iis2dh_int2_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_int2_duration_t int2_duration;
   int32_t ret;
@@ -1260,7 +1243,7 @@ int32_t iis2dh_int2_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_int2_duration_t int2_duration;
   int32_t ret;
@@ -1292,7 +1275,7 @@ int32_t iis2dh_int2_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_high_pass_int_conf_set(iis2dh_ctx_t *ctx, iis2dh_hp_t val)
+int32_t iis2dh_high_pass_int_conf_set(stmdev_ctx_t *ctx, iis2dh_hp_t val)
 {
   iis2dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1313,7 +1296,7 @@ int32_t iis2dh_high_pass_int_conf_set(iis2dh_ctx_t *ctx, iis2dh_hp_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_high_pass_int_conf_get(iis2dh_ctx_t *ctx, iis2dh_hp_t *val)
+int32_t iis2dh_high_pass_int_conf_get(stmdev_ctx_t *ctx, iis2dh_hp_t *val)
 {
   iis2dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1359,7 +1342,7 @@ int32_t iis2dh_high_pass_int_conf_get(iis2dh_ctx_t *ctx, iis2dh_hp_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_pin_int1_config_set(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg3_t *val)
+int32_t iis2dh_pin_int1_config_set(stmdev_ctx_t *ctx, iis2dh_ctrl_reg3_t *val)
 {
   int32_t ret;
   ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG3, (uint8_t*) val, 1);
@@ -1374,7 +1357,7 @@ int32_t iis2dh_pin_int1_config_set(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg3_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_pin_int1_config_get(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg3_t *val)
+int32_t iis2dh_pin_int1_config_get(stmdev_ctx_t *ctx, iis2dh_ctrl_reg3_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG3, (uint8_t*) val, 1);
@@ -1390,7 +1373,7 @@ int32_t iis2dh_pin_int1_config_get(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg3_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1412,7 +1395,7 @@ int32_t iis2dh_int2_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1433,7 +1416,7 @@ int32_t iis2dh_int2_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_pin_notification_mode_set(iis2dh_ctx_t *ctx,
+int32_t iis2dh_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                               iis2dh_lir_int2_t val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
@@ -1457,7 +1440,7 @@ int32_t iis2dh_int2_pin_notification_mode_set(iis2dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int2_pin_notification_mode_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                               iis2dh_lir_int2_t *val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
@@ -1487,7 +1470,7 @@ int32_t iis2dh_int2_pin_notification_mode_get(iis2dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1509,7 +1492,7 @@ int32_t iis2dh_int1_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1529,7 +1512,7 @@ int32_t iis2dh_int1_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_pin_notification_mode_set(iis2dh_ctx_t *ctx,
+int32_t iis2dh_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                               iis2dh_lir_int1_t val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
@@ -1552,7 +1535,7 @@ int32_t iis2dh_int1_pin_notification_mode_set(iis2dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_int1_pin_notification_mode_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                               iis2dh_lir_int1_t *val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
@@ -1581,7 +1564,7 @@ int32_t iis2dh_int1_pin_notification_mode_get(iis2dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_pin_int2_config_set(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg6_t *val)
+int32_t iis2dh_pin_int2_config_set(stmdev_ctx_t *ctx, iis2dh_ctrl_reg6_t *val)
 {
   int32_t ret;
   ret = iis2dh_write_reg(ctx, IIS2DH_CTRL_REG6, (uint8_t*) val, 1);
@@ -1596,7 +1579,7 @@ int32_t iis2dh_pin_int2_config_set(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg6_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_pin_int2_config_get(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg6_t *val)
+int32_t iis2dh_pin_int2_config_get(stmdev_ctx_t *ctx, iis2dh_ctrl_reg6_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_CTRL_REG6, (uint8_t*) val, 1);
@@ -1623,7 +1606,7 @@ int32_t iis2dh_pin_int2_config_get(iis2dh_ctx_t *ctx, iis2dh_ctrl_reg6_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1644,7 +1627,7 @@ int32_t iis2dh_fifo_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1663,7 +1646,7 @@ int32_t iis2dh_fifo_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_watermark_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1686,7 +1669,7 @@ int32_t iis2dh_fifo_watermark_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_watermark_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1706,7 +1689,7 @@ int32_t iis2dh_fifo_watermark_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_trigger_event_set(iis2dh_ctx_t *ctx, iis2dh_tr_t val)
+int32_t iis2dh_fifo_trigger_event_set(stmdev_ctx_t *ctx, iis2dh_tr_t val)
 {
   iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1729,7 +1712,7 @@ int32_t iis2dh_fifo_trigger_event_set(iis2dh_ctx_t *ctx, iis2dh_tr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_trigger_event_get(iis2dh_ctx_t *ctx, iis2dh_tr_t *val)
+int32_t iis2dh_fifo_trigger_event_get(stmdev_ctx_t *ctx, iis2dh_tr_t *val)
 {
   iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1758,7 +1741,7 @@ int32_t iis2dh_fifo_trigger_event_get(iis2dh_ctx_t *ctx, iis2dh_tr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_mode_set(iis2dh_ctx_t *ctx, iis2dh_fm_t val)
+int32_t iis2dh_fifo_mode_set(stmdev_ctx_t *ctx, iis2dh_fm_t val)
 {
   iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1781,7 +1764,7 @@ int32_t iis2dh_fifo_mode_set(iis2dh_ctx_t *ctx, iis2dh_fm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_mode_get(iis2dh_ctx_t *ctx, iis2dh_fm_t *val)
+int32_t iis2dh_fifo_mode_get(stmdev_ctx_t *ctx, iis2dh_fm_t *val)
 {
   iis2dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1816,7 +1799,7 @@ int32_t iis2dh_fifo_mode_get(iis2dh_ctx_t *ctx, iis2dh_fm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_status_get(iis2dh_ctx_t *ctx, iis2dh_fifo_src_reg_t *val)
+int32_t iis2dh_fifo_status_get(stmdev_ctx_t *ctx, iis2dh_fifo_src_reg_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_FIFO_SRC_REG, (uint8_t*) val, 1);
@@ -1830,7 +1813,7 @@ int32_t iis2dh_fifo_status_get(iis2dh_ctx_t *ctx, iis2dh_fifo_src_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_data_level_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1848,7 +1831,7 @@ int32_t iis2dh_fifo_data_level_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_empty_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1866,7 +1849,7 @@ int32_t iis2dh_fifo_empty_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_ovr_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1884,7 +1867,7 @@ int32_t iis2dh_fifo_ovr_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_fifo_fth_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1915,7 +1898,7 @@ int32_t iis2dh_fifo_fth_flag_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_tap_conf_set(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val)
+int32_t iis2dh_tap_conf_set(stmdev_ctx_t *ctx, iis2dh_click_cfg_t *val)
 {
   int32_t ret;
   ret = iis2dh_write_reg(ctx, IIS2DH_CLICK_CFG, (uint8_t*) val, 1);
@@ -1930,7 +1913,7 @@ int32_t iis2dh_tap_conf_set(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_tap_conf_get(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val)
+int32_t iis2dh_tap_conf_get(stmdev_ctx_t *ctx, iis2dh_click_cfg_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_CLICK_CFG, (uint8_t*) val, 1);
@@ -1944,7 +1927,7 @@ int32_t iis2dh_tap_conf_get(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_tap_source_get(iis2dh_ctx_t *ctx, iis2dh_click_src_t *val)
+int32_t iis2dh_tap_source_get(stmdev_ctx_t *ctx, iis2dh_click_src_t *val)
 {
   int32_t ret;
   ret = iis2dh_read_reg(ctx, IIS2DH_CLICK_SRC, (uint8_t*) val, 1);
@@ -1959,7 +1942,7 @@ int32_t iis2dh_tap_source_get(iis2dh_ctx_t *ctx, iis2dh_click_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_tap_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_click_ths_t click_ths;
   int32_t ret;
@@ -1981,7 +1964,7 @@ int32_t iis2dh_tap_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_tap_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_click_ths_t click_ths;
   int32_t ret;
@@ -2002,7 +1985,7 @@ int32_t iis2dh_tap_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_shock_dur_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_time_limit_t time_limit;
   int32_t ret;
@@ -2025,7 +2008,7 @@ int32_t iis2dh_shock_dur_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_shock_dur_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_time_limit_t time_limit;
   int32_t ret;
@@ -2047,7 +2030,7 @@ int32_t iis2dh_shock_dur_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_quiet_dur_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_time_latency_t time_latency;
   int32_t ret;
@@ -2072,7 +2055,7 @@ int32_t iis2dh_quiet_dur_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_quiet_dur_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_time_latency_t time_latency;
   int32_t ret;
@@ -2094,7 +2077,7 @@ int32_t iis2dh_quiet_dur_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_double_tap_timeout_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_time_window_t time_window;
   int32_t ret;
@@ -2118,7 +2101,7 @@ int32_t iis2dh_double_tap_timeout_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_double_tap_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_time_window_t time_window;
   int32_t ret;
@@ -2152,7 +2135,7 @@ int32_t iis2dh_double_tap_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_act_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_act_ths_t act_ths;
   int32_t ret;
@@ -2175,7 +2158,7 @@ int32_t iis2dh_act_threshold_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_act_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_act_ths_t act_ths;
   int32_t ret;
@@ -2195,7 +2178,7 @@ int32_t iis2dh_act_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_act_timeout_set(iis2dh_ctx_t *ctx, uint8_t val)
+int32_t iis2dh_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dh_act_dur_t act_dur;
   int32_t ret;
@@ -2217,7 +2200,7 @@ int32_t iis2dh_act_timeout_set(iis2dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_act_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val)
+int32_t iis2dh_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dh_act_dur_t act_dur;
   int32_t ret;
@@ -2249,7 +2232,7 @@ int32_t iis2dh_act_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_spi_mode_set(iis2dh_ctx_t *ctx, iis2dh_sim_t val)
+int32_t iis2dh_spi_mode_set(stmdev_ctx_t *ctx, iis2dh_sim_t val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -2270,7 +2253,7 @@ int32_t iis2dh_spi_mode_set(iis2dh_ctx_t *ctx, iis2dh_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dh_spi_mode_get(iis2dh_ctx_t *ctx, iis2dh_sim_t *val)
+int32_t iis2dh_spi_mode_get(stmdev_ctx_t *ctx, iis2dh_sim_t *val)
 {
   iis2dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;

--- a/sensor/stmemsc/iis2dh_STdC/driver/iis2dh_reg.h
+++ b/sensor/stmemsc/iis2dh_STdC/driver/iis2dh_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup IIS2DH_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup LIS3MDL_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*iis2dh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*iis2dh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  iis2dh_write_ptr  write_reg;
-  iis2dh_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} iis2dh_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -452,9 +424,9 @@ typedef union{
   *
   */
 
-int32_t iis2dh_read_reg(iis2dh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis2dh_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                         uint16_t len);
-int32_t iis2dh_write_reg(iis2dh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis2dh_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
 
 extern float iis2dh_from_fs2_hr_to_mg(int16_t lsb);
@@ -475,27 +447,27 @@ extern float iis2dh_from_fs8_lp_to_mg(int16_t lsb);
 extern float iis2dh_from_fs16_lp_to_mg(int16_t lsb);
 extern float iis2dh_from_lsb_lp_to_celsius(int16_t lsb);
 
-int32_t iis2dh_temp_status_reg_get(iis2dh_ctx_t *ctx, uint8_t *buff);
-int32_t iis2dh_temp_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dh_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_temp_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_temperature_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dh_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   IIS2DH_TEMP_DISABLE  = 0,
   IIS2DH_TEMP_ENABLE   = 3,
 } iis2dh_temp_en_t;
-int32_t iis2dh_temperature_meas_set(iis2dh_ctx_t *ctx, iis2dh_temp_en_t val);
-int32_t iis2dh_temperature_meas_get(iis2dh_ctx_t *ctx, iis2dh_temp_en_t *val);
+int32_t iis2dh_temperature_meas_set(stmdev_ctx_t *ctx, iis2dh_temp_en_t val);
+int32_t iis2dh_temperature_meas_get(stmdev_ctx_t *ctx, iis2dh_temp_en_t *val);
 
 typedef enum {
   IIS2DH_HR_12bit   = 0,
   IIS2DH_NM_10bit   = 1,
   IIS2DH_LP_8bit    = 2,
 } iis2dh_op_md_t;
-int32_t iis2dh_operating_mode_set(iis2dh_ctx_t *ctx, iis2dh_op_md_t val);
-int32_t iis2dh_operating_mode_get(iis2dh_ctx_t *ctx, iis2dh_op_md_t *val);
+int32_t iis2dh_operating_mode_set(stmdev_ctx_t *ctx, iis2dh_op_md_t val);
+int32_t iis2dh_operating_mode_get(stmdev_ctx_t *ctx, iis2dh_op_md_t *val);
 
 typedef enum {
   IIS2DH_POWER_DOWN                      = 0x00,
@@ -509,11 +481,11 @@ typedef enum {
   IIS2DH_ODR_1kHz620_LP                  = 0x08,
   IIS2DH_ODR_5kHz376_LP_1kHz344_NM_HP    = 0x09,
 } iis2dh_odr_t;
-int32_t iis2dh_data_rate_set(iis2dh_ctx_t *ctx, iis2dh_odr_t val);
-int32_t iis2dh_data_rate_get(iis2dh_ctx_t *ctx, iis2dh_odr_t *val);
+int32_t iis2dh_data_rate_set(stmdev_ctx_t *ctx, iis2dh_odr_t val);
+int32_t iis2dh_data_rate_get(stmdev_ctx_t *ctx, iis2dh_odr_t *val);
 
-int32_t iis2dh_high_pass_on_outputs_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_high_pass_on_outputs_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DH_AGGRESSIVE  = 0,
@@ -521,8 +493,8 @@ typedef enum {
   IIS2DH_MEDIUM      = 2,
   IIS2DH_LIGHT       = 3,
 } iis2dh_hpcf_t;
-int32_t iis2dh_high_pass_bandwidth_set(iis2dh_ctx_t *ctx, iis2dh_hpcf_t val);
-int32_t iis2dh_high_pass_bandwidth_get(iis2dh_ctx_t *ctx, iis2dh_hpcf_t *val);
+int32_t iis2dh_high_pass_bandwidth_set(stmdev_ctx_t *ctx, iis2dh_hpcf_t val);
+int32_t iis2dh_high_pass_bandwidth_get(stmdev_ctx_t *ctx, iis2dh_hpcf_t *val);
 
 typedef enum {
   IIS2DH_NORMAL_WITH_RST  = 0,
@@ -530,8 +502,8 @@ typedef enum {
   IIS2DH_NORMAL           = 2,
   IIS2DH_AUTORST_ON_INT   = 3,
 } iis2dh_hpm_t;
-int32_t iis2dh_high_pass_mode_set(iis2dh_ctx_t *ctx, iis2dh_hpm_t val);
-int32_t iis2dh_high_pass_mode_get(iis2dh_ctx_t *ctx, iis2dh_hpm_t *val);
+int32_t iis2dh_high_pass_mode_set(stmdev_ctx_t *ctx, iis2dh_hpm_t val);
+int32_t iis2dh_high_pass_mode_get(stmdev_ctx_t *ctx, iis2dh_hpm_t *val);
 
 typedef enum {
   IIS2DH_2g   = 0,
@@ -539,65 +511,65 @@ typedef enum {
   IIS2DH_8g   = 2,
   IIS2DH_16g  = 3,
 } iis2dh_fs_t;
-int32_t iis2dh_full_scale_set(iis2dh_ctx_t *ctx, iis2dh_fs_t val);
-int32_t iis2dh_full_scale_get(iis2dh_ctx_t *ctx, iis2dh_fs_t *val);
+int32_t iis2dh_full_scale_set(stmdev_ctx_t *ctx, iis2dh_fs_t val);
+int32_t iis2dh_full_scale_get(stmdev_ctx_t *ctx, iis2dh_fs_t *val);
 
-int32_t iis2dh_block_data_update_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_block_data_update_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_filter_reference_set(iis2dh_ctx_t *ctx, uint8_t *buff);
-int32_t iis2dh_filter_reference_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dh_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dh_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2dh_xl_data_ready_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_xl_data_ovr_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_acceleration_raw_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2dh_device_id_get(iis2dh_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   IIS2DH_ST_DISABLE   = 0,
   IIS2DH_ST_POSITIVE  = 1,
   IIS2DH_ST_NEGATIVE  = 2,
 } iis2dh_st_t;
-int32_t iis2dh_self_test_set(iis2dh_ctx_t *ctx, iis2dh_st_t val);
-int32_t iis2dh_self_test_get(iis2dh_ctx_t *ctx, iis2dh_st_t *val);
+int32_t iis2dh_self_test_set(stmdev_ctx_t *ctx, iis2dh_st_t val);
+int32_t iis2dh_self_test_get(stmdev_ctx_t *ctx, iis2dh_st_t *val);
 
 typedef enum {
   IIS2DH_LSB_AT_LOW_ADD = 0,
   IIS2DH_MSB_AT_LOW_ADD = 1,
 } iis2dh_ble_t;
-int32_t iis2dh_data_format_set(iis2dh_ctx_t *ctx, iis2dh_ble_t val);
-int32_t iis2dh_data_format_get(iis2dh_ctx_t *ctx, iis2dh_ble_t *val);
+int32_t iis2dh_data_format_set(stmdev_ctx_t *ctx, iis2dh_ble_t val);
+int32_t iis2dh_data_format_get(stmdev_ctx_t *ctx, iis2dh_ble_t *val);
 
-int32_t iis2dh_boot_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_boot_get(iis2dh_ctx_t *ctx, uint8_t *val);
-int32_t iis2dh_int_occurrencies_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_int_occurrencies_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_status_get(iis2dh_ctx_t *ctx, iis2dh_status_reg_t *val);
+int32_t iis2dh_status_get(stmdev_ctx_t *ctx, iis2dh_status_reg_t *val);
 
-int32_t iis2dh_int1_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val);
-int32_t iis2dh_int1_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int1_cfg_t *val);
+int32_t iis2dh_int1_gen_conf_set(stmdev_ctx_t *ctx, iis2dh_int1_cfg_t *val);
+int32_t iis2dh_int1_gen_conf_get(stmdev_ctx_t *ctx, iis2dh_int1_cfg_t *val);
 
-int32_t iis2dh_int1_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int1_src_t *val);
+int32_t iis2dh_int1_gen_source_get(stmdev_ctx_t *ctx, iis2dh_int1_src_t *val);
 
-int32_t iis2dh_int1_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_int1_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_int1_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_int1_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_int2_gen_conf_set(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val);
-int32_t iis2dh_int2_gen_conf_get(iis2dh_ctx_t *ctx, iis2dh_int2_cfg_t *val);
+int32_t iis2dh_int2_gen_conf_set(stmdev_ctx_t *ctx, iis2dh_int2_cfg_t *val);
+int32_t iis2dh_int2_gen_conf_get(stmdev_ctx_t *ctx, iis2dh_int2_cfg_t *val);
 
-int32_t iis2dh_int2_gen_source_get(iis2dh_ctx_t *ctx, iis2dh_int2_src_t *val);
+int32_t iis2dh_int2_gen_source_get(stmdev_ctx_t *ctx, iis2dh_int2_src_t *val);
 
-int32_t iis2dh_int2_gen_threshold_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_int2_gen_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_int2_gen_duration_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_int2_gen_duration_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DH_DISC_FROM_INT_GENERATOR  = 0,
@@ -609,55 +581,55 @@ typedef enum {
   IIS2DH_ON_INT2_TAP_GEN          = 6,
   IIS2DH_ON_INT1_INT2_TAP_GEN     = 7,
 } iis2dh_hp_t;
-int32_t iis2dh_high_pass_int_conf_set(iis2dh_ctx_t *ctx, iis2dh_hp_t val);
-int32_t iis2dh_high_pass_int_conf_get(iis2dh_ctx_t *ctx, iis2dh_hp_t *val);
+int32_t iis2dh_high_pass_int_conf_set(stmdev_ctx_t *ctx, iis2dh_hp_t val);
+int32_t iis2dh_high_pass_int_conf_get(stmdev_ctx_t *ctx, iis2dh_hp_t *val);
 
-int32_t iis2dh_pin_int1_config_set(iis2dh_ctx_t *ctx,
+int32_t iis2dh_pin_int1_config_set(stmdev_ctx_t *ctx,
                                    iis2dh_ctrl_reg3_t *val);
-int32_t iis2dh_pin_int1_config_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_pin_int1_config_get(stmdev_ctx_t *ctx,
                                    iis2dh_ctrl_reg3_t *val);
 
-int32_t iis2dh_int2_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_int2_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DH_INT2_PULSED   = 0,
   IIS2DH_INT2_LATCHED  = 1,
 } iis2dh_lir_int2_t;
-int32_t iis2dh_int2_pin_notification_mode_set(iis2dh_ctx_t *ctx,
+int32_t iis2dh_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                               iis2dh_lir_int2_t val);
-int32_t iis2dh_int2_pin_notification_mode_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                               iis2dh_lir_int2_t *val);
 
-int32_t iis2dh_int1_pin_detect_4d_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_int1_pin_detect_4d_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DH_INT1_PULSED   = 0,
   IIS2DH_INT1_LATCHED  = 1,
 } iis2dh_lir_int1_t;
-int32_t iis2dh_int1_pin_notification_mode_set(iis2dh_ctx_t *ctx,
+int32_t iis2dh_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                               iis2dh_lir_int1_t val);
-int32_t iis2dh_int1_pin_notification_mode_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                               iis2dh_lir_int1_t *val);
 
-int32_t iis2dh_pin_int2_config_set(iis2dh_ctx_t *ctx,
+int32_t iis2dh_pin_int2_config_set(stmdev_ctx_t *ctx,
                                    iis2dh_ctrl_reg6_t *val);
-int32_t iis2dh_pin_int2_config_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_pin_int2_config_get(stmdev_ctx_t *ctx,
                                    iis2dh_ctrl_reg6_t *val);
 
-int32_t iis2dh_fifo_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_fifo_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_fifo_watermark_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_fifo_watermark_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DH_INT1_GEN = 0,
   IIS2DH_INT2_GEN = 1,
 } iis2dh_tr_t;
-int32_t iis2dh_fifo_trigger_event_set(iis2dh_ctx_t *ctx, iis2dh_tr_t val);
-int32_t iis2dh_fifo_trigger_event_get(iis2dh_ctx_t *ctx, iis2dh_tr_t *val);
+int32_t iis2dh_fifo_trigger_event_set(stmdev_ctx_t *ctx, iis2dh_tr_t val);
+int32_t iis2dh_fifo_trigger_event_get(stmdev_ctx_t *ctx, iis2dh_tr_t *val);
 
 typedef enum {
   IIS2DH_BYPASS_MODE           = 0,
@@ -665,67 +637,67 @@ typedef enum {
   IIS2DH_DYNAMIC_STREAM_MODE   = 2,
   IIS2DH_STREAM_TO_FIFO_MODE   = 3,
 } iis2dh_fm_t;
-int32_t iis2dh_fifo_mode_set(iis2dh_ctx_t *ctx, iis2dh_fm_t val);
-int32_t iis2dh_fifo_mode_get(iis2dh_ctx_t *ctx, iis2dh_fm_t *val);
+int32_t iis2dh_fifo_mode_set(stmdev_ctx_t *ctx, iis2dh_fm_t val);
+int32_t iis2dh_fifo_mode_get(stmdev_ctx_t *ctx, iis2dh_fm_t *val);
 
-int32_t iis2dh_fifo_status_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_fifo_status_get(stmdev_ctx_t *ctx,
                                  iis2dh_fifo_src_reg_t *val);
 
-int32_t iis2dh_fifo_data_level_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_fifo_empty_flag_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_fifo_ovr_flag_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_fifo_fth_flag_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_tap_conf_set(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val);
-int32_t iis2dh_tap_conf_get(iis2dh_ctx_t *ctx, iis2dh_click_cfg_t *val);
+int32_t iis2dh_tap_conf_set(stmdev_ctx_t *ctx, iis2dh_click_cfg_t *val);
+int32_t iis2dh_tap_conf_get(stmdev_ctx_t *ctx, iis2dh_click_cfg_t *val);
 
-int32_t iis2dh_tap_source_get(iis2dh_ctx_t *ctx, iis2dh_click_src_t *val);
+int32_t iis2dh_tap_source_get(stmdev_ctx_t *ctx, iis2dh_click_src_t *val);
 
-int32_t iis2dh_tap_threshold_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_tap_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DH_TAP_PULSED   = 0,
   IIS2DH_TAP_LATCHED  = 1,
 } iis2dh_lir_click_t;
-int32_t iis2dh_tap_notification_mode_set(iis2dh_ctx_t *ctx,
+int32_t iis2dh_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                          iis2dh_lir_click_t val);
-int32_t iis2dh_tap_notification_mode_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                          iis2dh_lir_click_t *val);
 
-int32_t iis2dh_shock_dur_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_shock_dur_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_quiet_dur_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_quiet_dur_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_double_tap_timeout_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_double_tap_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_act_threshold_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_act_threshold_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dh_act_timeout_set(iis2dh_ctx_t *ctx, uint8_t val);
-int32_t iis2dh_act_timeout_get(iis2dh_ctx_t *ctx, uint8_t *val);
+int32_t iis2dh_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dh_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DH_PULL_UP_DISCONNECT  = 0,
   IIS2DH_PULL_UP_CONNECT     = 1,
 } iis2dh_sdo_pu_disc_t;
-int32_t iis2dh_pin_sdo_sa0_mode_set(iis2dh_ctx_t *ctx,
+int32_t iis2dh_pin_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                     iis2dh_sdo_pu_disc_t val);
-int32_t iis2dh_pin_sdo_sa0_mode_get(iis2dh_ctx_t *ctx,
+int32_t iis2dh_pin_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                     iis2dh_sdo_pu_disc_t *val);
 
 typedef enum {
   IIS2DH_SPI_4_WIRE = 0,
   IIS2DH_SPI_3_WIRE = 1,
 } iis2dh_sim_t;
-int32_t iis2dh_spi_mode_set(iis2dh_ctx_t *ctx, iis2dh_sim_t val);
-int32_t iis2dh_spi_mode_get(iis2dh_ctx_t *ctx, iis2dh_sim_t *val);
+int32_t iis2dh_spi_mode_set(stmdev_ctx_t *ctx, iis2dh_sim_t val);
+int32_t iis2dh_spi_mode_get(stmdev_ctx_t *ctx, iis2dh_sim_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/iis2dlpc_STdC/driver/iis2dlpc_reg.c
+++ b/sensor/stmemsc/iis2dlpc_STdC/driver/iis2dlpc_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "iis2dlpc_reg.h"
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_read_reg(iis2dlpc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis2dlpc_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t iis2dlpc_read_reg(iis2dlpc_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_write_reg(iis2dlpc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis2dlpc_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -168,7 +151,7 @@ float_t iis2dlpc_from_lsb_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_power_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t val)
+int32_t iis2dlpc_power_mode_set(stmdev_ctx_t *ctx, iis2dlpc_mode_t val)
 {
   iis2dlpc_ctrl1_t ctrl1;
   iis2dlpc_ctrl6_t ctrl6;
@@ -201,7 +184,7 @@ int32_t iis2dlpc_power_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_power_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t *val)
+int32_t iis2dlpc_power_mode_get(stmdev_ctx_t *ctx, iis2dlpc_mode_t *val)
 {
   iis2dlpc_ctrl1_t ctrl1;
   iis2dlpc_ctrl6_t ctrl6;
@@ -283,7 +266,7 @@ int32_t iis2dlpc_power_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_data_rate_set(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t val)
+int32_t iis2dlpc_data_rate_set(stmdev_ctx_t *ctx, iis2dlpc_odr_t val)
 {
   iis2dlpc_ctrl1_t ctrl1;
   iis2dlpc_ctrl3_t ctrl3;
@@ -314,7 +297,7 @@ int32_t iis2dlpc_data_rate_set(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_data_rate_get(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t *val)
+int32_t iis2dlpc_data_rate_get(stmdev_ctx_t *ctx, iis2dlpc_odr_t *val)
 {
   iis2dlpc_ctrl1_t ctrl1;
   iis2dlpc_ctrl3_t ctrl3;
@@ -377,7 +360,7 @@ int32_t iis2dlpc_data_rate_get(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_block_data_update_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -398,7 +381,7 @@ int32_t iis2dlpc_block_data_update_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_block_data_update_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -417,7 +400,7 @@ int32_t iis2dlpc_block_data_update_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_full_scale_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t val)
+int32_t iis2dlpc_full_scale_set(stmdev_ctx_t *ctx, iis2dlpc_fs_t val)
 {
   iis2dlpc_ctrl6_t reg;
   int32_t ret;
@@ -438,7 +421,7 @@ int32_t iis2dlpc_full_scale_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_full_scale_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t *val)
+int32_t iis2dlpc_full_scale_get(stmdev_ctx_t *ctx, iis2dlpc_fs_t *val)
 {
   iis2dlpc_ctrl6_t reg;
   int32_t ret;
@@ -473,7 +456,7 @@ int32_t iis2dlpc_full_scale_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_status_reg_get(iis2dlpc_ctx_t *ctx, iis2dlpc_status_t *val)
+int32_t iis2dlpc_status_reg_get(stmdev_ctx_t *ctx, iis2dlpc_status_t *val)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_STATUS, (uint8_t*) val, 1);
@@ -488,7 +471,7 @@ int32_t iis2dlpc_status_reg_get(iis2dlpc_ctx_t *ctx, iis2dlpc_status_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_flag_data_ready_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_status_t reg;
   int32_t ret;
@@ -507,7 +490,7 @@ int32_t iis2dlpc_flag_data_ready_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_all_sources_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_all_sources_get(stmdev_ctx_t *ctx,
                                  iis2dlpc_all_sources_t *val)
 {
   int32_t ret;
@@ -525,7 +508,7 @@ int32_t iis2dlpc_all_sources_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_usr_offset_x_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_write_reg(ctx, IIS2DLPC_X_OFS_USR, buff, 1);
@@ -542,7 +525,7 @@ int32_t iis2dlpc_usr_offset_x_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_usr_offset_x_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_X_OFS_USR, buff, 1);
@@ -559,7 +542,7 @@ int32_t iis2dlpc_usr_offset_x_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_usr_offset_y_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_write_reg(ctx, IIS2DLPC_Y_OFS_USR, buff, 1);
@@ -576,7 +559,7 @@ int32_t iis2dlpc_usr_offset_y_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_usr_offset_y_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_Y_OFS_USR, buff, 1);
@@ -593,7 +576,7 @@ int32_t iis2dlpc_usr_offset_y_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_usr_offset_z_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_write_reg(ctx, IIS2DLPC_Z_OFS_USR, buff, 1);
@@ -610,7 +593,7 @@ int32_t iis2dlpc_usr_offset_z_set(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_usr_offset_z_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_Z_OFS_USR, buff, 1);
@@ -627,16 +610,16 @@ int32_t iis2dlpc_usr_offset_z_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_offset_weight_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_offset_weight_set(stmdev_ctx_t *ctx,
                                    iis2dlpc_usr_off_w_t val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   if (ret == 0) {
     reg.usr_off_w = (uint8_t) val;
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   }
   return ret;
 }
@@ -650,13 +633,13 @@ int32_t iis2dlpc_offset_weight_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_offset_weight_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_offset_weight_get(stmdev_ctx_t *ctx,
                                    iis2dlpc_usr_off_w_t *val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   switch (reg.usr_off_w) {
     case IIS2DLPC_LSb_977ug:
       *val = IIS2DLPC_LSb_977ug;
@@ -692,7 +675,7 @@ int32_t iis2dlpc_offset_weight_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_temperature_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_OUT_T_L, buff, 2);
@@ -708,7 +691,7 @@ int32_t iis2dlpc_temperature_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_acceleration_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_OUT_X_L, buff, 6);
@@ -735,7 +718,7 @@ int32_t iis2dlpc_acceleration_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_device_id_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2dlpc_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_WHO_AM_I, buff, 1);
@@ -751,7 +734,7 @@ int32_t iis2dlpc_device_id_get(iis2dlpc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_auto_increment_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -773,7 +756,7 @@ int32_t iis2dlpc_auto_increment_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_auto_increment_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -792,7 +775,7 @@ int32_t iis2dlpc_auto_increment_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_reset_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -814,7 +797,7 @@ int32_t iis2dlpc_reset_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_reset_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -833,7 +816,7 @@ int32_t iis2dlpc_reset_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_boot_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -854,7 +837,7 @@ int32_t iis2dlpc_boot_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_boot_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -873,7 +856,7 @@ int32_t iis2dlpc_boot_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_self_test_set(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t val)
+int32_t iis2dlpc_self_test_set(stmdev_ctx_t *ctx, iis2dlpc_st_t val)
 {
   iis2dlpc_ctrl3_t reg;
   int32_t ret;
@@ -895,7 +878,7 @@ int32_t iis2dlpc_self_test_set(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_self_test_get(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t *val)
+int32_t iis2dlpc_self_test_get(stmdev_ctx_t *ctx, iis2dlpc_st_t *val)
 {
   iis2dlpc_ctrl3_t reg;
   int32_t ret;
@@ -927,16 +910,16 @@ int32_t iis2dlpc_self_test_get(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_data_ready_mode_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_data_ready_mode_set(stmdev_ctx_t *ctx,
                                      iis2dlpc_drdy_pulsed_t val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   if (ret == 0) {
     reg.drdy_pulsed = (uint8_t) val;
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   }
 
   return ret;
@@ -950,13 +933,13 @@ int32_t iis2dlpc_data_ready_mode_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_data_ready_mode_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_data_ready_mode_get(stmdev_ctx_t *ctx,
                                      iis2dlpc_drdy_pulsed_t *val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
 
   switch (reg.drdy_pulsed) {
     case IIS2DLPC_DRDY_LATCHED:
@@ -993,10 +976,10 @@ int32_t iis2dlpc_data_ready_mode_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_filter_path_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t val)
+int32_t iis2dlpc_filter_path_set(stmdev_ctx_t *ctx, iis2dlpc_fds_t val)
 {
   iis2dlpc_ctrl6_t ctrl6;
-  iis2dlpc_ctrl_reg7_t ctrl_reg7;
+  iis2dlpc_ctrl7_t ctrl_reg7;
   int32_t ret;
 
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
@@ -1005,11 +988,11 @@ int32_t iis2dlpc_filter_path_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t val)
     ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
   }
   if (ret == 0) {
-    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &ctrl_reg7, 1);
   }
   if (ret == 0) {
     ctrl_reg7.usr_off_on_out = (uint8_t) val & 0x01U;
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &ctrl_reg7, 1);
   } else {
     ret = ret;
   }
@@ -1024,15 +1007,15 @@ int32_t iis2dlpc_filter_path_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_filter_path_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t *val)
+int32_t iis2dlpc_filter_path_get(stmdev_ctx_t *ctx, iis2dlpc_fds_t *val)
 {
   iis2dlpc_ctrl6_t ctrl6;
-  iis2dlpc_ctrl_reg7_t ctrl_reg7;
+  iis2dlpc_ctrl7_t ctrl_reg7;
   int32_t ret;
 
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL6,(uint8_t*) &ctrl6, 1);
   if (ret == 0) {
-   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &ctrl_reg7, 1);
 
     switch ((ctrl6.fds << 4 ) + ctrl_reg7.usr_off_on_out) {
       case IIS2DLPC_LPF_ON_OUT:
@@ -1061,7 +1044,7 @@ int32_t iis2dlpc_filter_path_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_filter_bandwidth_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_filter_bandwidth_set(stmdev_ctx_t *ctx,
                                          iis2dlpc_bw_filt_t val)
 {
   iis2dlpc_ctrl6_t reg;
@@ -1085,7 +1068,7 @@ int32_t iis2dlpc_filter_bandwidth_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_filter_bandwidth_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_filter_bandwidth_get(stmdev_ctx_t *ctx,
                                          iis2dlpc_bw_filt_t *val)
 {
   iis2dlpc_ctrl6_t reg;
@@ -1121,15 +1104,15 @@ int32_t iis2dlpc_filter_bandwidth_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_reference_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   if (ret == 0) {
     reg.hp_ref_mode = val;
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   }
   return ret;
 }
@@ -1142,12 +1125,12 @@ int32_t iis2dlpc_reference_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_reference_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   *val = reg.hp_ref_mode;
 
   return ret;
@@ -1174,7 +1157,7 @@ int32_t iis2dlpc_reference_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_spi_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t val)
+int32_t iis2dlpc_spi_mode_set(stmdev_ctx_t *ctx, iis2dlpc_sim_t val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -1195,7 +1178,7 @@ int32_t iis2dlpc_spi_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_spi_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t *val)
+int32_t iis2dlpc_spi_mode_get(stmdev_ctx_t *ctx, iis2dlpc_sim_t *val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -1225,7 +1208,7 @@ int32_t iis2dlpc_spi_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_i2c_interface_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_i2c_interface_set(stmdev_ctx_t *ctx,
                                    iis2dlpc_i2c_disable_t val)
 {
   iis2dlpc_ctrl2_t reg;
@@ -1247,7 +1230,7 @@ int32_t iis2dlpc_i2c_interface_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_i2c_interface_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_i2c_interface_get(stmdev_ctx_t *ctx,
                                    iis2dlpc_i2c_disable_t *val)
 {
   iis2dlpc_ctrl2_t reg;
@@ -1277,7 +1260,7 @@ int32_t iis2dlpc_i2c_interface_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_cs_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t val)
+int32_t iis2dlpc_cs_mode_set(stmdev_ctx_t *ctx, iis2dlpc_cs_pu_disc_t val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -1298,7 +1281,7 @@ int32_t iis2dlpc_cs_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_cs_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t *val)
+int32_t iis2dlpc_cs_mode_get(stmdev_ctx_t *ctx, iis2dlpc_cs_pu_disc_t *val)
 {
   iis2dlpc_ctrl2_t reg;
   int32_t ret;
@@ -1339,7 +1322,7 @@ int32_t iis2dlpc_cs_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_pin_polarity_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_polarity_set(stmdev_ctx_t *ctx,
                                   iis2dlpc_h_lactive_t val)
 {
   iis2dlpc_ctrl3_t reg;
@@ -1361,7 +1344,7 @@ int32_t iis2dlpc_pin_polarity_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_pin_polarity_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_polarity_get(stmdev_ctx_t *ctx,
                                   iis2dlpc_h_lactive_t *val)
 {
   iis2dlpc_ctrl3_t reg;
@@ -1391,7 +1374,7 @@ int32_t iis2dlpc_pin_polarity_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_int_notification_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_int_notification_set(stmdev_ctx_t *ctx,
                                       iis2dlpc_lir_t val)
 {
   iis2dlpc_ctrl3_t reg;
@@ -1413,7 +1396,7 @@ int32_t iis2dlpc_int_notification_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_int_notification_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_int_notification_get(stmdev_ctx_t *ctx,
                                       iis2dlpc_lir_t *val)
 {
   iis2dlpc_ctrl3_t reg;
@@ -1443,7 +1426,7 @@ int32_t iis2dlpc_int_notification_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_pin_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t val)
+int32_t iis2dlpc_pin_mode_set(stmdev_ctx_t *ctx, iis2dlpc_pp_od_t val)
 {
   iis2dlpc_ctrl3_t reg;
   int32_t ret;
@@ -1464,7 +1447,7 @@ int32_t iis2dlpc_pin_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_pin_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t *val)
+int32_t iis2dlpc_pin_mode_get(stmdev_ctx_t *ctx, iis2dlpc_pp_od_t *val)
 {
   iis2dlpc_ctrl3_t reg;
   int32_t ret;
@@ -1493,17 +1476,17 @@ int32_t iis2dlpc_pin_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_pin_int1_route_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     iis2dlpc_ctrl4_int1_pad_ctrl_t *val)
 {
   iis2dlpc_ctrl5_int2_pad_ctrl_t ctrl5_int2_pad_ctrl;
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL5_INT2_PAD_CTRL,
                           (uint8_t*) &ctrl5_int2_pad_ctrl, 1);
   if (ret == 0) {
-    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   }
   if (ret == 0) {
     if ((  ctrl5_int2_pad_ctrl.int2_sleep_state
@@ -1523,7 +1506,7 @@ int32_t iis2dlpc_pin_int1_route_set(iis2dlpc_ctx_t *ctx,
                                 (uint8_t*) val, 1);
   }
   if (ret == 0) {
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   } else {
     ret = ret;
   }
@@ -1538,7 +1521,7 @@ int32_t iis2dlpc_pin_int1_route_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_pin_int1_route_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     iis2dlpc_ctrl4_int1_pad_ctrl_t *val)
 {
   int32_t ret;
@@ -1555,17 +1538,17 @@ int32_t iis2dlpc_pin_int1_route_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_pin_int2_route_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     iis2dlpc_ctrl5_int2_pad_ctrl_t *val)
 {
-  iis2dlpc_ctrl_reg7_t ctrl_reg7;
+  iis2dlpc_ctrl7_t ctrl_reg7;
   iis2dlpc_ctrl4_int1_pad_ctrl_t  ctrl4_int1_pad;
   int32_t ret;
 
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL4_INT1_PAD_CTRL,
                           (uint8_t*)&ctrl4_int1_pad, 1);
   if (ret == 0) {
-    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+    ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &ctrl_reg7, 1);
   }
   if (ret == 0) {
     if ((  val->int2_sleep_state
@@ -1585,7 +1568,7 @@ int32_t iis2dlpc_pin_int2_route_set(iis2dlpc_ctx_t *ctx,
                              (uint8_t*) val, 1);
   }
   if (ret == 0) {
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &ctrl_reg7, 1);
   } else {
     ret = ret;
   }
@@ -1600,7 +1583,7 @@ int32_t iis2dlpc_pin_int2_route_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_pin_int2_route_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     iis2dlpc_ctrl5_int2_pad_ctrl_t *val)
 {
   int32_t ret;
@@ -1616,15 +1599,15 @@ int32_t iis2dlpc_pin_int2_route_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_all_on_int1_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   if (ret == 0) {
     reg.int2_on_int1 = val;
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   }
   return ret;
 }
@@ -1637,12 +1620,12 @@ int32_t iis2dlpc_all_on_int1_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_all_on_int1_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   *val = reg.int2_on_int1;
 
   return ret;
@@ -1669,7 +1652,7 @@ int32_t iis2dlpc_all_on_int1_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_wkup_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_wake_up_ths_t reg;
   int32_t ret;
@@ -1690,7 +1673,7 @@ int32_t iis2dlpc_wkup_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_wkup_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_wake_up_ths_t reg;
   int32_t ret;
@@ -1709,7 +1692,7 @@ int32_t iis2dlpc_wkup_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_wkup_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_wake_up_dur_t reg;
   int32_t ret;
@@ -1730,7 +1713,7 @@ int32_t iis2dlpc_wkup_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_wkup_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_wake_up_dur_t reg;
   int32_t ret;
@@ -1749,16 +1732,16 @@ int32_t iis2dlpc_wkup_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_wkup_feed_data_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_wkup_feed_data_set(stmdev_ctx_t *ctx,
                                     iis2dlpc_usr_off_on_wu_t val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   if (ret == 0) {
     reg.usr_off_on_wu = (uint8_t) val;
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   }
   return ret;
 }
@@ -1771,13 +1754,13 @@ int32_t iis2dlpc_wkup_feed_data_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_wkup_feed_data_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_wkup_feed_data_get(stmdev_ctx_t *ctx,
                                     iis2dlpc_usr_off_on_wu_t *val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
 
   switch (reg.usr_off_on_wu) {
     case IIS2DLPC_HP_FEED:
@@ -1816,7 +1799,7 @@ int32_t iis2dlpc_wkup_feed_data_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_act_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t val)
+int32_t iis2dlpc_act_mode_set(stmdev_ctx_t *ctx, iis2dlpc_sleep_on_t val)
 {
   iis2dlpc_wake_up_ths_t wake_up_ths;
   iis2dlpc_wake_up_dur_t wake_up_dur;
@@ -1846,7 +1829,7 @@ int32_t iis2dlpc_act_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_act_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t *val)
+int32_t iis2dlpc_act_mode_get(stmdev_ctx_t *ctx, iis2dlpc_sleep_on_t *val)
 {
   iis2dlpc_wake_up_ths_t wake_up_ths;
   iis2dlpc_wake_up_dur_t wake_up_dur;;
@@ -1882,7 +1865,7 @@ int32_t iis2dlpc_act_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_act_sleep_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_wake_up_dur_t reg;
   int32_t ret;
@@ -1903,7 +1886,7 @@ int32_t iis2dlpc_act_sleep_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_act_sleep_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_wake_up_dur_t reg;
   int32_t ret;
@@ -1935,7 +1918,7 @@ int32_t iis2dlpc_act_sleep_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_threshold_x_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_tap_ths_x_t reg;
   int32_t ret;
@@ -1956,7 +1939,7 @@ int32_t iis2dlpc_tap_threshold_x_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_threshold_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_tap_ths_x_t reg;
   int32_t ret;
@@ -1975,7 +1958,7 @@ int32_t iis2dlpc_tap_threshold_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_threshold_y_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_tap_ths_y_t reg;
   int32_t ret;
@@ -1996,7 +1979,7 @@ int32_t iis2dlpc_tap_threshold_y_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_threshold_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_tap_ths_y_t reg;
   int32_t ret;
@@ -2015,7 +1998,7 @@ int32_t iis2dlpc_tap_threshold_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_axis_priority_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_tap_axis_priority_set(stmdev_ctx_t *ctx,
                                        iis2dlpc_tap_prior_t val)
 {
   iis2dlpc_tap_ths_y_t reg;
@@ -2037,7 +2020,7 @@ int32_t iis2dlpc_tap_axis_priority_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_axis_priority_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                        iis2dlpc_tap_prior_t *val)
 {
   iis2dlpc_tap_ths_y_t reg;
@@ -2079,7 +2062,7 @@ int32_t iis2dlpc_tap_axis_priority_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_threshold_z_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_tap_ths_z_t reg;
   int32_t ret;
@@ -2101,7 +2084,7 @@ int32_t iis2dlpc_tap_threshold_z_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_threshold_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_tap_ths_z_t reg;
   int32_t ret;
@@ -2120,7 +2103,7 @@ int32_t iis2dlpc_tap_threshold_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_detection_on_z_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_tap_ths_z_t reg;
   int32_t ret;
@@ -2141,7 +2124,7 @@ int32_t iis2dlpc_tap_detection_on_z_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_detection_on_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_tap_ths_z_t reg;
   int32_t ret;
@@ -2160,7 +2143,7 @@ int32_t iis2dlpc_tap_detection_on_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_detection_on_y_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_tap_ths_z_t reg;
   int32_t ret;
@@ -2181,7 +2164,7 @@ int32_t iis2dlpc_tap_detection_on_y_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_detection_on_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_tap_ths_z_t reg;
   int32_t ret;
@@ -2200,7 +2183,7 @@ int32_t iis2dlpc_tap_detection_on_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_detection_on_x_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_tap_ths_z_t reg;
   int32_t ret;
@@ -2221,7 +2204,7 @@ int32_t iis2dlpc_tap_detection_on_x_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_detection_on_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_tap_ths_z_t reg;
   int32_t ret;
@@ -2244,7 +2227,7 @@ int32_t iis2dlpc_tap_detection_on_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_shock_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_int_dur_t reg;
   int32_t ret;
@@ -2270,7 +2253,7 @@ int32_t iis2dlpc_tap_shock_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_shock_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_int_dur_t reg;
   int32_t ret;
@@ -2293,7 +2276,7 @@ int32_t iis2dlpc_tap_shock_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_quiet_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_int_dur_t reg;
   int32_t ret;
@@ -2318,7 +2301,7 @@ int32_t iis2dlpc_tap_quiet_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_quiet_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_int_dur_t reg;
   int32_t ret;
@@ -2342,7 +2325,7 @@ int32_t iis2dlpc_tap_quiet_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_int_dur_t reg;
   int32_t ret;
@@ -2368,7 +2351,7 @@ int32_t iis2dlpc_tap_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_int_dur_t reg;
   int32_t ret;
@@ -2387,7 +2370,7 @@ int32_t iis2dlpc_tap_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_mode_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_tap_mode_set(stmdev_ctx_t *ctx,
                               iis2dlpc_single_double_tap_t val)
 {
   iis2dlpc_wake_up_ths_t reg;
@@ -2409,7 +2392,7 @@ int32_t iis2dlpc_tap_mode_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_mode_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_tap_mode_get(stmdev_ctx_t *ctx,
                               iis2dlpc_single_double_tap_t *val)
 {
   iis2dlpc_wake_up_ths_t reg;
@@ -2440,7 +2423,7 @@ int32_t iis2dlpc_tap_mode_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_tap_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_tap_src_t *val)
+int32_t iis2dlpc_tap_src_get(stmdev_ctx_t *ctx, iis2dlpc_tap_src_t *val)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_TAP_SRC, (uint8_t*) val, 1);
@@ -2468,7 +2451,7 @@ int32_t iis2dlpc_tap_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_tap_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_6d_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_tap_ths_x_t reg;
   int32_t ret;
@@ -2489,7 +2472,7 @@ int32_t iis2dlpc_6d_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_6d_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_tap_ths_x_t reg;
   int32_t ret;
@@ -2508,7 +2491,7 @@ int32_t iis2dlpc_6d_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_4d_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_tap_ths_x_t reg;
   int32_t ret;
@@ -2530,7 +2513,7 @@ int32_t iis2dlpc_4d_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_4d_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_tap_ths_x_t reg;
   int32_t ret;
@@ -2549,7 +2532,7 @@ int32_t iis2dlpc_4d_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_6d_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sixd_src_t *val)
+int32_t iis2dlpc_6d_src_get(stmdev_ctx_t *ctx, iis2dlpc_sixd_src_t *val)
 {
   int32_t ret;
   ret = iis2dlpc_read_reg(ctx, IIS2DLPC_SIXD_SRC, (uint8_t*) val, 1);
@@ -2563,16 +2546,16 @@ int32_t iis2dlpc_6d_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sixd_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_6d_feed_data_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_6d_feed_data_set(stmdev_ctx_t *ctx,
                                   iis2dlpc_lpass_on6d_t val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   if (ret == 0) {
     reg.lpass_on6d = (uint8_t) val;
-    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+    ret = iis2dlpc_write_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
   }
   return ret;
 }
@@ -2585,13 +2568,13 @@ int32_t iis2dlpc_6d_feed_data_set(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_6d_feed_data_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_6d_feed_data_get(stmdev_ctx_t *ctx,
                                   iis2dlpc_lpass_on6d_t *val)
 {
-  iis2dlpc_ctrl_reg7_t reg;
+  iis2dlpc_ctrl7_t reg;
   int32_t ret;
 
-  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL_REG7,(uint8_t*) &reg, 1);
+  ret = iis2dlpc_read_reg(ctx, IIS2DLPC_CTRL7,(uint8_t*) &reg, 1);
 
   switch (reg.lpass_on6d) {
     case IIS2DLPC_ODR_DIV_2_FEED:
@@ -2629,7 +2612,7 @@ int32_t iis2dlpc_6d_feed_data_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_ff_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_wake_up_dur_t wake_up_dur;
   iis2dlpc_free_fall_t free_fall;
@@ -2660,7 +2643,7 @@ int32_t iis2dlpc_ff_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_ff_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_wake_up_dur_t wake_up_dur;
   iis2dlpc_free_fall_t free_fall;
@@ -2682,7 +2665,7 @@ int32_t iis2dlpc_ff_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_ff_threshold_set(iis2dlpc_ctx_t *ctx, iis2dlpc_ff_ths_t val)
+int32_t iis2dlpc_ff_threshold_set(stmdev_ctx_t *ctx, iis2dlpc_ff_ths_t val)
 {
   iis2dlpc_free_fall_t reg;
   int32_t ret;
@@ -2704,7 +2687,7 @@ int32_t iis2dlpc_ff_threshold_set(iis2dlpc_ctx_t *ctx, iis2dlpc_ff_ths_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_ff_threshold_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_ff_threshold_get(stmdev_ctx_t *ctx,
                                   iis2dlpc_ff_ths_t *val)
 {
   iis2dlpc_free_fall_t reg;
@@ -2764,7 +2747,7 @@ int32_t iis2dlpc_ff_threshold_get(iis2dlpc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_fifo_watermark_set(iis2dlpc_ctx_t *ctx, uint8_t val)
+int32_t iis2dlpc_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2dlpc_fifo_ctrl_t reg;
   int32_t ret;
@@ -2786,7 +2769,7 @@ int32_t iis2dlpc_fifo_watermark_set(iis2dlpc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_fifo_watermark_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_fifo_ctrl_t reg;
   int32_t ret;
@@ -2805,7 +2788,7 @@ int32_t iis2dlpc_fifo_watermark_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_fifo_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t val)
+int32_t iis2dlpc_fifo_mode_set(stmdev_ctx_t *ctx, iis2dlpc_fmode_t val)
 {
   iis2dlpc_fifo_ctrl_t reg;
   int32_t ret;
@@ -2826,7 +2809,7 @@ int32_t iis2dlpc_fifo_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_fifo_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t *val)
+int32_t iis2dlpc_fifo_mode_get(stmdev_ctx_t *ctx, iis2dlpc_fmode_t *val)
 {
   iis2dlpc_fifo_ctrl_t reg;
   int32_t ret;
@@ -2864,7 +2847,7 @@ int32_t iis2dlpc_fifo_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_fifo_data_level_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_fifo_samples_t reg;
   int32_t ret;
@@ -2882,7 +2865,7 @@ int32_t iis2dlpc_fifo_data_level_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_fifo_ovr_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_fifo_samples_t reg;
   int32_t ret;
@@ -2900,7 +2883,7 @@ int32_t iis2dlpc_fifo_ovr_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2dlpc_fifo_wtm_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val)
+int32_t iis2dlpc_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2dlpc_fifo_samples_t reg;
   int32_t ret;

--- a/sensor/stmemsc/iis2dlpc_STdC/driver/iis2dlpc_reg.h
+++ b/sensor/stmemsc/iis2dlpc_STdC/driver/iis2dlpc_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup IIS2DLPC_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  IIS2DLPC_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*iis2dlpc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*iis2dlpc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  iis2dlpc_write_ptr  write_reg;
-  iis2dlpc_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} iis2dlpc_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -366,7 +338,7 @@ typedef struct {
 #define IIS2DLPC_X_OFS_USR                   0x3CU
 #define IIS2DLPC_Y_OFS_USR                   0x3DU
 #define IIS2DLPC_Z_OFS_USR                   0x3EU
-#define IIS2DLPC_CTRL_REG7                   0x3FU
+#define IIS2DLPC_CTRL7                       0x3FU
 typedef struct {
   uint8_t lpass_on6d                 : 1;
   uint8_t hp_ref_mode                : 1;
@@ -376,7 +348,7 @@ typedef struct {
   uint8_t interrupts_enable          : 1;
   uint8_t int2_on_int1               : 1;
   uint8_t drdy_pulsed                : 1;
-} iis2dlpc_ctrl_reg7_t;
+} iis2dlpc_ctrl7_t;
 
 /**
   * @defgroup IIS2DLPC_Register_Union
@@ -412,7 +384,7 @@ typedef union{
   iis2dlpc_tap_src_t                 tap_src;
   iis2dlpc_sixd_src_t                sixd_src;
   iis2dlpc_all_int_src_t             all_int_src;
-  iis2dlpc_ctrl_reg7_t               ctrl_reg7;
+  iis2dlpc_ctrl7_t                   ctrl7;
   bitwise_t                          bitwise;
   uint8_t                            byte;
 } iis2dlpc_reg_t;
@@ -422,9 +394,9 @@ typedef union{
   *
   */
 
-int32_t iis2dlpc_read_reg(iis2dlpc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis2dlpc_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t iis2dlpc_write_reg(iis2dlpc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis2dlpc_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t iis2dlpc_from_fs2_to_mg(int16_t lsb);
@@ -457,8 +429,8 @@ typedef enum {
   IIS2DLPC_SINGLE_LOW_PWR_LOW_NOISE_2          = 0x19,
   IIS2DLPC_SINGLE_LOW_LOW_NOISE_PWR_12bit      = 0x18,
 } iis2dlpc_mode_t;
-int32_t iis2dlpc_power_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t val);
-int32_t iis2dlpc_power_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_mode_t *val);
+int32_t iis2dlpc_power_mode_set(stmdev_ctx_t *ctx, iis2dlpc_mode_t val);
+int32_t iis2dlpc_power_mode_get(stmdev_ctx_t *ctx, iis2dlpc_mode_t *val);
 
 typedef enum {
   IIS2DLPC_XL_ODR_OFF            = 0x00,
@@ -471,14 +443,14 @@ typedef enum {
   IIS2DLPC_XL_ODR_400Hz          = 0x07,
   IIS2DLPC_XL_ODR_800Hz          = 0x08,
   IIS2DLPC_XL_ODR_1k6Hz          = 0x09,
-  IIS2DLPC_XL_SET_SW_TRIG        = 0x10,  /* Use this only in SINGLE mode */
-  IIS2DLPC_XL_SET_PIN_TRIG       = 0x20,  /* Use this only in SINGLE mode */
+  IIS2DLPC_XL_SET_SW_TRIG        = 0x12,  /* Use this only in SINGLE mode */
+  IIS2DLPC_XL_SET_PIN_TRIG       = 0x22,  /* Use this only in SINGLE mode */
 } iis2dlpc_odr_t;
-int32_t iis2dlpc_data_rate_set(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t val);
-int32_t iis2dlpc_data_rate_get(iis2dlpc_ctx_t *ctx, iis2dlpc_odr_t *val);
+int32_t iis2dlpc_data_rate_set(stmdev_ctx_t *ctx, iis2dlpc_odr_t val);
+int32_t iis2dlpc_data_rate_get(stmdev_ctx_t *ctx, iis2dlpc_odr_t *val);
 
-int32_t iis2dlpc_block_data_update_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_block_data_update_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DLPC_2g     = 0,
@@ -486,12 +458,12 @@ typedef enum {
   IIS2DLPC_8g     = 2,
   IIS2DLPC_16g    = 3,
 } iis2dlpc_fs_t;
-int32_t iis2dlpc_full_scale_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t val);
-int32_t iis2dlpc_full_scale_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fs_t *val);
+int32_t iis2dlpc_full_scale_set(stmdev_ctx_t *ctx, iis2dlpc_fs_t val);
+int32_t iis2dlpc_full_scale_get(stmdev_ctx_t *ctx, iis2dlpc_fs_t *val);
 
-int32_t iis2dlpc_status_reg_get(iis2dlpc_ctx_t *ctx, iis2dlpc_status_t *val);
+int32_t iis2dlpc_status_reg_get(stmdev_ctx_t *ctx, iis2dlpc_status_t *val);
 
-int32_t iis2dlpc_flag_data_ready_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct{
   iis2dlpc_status_dup_t   status_dup;
@@ -500,57 +472,57 @@ typedef struct{
   iis2dlpc_sixd_src_t     sixd_src;
   iis2dlpc_all_int_src_t  all_int_src;
 } iis2dlpc_all_sources_t;
-int32_t iis2dlpc_all_sources_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_all_sources_get(stmdev_ctx_t *ctx,
                                  iis2dlpc_all_sources_t *val);
 
-int32_t iis2dlpc_usr_offset_x_set(iis2dlpc_ctx_t *ctx, uint8_t *buff);
-int32_t iis2dlpc_usr_offset_x_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2dlpc_usr_offset_y_set(iis2dlpc_ctx_t *ctx, uint8_t *buff);
-int32_t iis2dlpc_usr_offset_y_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2dlpc_usr_offset_z_set(iis2dlpc_ctx_t *ctx, uint8_t *buff);
-int32_t iis2dlpc_usr_offset_z_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   IIS2DLPC_LSb_977ug    = 0,
   IIS2DLPC_LSb_15mg6    = 1,
 } iis2dlpc_usr_off_w_t;
-int32_t iis2dlpc_offset_weight_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_offset_weight_set(stmdev_ctx_t *ctx,
                                       iis2dlpc_usr_off_w_t val);
-int32_t iis2dlpc_offset_weight_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_offset_weight_get(stmdev_ctx_t *ctx,
                                       iis2dlpc_usr_off_w_t *val);
 
-int32_t iis2dlpc_temperature_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2dlpc_acceleration_raw_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2dlpc_device_id_get(iis2dlpc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2dlpc_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2dlpc_auto_increment_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_auto_increment_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_reset_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_reset_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_boot_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_boot_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DLPC_XL_ST_DISABLE      = 0,
   IIS2DLPC_XL_ST_POSITIVE     = 1,
   IIS2DLPC_XL_ST_NEGATIVE     = 2,
 } iis2dlpc_st_t;
-int32_t iis2dlpc_self_test_set(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t val);
-int32_t iis2dlpc_self_test_get(iis2dlpc_ctx_t *ctx, iis2dlpc_st_t *val);
+int32_t iis2dlpc_self_test_set(stmdev_ctx_t *ctx, iis2dlpc_st_t val);
+int32_t iis2dlpc_self_test_get(stmdev_ctx_t *ctx, iis2dlpc_st_t *val);
 
 typedef enum {
   IIS2DLPC_DRDY_LATCHED   = 0,
   IIS2DLPC_DRDY_PULSED    = 1,
 } iis2dlpc_drdy_pulsed_t;
-int32_t iis2dlpc_data_ready_mode_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_data_ready_mode_set(stmdev_ctx_t *ctx,
                                      iis2dlpc_drdy_pulsed_t val);
-int32_t iis2dlpc_data_ready_mode_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_data_ready_mode_get(stmdev_ctx_t *ctx,
                                      iis2dlpc_drdy_pulsed_t *val);
 
 typedef enum {
@@ -558,8 +530,8 @@ typedef enum {
   IIS2DLPC_USER_OFFSET_ON_OUT  = 0x01,
   IIS2DLPC_HIGH_PASS_ON_OUT    = 0x10,
 } iis2dlpc_fds_t;
-int32_t iis2dlpc_filter_path_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t val);
-int32_t iis2dlpc_filter_path_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fds_t *val);
+int32_t iis2dlpc_filter_path_set(stmdev_ctx_t *ctx, iis2dlpc_fds_t val);
+int32_t iis2dlpc_filter_path_get(stmdev_ctx_t *ctx, iis2dlpc_fds_t *val);
 
 typedef enum {
   IIS2DLPC_ODR_DIV_2     = 0,
@@ -567,88 +539,88 @@ typedef enum {
   IIS2DLPC_ODR_DIV_10    = 2,
   IIS2DLPC_ODR_DIV_20    = 3,
 } iis2dlpc_bw_filt_t;
-int32_t iis2dlpc_filter_bandwidth_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_filter_bandwidth_set(stmdev_ctx_t *ctx,
                                          iis2dlpc_bw_filt_t val);
-int32_t iis2dlpc_filter_bandwidth_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_filter_bandwidth_get(stmdev_ctx_t *ctx,
                                          iis2dlpc_bw_filt_t *val);
 
-int32_t iis2dlpc_reference_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_reference_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DLPC_SPI_4_WIRE   = 0,
   IIS2DLPC_SPI_3_WIRE   = 1,
 } iis2dlpc_sim_t;
-int32_t iis2dlpc_spi_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t val);
-int32_t iis2dlpc_spi_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sim_t *val);
+int32_t iis2dlpc_spi_mode_set(stmdev_ctx_t *ctx, iis2dlpc_sim_t val);
+int32_t iis2dlpc_spi_mode_get(stmdev_ctx_t *ctx, iis2dlpc_sim_t *val);
 
 typedef enum {
   IIS2DLPC_I2C_ENABLE    = 0,
   IIS2DLPC_I2C_DISABLE   = 1,
 } iis2dlpc_i2c_disable_t;
-int32_t iis2dlpc_i2c_interface_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_i2c_interface_set(stmdev_ctx_t *ctx,
                                    iis2dlpc_i2c_disable_t val);
-int32_t iis2dlpc_i2c_interface_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_i2c_interface_get(stmdev_ctx_t *ctx,
                                    iis2dlpc_i2c_disable_t *val);
 
 typedef enum {
   IIS2DLPC_PULL_UP_CONNECT     = 0,
   IIS2DLPC_PULL_UP_DISCONNECT  = 1,
 } iis2dlpc_cs_pu_disc_t;
-int32_t iis2dlpc_cs_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t val);
-int32_t iis2dlpc_cs_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_cs_pu_disc_t *val);
+int32_t iis2dlpc_cs_mode_set(stmdev_ctx_t *ctx, iis2dlpc_cs_pu_disc_t val);
+int32_t iis2dlpc_cs_mode_get(stmdev_ctx_t *ctx, iis2dlpc_cs_pu_disc_t *val);
 
 typedef enum {
   IIS2DLPC_ACTIVE_HIGH  = 0,
   IIS2DLPC_ACTIVE_LOW   = 1,
 } iis2dlpc_h_lactive_t;
-int32_t iis2dlpc_pin_polarity_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_polarity_set(stmdev_ctx_t *ctx,
                                   iis2dlpc_h_lactive_t val);
-int32_t iis2dlpc_pin_polarity_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_polarity_get(stmdev_ctx_t *ctx,
                                   iis2dlpc_h_lactive_t *val);
 
 typedef enum {
   IIS2DLPC_INT_PULSED   = 0,
   IIS2DLPC_INT_LATCHED  = 1,
 } iis2dlpc_lir_t;
-int32_t iis2dlpc_int_notification_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_int_notification_set(stmdev_ctx_t *ctx,
                                       iis2dlpc_lir_t val);
-int32_t iis2dlpc_int_notification_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_int_notification_get(stmdev_ctx_t *ctx,
                                       iis2dlpc_lir_t *val);
 
 typedef enum {
   IIS2DLPC_PUSH_PULL   = 0,
   IIS2DLPC_OPEN_DRAIN  = 1,
 } iis2dlpc_pp_od_t;
-int32_t iis2dlpc_pin_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t val);
-int32_t iis2dlpc_pin_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_pp_od_t *val);
+int32_t iis2dlpc_pin_mode_set(stmdev_ctx_t *ctx, iis2dlpc_pp_od_t val);
+int32_t iis2dlpc_pin_mode_get(stmdev_ctx_t *ctx, iis2dlpc_pp_od_t *val);
 
-int32_t iis2dlpc_pin_int1_route_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     iis2dlpc_ctrl4_int1_pad_ctrl_t *val);
-int32_t iis2dlpc_pin_int1_route_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     iis2dlpc_ctrl4_int1_pad_ctrl_t *val);
 
-int32_t iis2dlpc_pin_int2_route_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     iis2dlpc_ctrl5_int2_pad_ctrl_t *val);
-int32_t iis2dlpc_pin_int2_route_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     iis2dlpc_ctrl5_int2_pad_ctrl_t *val);
 
-int32_t iis2dlpc_all_on_int1_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_all_on_int1_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_wkup_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_wkup_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_wkup_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_wkup_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DLPC_HP_FEED           = 0,
   IIS2DLPC_USER_OFFSET_FEED  = 1,
 } iis2dlpc_usr_off_on_wu_t;
-int32_t iis2dlpc_wkup_feed_data_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_wkup_feed_data_set(stmdev_ctx_t *ctx,
                                     iis2dlpc_usr_off_on_wu_t val);
-int32_t iis2dlpc_wkup_feed_data_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_wkup_feed_data_get(stmdev_ctx_t *ctx,
                                     iis2dlpc_usr_off_on_wu_t *val);
 
 typedef enum {
@@ -656,17 +628,17 @@ typedef enum {
   IIS2DLPC_DETECT_ACT_INACT    = 1,
   IIS2DLPC_DETECT_STAT_MOTION  = 3,
 } iis2dlpc_sleep_on_t;
-int32_t iis2dlpc_act_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t val);
-int32_t iis2dlpc_act_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sleep_on_t *val);
+int32_t iis2dlpc_act_mode_set(stmdev_ctx_t *ctx, iis2dlpc_sleep_on_t val);
+int32_t iis2dlpc_act_mode_get(stmdev_ctx_t *ctx, iis2dlpc_sleep_on_t *val);
 
-int32_t iis2dlpc_act_sleep_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_act_sleep_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_tap_threshold_x_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_threshold_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_tap_threshold_y_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_threshold_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DLPC_XYZ    = 0,
@@ -676,62 +648,62 @@ typedef enum {
   IIS2DLPC_YZX    = 5,
   IIS2DLPC_ZXY    = 6,
 } iis2dlpc_tap_prior_t;
-int32_t iis2dlpc_tap_axis_priority_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_tap_axis_priority_set(stmdev_ctx_t *ctx,
                                        iis2dlpc_tap_prior_t val);
-int32_t iis2dlpc_tap_axis_priority_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                        iis2dlpc_tap_prior_t *val);
 
-int32_t iis2dlpc_tap_threshold_z_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_threshold_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_tap_detection_on_z_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_detection_on_z_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_tap_detection_on_y_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_detection_on_y_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_tap_detection_on_x_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_detection_on_x_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_tap_shock_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_shock_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_tap_quiet_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_quiet_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_tap_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_tap_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DLPC_ONLY_SINGLE          = 0,
   IIS2DLPC_BOTH_SINGLE_DOUBLE   = 1,
 } iis2dlpc_single_double_tap_t;
-int32_t iis2dlpc_tap_mode_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_tap_mode_set(stmdev_ctx_t *ctx,
                               iis2dlpc_single_double_tap_t val);
-int32_t iis2dlpc_tap_mode_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_tap_mode_get(stmdev_ctx_t *ctx,
                               iis2dlpc_single_double_tap_t *val);
 
-int32_t iis2dlpc_tap_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_tap_src_t *val);
+int32_t iis2dlpc_tap_src_get(stmdev_ctx_t *ctx, iis2dlpc_tap_src_t *val);
 
-int32_t iis2dlpc_6d_threshold_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_6d_threshold_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_4d_mode_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_4d_mode_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_6d_src_get(iis2dlpc_ctx_t *ctx, iis2dlpc_sixd_src_t *val);
+int32_t iis2dlpc_6d_src_get(stmdev_ctx_t *ctx, iis2dlpc_sixd_src_t *val);
 
 typedef enum {
   IIS2DLPC_ODR_DIV_2_FEED   = 0,
   IIS2DLPC_LPF2_FEED        = 1,
 } iis2dlpc_lpass_on6d_t;
-int32_t iis2dlpc_6d_feed_data_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_6d_feed_data_set(stmdev_ctx_t *ctx,
                                   iis2dlpc_lpass_on6d_t val);
-int32_t iis2dlpc_6d_feed_data_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_6d_feed_data_get(stmdev_ctx_t *ctx,
                                   iis2dlpc_lpass_on6d_t *val);
 
-int32_t iis2dlpc_ff_dur_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_ff_dur_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DLPC_FF_TSH_5LSb_FS2g  = 0,
@@ -743,13 +715,13 @@ typedef enum {
   IIS2DLPC_FF_TSH_15LSb_FS2g = 6,
   IIS2DLPC_FF_TSH_16LSb_FS2g = 7,
 } iis2dlpc_ff_ths_t;
-int32_t iis2dlpc_ff_threshold_set(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_ff_threshold_set(stmdev_ctx_t *ctx,
                                   iis2dlpc_ff_ths_t val);
-int32_t iis2dlpc_ff_threshold_get(iis2dlpc_ctx_t *ctx,
+int32_t iis2dlpc_ff_threshold_get(stmdev_ctx_t *ctx,
                                   iis2dlpc_ff_ths_t *val);
 
-int32_t iis2dlpc_fifo_watermark_set(iis2dlpc_ctx_t *ctx, uint8_t val);
-int32_t iis2dlpc_fifo_watermark_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2dlpc_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2DLPC_BYPASS_MODE             = 0,
@@ -758,14 +730,14 @@ typedef enum {
   IIS2DLPC_BYPASS_TO_STREAM_MODE   = 4,
   IIS2DLPC_STREAM_MODE             = 6,
 } iis2dlpc_fmode_t;
-int32_t iis2dlpc_fifo_mode_set(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t val);
-int32_t iis2dlpc_fifo_mode_get(iis2dlpc_ctx_t *ctx, iis2dlpc_fmode_t *val);
+int32_t iis2dlpc_fifo_mode_set(stmdev_ctx_t *ctx, iis2dlpc_fmode_t val);
+int32_t iis2dlpc_fifo_mode_get(stmdev_ctx_t *ctx, iis2dlpc_fmode_t *val);
 
-int32_t iis2dlpc_fifo_data_level_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_fifo_ovr_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2dlpc_fifo_wtm_flag_get(iis2dlpc_ctx_t *ctx, uint8_t *val);
+int32_t iis2dlpc_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.c
+++ b/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.c
@@ -6,33 +6,16 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 #include "iis2mdc_reg.h"
 /**
@@ -62,7 +45,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_read_reg(iis2mdc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis2mdc_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -80,7 +63,7 @@ int32_t iis2mdc_read_reg(iis2mdc_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_write_reg(iis2mdc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis2mdc_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -136,7 +119,7 @@ float iis2mdc_from_lsb_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_mag_user_offset_set(iis2mdc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2mdc_mag_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  iis2mdc_write_reg(ctx, IIS2MDC_OFFSET_X_REG_L, buff, 6);
@@ -156,7 +139,7 @@ int32_t iis2mdc_mag_user_offset_set(iis2mdc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_mag_user_offset_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2mdc_mag_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  iis2mdc_read_reg(ctx, IIS2MDC_OFFSET_X_REG_L, buff, 6);
@@ -171,7 +154,7 @@ int32_t iis2mdc_mag_user_offset_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_operating_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_md_t val)
+int32_t iis2mdc_operating_mode_set(stmdev_ctx_t *ctx, iis2mdc_md_t val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -192,7 +175,7 @@ int32_t iis2mdc_operating_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_md_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_operating_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_md_t *val)
+int32_t iis2mdc_operating_mode_get(stmdev_ctx_t *ctx, iis2mdc_md_t *val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -223,7 +206,7 @@ int32_t iis2mdc_operating_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_data_rate_set(iis2mdc_ctx_t *ctx, iis2mdc_odr_t val)
+int32_t iis2mdc_data_rate_set(stmdev_ctx_t *ctx, iis2mdc_odr_t val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -244,7 +227,7 @@ int32_t iis2mdc_data_rate_set(iis2mdc_ctx_t *ctx, iis2mdc_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_data_rate_get(iis2mdc_ctx_t *ctx, iis2mdc_odr_t *val)
+int32_t iis2mdc_data_rate_get(stmdev_ctx_t *ctx, iis2mdc_odr_t *val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -278,7 +261,7 @@ int32_t iis2mdc_data_rate_get(iis2mdc_ctx_t *ctx, iis2mdc_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_power_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_lp_t val)
+int32_t iis2mdc_power_mode_set(stmdev_ctx_t *ctx, iis2mdc_lp_t val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -299,7 +282,7 @@ int32_t iis2mdc_power_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_lp_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_power_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_lp_t *val)
+int32_t iis2mdc_power_mode_get(stmdev_ctx_t *ctx, iis2mdc_lp_t *val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -327,7 +310,7 @@ int32_t iis2mdc_power_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_lp_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_offset_temp_comp_set(iis2mdc_ctx_t *ctx, uint8_t val)
+int32_t iis2mdc_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -348,7 +331,7 @@ int32_t iis2mdc_offset_temp_comp_set(iis2mdc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_offset_temp_comp_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -367,7 +350,7 @@ int32_t iis2mdc_offset_temp_comp_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_low_pass_bandwidth_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                        iis2mdc_lpf_t val)
 {
   iis2mdc_cfg_reg_b_t reg;
@@ -389,7 +372,7 @@ int32_t iis2mdc_low_pass_bandwidth_set(iis2mdc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_low_pass_bandwidth_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                        iis2mdc_lpf_t *val)
 {
   iis2mdc_cfg_reg_b_t reg;
@@ -419,7 +402,7 @@ int32_t iis2mdc_low_pass_bandwidth_get(iis2mdc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_set_rst_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_set_rst_t val)
+int32_t iis2mdc_set_rst_mode_set(stmdev_ctx_t *ctx, iis2mdc_set_rst_t val)
 {
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
@@ -440,7 +423,7 @@ int32_t iis2mdc_set_rst_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_set_rst_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_set_rst_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_set_rst_t *val)
+int32_t iis2mdc_set_rst_mode_get(stmdev_ctx_t *ctx, iis2mdc_set_rst_t *val)
 {
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
@@ -476,7 +459,7 @@ int32_t iis2mdc_set_rst_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_set_rst_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_set_rst_sensor_single_set(iis2mdc_ctx_t *ctx, uint8_t val)
+int32_t iis2mdc_set_rst_sensor_single_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
@@ -501,7 +484,7 @@ int32_t iis2mdc_set_rst_sensor_single_set(iis2mdc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_set_rst_sensor_single_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_set_rst_sensor_single_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_b_t reg;
   int32_t ret;
@@ -520,7 +503,7 @@ int32_t iis2mdc_set_rst_sensor_single_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_block_data_update_set(iis2mdc_ctx_t *ctx, uint8_t val)
+int32_t iis2mdc_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -541,7 +524,7 @@ int32_t iis2mdc_block_data_update_set(iis2mdc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_block_data_update_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -560,7 +543,7 @@ int32_t iis2mdc_block_data_update_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_mag_data_ready_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_mag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_status_reg_t reg;
   int32_t ret;
@@ -579,7 +562,7 @@ int32_t iis2mdc_mag_data_ready_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_mag_data_ovr_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_mag_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_status_reg_t reg;
   int32_t ret;
@@ -598,7 +581,7 @@ int32_t iis2mdc_mag_data_ovr_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_magnetic_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2mdc_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  iis2mdc_read_reg(ctx, IIS2MDC_OUTX_L_REG, buff, 6);
@@ -613,7 +596,7 @@ int32_t iis2mdc_magnetic_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_temperature_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2mdc_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  iis2mdc_read_reg(ctx, IIS2MDC_TEMP_OUT_L_REG, buff, 2);
@@ -640,7 +623,7 @@ int32_t iis2mdc_temperature_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_device_id_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2mdc_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  iis2mdc_read_reg(ctx, IIS2MDC_WHO_AM_I, buff, 1);
@@ -656,7 +639,7 @@ int32_t iis2mdc_device_id_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_reset_set(iis2mdc_ctx_t *ctx, uint8_t val)
+int32_t iis2mdc_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -677,7 +660,7 @@ int32_t iis2mdc_reset_set(iis2mdc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_reset_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -696,7 +679,7 @@ int32_t iis2mdc_reset_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_boot_set(iis2mdc_ctx_t *ctx, uint8_t val)
+int32_t iis2mdc_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -717,7 +700,7 @@ int32_t iis2mdc_boot_set(iis2mdc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_boot_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_a_t reg;
   int32_t ret;
@@ -736,7 +719,7 @@ int32_t iis2mdc_boot_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_self_test_set(iis2mdc_ctx_t *ctx, uint8_t val)
+int32_t iis2mdc_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -757,7 +740,7 @@ int32_t iis2mdc_self_test_set(iis2mdc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_self_test_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -776,7 +759,7 @@ int32_t iis2mdc_self_test_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_data_format_set(iis2mdc_ctx_t *ctx, iis2mdc_ble_t val)
+int32_t iis2mdc_data_format_set(stmdev_ctx_t *ctx, iis2mdc_ble_t val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -797,7 +780,7 @@ int32_t iis2mdc_data_format_set(iis2mdc_ctx_t *ctx, iis2mdc_ble_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_data_format_get(iis2mdc_ctx_t *ctx, iis2mdc_ble_t *val)
+int32_t iis2mdc_data_format_get(stmdev_ctx_t *ctx, iis2mdc_ble_t *val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -825,7 +808,7 @@ int32_t iis2mdc_data_format_get(iis2mdc_ctx_t *ctx, iis2mdc_ble_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_status_get(iis2mdc_ctx_t *ctx, iis2mdc_status_reg_t *val)
+int32_t iis2mdc_status_get(stmdev_ctx_t *ctx, iis2mdc_status_reg_t *val)
 {
   int32_t ret;
   ret =  iis2mdc_read_reg(ctx, IIS2MDC_STATUS_REG, (uint8_t*) val, 1);
@@ -855,7 +838,7 @@ int32_t iis2mdc_status_get(iis2mdc_ctx_t *ctx, iis2mdc_status_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_offset_int_conf_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_offset_int_conf_set(stmdev_ctx_t *ctx,
                                     iis2mdc_int_on_dataoff_t val)
 {
   iis2mdc_cfg_reg_b_t reg;
@@ -879,7 +862,7 @@ int32_t iis2mdc_offset_int_conf_set(iis2mdc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_offset_int_conf_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_offset_int_conf_get(stmdev_ctx_t *ctx,
                                     iis2mdc_int_on_dataoff_t *val)
 {
   iis2mdc_cfg_reg_b_t reg;
@@ -908,7 +891,7 @@ int32_t iis2mdc_offset_int_conf_get(iis2mdc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_drdy_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val)
+int32_t iis2mdc_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -929,7 +912,7 @@ int32_t iis2mdc_drdy_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_drdy_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -948,7 +931,7 @@ int32_t iis2mdc_drdy_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_int_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val)
+int32_t iis2mdc_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -969,7 +952,7 @@ int32_t iis2mdc_int_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_int_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val)
+int32_t iis2mdc_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -988,7 +971,7 @@ int32_t iis2mdc_int_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_int_gen_conf_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_int_gen_conf_set(stmdev_ctx_t *ctx,
                                  iis2mdc_int_crtl_reg_t *val)
 {
   int32_t ret;
@@ -1004,7 +987,7 @@ int32_t iis2mdc_int_gen_conf_set(iis2mdc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_int_gen_conf_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_int_gen_conf_get(stmdev_ctx_t *ctx,
                                  iis2mdc_int_crtl_reg_t *val)
 {
   int32_t ret;
@@ -1020,7 +1003,7 @@ int32_t iis2mdc_int_gen_conf_get(iis2mdc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_int_gen_source_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_int_gen_source_get(stmdev_ctx_t *ctx,
                                    iis2mdc_int_source_reg_t *val)
 {
   int32_t ret;
@@ -1038,7 +1021,7 @@ int32_t iis2mdc_int_gen_source_get(iis2mdc_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_int_gen_treshold_set(iis2mdc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2mdc_int_gen_treshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  iis2mdc_write_reg(ctx, IIS2MDC_INT_THS_L_REG, buff, 2);
@@ -1055,7 +1038,7 @@ int32_t iis2mdc_int_gen_treshold_set(iis2mdc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_int_gen_treshold_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
+int32_t iis2mdc_int_gen_treshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  iis2mdc_read_reg(ctx, IIS2MDC_INT_THS_L_REG, buff, 2);
@@ -1083,7 +1066,7 @@ int32_t iis2mdc_int_gen_treshold_get(iis2mdc_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_i2c_interface_set(iis2mdc_ctx_t *ctx, iis2mdc_i2c_dis_t val)
+int32_t iis2mdc_i2c_interface_set(stmdev_ctx_t *ctx, iis2mdc_i2c_dis_t val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;
@@ -1104,7 +1087,7 @@ int32_t iis2mdc_i2c_interface_set(iis2mdc_ctx_t *ctx, iis2mdc_i2c_dis_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis2mdc_i2c_interface_get(iis2mdc_ctx_t *ctx, iis2mdc_i2c_dis_t *val)
+int32_t iis2mdc_i2c_interface_get(stmdev_ctx_t *ctx, iis2mdc_i2c_dis_t *val)
 {
   iis2mdc_cfg_reg_c_t reg;
   int32_t ret;

--- a/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.h
+++ b/sensor/stmemsc/iis2mdc_STdC/driver/iis2mdc_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup IIS2MDC_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,19 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  IIS2MDC_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -131,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*iis2mdc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*iis2mdc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  iis2mdc_write_ptr  write_reg;
-  iis2mdc_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} iis2mdc_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -280,23 +247,23 @@ typedef union{
   uint8_t                        byte;
 } iis2mdc_reg_t;
 
-int32_t iis2mdc_read_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis2mdc_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t iis2mdc_write_reg(iis2mdc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis2mdc_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 float iis2mdc_from_lsb_to_mgauss(int16_t lsb);
 float iis2mdc_from_lsb_to_celsius(int16_t lsb);
 
-int32_t iis2mdc_mag_user_offset_set(iis2mdc_ctx_t *ctx, uint8_t *buff);
-int32_t iis2mdc_mag_user_offset_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_mag_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_mag_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 typedef enum {
   IIS2MDC_CONTINUOUS_MODE  = 0,
   IIS2MDC_SINGLE_TRIGGER   = 1,
   IIS2MDC_POWER_DOWN       = 2,
 } iis2mdc_md_t;
-int32_t iis2mdc_operating_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_md_t val);
-int32_t iis2mdc_operating_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_md_t *val);
+int32_t iis2mdc_operating_mode_set(stmdev_ctx_t *ctx, iis2mdc_md_t val);
+int32_t iis2mdc_operating_mode_get(stmdev_ctx_t *ctx, iis2mdc_md_t *val);
 
 typedef enum {
   IIS2MDC_ODR_10Hz   = 0,
@@ -304,26 +271,26 @@ typedef enum {
   IIS2MDC_ODR_50Hz   = 2,
   IIS2MDC_ODR_100Hz  = 3,
 } iis2mdc_odr_t;
-int32_t iis2mdc_data_rate_set(iis2mdc_ctx_t *ctx, iis2mdc_odr_t val);
-int32_t iis2mdc_data_rate_get(iis2mdc_ctx_t *ctx, iis2mdc_odr_t *val);
+int32_t iis2mdc_data_rate_set(stmdev_ctx_t *ctx, iis2mdc_odr_t val);
+int32_t iis2mdc_data_rate_get(stmdev_ctx_t *ctx, iis2mdc_odr_t *val);
 
 typedef enum {
   IIS2MDC_HIGH_RESOLUTION  = 0,
   IIS2MDC_LOW_POWER        = 1,
 } iis2mdc_lp_t;
-int32_t iis2mdc_power_mode_set(iis2mdc_ctx_t *ctx, iis2mdc_lp_t val);
-int32_t iis2mdc_power_mode_get(iis2mdc_ctx_t *ctx, iis2mdc_lp_t *val);
+int32_t iis2mdc_power_mode_set(stmdev_ctx_t *ctx, iis2mdc_lp_t val);
+int32_t iis2mdc_power_mode_get(stmdev_ctx_t *ctx, iis2mdc_lp_t *val);
 
-int32_t iis2mdc_offset_temp_comp_set(iis2mdc_ctx_t *ctx, uint8_t val);
-int32_t iis2mdc_offset_temp_comp_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2MDC_ODR_DIV_2  = 0,
   IIS2MDC_ODR_DIV_4  = 1,
 } iis2mdc_lpf_t;
-int32_t iis2mdc_low_pass_bandwidth_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                        iis2mdc_lpf_t val);
-int32_t iis2mdc_low_pass_bandwidth_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                        iis2mdc_lpf_t *val);
 
 typedef enum {
@@ -331,80 +298,80 @@ typedef enum {
   IIS2MDC_SENS_OFF_CANC_EVERY_ODR    = 1,
   IIS2MDC_SET_SENS_ONLY_AT_POWER_ON  = 2,
 } iis2mdc_set_rst_t;
-int32_t iis2mdc_set_rst_mode_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_set_rst_mode_set(stmdev_ctx_t *ctx,
                                  iis2mdc_set_rst_t val);
-int32_t iis2mdc_set_rst_mode_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_set_rst_mode_get(stmdev_ctx_t *ctx,
                                  iis2mdc_set_rst_t *val);
 
-int32_t iis2mdc_set_rst_sensor_single_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_set_rst_sensor_single_set(stmdev_ctx_t *ctx,
                                           uint8_t val);
-int32_t iis2mdc_set_rst_sensor_single_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_set_rst_sensor_single_get(stmdev_ctx_t *ctx,
                                           uint8_t *val);
 
-int32_t iis2mdc_block_data_update_set(iis2mdc_ctx_t *ctx, uint8_t val);
-int32_t iis2mdc_block_data_update_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2mdc_mag_data_ready_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_mag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2mdc_mag_data_ovr_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_mag_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2mdc_magnetic_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2mdc_temperature_raw_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2mdc_device_id_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis2mdc_reset_set(iis2mdc_ctx_t *ctx, uint8_t val);
-int32_t iis2mdc_reset_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2mdc_boot_set(iis2mdc_ctx_t *ctx, uint8_t val);
-int32_t iis2mdc_boot_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2mdc_self_test_set(iis2mdc_ctx_t *ctx, uint8_t val);
-int32_t iis2mdc_self_test_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_self_test_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_self_test_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS2MDC_LSB_AT_LOW_ADD  = 0,
   IIS2MDC_MSB_AT_LOW_ADD  = 1,
 } iis2mdc_ble_t;
-int32_t iis2mdc_data_format_set(iis2mdc_ctx_t *ctx, iis2mdc_ble_t val);
-int32_t iis2mdc_data_format_get(iis2mdc_ctx_t *ctx, iis2mdc_ble_t *val);
+int32_t iis2mdc_data_format_set(stmdev_ctx_t *ctx, iis2mdc_ble_t val);
+int32_t iis2mdc_data_format_get(stmdev_ctx_t *ctx, iis2mdc_ble_t *val);
 
-int32_t iis2mdc_status_get(iis2mdc_ctx_t *ctx, iis2mdc_status_reg_t *val);
+int32_t iis2mdc_status_get(stmdev_ctx_t *ctx, iis2mdc_status_reg_t *val);
 
 typedef enum {
   IIS2MDC_CHECK_BEFORE  = 0,
   IIS2MDC_CHECK_AFTER   = 1,
 } iis2mdc_int_on_dataoff_t;
-int32_t iis2mdc_offset_int_conf_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_offset_int_conf_set(stmdev_ctx_t *ctx,
                                     iis2mdc_int_on_dataoff_t val);
-int32_t iis2mdc_offset_int_conf_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_offset_int_conf_get(stmdev_ctx_t *ctx,
                                     iis2mdc_int_on_dataoff_t *val);
 
-int32_t iis2mdc_drdy_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val);
-int32_t iis2mdc_drdy_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2mdc_int_on_pin_set(iis2mdc_ctx_t *ctx, uint8_t val);
-int32_t iis2mdc_int_on_pin_get(iis2mdc_ctx_t *ctx, uint8_t *val);
+int32_t iis2mdc_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis2mdc_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis2mdc_int_gen_conf_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_int_gen_conf_set(stmdev_ctx_t *ctx,
                                  iis2mdc_int_crtl_reg_t *val);
-int32_t iis2mdc_int_gen_conf_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_int_gen_conf_get(stmdev_ctx_t *ctx,
                                  iis2mdc_int_crtl_reg_t *val);
 
-int32_t iis2mdc_int_gen_source_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_int_gen_source_get(stmdev_ctx_t *ctx,
                                    iis2mdc_int_source_reg_t *val);
 
-int32_t iis2mdc_int_gen_treshold_set(iis2mdc_ctx_t *ctx, uint8_t *buff);
-int32_t iis2mdc_int_gen_treshold_get(iis2mdc_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_int_gen_treshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis2mdc_int_gen_treshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   IIS2MDC_I2C_ENABLE   = 0,
   IIS2MDC_I2C_DISABLE  = 1,
 } iis2mdc_i2c_dis_t;
-int32_t iis2mdc_i2c_interface_set(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_i2c_interface_set(stmdev_ctx_t *ctx,
                                   iis2mdc_i2c_dis_t val);
-int32_t iis2mdc_i2c_interface_get(iis2mdc_ctx_t *ctx,
+int32_t iis2mdc_i2c_interface_get(stmdev_ctx_t *ctx,
                                   iis2mdc_i2c_dis_t *val);
 
 /**

--- a/sensor/stmemsc/iis328dq_STdC/driver/iis328dq_reg.c
+++ b/sensor/stmemsc/iis328dq_STdC/driver/iis328dq_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "iis328dq_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis328dq_read_reg(iis328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis328dq_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t iis328dq_read_reg(iis328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis328dq_write_reg(iis328dq_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis328dq_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                             uint16_t len)
 {
   int32_t ret;
@@ -136,7 +119,7 @@ float iis328dq_from_fs8_to_mg(int16_t lsb)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t iis328dq_axis_x_data_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -157,7 +140,7 @@ int32_t iis328dq_axis_x_data_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t iis328dq_axis_x_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -175,7 +158,7 @@ int32_t iis328dq_axis_x_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t iis328dq_axis_y_data_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -196,7 +179,7 @@ int32_t iis328dq_axis_y_data_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t iis328dq_axis_y_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -214,7 +197,7 @@ int32_t iis328dq_axis_y_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t iis328dq_axis_z_data_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -235,7 +218,7 @@ int32_t iis328dq_axis_z_data_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t iis328dq_axis_z_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -253,7 +236,7 @@ int32_t iis328dq_axis_z_data_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of dr in reg CTRL_REG1
   *
   */
-int32_t iis328dq_data_rate_set(iis328dq_ctx_t *ctx, iis328dq_dr_t val)
+int32_t iis328dq_data_rate_set(stmdev_ctx_t *ctx, iis328dq_dr_t val)
 {
   iis328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -276,7 +259,7 @@ int32_t iis328dq_data_rate_set(iis328dq_ctx_t *ctx, iis328dq_dr_t val)
   * @param  val         Get the values of dr in reg CTRL_REG1
   *
   */
-int32_t iis328dq_data_rate_get(iis328dq_ctx_t *ctx, iis328dq_dr_t *val)
+int32_t iis328dq_data_rate_get(stmdev_ctx_t *ctx, iis328dq_dr_t *val)
 {
   iis328dq_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -331,7 +314,7 @@ int32_t iis328dq_data_rate_get(iis328dq_ctx_t *ctx, iis328dq_dr_t *val)
   * @param  val         change the values of hpm in reg CTRL_REG2
   *
   */
-int32_t iis328dq_reference_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_reference_mode_set(stmdev_ctx_t *ctx,
                                      iis328dq_hpm_t val)
 {
   iis328dq_ctrl_reg2_t ctrl_reg2;
@@ -353,7 +336,7 @@ int32_t iis328dq_reference_mode_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of hpm in reg CTRL_REG2
   *
   */
-int32_t iis328dq_reference_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_reference_mode_get(stmdev_ctx_t *ctx,
                                      iis328dq_hpm_t *val)
 {
   iis328dq_ctrl_reg2_t ctrl_reg2;
@@ -384,7 +367,7 @@ int32_t iis328dq_reference_mode_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of fs in reg CTRL_REG4
   *
   */
-int32_t iis328dq_full_scale_set(iis328dq_ctx_t *ctx, iis328dq_fs_t val)
+int32_t iis328dq_full_scale_set(stmdev_ctx_t *ctx, iis328dq_fs_t val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -405,7 +388,7 @@ int32_t iis328dq_full_scale_set(iis328dq_ctx_t *ctx, iis328dq_fs_t val)
   * @param  val         Get the values of fs in reg CTRL_REG4
   *
   */
-int32_t iis328dq_full_scale_get(iis328dq_ctx_t *ctx, iis328dq_fs_t *val)
+int32_t iis328dq_full_scale_get(stmdev_ctx_t *ctx, iis328dq_fs_t *val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -438,7 +421,7 @@ int32_t iis328dq_full_scale_get(iis328dq_ctx_t *ctx, iis328dq_fs_t *val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t iis328dq_block_data_update_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -459,7 +442,7 @@ int32_t iis328dq_block_data_update_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t iis328dq_block_data_update_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -477,7 +460,7 @@ int32_t iis328dq_block_data_update_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         registers STATUS_REG
   *
   */
-int32_t iis328dq_status_reg_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_status_reg_get(stmdev_ctx_t *ctx,
                                  iis328dq_status_reg_t *val)
 {
   int32_t ret;
@@ -492,7 +475,7 @@ int32_t iis328dq_status_reg_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of zyxda in reg STATUS_REG
   *
   */
-int32_t iis328dq_flag_data_ready_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_status_reg_t status_reg;
   int32_t ret;
@@ -524,7 +507,7 @@ int32_t iis328dq_flag_data_ready_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t iis328dq_acceleration_raw_get(iis328dq_ctx_t *ctx, uint8_t *buff)
+int32_t iis328dq_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis328dq_read_reg(ctx, IIS328DQ_OUT_X_L, buff, 6);
@@ -550,7 +533,7 @@ int32_t iis328dq_acceleration_raw_get(iis328dq_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t iis328dq_device_id_get(iis328dq_ctx_t *ctx, uint8_t *buff)
+int32_t iis328dq_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = iis328dq_read_reg(ctx, IIS328DQ_WHO_AM_I, buff, 1);
@@ -564,7 +547,7 @@ int32_t iis328dq_device_id_get(iis328dq_ctx_t *ctx, uint8_t *buff)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t iis328dq_boot_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -585,7 +568,7 @@ int32_t iis328dq_boot_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t iis328dq_boot_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -603,7 +586,7 @@ int32_t iis328dq_boot_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of st in reg CTRL_REG4
   *
   */
-int32_t iis328dq_self_test_set(iis328dq_ctx_t *ctx, iis328dq_st_t val)
+int32_t iis328dq_self_test_set(stmdev_ctx_t *ctx, iis328dq_st_t val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -624,7 +607,7 @@ int32_t iis328dq_self_test_set(iis328dq_ctx_t *ctx, iis328dq_st_t val)
   * @param  val         Get the values of st in reg CTRL_REG4
   *
   */
-int32_t iis328dq_self_test_get(iis328dq_ctx_t *ctx, iis328dq_st_t *val)
+int32_t iis328dq_self_test_get(stmdev_ctx_t *ctx, iis328dq_st_t *val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -657,7 +640,7 @@ int32_t iis328dq_self_test_get(iis328dq_ctx_t *ctx, iis328dq_st_t *val)
   * @param  val         change the values of ble in reg CTRL_REG4
   *
   */
-int32_t iis328dq_data_format_set(iis328dq_ctx_t *ctx, iis328dq_ble_t val)
+int32_t iis328dq_data_format_set(stmdev_ctx_t *ctx, iis328dq_ble_t val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -678,7 +661,7 @@ int32_t iis328dq_data_format_set(iis328dq_ctx_t *ctx, iis328dq_ble_t val)
   * @param  val         Get the values of ble in reg CTRL_REG4
   *
   */
-int32_t iis328dq_data_format_get(iis328dq_ctx_t *ctx, iis328dq_ble_t *val)
+int32_t iis328dq_data_format_get(stmdev_ctx_t *ctx, iis328dq_ble_t *val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -721,7 +704,7 @@ int32_t iis328dq_data_format_get(iis328dq_ctx_t *ctx, iis328dq_ble_t *val)
   * @param  val         change the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t iis328dq_hp_bandwidth_set(iis328dq_ctx_t *ctx, iis328dq_hpcf_t val)
+int32_t iis328dq_hp_bandwidth_set(stmdev_ctx_t *ctx, iis328dq_hpcf_t val)
 {
   iis328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -742,7 +725,7 @@ int32_t iis328dq_hp_bandwidth_set(iis328dq_ctx_t *ctx, iis328dq_hpcf_t val)
   * @param  val         Get the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t iis328dq_hp_bandwidth_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    iis328dq_hpcf_t *val)
 {
   iis328dq_ctrl_reg2_t ctrl_reg2;
@@ -779,7 +762,7 @@ int32_t iis328dq_hp_bandwidth_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of hpen in reg CTRL_REG2
   *
   */
-int32_t iis328dq_hp_path_set(iis328dq_ctx_t *ctx, iis328dq_hpen_t val)
+int32_t iis328dq_hp_path_set(stmdev_ctx_t *ctx, iis328dq_hpen_t val)
 {
   iis328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -801,7 +784,7 @@ int32_t iis328dq_hp_path_set(iis328dq_ctx_t *ctx, iis328dq_hpen_t val)
   * @param  val         Get the values of hpen in reg CTRL_REG2
   *
   */
-int32_t iis328dq_hp_path_get(iis328dq_ctx_t *ctx, iis328dq_hpen_t *val)
+int32_t iis328dq_hp_path_get(stmdev_ctx_t *ctx, iis328dq_hpen_t *val)
 {
   iis328dq_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -852,7 +835,7 @@ int32_t iis328dq_hp_path_get(iis328dq_ctx_t *ctx, iis328dq_hpen_t *val)
   * @param  ctx         read / write interface definitions(ptr)
   *
   */
-int32_t iis328dq_hp_reset_get(iis328dq_ctx_t *ctx)
+int32_t iis328dq_hp_reset_get(stmdev_ctx_t *ctx)
 {
   uint8_t dummy;
   int32_t ret;
@@ -868,7 +851,7 @@ int32_t iis328dq_hp_reset_get(iis328dq_ctx_t *ctx)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t iis328dq_hp_reference_value_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
   ret = iis328dq_write_reg(ctx, IIS328DQ_REFERENCE, (uint8_t*)&val, 1);
@@ -882,7 +865,7 @@ int32_t iis328dq_hp_reference_value_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t iis328dq_hp_reference_value_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
   ret = iis328dq_read_reg(ctx, IIS328DQ_REFERENCE, val, 1);
@@ -909,7 +892,7 @@ int32_t iis328dq_hp_reference_value_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of sim in reg CTRL_REG4
   *
   */
-int32_t iis328dq_spi_mode_set(iis328dq_ctx_t *ctx, iis328dq_sim_t val)
+int32_t iis328dq_spi_mode_set(stmdev_ctx_t *ctx, iis328dq_sim_t val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -930,7 +913,7 @@ int32_t iis328dq_spi_mode_set(iis328dq_ctx_t *ctx, iis328dq_sim_t val)
   * @param  val         Get the values of sim in reg CTRL_REG4
   *
   */
-int32_t iis328dq_spi_mode_get(iis328dq_ctx_t *ctx, iis328dq_sim_t *val)
+int32_t iis328dq_spi_mode_get(stmdev_ctx_t *ctx, iis328dq_sim_t *val)
 {
   iis328dq_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -973,7 +956,7 @@ int32_t iis328dq_spi_mode_get(iis328dq_ctx_t *ctx, iis328dq_sim_t *val)
   * @param  val         change the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t iis328dq_pin_int1_route_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      iis328dq_i1_cfg_t val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
@@ -995,7 +978,7 @@ int32_t iis328dq_pin_int1_route_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t iis328dq_pin_int1_route_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      iis328dq_i1_cfg_t *val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
@@ -1033,7 +1016,7 @@ int32_t iis328dq_pin_int1_route_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t iis328dq_int1_notification_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_notification_set(stmdev_ctx_t *ctx,
                                         iis328dq_lir1_t val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
@@ -1056,7 +1039,7 @@ int32_t iis328dq_int1_notification_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t iis328dq_int1_notification_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_notification_get(stmdev_ctx_t *ctx,
                                         iis328dq_lir1_t *val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
@@ -1087,7 +1070,7 @@ int32_t iis328dq_int1_notification_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t iis328dq_pin_int2_route_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      iis328dq_i2_cfg_t val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
@@ -1109,7 +1092,7 @@ int32_t iis328dq_pin_int2_route_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t iis328dq_pin_int2_route_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      iis328dq_i2_cfg_t *val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
@@ -1147,7 +1130,7 @@ int32_t iis328dq_pin_int2_route_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t iis328dq_int2_notification_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_notification_set(stmdev_ctx_t *ctx,
                                         iis328dq_lir2_t val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
@@ -1170,7 +1153,7 @@ int32_t iis328dq_int2_notification_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t iis328dq_int2_notification_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_notification_get(stmdev_ctx_t *ctx,
                                         iis328dq_lir2_t *val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
@@ -1201,7 +1184,7 @@ int32_t iis328dq_int2_notification_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t iis328dq_pin_mode_set(iis328dq_ctx_t *ctx, iis328dq_pp_od_t val)
+int32_t iis328dq_pin_mode_set(stmdev_ctx_t *ctx, iis328dq_pp_od_t val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1222,7 +1205,7 @@ int32_t iis328dq_pin_mode_set(iis328dq_ctx_t *ctx, iis328dq_pp_od_t val)
   * @param  val         Get the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t iis328dq_pin_mode_get(iis328dq_ctx_t *ctx, iis328dq_pp_od_t *val)
+int32_t iis328dq_pin_mode_get(stmdev_ctx_t *ctx, iis328dq_pp_od_t *val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1252,7 +1235,7 @@ int32_t iis328dq_pin_mode_get(iis328dq_ctx_t *ctx, iis328dq_pp_od_t *val)
   * @param  val         change the values of ihl in reg CTRL_REG3
   *
   */
-int32_t iis328dq_pin_polarity_set(iis328dq_ctx_t *ctx, iis328dq_ihl_t val)
+int32_t iis328dq_pin_polarity_set(stmdev_ctx_t *ctx, iis328dq_ihl_t val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1273,7 +1256,7 @@ int32_t iis328dq_pin_polarity_set(iis328dq_ctx_t *ctx, iis328dq_ihl_t val)
   * @param  val         Get the values of ihl in reg CTRL_REG3
   *
   */
-int32_t iis328dq_pin_polarity_get(iis328dq_ctx_t *ctx, iis328dq_ihl_t *val)
+int32_t iis328dq_pin_polarity_get(stmdev_ctx_t *ctx, iis328dq_ihl_t *val)
 {
   iis328dq_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1316,7 +1299,7 @@ int32_t iis328dq_pin_polarity_get(iis328dq_ctx_t *ctx, iis328dq_ihl_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t iis328dq_int1_on_threshold_conf_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                               int1_on_th_conf_t val)
 {
   iis328dq_int1_cfg_t int1_cfg;
@@ -1343,7 +1326,7 @@ int32_t iis328dq_int1_on_threshold_conf_set(iis328dq_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t iis328dq_int1_on_threshold_conf_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                              int1_on_th_conf_t *val)
 {
   iis328dq_int1_cfg_t int1_cfg;
@@ -1367,7 +1350,7 @@ int32_t iis328dq_int1_on_threshold_conf_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT1_CFG
   *
   */
-int32_t iis328dq_int1_on_threshold_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              iis328dq_int1_aoi_t val)
 {
   iis328dq_int1_cfg_t int1_cfg;
@@ -1389,7 +1372,7 @@ int32_t iis328dq_int1_on_threshold_mode_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT1_CFG
   *
   */
-int32_t iis328dq_int1_on_threshold_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              iis328dq_int1_aoi_t *val)
 {
   iis328dq_int1_cfg_t int1_cfg;
@@ -1420,7 +1403,7 @@ int32_t iis328dq_int1_on_threshold_mode_get(iis328dq_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t iis328dq_int1_src_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_src_get(stmdev_ctx_t *ctx,
                                iis328dq_int1_src_t *val)
 {
   int32_t ret;
@@ -1435,7 +1418,7 @@ int32_t iis328dq_int1_src_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t iis328dq_int1_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1456,7 +1439,7 @@ int32_t iis328dq_int1_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t iis328dq_int1_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1474,7 +1457,7 @@ int32_t iis328dq_int1_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t iis328dq_int1_dur_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_int1_duration_t int1_duration;
   int32_t ret;
@@ -1496,7 +1479,7 @@ int32_t iis328dq_int1_dur_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t iis328dq_int1_dur_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_int1_duration_t int1_duration;
   int32_t ret;
@@ -1515,7 +1498,7 @@ int32_t iis328dq_int1_dur_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t iis328dq_int2_on_threshold_conf_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                               int2_on_th_conf_t val)
 {
   iis328dq_int2_cfg_t int2_cfg;
@@ -1543,7 +1526,7 @@ int32_t iis328dq_int2_on_threshold_conf_set(iis328dq_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t iis328dq_int2_on_threshold_conf_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                               int2_on_th_conf_t *val)
 {
   iis328dq_int2_cfg_t int2_cfg;
@@ -1567,7 +1550,7 @@ int32_t iis328dq_int2_on_threshold_conf_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT2_CFG
   *
   */
-int32_t iis328dq_int2_on_threshold_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              iis328dq_int2_aoi_t val)
 {
   iis328dq_int2_cfg_t int2_cfg;
@@ -1589,7 +1572,7 @@ int32_t iis328dq_int2_on_threshold_mode_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT2_CFG
   *
   */
-int32_t iis328dq_int2_on_threshold_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              iis328dq_int2_aoi_t *val)
 {
   iis328dq_int2_cfg_t int2_cfg;
@@ -1620,7 +1603,7 @@ int32_t iis328dq_int2_on_threshold_mode_get(iis328dq_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t iis328dq_int2_src_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_src_get(stmdev_ctx_t *ctx,
                                iis328dq_int2_src_t *val)
 {
   int32_t ret;
@@ -1635,7 +1618,7 @@ int32_t iis328dq_int2_src_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t iis328dq_int2_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1656,7 +1639,7 @@ int32_t iis328dq_int2_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t iis328dq_int2_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1674,7 +1657,7 @@ int32_t iis328dq_int2_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t iis328dq_int2_dur_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_int2_duration_t int2_duration;
   int32_t ret;
@@ -1696,7 +1679,7 @@ int32_t iis328dq_int2_dur_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t iis328dq_int2_dur_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_int2_duration_t int2_duration;
   int32_t ret;
@@ -1728,7 +1711,7 @@ int32_t iis328dq_int2_dur_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t iis328dq_wkup_to_sleep_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1749,7 +1732,7 @@ int32_t iis328dq_wkup_to_sleep_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t iis328dq_wkup_to_sleep_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1780,7 +1763,7 @@ int32_t iis328dq_wkup_to_sleep_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of 6d in reg INT1_CFG
   *
   */
-int32_t iis328dq_int1_6d_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_6d_mode_set(stmdev_ctx_t *ctx,
                                    iis328dq_int1_6d_t val)
 {
   iis328dq_int1_cfg_t int1_cfg;
@@ -1802,7 +1785,7 @@ int32_t iis328dq_int1_6d_mode_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of 6d in reg INT1_CFG
   *
   */
-int32_t iis328dq_int1_6d_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_6d_mode_get(stmdev_ctx_t *ctx,
                                    iis328dq_int1_6d_t *val)
 {
   iis328dq_int1_cfg_t int1_cfg;
@@ -1836,7 +1819,7 @@ int32_t iis328dq_int1_6d_mode_get(iis328dq_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t iis328dq_int1_6d_src_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_6d_src_get(stmdev_ctx_t *ctx,
                                   iis328dq_int1_src_t *val)
 {
   int32_t ret;
@@ -1851,7 +1834,7 @@ int32_t iis328dq_int1_6d_src_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t iis328dq_int1_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_int1_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1871,7 +1854,7 @@ int32_t iis328dq_int1_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t iis328dq_int1_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_int1_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_int1_ths_t int1_ths;
   int32_t ret;
@@ -1889,7 +1872,7 @@ int32_t iis328dq_int1_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of 6d in reg INT2_CFG
   *
   */
-int32_t iis328dq_int2_6d_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_6d_mode_set(stmdev_ctx_t *ctx,
                                    iis328dq_int2_6d_t val)
 {
   iis328dq_int2_cfg_t int2_cfg;
@@ -1912,7 +1895,7 @@ int32_t iis328dq_int2_6d_mode_set(iis328dq_ctx_t *ctx,
   * @param  val         Get the values of 6d in reg INT2_CFG
   *
   */
-int32_t iis328dq_int2_6d_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_6d_mode_get(stmdev_ctx_t *ctx,
                                    iis328dq_int2_6d_t *val)
 {
   iis328dq_int2_cfg_t int2_cfg;
@@ -1946,7 +1929,7 @@ int32_t iis328dq_int2_6d_mode_get(iis328dq_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t iis328dq_int2_6d_src_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_6d_src_get(stmdev_ctx_t *ctx,
                                   iis328dq_int2_src_t *val)
 {
   int32_t ret;
@@ -1961,7 +1944,7 @@ int32_t iis328dq_int2_6d_src_get(iis328dq_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t iis328dq_int2_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
+int32_t iis328dq_int2_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   iis328dq_int2_ths_t int2_ths;
   int32_t ret;
@@ -1982,7 +1965,7 @@ int32_t iis328dq_int2_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t iis328dq_int2_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val)
+int32_t iis328dq_int2_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   iis328dq_int2_ths_t int2_ths;
   int32_t ret;

--- a/sensor/stmemsc/iis328dq_STdC/driver/iis328dq_reg.h
+++ b/sensor/stmemsc/iis328dq_STdC/driver/iis328dq_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup IIS328DQ_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  IIS328DQ_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*iis328dq_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*iis328dq_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  iis328dq_write_ptr  write_reg;
-  iis328dq_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} iis328dq_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -356,23 +328,23 @@ typedef union{
   *
   */
 
-int32_t iis328dq_read_reg(iis328dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis328dq_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
-int32_t iis328dq_write_reg(iis328dq_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t iis328dq_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                             uint16_t len);
 
 extern float iis328dq_from_fs2_to_mg(int16_t lsb);
 extern float iis328dq_from_fs4_to_mg(int16_t lsb);
 extern float iis328dq_from_fs8_to_mg(int16_t lsb);
 
-int32_t iis328dq_axis_x_data_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_axis_x_data_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis328dq_axis_y_data_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_axis_y_data_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis328dq_axis_z_data_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_axis_z_data_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS328DQ_ODR_OFF   = 0x00,
@@ -386,16 +358,16 @@ typedef enum {
   IIS328DQ_ODR_400Hz = 0x21,
   IIS328DQ_ODR_1kHz  = 0x31,
 } iis328dq_dr_t;
-int32_t iis328dq_data_rate_set(iis328dq_ctx_t *ctx, iis328dq_dr_t val);
-int32_t iis328dq_data_rate_get(iis328dq_ctx_t *ctx, iis328dq_dr_t *val);
+int32_t iis328dq_data_rate_set(stmdev_ctx_t *ctx, iis328dq_dr_t val);
+int32_t iis328dq_data_rate_get(stmdev_ctx_t *ctx, iis328dq_dr_t *val);
 
 typedef enum {
   IIS328DQ_NORMAL_MODE      = 0,
   IIS328DQ_REF_MODE_ENABLE  = 1,
 } iis328dq_hpm_t;
-int32_t iis328dq_reference_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_reference_mode_set(stmdev_ctx_t *ctx,
                                      iis328dq_hpm_t val);
-int32_t iis328dq_reference_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_reference_mode_get(stmdev_ctx_t *ctx,
                                      iis328dq_hpm_t *val);
 
 typedef enum {
@@ -403,39 +375,39 @@ typedef enum {
   IIS328DQ_4g  = 1,
   IIS328DQ_8g  = 3,
 } iis328dq_fs_t;
-int32_t iis328dq_full_scale_set(iis328dq_ctx_t *ctx, iis328dq_fs_t val);
-int32_t iis328dq_full_scale_get(iis328dq_ctx_t *ctx, iis328dq_fs_t *val);
+int32_t iis328dq_full_scale_set(stmdev_ctx_t *ctx, iis328dq_fs_t val);
+int32_t iis328dq_full_scale_get(stmdev_ctx_t *ctx, iis328dq_fs_t *val);
 
-int32_t iis328dq_block_data_update_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_block_data_update_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis328dq_status_reg_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_status_reg_get(stmdev_ctx_t *ctx,
                                  iis328dq_status_reg_t *val);
 
-int32_t iis328dq_flag_data_ready_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_flag_data_ready_get(stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t iis328dq_acceleration_raw_get(iis328dq_ctx_t *ctx, uint8_t *buff);
+int32_t iis328dq_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis328dq_device_id_get(iis328dq_ctx_t *ctx, uint8_t *buff);
+int32_t iis328dq_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis328dq_boot_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_boot_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS328DQ_ST_DISABLE   = 0,
   IIS328DQ_ST_POSITIVE  = 1,
   IIS328DQ_ST_NEGATIVE  = 5,
 } iis328dq_st_t;
-int32_t iis328dq_self_test_set(iis328dq_ctx_t *ctx, iis328dq_st_t val);
-int32_t iis328dq_self_test_get(iis328dq_ctx_t *ctx, iis328dq_st_t *val);
+int32_t iis328dq_self_test_set(stmdev_ctx_t *ctx, iis328dq_st_t val);
+int32_t iis328dq_self_test_get(stmdev_ctx_t *ctx, iis328dq_st_t *val);
 
 typedef enum {
   IIS328DQ_LSB_AT_LOW_ADD  = 0,
   IIS328DQ_MSB_AT_LOW_ADD  = 1,
 } iis328dq_ble_t;
-int32_t iis328dq_data_format_set(iis328dq_ctx_t *ctx, iis328dq_ble_t val);
-int32_t iis328dq_data_format_get(iis328dq_ctx_t *ctx, iis328dq_ble_t *val);
+int32_t iis328dq_data_format_set(stmdev_ctx_t *ctx, iis328dq_ble_t val);
+int32_t iis328dq_data_format_get(stmdev_ctx_t *ctx, iis328dq_ble_t *val);
 
 typedef enum {
   IIS328DQ_CUT_OFF_8Hz   = 0,
@@ -443,9 +415,9 @@ typedef enum {
   IIS328DQ_CUT_OFF_32Hz  = 2,
   IIS328DQ_CUT_OFF_64Hz  = 3,
 } iis328dq_hpcf_t;
-int32_t iis328dq_hp_bandwidth_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                    iis328dq_hpcf_t val);
-int32_t iis328dq_hp_bandwidth_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    iis328dq_hpcf_t *val);
 
 typedef enum {
@@ -458,20 +430,20 @@ typedef enum {
   IIS328DQ_HP_ON_INT2_OUT        = 6,
   IIS328DQ_HP_ON_INT1_OUT        = 5,
 } iis328dq_hpen_t;
-int32_t iis328dq_hp_path_set(iis328dq_ctx_t *ctx, iis328dq_hpen_t val);
-int32_t iis328dq_hp_path_get(iis328dq_ctx_t *ctx, iis328dq_hpen_t *val);
+int32_t iis328dq_hp_path_set(stmdev_ctx_t *ctx, iis328dq_hpen_t val);
+int32_t iis328dq_hp_path_get(stmdev_ctx_t *ctx, iis328dq_hpen_t *val);
 
-int32_t iis328dq_hp_reset_get(iis328dq_ctx_t *ctx);
+int32_t iis328dq_hp_reset_get(stmdev_ctx_t *ctx);
 
-int32_t iis328dq_hp_reference_value_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_hp_reference_value_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS328DQ_SPI_4_WIRE  = 0,
   IIS328DQ_SPI_3_WIRE  = 1,
 } iis328dq_sim_t;
-int32_t iis328dq_spi_mode_set(iis328dq_ctx_t *ctx, iis328dq_sim_t val);
-int32_t iis328dq_spi_mode_get(iis328dq_ctx_t *ctx, iis328dq_sim_t *val);
+int32_t iis328dq_spi_mode_set(stmdev_ctx_t *ctx, iis328dq_sim_t val);
+int32_t iis328dq_spi_mode_get(stmdev_ctx_t *ctx, iis328dq_sim_t *val);
 
 typedef enum {
   IIS328DQ_PAD1_INT1_SRC           = 0,
@@ -479,18 +451,18 @@ typedef enum {
   IIS328DQ_PAD1_DRDY               = 2,
   IIS328DQ_PAD1_BOOT               = 3,
 } iis328dq_i1_cfg_t;
-int32_t iis328dq_pin_int1_route_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      iis328dq_i1_cfg_t val);
-int32_t iis328dq_pin_int1_route_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      iis328dq_i1_cfg_t *val);
 
 typedef enum {
   IIS328DQ_INT1_PULSED   = 0,
   IIS328DQ_INT1_LATCHED  = 1,
 } iis328dq_lir1_t;
-int32_t iis328dq_int1_notification_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_notification_set(stmdev_ctx_t *ctx,
                                         iis328dq_lir1_t val);
-int32_t iis328dq_int1_notification_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_notification_get(stmdev_ctx_t *ctx,
                                         iis328dq_lir1_t *val);
 
 typedef enum {
@@ -499,34 +471,34 @@ typedef enum {
   IIS328DQ_PAD2_DRDY               = 2,
   IIS328DQ_PAD2_BOOT               = 3,
 } iis328dq_i2_cfg_t;
-int32_t iis328dq_pin_int2_route_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      iis328dq_i2_cfg_t val);
-int32_t iis328dq_pin_int2_route_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      iis328dq_i2_cfg_t *val);
 
 typedef enum {
   IIS328DQ_INT2_PULSED   = 0,
   IIS328DQ_INT2_LATCHED  = 1,
 } iis328dq_lir2_t;
-int32_t iis328dq_int2_notification_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_notification_set(stmdev_ctx_t *ctx,
                                         iis328dq_lir2_t val);
-int32_t iis328dq_int2_notification_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_notification_get(stmdev_ctx_t *ctx,
                                         iis328dq_lir2_t *val);
 
 typedef enum {
   IIS328DQ_PUSH_PULL   = 0,
   IIS328DQ_OPEN_DRAIN  = 1,
 } iis328dq_pp_od_t;
-int32_t iis328dq_pin_mode_set(iis328dq_ctx_t *ctx, iis328dq_pp_od_t val);
-int32_t iis328dq_pin_mode_get(iis328dq_ctx_t *ctx, iis328dq_pp_od_t *val);
+int32_t iis328dq_pin_mode_set(stmdev_ctx_t *ctx, iis328dq_pp_od_t val);
+int32_t iis328dq_pin_mode_get(stmdev_ctx_t *ctx, iis328dq_pp_od_t *val);
 
 typedef enum {
   IIS328DQ_ACTIVE_HIGH  = 0,
   IIS328DQ_ACTIVE_LOW   = 1,
 } iis328dq_ihl_t;
-int32_t iis328dq_pin_polarity_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_polarity_set(stmdev_ctx_t *ctx,
                                    iis328dq_ihl_t val);
-int32_t iis328dq_pin_polarity_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_pin_polarity_get(stmdev_ctx_t *ctx,
                                    iis328dq_ihl_t *val);
 
 typedef struct {
@@ -537,28 +509,28 @@ typedef struct {
   uint8_t int1_zlie             : 1;
   uint8_t int1_zhie             : 1;
 } int1_on_th_conf_t;
-int32_t iis328dq_int1_on_threshold_conf_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                              int1_on_th_conf_t val);
-int32_t iis328dq_int1_on_threshold_conf_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                              int1_on_th_conf_t *val);
 
 typedef enum {
   IIS328DQ_INT1_ON_THRESHOLD_OR   = 0,
   IIS328DQ_INT1_ON_THRESHOLD_AND  = 1,
 } iis328dq_int1_aoi_t;
-int32_t iis328dq_int1_on_threshold_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              iis328dq_int1_aoi_t val);
-int32_t iis328dq_int1_on_threshold_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              iis328dq_int1_aoi_t *val);
 
-int32_t iis328dq_int1_src_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_src_get(stmdev_ctx_t *ctx,
                                iis328dq_int1_src_t *val);
 
-int32_t iis328dq_int1_treshold_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_int1_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis328dq_int1_dur_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_int1_dur_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t int2_xlie             : 1;
@@ -568,63 +540,63 @@ typedef struct {
   uint8_t int2_zlie             : 1;
   uint8_t int2_zhie             : 1;
 } int2_on_th_conf_t;
-int32_t iis328dq_int2_on_threshold_conf_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                              int2_on_th_conf_t val);
-int32_t iis328dq_int2_on_threshold_conf_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                              int2_on_th_conf_t *val);
 
 typedef enum {
   IIS328DQ_INT2_ON_THRESHOLD_OR   = 0,
   IIS328DQ_INT2_ON_THRESHOLD_AND  = 1,
 } iis328dq_int2_aoi_t;
-int32_t iis328dq_int2_on_threshold_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              iis328dq_int2_aoi_t val);
-int32_t iis328dq_int2_on_threshold_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              iis328dq_int2_aoi_t *val);
 
-int32_t iis328dq_int2_src_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_src_get(stmdev_ctx_t *ctx,
                                iis328dq_int2_src_t *val);
 
-int32_t iis328dq_int2_treshold_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_int2_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis328dq_int2_dur_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_int2_dur_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis328dq_wkup_to_sleep_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_wkup_to_sleep_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS328DQ_6D_INT1_DISABLE   = 0,
   IIS328DQ_6D_INT1_MOVEMENT  = 1,
   IIS328DQ_6D_INT1_POSITION  = 3,
 } iis328dq_int1_6d_t;
-int32_t iis328dq_int1_6d_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_6d_mode_set(stmdev_ctx_t *ctx,
                                    iis328dq_int1_6d_t val);
-int32_t iis328dq_int1_6d_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_6d_mode_get(stmdev_ctx_t *ctx,
                                    iis328dq_int1_6d_t *val);
 
-int32_t iis328dq_int1_6d_src_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int1_6d_src_get(stmdev_ctx_t *ctx,
                                   iis328dq_int1_src_t *val);
 
-int32_t iis328dq_int1_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_int1_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_int1_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int1_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS328DQ_6D_INT2_DISABLE   = 0,
   IIS328DQ_6D_INT2_MOVEMENT  = 1,
   IIS328DQ_6D_INT2_POSITION  = 3,
 } iis328dq_int2_6d_t;
-int32_t iis328dq_int2_6d_mode_set(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_6d_mode_set(stmdev_ctx_t *ctx,
                                    iis328dq_int2_6d_t val);
-int32_t iis328dq_int2_6d_mode_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_6d_mode_get(stmdev_ctx_t *ctx,
                                    iis328dq_int2_6d_t *val);
 
-int32_t iis328dq_int2_6d_src_get(iis328dq_ctx_t *ctx,
+int32_t iis328dq_int2_6d_src_get(stmdev_ctx_t *ctx,
                                   iis328dq_int2_src_t *val);
 
-int32_t iis328dq_int2_6d_treshold_set(iis328dq_ctx_t *ctx, uint8_t val);
-int32_t iis328dq_int2_6d_treshold_get(iis328dq_ctx_t *ctx, uint8_t *val);
+int32_t iis328dq_int2_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis328dq_int2_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/iis3dhhc_STdC/driver/iis3dhhc_reg.c
+++ b/sensor/stmemsc/iis3dhhc_STdC/driver/iis3dhhc_reg.c
@@ -1,1255 +1,1479 @@
 /*
  ******************************************************************************
  * @file    iis3dhhc_reg.c
- * @author  MEMS Software Solution Team
- * @date    20-December-2017
+ * @author  Sensors Software Solution Team
  * @brief   IIS3DHHC driver file
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "iis3dhhc_reg.h"
 
 /**
-  * @addtogroup  iis3dhhc
-  * @brief  This file provides a set of functions needed to drive the
-  *         iis3dhhc enanced inertial module.
+  * @defgroup  IIS3DHHC
+  * @brief     This file provides a set of functions needed to drive the
+  *            iis3dhhc enhanced inertial module.
   * @{
+  *
   */
 
 /**
-  * @addtogroup  interfaces_functions
-  * @brief  This section provide a set of functions used to read and write
-  *         a generic register of the device.
+  * @defgroup  IIS3DHHC_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
   * @{
+  *
   */
 
 /**
   * @brief  Read generic device register
   *
-  * @param  iis3dhhc_ctx_t* ctx: read / write interface definitions
-  * @param  uint8_t reg: register to read
-  * @param  uint8_t* data: pointer to buffer that store the data read
-  * @param  uint16_t len: number of consecutive register to read
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t iis3dhhc_read_reg(iis3dhhc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t iis3dhhc_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
-  return ctx->read_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @brief  Write generic device register
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t reg: register to write
-  * @param  uint8_t* data: pointer to data to write in register reg
-  * @param  uint16_t len: number of consecutive register to write
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
-*/
-int32_t iis3dhhc_write_reg(iis3dhhc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+  */
+int32_t iis3dhhc_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
-  return ctx->write_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
-/**
-  * @addtogroup  data_generation_c
-  * @brief   This section group all the functions concerning data generation
+  /**
+  * @defgroup    IIS3DHHC_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
   * @{
+  *
   */
 
-/**
-  * @brief  block_data_update: [set] Blockdataupdate.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of bdu in reg CTRL_REG1
-  *
-  */
-int32_t iis3dhhc_block_data_update_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+float_t iis3dhhc_from_lsb_to_mg(int16_t lsb)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.bdu = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-
-  return mm_error;
+  return ((float_t)lsb *0.076f);
 }
 
-/**
-  * @brief  block_data_update: [get] Blockdataupdate.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of bdu in reg CTRL_REG1
-  *
-  */
-int32_t iis3dhhc_block_data_update_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+float_t iis3dhhc_from_lsb_to_celsius(int16_t lsb)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  *val = reg.ctrl_reg1.bdu;
-
-  return mm_error;
-}
-
-/**
-  * @brief  data_rate: [set]  Output data rate selection.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_norm_mod_en_t: change the values of norm_mod_en in
-  *                                reg CTRL_REG1
-  *
-  */
-int32_t iis3dhhc_data_rate_set(iis3dhhc_ctx_t *ctx, iis3dhhc_norm_mod_en_t val)
-{
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.norm_mod_en = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  data_rate: [get]  Output data rate selection.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_norm_mod_en_t: Get the values of norm_mod_en in
-  *                                reg CTRL_REG1
-  *
-  */
-int32_t iis3dhhc_data_rate_get(iis3dhhc_ctx_t *ctx, iis3dhhc_norm_mod_en_t *val)
-{
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  *val = (iis3dhhc_norm_mod_en_t) reg.ctrl_reg1.norm_mod_en;
-
-  return mm_error;
-}
-
-/**
-  * @brief  offset_temp_comp: [set]  Offset temperature compensation enable.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of off_tcomp_en in reg CTRL_REG4
-  *
-  */
-int32_t iis3dhhc_offset_temp_comp_set(iis3dhhc_ctx_t *ctx, uint8_t val)
-{
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.off_tcomp_en = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  offset_temp_comp: [get]  Offset temperature compensation enable.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of off_tcomp_en in reg CTRL_REG4
-  *
-  */
-int32_t iis3dhhc_offset_temp_comp_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
-{
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  *val = reg.ctrl_reg4.off_tcomp_en;
-
-  return mm_error;
-}
-
-/**
-  * @brief  temperature_raw: [get]  Temperature output value.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
-  *
-  */
-int32_t iis3dhhc_temperature_raw_get(iis3dhhc_ctx_t *ctx, uint8_t *buff)
-{
-  return iis3dhhc_read_reg(ctx, IIS3DHHC_OUT_TEMP_L, buff, 2);
-}
-
-/**
-  * @brief  acceleration_raw: [get]  acceleration output value.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
-  *
-  */
-int32_t iis3dhhc_acceleration_raw_get(iis3dhhc_ctx_t *ctx, uint8_t *buff)
-{
-  return iis3dhhc_read_reg(ctx, IIS3DHHC_OUT_X_L_XL, buff, 6);
-}
-
-/**
-  * @brief  xl_data_ready: [get]  Acceleration set of data available.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of zyxda in reg STATUS
-  *
-  */
-int32_t iis3dhhc_xl_data_ready_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
-{
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, &reg.byte, 1);
-  *val = reg.status.zyxda;
-
-  return mm_error;
-}
-
-/**
-  * @brief  xl_data_ovr: [get]  Acceleration set of data overrun.
-  *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of zyxor in reg STATUS
-  *
-  */
-int32_t iis3dhhc_xl_data_ovr_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
-{
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, &reg.byte, 1);
-  *val = reg.status.zyxor;
-
-  return mm_error;
+  return (((float_t)lsb / 16.0f) + 25.0f);
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  common
-  * @brief   This section group common usefull functions
+  * @defgroup   IIS3DHHC_Data_generation
+  * @brief      This section groups all the functions concerning data
+  *             generation
   * @{
+  *
   */
 
 /**
-  * @brief  device_id: [get] DeviceWhoamI.
+  * @brief  Blockdataupdate.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_device_id_get(iis3dhhc_ctx_t *ctx, uint8_t *buff)
+int32_t iis3dhhc_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  return iis3dhhc_read_reg(ctx, IIS3DHHC_WHO_AM_I, buff, 1);
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.bdu = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  reset: [set]  Software reset. Restore the default values
-  *                       in user registers.
+  * @brief  Blockdataupdate.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sw_reset in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_reset_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.sw_reset = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.bdu;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  reset: [get]  Software reset. Restore the default values
-  *                       in user registers.
+  * @brief  Output data rate selection.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sw_reset in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of norm_mod_en in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_reset_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_data_rate_set(stmdev_ctx_t *ctx, iis3dhhc_norm_mod_en_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  *val = reg.ctrl_reg1.sw_reset;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.norm_mod_en = (uint8_t)val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot: [set]  Reboot memory content. Reload the
-  *                      calibration parameters.
+  * @brief  Output data rate selection.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of boot in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of norm_mod_en in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_boot_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_data_rate_get(stmdev_ctx_t *ctx, iis3dhhc_norm_mod_en_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.boot = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
 
-  return mm_error;
+  switch (ctrl_reg1.norm_mod_en){
+    case IIS3DHHC_POWER_DOWN:
+      *val = IIS3DHHC_POWER_DOWN;
+      break;
+    case IIS3DHHC_1kHz1:
+      *val = IIS3DHHC_1kHz1;
+      break;
+    default:
+      *val = IIS3DHHC_POWER_DOWN;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  boot: [get]  Reboot memory content. Reload
-  *                      the calibration parameters.
+  * @brief  Offset temperature compensation enable.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of boot in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of off_tcomp_en in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_boot_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  *val = reg.ctrl_reg1.boot;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.off_tcomp_en = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  self_test: [set] Selftest.
+  * @brief  Offset temperature compensation enable.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_st_t: change the values of st in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of off_tcomp_en in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_self_test_set(iis3dhhc_ctx_t *ctx, iis3dhhc_st_t val)
+int32_t iis3dhhc_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.st = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.off_tcomp_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  self_test: [get] Selftest.
+  * @brief  Temperature output value.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_st_t: Get the values of st in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_self_test_get(iis3dhhc_ctx_t *ctx, iis3dhhc_st_t *val)
+int32_t iis3dhhc_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  *val = (iis3dhhc_st_t) reg.ctrl_reg4.st;
-
-  return mm_error;
+  int32_t ret;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_OUT_TEMP_L, buff, 2);
+  return ret;
 }
 
 /**
-  * @brief  filter_config: [set]  Digital filtering Phase/bandwidth selection.
+  * @brief  acceleration output value.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_dsp_t: change the values of dsp in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_filter_config_set(iis3dhhc_ctx_t *ctx, iis3dhhc_dsp_t val)
+int32_t iis3dhhc_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.dsp = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-
-  return mm_error;
+  int32_t ret;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_OUT_X_L_XL, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  filter_config: [get]  Digital filtering Phase/bandwidth selection.
+  * @brief  Acceleration set of data available.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_dsp_t: Get the values of dsp in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxda in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_filter_config_get(iis3dhhc_ctx_t *ctx, iis3dhhc_dsp_t *val)
+int32_t iis3dhhc_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_status_t status;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  *val = (iis3dhhc_dsp_t) reg.ctrl_reg4.dsp;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, (uint8_t*)&status, 1);
+  *val = status.zyxda;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  status: [get] Statusregister.
+  * @brief  Acceleration set of data overrun.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_status_t: Registers STATUS
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxor in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_status_get(iis3dhhc_ctx_t *ctx, iis3dhhc_status_t *val)
+int32_t iis3dhhc_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  return iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, (uint8_t*) val, 1);
+  iis3dhhc_status_t status;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, (uint8_t*)&status, 1);
+  *val = status.zyxor;
+
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  interrupts
-  * @brief   This section group all the functions that manage interrupts
+  * @defgroup  IIS3DHHC_common
+  * @brief     This section group common useful functions
   * @{
+  *
   */
 
 /**
-  * @brief   drdy_notification_mode: [set]  DRDY latched / pulsed, pulse
-  *                                         duration is 1/4 ODR
+  * @brief  DeviceWhoamI.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_drdy_pulse_t: change the values of drdy_pulse in
-  *                               reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_drdy_notification_mode_set(iis3dhhc_ctx_t *ctx,
+int32_t iis3dhhc_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.sw_reset = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sw_reset in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.boot = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_self_test_set(stmdev_ctx_t *ctx, iis3dhhc_st_t val)
+{
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.st = (uint8_t)val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selftest.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_self_test_get(stmdev_ctx_t *ctx, iis3dhhc_st_t *val)
+{
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.st){
+    case IIS3DHHC_ST_DISABLE:
+      *val = IIS3DHHC_ST_DISABLE;
+      break;
+    case IIS3DHHC_ST_POSITIVE:
+      *val = IIS3DHHC_ST_POSITIVE;
+      break;
+    case IIS3DHHC_ST_NEGATIVE:
+      *val = IIS3DHHC_ST_NEGATIVE;
+      break;
+    default:
+      *val = IIS3DHHC_ST_DISABLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Digital filtering Phase/bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dsp in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_filter_config_set(stmdev_ctx_t *ctx, iis3dhhc_dsp_t val)
+{
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.dsp = (uint8_t)val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Digital filtering Phase/bandwidth selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dsp in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_filter_config_get(stmdev_ctx_t *ctx, iis3dhhc_dsp_t *val)
+{
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
+
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+
+  switch (ctrl_reg4.dsp){
+    case IIS3DHHC_LINEAR_PHASE_440Hz:
+      *val = IIS3DHHC_LINEAR_PHASE_440Hz;
+      break;
+    case IIS3DHHC_LINEAR_PHASE_235Hz:
+      *val = IIS3DHHC_LINEAR_PHASE_235Hz;
+      break;
+    case IIS3DHHC_NO_LINEAR_PHASE_440Hz:
+      *val = IIS3DHHC_NO_LINEAR_PHASE_440Hz;
+      break;
+    case IIS3DHHC_NO_LINEAR_PHASE_235Hz:
+      *val = IIS3DHHC_NO_LINEAR_PHASE_235Hz;
+      break;
+    default:
+      *val = IIS3DHHC_LINEAR_PHASE_440Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Statusregister.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_status_get(stmdev_ctx_t *ctx, iis3dhhc_status_t *val)
+{
+  int32_t ret;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_STATUS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  IIS3DHHC_interrupts
+  * @brief     This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  DRDY latched / pulsed, pulse duration is 1/4 ODR.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_pulse in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dhhc_drdy_notification_mode_set(stmdev_ctx_t *ctx,
                                             iis3dhhc_drdy_pulse_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.drdy_pulse = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.drdy_pulse = (uint8_t)val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   drdy_notification_mode: [get]  DRDY latched / pulsed, pulse
-  *                                         duration is 1/4 ODR
+  * @brief   DRDY latched / pulsed, pulse duration is 1/4 ODR.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_drdy_pulse_t: Get the values of drdy_pulse in
-  *                               reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_pulse in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_drdy_notification_mode_get(iis3dhhc_ctx_t *ctx,
+int32_t iis3dhhc_drdy_notification_mode_get(stmdev_ctx_t *ctx,
                                             iis3dhhc_drdy_pulse_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  *val = (iis3dhhc_drdy_pulse_t) reg.ctrl_reg1.drdy_pulse;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
 
-  return mm_error;
+  switch (ctrl_reg1.drdy_pulse){
+    case IIS3DHHC_LATCHED:
+      *val = IIS3DHHC_LATCHED;
+      break;
+    case IIS3DHHC_PULSED:
+      *val = IIS3DHHC_PULSED;
+      break;
+    default:
+      *val = IIS3DHHC_LATCHED;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  int1_mode: [set]  It configures the INT1 pad as output for
-  *                           FIFO flags or as external asynchronous
-  *                           input trigger to FIFO.
+  * @brief  It configures the INT1 pad as output for FIFO flags or as
+  *                external asynchronous input trigger to FIFO.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_int1_ext_t: change the values of int1_ext in
-  *                             reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_ext in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_int1_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_int1_ext_t val)
+int32_t iis3dhhc_int1_mode_set(stmdev_ctx_t *ctx, iis3dhhc_int1_ext_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  reg.int1_ctrl.int1_ext = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_ext = (uint8_t)val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int1_mode: [get]  It configures the INT1 pad as output
-  *                           for FIFO flags or as external asynchronous
-  *                           input trigger to FIFO.
+  * @brief  It configures the INT1 pad as output for FIFO flags or as
+  *                external asynchronous input trigger to FIFO.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_int1_ext_t: Get the values of int1_ext in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_ext in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_int1_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_int1_ext_t *val)
+int32_t iis3dhhc_int1_mode_get(stmdev_ctx_t *ctx, iis3dhhc_int1_ext_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  *val = (iis3dhhc_int1_ext_t) reg.int1_ctrl.int1_ext;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
 
-  return mm_error;
+  switch (int1_ctrl.int1_ext){
+    case IIS3DHHC_PIN_AS_INTERRUPT:
+      *val = IIS3DHHC_PIN_AS_INTERRUPT;
+      break;
+    case IIS3DHHC_PIN_AS_TRIGGER:
+      *val = IIS3DHHC_PIN_AS_TRIGGER;
+      break;
+    default:
+      *val = IIS3DHHC_PIN_AS_INTERRUPT;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief   fifo_threshold_on_int1: [set]  FIFO watermark status
-  *                                         on INT1 pin.
+  * @brief  FIFO watermark status on INT1 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int1_fth in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_fth in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_threshold_on_int1_set(iis3dhhc_ctx_t *ctx,
-                                            uint8_t val)
+int32_t iis3dhhc_fifo_threshold_on_int1_set(stmdev_ctx_t *ctx,
+                                           uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  reg.int1_ctrl.int1_fth = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_fth = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   fifo_threshold_on_int1: [get]  FIFO watermark status
-  *                                         on INT1 pin.
+  * @brief  FIFO watermark status on INT1 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int1_fth in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_fth in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_threshold_on_int1_get(iis3dhhc_ctx_t *ctx,
-                                            uint8_t *val)
+int32_t iis3dhhc_fifo_threshold_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  *val = reg.int1_ctrl.int1_fth;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_fth;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_full_on_int1: [set]  FIFO full flag on INT1 pin.
+  * @brief  FIFO full flag on INT1 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int1_fss5 in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_fss5 in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_full_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_fifo_full_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  reg.int1_ctrl.int1_fss5 = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_fss5 = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_full_on_int1: [get]  FIFO full flag on INT1 pin.
+  * @brief  FIFO full flag on INT1 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int1_fss5 in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_fss5 in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_full_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_full_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  *val = reg.int1_ctrl.int1_fss5;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_fss5;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_on_int1: [set]  FIFO overrun interrupt on INT1 pin.
+  * @brief  FIFO overrun interrupt on INT1 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int1_ovr in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_ovr in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_ovr_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_fifo_ovr_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  reg.int1_ctrl.int1_ovr = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_ovr = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_on_int1: [get]  FIFO overrun interrupt on INT1 pin.
+  * @brief  FIFO overrun interrupt on INT1 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int1_ovr in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_ovr in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_ovr_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_ovr_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  *val = reg.int1_ctrl.int1_ovr;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_ovr;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot_on_int1: [set]  BOOT status on INT1 pin.
+  * @brief  BOOT status on INT1 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int1_boot in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_boot in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_boot_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_boot_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  reg.int1_ctrl.int1_boot = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_boot = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot_on_int1: [get]  BOOT status on INT1 pin.
+  * @brief  BOOT status on INT1 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int1_boot in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_boot in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_boot_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_boot_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  *val = reg.int1_ctrl.int1_boot;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_boot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_int1: [set]  Data-ready signal on INT1 pin.
+  * @brief  Data-ready signal on INT1 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int1_drdy in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int1_drdy in reg INT1_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_drdy_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  reg.int1_ctrl.int1_drdy = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_drdy = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_int1: [get]  Data-ready signal on INT1 pin.
+  * @brief  Data-ready signal on INT1 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int1_drdy in reg INT1_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int1_drdy in reg INT1_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_drdy_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int1_ctrl_t int1_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, &reg.byte, 1);
-  *val = reg.int1_ctrl.int1_drdy;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  *val = int1_ctrl.int1_drdy;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   fifo_threshold_on_int2: [set]  FIFO watermark status
-  *                                         on INT2 pin.
+  * @brief  FIFO watermark status on INT2 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int2_fth in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_fth in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_threshold_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_fifo_threshold_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  reg.int2_ctrl.int2_fth = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_fth = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   fifo_threshold_on_int2: [get]  FIFO watermark status on
-  *                                         INT2 pin.
+  * @brief  FIFO watermark status on INT2 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int2_fth in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_fth in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_threshold_on_int2_get(iis3dhhc_ctx_t *ctx,
-                                            uint8_t *val)
+int32_t iis3dhhc_fifo_threshold_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  *val = reg.int2_ctrl.int2_fth;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_fth;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_full_on_int2: [set]  FIFO full flag on INT2 pin.
+  * @brief  FIFO full flag on INT2 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int2_fss5 in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_fss5 in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_full_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_fifo_full_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  reg.int2_ctrl.int2_fss5 = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_fss5 = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_full_on_int2: [get]  FIFO full flag on INT2 pin.
+  * @brief  FIFO full flag on INT2 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int2_fss5 in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_fss5 in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_full_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_full_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  *val = reg.int2_ctrl.int2_fss5;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_fss5;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_on_int2: [set]  FIFO overrun interrupt on INT2 pin.
+  * @brief  FIFO overrun interrupt on INT2 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int2_ovr in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_ovr in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_ovr_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_fifo_ovr_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  reg.int2_ctrl.int2_ovr = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_ovr = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_on_int2: [get]  FIFO overrun interrupt on INT2 pin.
+  * @brief  FIFO overrun interrupt on INT2 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int2_ovr in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_ovr in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_ovr_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_ovr_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  *val = reg.int2_ctrl.int2_ovr;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_ovr;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot_on_int2: [set]  BOOT status on INT2 pin.
+  * @brief  BOOT status on INT2 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int2_boot in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_boot in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_boot_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_boot_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  reg.int2_ctrl.int2_boot = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_boot = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot_on_int2: [get]  BOOT status on INT2 pin.
+  * @brief  BOOT status on INT2 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int2_boot in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_boot in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_boot_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_boot_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  *val = reg.int2_ctrl.int2_boot;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_boot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_int2: [set]  Data-ready signal on INT2 pin.
+  * @brief  Data-ready signal on INT2 pin.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int2_drdy in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_drdy in reg INT2_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_drdy_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  reg.int2_ctrl.int2_drdy = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_drdy = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_int2: [get]  Data-ready signal on INT2 pin.
+  * @brief  Data-ready signal on INT2 pin.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int2_drdy in reg INT2_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_drdy in reg INT2_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_drdy_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_int2_ctrl_t int2_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, &reg.byte, 1);
-  *val = reg.int2_ctrl.int2_drdy;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  *val = int2_ctrl.int2_drdy;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_mode: [set]  Push-pull/open drain selection on
-  *                          interrupt pads.
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_pp_od_t: change the values of pp_od in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_pin_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_pp_od_t val)
+int32_t iis3dhhc_pin_mode_set(stmdev_ctx_t *ctx, iis3dhhc_pp_od_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.pp_od = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.pp_od = (uint8_t)val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_mode: [get]  Push-pull/open drain selection on
-  *                          interrupt pads.
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_pp_od_t: Get the values of pp_od in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_pin_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_pp_od_t *val)
+int32_t iis3dhhc_pin_mode_get(stmdev_ctx_t *ctx, iis3dhhc_pp_od_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  *val = (iis3dhhc_pp_od_t) reg.ctrl_reg4.pp_od;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
 
-  return mm_error;
+  switch (ctrl_reg4.pp_od){
+    case IIS3DHHC_ALL_PUSH_PULL:
+      *val = IIS3DHHC_ALL_PUSH_PULL;
+      break;
+    case IIS3DHHC_INT1_OD_INT2_PP:
+      *val = IIS3DHHC_INT1_OD_INT2_PP;
+      break;
+    case IIS3DHHC_INT1_PP_INT2_OD:
+      *val = IIS3DHHC_INT1_PP_INT2_OD;
+      break;
+    case IIS3DHHC_ALL_OPEN_DRAIN:
+      *val = IIS3DHHC_ALL_OPEN_DRAIN;
+      break;
+    default:
+      *val = IIS3DHHC_ALL_PUSH_PULL;
+      break;
+  }
+
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  fifo
-  * @brief   This section group all the functions concerning the
-  *          fifo usage
+  * @defgroup  IIS3DHHC_fifo
+  * @brief     This section group all the functions concerning the
+  *            fifo usage
   * @{
+  *
   */
 
 /**
-  * @brief  fifo: [set] FIFOenable.
+  * @brief  FIFOenable.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of fifo_en in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_en in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.fifo_en = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  if(ret == 0){
+    ctrl_reg4.fifo_en = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo: [get] FIFOenable.
+  * @brief  FIFOenable.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_en in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg4_t ctrl_reg4;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, &reg.byte, 1);
-  *val = reg.ctrl_reg4.fifo_en;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
+  *val = ctrl_reg4.fifo_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_block_spi_hs: [set]  Enables the SPI high speed
-                                      configuration for the FIFO block that
-                                      is used to guarantee a minimum duration
-                                      of the window in which writing operation
-                                      of RAM output is blocked. This bit is
-                                      recommended for SPI clock frequencies
-                                      higher than 6 MHz.
+  * @brief  Enables the SPI high speed configuration for the FIFO block that
+            is used to guarantee a minimum duration of the window in which
+            writing operation of RAM output is blocked. This bit is recommended
+            for SPI clock frequencies higher than 6 MHz.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of fifo_spi_hs_on in reg CTRL_REG5
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_spi_hs_on in reg CTRL_REG5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_block_spi_hs_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_fifo_block_spi_hs_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG5, &reg.byte, 1);
-  reg.ctrl_reg5.fifo_spi_hs_on = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG5, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  if(ret == 0){
+    ctrl_reg5.fifo_spi_hs_on = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_block_spi_hs: [get]  Enables the SPI high speed configuration
-                                      for the FIFO block that is used to
-                                      guarantee a minimum duration of the
-                                      window in which writing operation of
-                                      RAM output is blocked.
-                                      This bit is recommended for SPI
-                                      clock frequencies higher than 6 MHz.
+  * @brief  Enables the SPI high speed configuration for the FIFO block that
+            is used to guarantee a minimum duration of the window in which
+            writing operation of RAM output is blocked. This bit is recommended
+            for SPI clock frequencies higher than 6 MHz.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_spi_hs_on in reg CTRL_REG5
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_spi_hs_on in reg CTRL_REG5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_block_spi_hs_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_block_spi_hs_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg5_t ctrl_reg5;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG5, &reg.byte, 1);
-  *val = reg.ctrl_reg5.fifo_spi_hs_on;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG5, (uint8_t*)&ctrl_reg5, 1);
+  *val = ctrl_reg5.fifo_spi_hs_on;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of fth in reg FIFO_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fth in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_watermark_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
-  reg.fifo_ctrl.fth = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.fth = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fth in reg FIFO_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_watermark_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
-  *val = reg.fifo_ctrl.fth;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = fifo_ctrl.fth;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [set]  FIFO mode selection.
+  * @brief  FIFO mode selection.[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_fmode_t: change the values of fmode in reg FIFO_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fmode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_fmode_t val)
+int32_t iis3dhhc_fifo_mode_set(stmdev_ctx_t *ctx, iis3dhhc_fmode_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
-  reg.fifo_ctrl.fmode = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.fmode = (uint8_t)val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [get]  FIFO mode selection.
+  * @brief  FIFO mode selection.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_fmode_t: Get the values of fmode in reg FIFO_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fmode in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_fmode_t *val)
+int32_t iis3dhhc_fifo_mode_get(stmdev_ctx_t *ctx, iis3dhhc_fmode_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, &reg.byte, 1);
-  *val = (iis3dhhc_fmode_t) reg.fifo_ctrl.fmode;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
 
-  return mm_error;
+  switch (fifo_ctrl.fmode){
+    case IIS3DHHC_BYPASS_MODE:
+      *val = IIS3DHHC_BYPASS_MODE;
+      break;
+    case IIS3DHHC_FIFO_MODE:
+      *val = IIS3DHHC_FIFO_MODE;
+      break;
+    case IIS3DHHC_STREAM_TO_FIFO_MODE:
+      *val = IIS3DHHC_STREAM_TO_FIFO_MODE;
+      break;
+    case IIS3DHHC_BYPASS_TO_STREAM_MODE:
+      *val = IIS3DHHC_BYPASS_TO_STREAM_MODE;
+      break;
+    case IIS3DHHC_DYNAMIC_STREAM_MODE:
+      *val = IIS3DHHC_DYNAMIC_STREAM_MODE;
+      break;
+    default:
+      *val = IIS3DHHC_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  fifo_status: [get]  FIFO status register.
+  * @brief  FIFO status register.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  iis3dhhc_fifo_src_t: Registers FIFO_SRC
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_status_get(iis3dhhc_ctx_t *ctx, iis3dhhc_fifo_src_t *val)
+int32_t iis3dhhc_fifo_status_get(stmdev_ctx_t *ctx, iis3dhhc_fifo_src_t *val)
 {
-  return iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  fifo_full_flag: [get]  FIFO stored data level.
+  * @brief  FIFO stored data level.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fss in reg FIFO_SRC
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fss in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_full_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_fifo_src_t fifo_src;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, &reg.byte, 1);
-  *val = reg.fifo_src.fss;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fss;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_flag: [get]  FIFO overrun status flag.
+  * @brief  FIFO overrun status flag.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ovrn in reg FIFO_SRC
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ovrn in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_ovr_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_fifo_src_t fifo_src;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, &reg.byte, 1);
-  *val = reg.fifo_src.ovrn;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.ovrn;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_fth_flag: [get]  FIFO watermark status.
+  * @brief  FIFO watermark status.[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fth in reg FIFO_SRC
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_fifo_fth_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_fifo_src_t fifo_src;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, &reg.byte, 1);
-  *val = reg.fifo_src.fth;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fth;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  serial_interface
-  * @brief   This section group all the functions concerning serial
-  *          interface management
+  * @defgroup  IIS3DHHC_serial_interface
+  * @brief     This section group all the functions concerning serial
+  *            interface management
   * @{
+  *
   */
 
 /**
-  * @brief  auto_add_inc: [set]  Register address automatically
-  *                              incremented during a multiple byte access
-  *                              with a serial interface (I2C or SPI).
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface (I2C or SPI).[set]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of if_add_inc in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_add_inc in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_auto_add_inc_set(iis3dhhc_ctx_t *ctx, uint8_t val)
+int32_t iis3dhhc_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.if_add_inc = val;
-  mm_error = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.if_add_inc = val;
+    ret = iis3dhhc_write_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  auto_add_inc: [get]  Register address automatically incremented
-  *                              during a multiple byte access with a serial
-  *                              interface (I2C or SPI).
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface (I2C or SPI).[get]
   *
-  * @param  iis3dhhc_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of if_add_inc in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_add_inc in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t iis3dhhc_auto_add_inc_get(iis3dhhc_ctx_t *ctx, uint8_t *val)
+int32_t iis3dhhc_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  iis3dhhc_reg_t reg;
-  int32_t mm_error;
+  iis3dhhc_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
 
-  mm_error = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, &reg.byte, 1);
-  *val = reg.ctrl_reg1.if_add_inc;
+  ret = iis3dhhc_read_reg(ctx, IIS3DHHC_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.if_add_inc;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
+  */
+
+/**
+  * @}
+  *
   */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis3dhhc_STdC/driver/iis3dhhc_reg.h
+++ b/sensor/stmemsc/iis3dhhc_STdC/driver/iis3dhhc_reg.h
@@ -1,42 +1,26 @@
 /*
  ******************************************************************************
  * @file    iis3dhhc_reg.h
- * @author  MEMS Software Solution Team
- * @date    20-December-2017
+ * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
  *          iis3dhhc_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __IIS3DHHC_DRIVER__H
-#define __IIS3DHHC_DRIVER__H
+#ifndef IIS3DHHC_REGS_H
+#define IIS3DHHC_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -51,33 +35,13 @@
   *
   */
 
-/** @defgroup IIS3DHHC_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -93,59 +57,83 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
-/** @defgroup iis3dhhc_interface
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
   * @{
+  *
   */
 
-typedef int32_t (*iis3dhhc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*iis3dhhc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
-
 typedef struct {
-  /** Component mandatory fields **/
-  iis3dhhc_write_ptr  write_reg;
-  iis3dhhc_read_ptr   read_reg;
-  /** Customizable optional pointer **/
-  void *handle;
-} iis3dhhc_ctx_t;
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
 
 /**
   * @}
+  *
   */
 
+#endif /* MEMS_UCF_SHARED_TYPES */
 
-/** @defgroup iis3dhhc_Infos
+/**
+  * @}
+  *
+  */
+
+/** @defgroup IIS3DHHC_Infos
   * @{
+  *
   */
 
 /** Device Identification (Who am I) **/
-#define IIS3DHHC_ID            0x11
+#define IIS3DHHC_ID            0x11U
 
 /**
   * @}
+  *
   */
 
-/**
-  * @defgroup iis3dhhc_Sensitivity
-  * @{
-  */
+#define IIS3DHHC_WHO_AM_I      0x0FU
+typedef struct {
+  uint8_t not_used_01      : 7;
+  uint8_t asic_id          : 1;
+} iis3dhhc_id_reg_t;
 
-#define IIS3DHHC_FROM_LSB_TO_mg(lsb)   (float)((lsb * 76.0f) / 1000.0f)
-#define IIS3DHHC_FROM_LSB_TO_degC(lsb) (float)(((int16_t)lsb>>4) / 16.0f) + 25.0f
-
-/**
-  * @}
-  */
-
-#define IIS3DHHC_WHO_AM_I      0x0F
-
-#define IIS3DHHC_CTRL_REG1     0x20
+#define IIS3DHHC_CTRL_REG1     0x20U
 typedef struct {
   uint8_t bdu              : 1;
   uint8_t drdy_pulse       : 1;
@@ -156,7 +144,7 @@ typedef struct {
   uint8_t norm_mod_en      : 1;
 } iis3dhhc_ctrl_reg1_t;
 
-#define IIS3DHHC_INT1_CTRL     0x21
+#define IIS3DHHC_INT1_CTRL     0x21U
 typedef struct {
   uint8_t not_used_01      : 2;
   uint8_t int1_ext         : 1;
@@ -167,7 +155,7 @@ typedef struct {
   uint8_t int1_drdy        : 1;
 } iis3dhhc_int1_ctrl_t;
 
-#define IIS3DHHC_INT2_CTRL     0x22
+#define IIS3DHHC_INT2_CTRL     0x22U
 typedef struct {
   uint8_t not_used_01      : 3;
   uint8_t int2_fth         : 1;
@@ -177,24 +165,24 @@ typedef struct {
   uint8_t int2_drdy        : 1;
 } iis3dhhc_int2_ctrl_t;
 
-#define IIS3DHHC_CTRL_REG4     0x23
+#define IIS3DHHC_CTRL_REG4     0x23U
 typedef struct {
   uint8_t off_tcomp_en     : 1;
   uint8_t fifo_en          : 1;
   uint8_t pp_od            : 2;
   uint8_t st               : 2;
-  uint8_t dsp              : 2;
+  uint8_t dsp              : 2;  /* dsp_lp_type + dsp_bw_sel */
 } iis3dhhc_ctrl_reg4_t;
 
-#define IIS3DHHC_CTRL_REG5     0x24
+#define IIS3DHHC_CTRL_REG5     0x24U
 typedef struct {
   uint8_t fifo_spi_hs_on   : 1;
   uint8_t not_used_01      : 7;
 } iis3dhhc_ctrl_reg5_t;
 
-#define IIS3DHHC_OUT_TEMP_L    0x25
-#define IIS3DHHC_OUT_TEMP_H    0x26
-#define IIS3DHHC_STATUS        0x27
+#define IIS3DHHC_OUT_TEMP_L    0x25U
+#define IIS3DHHC_OUT_TEMP_H    0x26U
+#define IIS3DHHC_STATUS        0x27U
 typedef struct {
   uint8_t xda              : 1;
   uint8_t yda              : 1;
@@ -206,26 +194,39 @@ typedef struct {
   uint8_t zyxor            : 1;
 } iis3dhhc_status_t;
 
-#define IIS3DHHC_OUT_X_L_XL    0x28
-#define IIS3DHHC_OUT_X_H_XL    0x29
-#define IIS3DHHC_OUT_Y_L_XL    0x2A
-#define IIS3DHHC_OUT_Y_H_XL    0x2B
-#define IIS3DHHC_OUT_Z_L_XL    0x2C
-#define IIS3DHHC_OUT_Z_H_XL    0x2D
-#define IIS3DHHC_FIFO_CTRL     0x2E
+#define IIS3DHHC_OUT_X_L_XL    0x28U
+#define IIS3DHHC_OUT_X_H_XL    0x29U
+#define IIS3DHHC_OUT_Y_L_XL    0x2AU
+#define IIS3DHHC_OUT_Y_H_XL    0x2BU
+#define IIS3DHHC_OUT_Z_L_XL    0x2CU
+#define IIS3DHHC_OUT_Z_H_XL    0x2DU
+#define IIS3DHHC_FIFO_CTRL     0x2EU
 typedef struct {
   uint8_t fth              : 5;
   uint8_t fmode            : 3;
 } iis3dhhc_fifo_ctrl_t;
 
-#define IIS3DHHC_FIFO_SRC      0x2F
+#define IIS3DHHC_FIFO_SRC      0x2FU
 typedef struct {
-  uint8_t fss      : 6;
-  uint8_t ovrn      : 1;
-  uint8_t fth      : 1;
+  uint8_t fss             : 6;
+  uint8_t ovrn            : 1;
+  uint8_t fth             : 1;
 } iis3dhhc_fifo_src_t;
 
+/**
+  * @defgroup IIS3DHHC_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
 typedef union{
+  iis3dhhc_id_reg_t       id_reg;
   iis3dhhc_ctrl_reg1_t    ctrl_reg1;
   iis3dhhc_int1_ctrl_t    int1_ctrl;
   iis3dhhc_int2_ctrl_t    int2_ctrl;
@@ -234,112 +235,122 @@ typedef union{
   iis3dhhc_status_t       status;
   iis3dhhc_fifo_ctrl_t    fifo_ctrl;
   iis3dhhc_fifo_src_t     fifo_src;
-  bitwise_t              bitwise;
-  uint8_t                byte;
+  bitwise_t               bitwise;
+  uint8_t                 byte;
 } iis3dhhc_reg_t;
-int32_t iis3dhhc_read_reg(iis3dhhc_ctx_t *ctx, uint8_t reg, uint8_t* data,
-                         uint16_t len);
-int32_t iis3dhhc_write_reg(iis3dhhc_ctx_t *ctx, uint8_t reg, uint8_t* data,
-                          uint16_t len);
 
-int32_t iis3dhhc_block_data_update_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_block_data_update_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+/**
+  * @}
+  *
+  */
+
+int32_t iis3dhhc_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t iis3dhhc_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+
+extern float_t iis3dhhc_from_lsb_to_mg(int16_t lsb);
+extern float_t iis3dhhc_from_lsb_to_celsius(int16_t lsb);
+
+int32_t iis3dhhc_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS3DHHC_POWER_DOWN  = 0,
   IIS3DHHC_1kHz1       = 1,
 } iis3dhhc_norm_mod_en_t;
-int32_t iis3dhhc_data_rate_set(iis3dhhc_ctx_t *ctx, iis3dhhc_norm_mod_en_t val);
-int32_t iis3dhhc_data_rate_get(iis3dhhc_ctx_t *ctx, iis3dhhc_norm_mod_en_t *val);
+int32_t iis3dhhc_data_rate_set(stmdev_ctx_t *ctx,
+                               iis3dhhc_norm_mod_en_t val);
+int32_t iis3dhhc_data_rate_get(stmdev_ctx_t *ctx,
+                               iis3dhhc_norm_mod_en_t *val);
 
-int32_t iis3dhhc_offset_temp_comp_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_offset_temp_comp_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_temperature_raw_get(iis3dhhc_ctx_t *ctx, uint8_t *buff);
-int32_t iis3dhhc_acceleration_raw_get(iis3dhhc_ctx_t *ctx, uint8_t *buff);
+int32_t iis3dhhc_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis3dhhc_xl_data_ready_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis3dhhc_xl_data_ovr_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_device_id_get(iis3dhhc_ctx_t *ctx, uint8_t *buff);
+int32_t iis3dhhc_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_reset_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_reset_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t iis3dhhc_boot_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_boot_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dhhc_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS3DHHC_ST_DISABLE   = 0,
   IIS3DHHC_ST_POSITIVE  = 1,
   IIS3DHHC_ST_NEGATIVE  = 2,
 } iis3dhhc_st_t;
-int32_t iis3dhhc_self_test_set(iis3dhhc_ctx_t *ctx, iis3dhhc_st_t val);
-int32_t iis3dhhc_self_test_get(iis3dhhc_ctx_t *ctx, iis3dhhc_st_t *val);
+int32_t iis3dhhc_self_test_set(stmdev_ctx_t *ctx, iis3dhhc_st_t val);
+int32_t iis3dhhc_self_test_get(stmdev_ctx_t *ctx, iis3dhhc_st_t *val);
 
 typedef enum {
   IIS3DHHC_LINEAR_PHASE_440Hz      = 0,
   IIS3DHHC_LINEAR_PHASE_235Hz      = 1,
-  IIS3DHHC_NO_LINEAR_PHASE_440Hz  = 2,
-  IIS3DHHC_NO_LINEAR_PHASE_235Hz  = 3,
+  IIS3DHHC_NO_LINEAR_PHASE_440Hz   = 2,
+  IIS3DHHC_NO_LINEAR_PHASE_235Hz   = 3,
 } iis3dhhc_dsp_t;
-int32_t iis3dhhc_filter_config_set(iis3dhhc_ctx_t *ctx, iis3dhhc_dsp_t val);
-int32_t iis3dhhc_filter_config_get(iis3dhhc_ctx_t *ctx, iis3dhhc_dsp_t *val);
+int32_t iis3dhhc_filter_config_set(stmdev_ctx_t *ctx, iis3dhhc_dsp_t val);
+int32_t iis3dhhc_filter_config_get(stmdev_ctx_t *ctx, iis3dhhc_dsp_t *val);
 
-int32_t iis3dhhc_status_get(iis3dhhc_ctx_t *ctx, iis3dhhc_status_t *val);
+int32_t iis3dhhc_status_get(stmdev_ctx_t *ctx, iis3dhhc_status_t *val);
 
 typedef enum {
   IIS3DHHC_LATCHED  = 0,
   IIS3DHHC_PULSED   = 1,
 } iis3dhhc_drdy_pulse_t;
-int32_t iis3dhhc_drdy_notification_mode_set(iis3dhhc_ctx_t *ctx,
+int32_t iis3dhhc_drdy_notification_mode_set(stmdev_ctx_t *ctx,
                                             iis3dhhc_drdy_pulse_t val);
-int32_t iis3dhhc_drdy_notification_mode_get(iis3dhhc_ctx_t *ctx,
+int32_t iis3dhhc_drdy_notification_mode_get(stmdev_ctx_t *ctx,
                                             iis3dhhc_drdy_pulse_t *val);
 
-
 typedef enum {
-  IIS3DHHC_PIN_AS_INTERRUPT  = 0,
+  IIS3DHHC_PIN_AS_INTERRUPT   = 0,
   IIS3DHHC_PIN_AS_TRIGGER     = 1,
 } iis3dhhc_int1_ext_t;
-int32_t iis3dhhc_int1_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_int1_ext_t val);
-int32_t iis3dhhc_int1_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_int1_ext_t *val);
+int32_t iis3dhhc_int1_mode_set(stmdev_ctx_t *ctx, iis3dhhc_int1_ext_t val);
+int32_t iis3dhhc_int1_mode_get(stmdev_ctx_t *ctx, iis3dhhc_int1_ext_t *val);
 
-
-int32_t iis3dhhc_fifo_threshold_on_int1_set(iis3dhhc_ctx_t *ctx,
+int32_t iis3dhhc_fifo_threshold_on_int1_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t iis3dhhc_fifo_threshold_on_int1_get(iis3dhhc_ctx_t *ctx,
+int32_t iis3dhhc_fifo_threshold_on_int1_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
-int32_t iis3dhhc_fifo_full_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_fifo_full_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_full_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_full_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_fifo_ovr_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_fifo_ovr_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_ovr_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_ovr_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_boot_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_boot_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_boot_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_boot_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_drdy_on_int1_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_drdy_on_int1_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_fifo_threshold_on_int2_set(iis3dhhc_ctx_t *ctx,
+int32_t iis3dhhc_fifo_threshold_on_int2_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t iis3dhhc_fifo_threshold_on_int2_get(iis3dhhc_ctx_t *ctx,
+int32_t iis3dhhc_fifo_threshold_on_int2_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
-int32_t iis3dhhc_fifo_full_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_fifo_full_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_full_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_full_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_fifo_ovr_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_fifo_ovr_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_ovr_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_ovr_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_boot_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_boot_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_boot_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_boot_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_drdy_on_int2_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_drdy_on_int2_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS3DHHC_ALL_PUSH_PULL    = 0,
@@ -347,48 +358,49 @@ typedef enum {
   IIS3DHHC_INT1_PP_INT2_OD  = 2,
   IIS3DHHC_ALL_OPEN_DRAIN   = 3,
 } iis3dhhc_pp_od_t;
-int32_t iis3dhhc_pin_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_pp_od_t val);
-int32_t iis3dhhc_pin_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_pp_od_t *val);
+int32_t iis3dhhc_pin_mode_set(stmdev_ctx_t *ctx, iis3dhhc_pp_od_t val);
+int32_t iis3dhhc_pin_mode_get(stmdev_ctx_t *ctx, iis3dhhc_pp_od_t *val);
 
-int32_t iis3dhhc_fifo_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_fifo_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_fifo_block_spi_hs_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_fifo_block_spi_hs_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_block_spi_hs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_block_spi_hs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_fifo_watermark_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_fifo_watermark_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   IIS3DHHC_BYPASS_MODE             = 0,
   IIS3DHHC_FIFO_MODE               = 1,
-  IIS3DHHC_STREAM_TO_FIFO_MODE    = 3,
-  IIS3DHHC_BYPASS_TO_STREAM_MODE  = 4,
-  IIS3DHHC_DYNAMIC_STREAM_MODE    = 6,
+  IIS3DHHC_STREAM_TO_FIFO_MODE     = 3,
+  IIS3DHHC_BYPASS_TO_STREAM_MODE   = 4,
+  IIS3DHHC_DYNAMIC_STREAM_MODE     = 6,
 } iis3dhhc_fmode_t;
-int32_t iis3dhhc_fifo_mode_set(iis3dhhc_ctx_t *ctx, iis3dhhc_fmode_t val);
-int32_t iis3dhhc_fifo_mode_get(iis3dhhc_ctx_t *ctx, iis3dhhc_fmode_t *val);
+int32_t iis3dhhc_fifo_mode_set(stmdev_ctx_t *ctx, iis3dhhc_fmode_t val);
+int32_t iis3dhhc_fifo_mode_get(stmdev_ctx_t *ctx, iis3dhhc_fmode_t *val);
 
-int32_t iis3dhhc_fifo_status_get(iis3dhhc_ctx_t *ctx,
-                                iis3dhhc_fifo_src_t *val);
+int32_t iis3dhhc_fifo_status_get(stmdev_ctx_t *ctx,
+                                 iis3dhhc_fifo_src_t *val);
 
-int32_t iis3dhhc_fifo_full_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_fifo_ovr_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_fifo_fth_flag_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t iis3dhhc_auto_add_inc_set(iis3dhhc_ctx_t *ctx, uint8_t val);
-int32_t iis3dhhc_auto_add_inc_get(iis3dhhc_ctx_t *ctx, uint8_t *val);
+int32_t iis3dhhc_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dhhc_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
-  * @}
+  *@}
+  *
   */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /*__IIS3DHHC_DRIVER__H */
+#endif /* IIS3DHHC_REGS_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis3dwb_STdC/driver/iis3dwb_reg.c
+++ b/sensor/stmemsc/iis3dwb_STdC/driver/iis3dwb_reg.c
@@ -1,0 +1,2745 @@
+/*
+ ******************************************************************************
+ * @file    iis3dwb_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   IIS3DWB driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "iis3dwb_reg.h"
+
+/**
+  * @defgroup    IIS3DWB
+  * @brief       This file provides a set of functions needed to drive the
+  *              iis3dwb enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    IIS3DWB_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis3dwb_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t iis3dwb_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    IIS3DWB_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t iis3dwb_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t iis3dwb_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t iis3dwb_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t iis3dwb_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t iis3dwb_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+float_t iis3dwb_from_lsb_to_nsec(int32_t lsb)
+{
+  return ((float_t)lsb * 25000.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM9DS1_Data_generation
+  * @brief      This section groups all the functions concerning data
+  *             generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer full-scale selection[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                    iis3dwb_fs_xl_t val)
+{
+  iis3dwb_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                    iis3dwb_fs_xl_t *val)
+{
+  iis3dwb_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.fs_xl){
+    case IIS3DWB_2g:
+      *val = IIS3DWB_2g;
+      break;
+    case IIS3DWB_16g:
+      *val = IIS3DWB_16g;
+      break;
+    case IIS3DWB_4g:
+      *val = IIS3DWB_4g;
+      break;
+    case IIS3DWB_8g:
+      *val = IIS3DWB_8g;
+      break;
+    default:
+      *val = IIS3DWB_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_data_rate_set(stmdev_ctx_t *ctx,
+                                   iis3dwb_odr_xl_t val)
+{
+  iis3dwb_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.xl_en= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_data_rate_get(stmdev_ctx_t *ctx,
+                                   iis3dwb_odr_xl_t *val)
+{
+  iis3dwb_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.xl_en){
+    case IIS3DWB_XL_ODR_OFF:
+      *val = IIS3DWB_XL_ODR_OFF;
+      break;
+    case IIS3DWB_XL_ODR_26k7Hz:
+      *val = IIS3DWB_XL_ODR_26k7Hz;
+      break;
+    default:
+      *val = IIS3DWB_XL_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_offset_weight_set(stmdev_ctx_t *ctx,
+                                     iis3dwb_usr_off_w_t val)
+{
+  iis3dwb_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.usr_off_w= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_offset_weight_get(stmdev_ctx_t *ctx,
+                                       iis3dwb_usr_off_w_t *val)
+{
+  iis3dwb_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.usr_off_w){
+    case IIS3DWB_LSb_1mg:
+      *val = IIS3DWB_LSb_1mg;
+      break;
+    case IIS3DWB_LSb_16mg:
+      *val = IIS3DWB_LSb_16mg;
+      break;
+    default:
+      *val = IIS3DWB_LSb_1mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  select accelerometer axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xl_axis_sel in reg CTRL6_C and
+  *                the values of _1ax_to_3regout in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_axis_selection_set(stmdev_ctx_t *ctx,
+                                     iis3dwb_xl_axis_sel_t val)
+{
+  iis3dwb_ctrl4_c_t ctrl4_c;
+  iis3dwb_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c._1ax_to_3regout = ( (uint8_t)val & 0x10U ) >> 4;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  if(ret == 0){
+    ctrl6_c.xl_axis_sel = (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  select accelerometer axis.[get] 
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of xl_axis_sel in reg CTRL6_C and
+  *                the values of _1ax_to_3regout in reg CTRL4_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_axis_selection_get(stmdev_ctx_t *ctx,
+                                     iis3dwb_xl_axis_sel_t *val)
+{
+  iis3dwb_ctrl4_c_t ctrl4_c;
+  iis3dwb_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+
+  switch ( ( ctrl4_c._1ax_to_3regout << 4 ) + ctrl6_c.xl_axis_sel ){
+    case IIS3DWB_ENABLE_ALL:
+      *val = IIS3DWB_ENABLE_ALL;
+      break;
+    case IIS3DWB_ONLY_X_ON_ONE_OUT_REG:
+      *val = IIS3DWB_ONLY_X_ON_ONE_OUT_REG;
+      break;
+    case IIS3DWB_ONLY_Y_ON_ONE_OUT_REG:
+      *val = IIS3DWB_ONLY_Y_ON_ONE_OUT_REG;
+      break;
+    case IIS3DWB_ONLY_Z_ON_ONE_OUT_REG:
+      *val = IIS3DWB_ONLY_Z_ON_ONE_OUT_REG;
+      break;
+    case IIS3DWB_ONLY_X_ON_ALL_OUT_REG:
+      *val = IIS3DWB_ONLY_X_ON_ALL_OUT_REG;
+      break;
+    case IIS3DWB_ONLY_Y_ON_ALL_OUT_REG:
+      *val = IIS3DWB_ONLY_Y_ON_ALL_OUT_REG;
+      break;
+    case IIS3DWB_ONLY_Z_ON_ALL_OUT_REG:
+      *val = IIS3DWB_ONLY_Z_ON_ALL_OUT_REG;
+      break;
+    default:
+      *val = IIS3DWB_ENABLE_ALL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt flag of the device.[get]
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers ALL_INT_SRC; WAKE_UP_SRC;
+  *                              TAP_SRC; D6D_SRC; STATUS_REG;
+  *                              EMB_FUNC_STATUS; FSM_STATUS_A/B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_all_sources_get(stmdev_ctx_t *ctx,
+                                  iis3dwb_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_ALL_INT_SRC,
+                           (uint8_t*)&val->all_int_src, 1);
+  if(ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_SRC,
+                             (uint8_t*)&val->wake_up_src, 1);
+  }
+  if(ret == 0){
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_STATUS_REG,
+                           (uint8_t*)&val->status_reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get register STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_status_reg_get(stmdev_ctx_t *ctx,
+                                 iis3dwb_status_reg_t *val)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_write_reg(ctx, IIS3DWB_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_write_reg(ctx, IIS3DWB_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_write_reg(ctx, IIS3DWB_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_Timestamp
+  * @brief      This section groups all the functions that manage the
+  *             timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.timestamp_en= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL10_C,
+                              (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp first data output register (r).
+  *         The value is expressed as a 32-bit word and the bit resolution
+  *         is 25 μs.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_TIMESTAMP0, buff, 4);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_Data output
+  * @brief      This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read of the output registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_rounding_mode_set(stmdev_ctx_t *ctx,
+                                    iis3dwb_rounding_t val)
+{
+  iis3dwb_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_rounding_mode_get(stmdev_ctx_t *ctx,
+                                    iis3dwb_rounding_t *val)
+{
+  iis3dwb_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.rounding){
+    case IIS3DWB_NO_ROUND:
+      *val = IIS3DWB_NO_ROUND;
+      break;
+    case IIS3DWB_ROUND:
+      *val = IIS3DWB_ROUND;
+      break;
+    default:
+      *val = IIS3DWB_NO_ROUND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r).
+  *         L and H registers together express a 16-bit word in two’s
+  *         complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as a
+  *         16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_OUTX_L_A, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  FIFO data output.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_DATA_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_common
+  * @brief      This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate)
+  *         with respect to the typical.[set]
+  *         Step:  0.15%. 8-bit format, 2's complement.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_internal_freq_fine_t internal_freq_fine;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_INTERNAL_FREQ_FINE,
+                           (uint8_t*)&internal_freq_fine, 1);
+  if(ret == 0){
+    internal_freq_fine.freq_fine= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_INTERNAL_FREQ_FINE,
+                              (uint8_t*)&internal_freq_fine, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate)
+  *         with respect to the typical.[get]
+  *         Step:  0.15%. 8-bit format, 2's complement.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_internal_freq_fine_t internal_freq_fine;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_INTERNAL_FREQ_FINE,
+                           (uint8_t*)&internal_freq_fine, 1);
+  *val = internal_freq_fine.freq_fine;
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dataready_pulsed in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                      iis3dwb_dataready_pulsed_t val)
+{
+  iis3dwb_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.dataready_pulsed= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dataready_pulsed in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                      iis3dwb_dataready_pulsed_t *val)
+{
+  iis3dwb_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  switch (counter_bdr_reg1.dataready_pulsed){
+    case IIS3DWB_DRDY_LATCHED:
+      *val = IIS3DWB_DRDY_LATCHED;
+      break;
+    case IIS3DWB_DRDY_PULSED:
+      *val = IIS3DWB_DRDY_PULSED;
+      break;
+    default:
+      *val = IIS3DWB_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.boot;
+
+  return ret;
+}
+
+
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_self_test_set(stmdev_ctx_t *ctx,
+                                   iis3dwb_st_xl_t val)
+{
+  iis3dwb_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_self_test_get(stmdev_ctx_t *ctx,
+                                   iis3dwb_st_xl_t *val)
+{
+  iis3dwb_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_xl){
+    case IIS3DWB_XL_ST_DISABLE:
+      *val = IIS3DWB_XL_ST_DISABLE;
+      break;
+    case IIS3DWB_XL_ST_POSITIVE:
+      *val = IIS3DWB_XL_ST_POSITIVE;
+      break;
+    case IIS3DWB_XL_ST_NEGATIVE:
+      *val = IIS3DWB_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = IIS3DWB_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_filters
+  * @brief      This section group all the functions concerning the
+  *             filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf2_xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf2_xl_en= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf2_xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  *val = ctrl1_xl.lpf2_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_filter_settling_mask_get(stmdev_ctx_t *ctx,
+                                           uint8_t *val)
+{
+  iis3dwb_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection
+  *         on output.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
+                                        iis3dwb_hp_slope_xl_en_t val)
+{
+  iis3dwb_ctrl1_xl_t ctrl1_xl;
+  iis3dwb_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf2_xl_en = ((uint8_t)val & 0x80U) >> 7;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  if(ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  if(ret == 0){
+    ctrl8_xl.fds = ((uint8_t)val & 0x10U) >> 4;
+    ctrl8_xl.hp_ref_mode_xl = ((uint8_t)val & 0x20U) >> 5;
+    ctrl8_xl.hpcf_xl = (uint8_t)val & 0x07U;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection on
+  *         output.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
+                                        iis3dwb_hp_slope_xl_en_t *val)
+{
+  iis3dwb_ctrl1_xl_t ctrl1_xl;
+  iis3dwb_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+
+  switch ( (ctrl1_xl.lpf2_xl_en << 7) + (ctrl8_xl.hp_ref_mode_xl << 5) +
+           (ctrl8_xl.fds << 4) + ctrl8_xl.hpcf_xl ){
+    case IIS3DWB_SLOPE_ODR_DIV_4:
+      *val = IIS3DWB_SLOPE_ODR_DIV_4;
+      break;
+    case IIS3DWB_HP_ODR_DIV_10:
+      *val = IIS3DWB_HP_ODR_DIV_10;
+      break;
+    case IIS3DWB_HP_ODR_DIV_20:
+      *val = IIS3DWB_HP_ODR_DIV_20;
+      break;
+    case IIS3DWB_HP_ODR_DIV_45:
+      *val = IIS3DWB_HP_ODR_DIV_45;
+      break;
+    case IIS3DWB_HP_ODR_DIV_100:
+      *val = IIS3DWB_HP_ODR_DIV_100;
+      break;
+    case IIS3DWB_HP_ODR_DIV_200:
+      *val = IIS3DWB_HP_ODR_DIV_200;
+      break;
+    case IIS3DWB_HP_ODR_DIV_400:
+      *val = IIS3DWB_HP_ODR_DIV_400;
+      break;
+    case IIS3DWB_HP_ODR_DIV_800:
+      *val = IIS3DWB_HP_ODR_DIV_800;
+      break;
+    case IIS3DWB_LP_ODR_DIV_4:
+      *val = IIS3DWB_LP_ODR_DIV_4;
+      break;
+    case IIS3DWB_LP_5kHz:
+      *val = IIS3DWB_LP_5kHz;
+      break;
+    case IIS3DWB_LP_ODR_DIV_10:
+      *val = IIS3DWB_LP_ODR_DIV_10;
+      break;
+    case IIS3DWB_LP_ODR_DIV_20:
+      *val = IIS3DWB_LP_ODR_DIV_20;
+      break;
+    case IIS3DWB_LP_ODR_DIV_45:
+      *val = IIS3DWB_LP_ODR_DIV_45;
+      break;
+    case IIS3DWB_LP_ODR_DIV_100:
+      *val = IIS3DWB_LP_ODR_DIV_100;
+      break;
+    case IIS3DWB_LP_ODR_DIV_200:
+      *val = IIS3DWB_LP_ODR_DIV_200;
+      break;
+    case IIS3DWB_LP_ODR_DIV_400:
+      *val = IIS3DWB_LP_ODR_DIV_400;
+      break;
+    case IIS3DWB_LP_ODR_DIV_800:
+      *val = IIS3DWB_LP_ODR_DIV_800;
+      break;
+    default:
+      *val = IIS3DWB_SLOPE_ODR_DIV_4;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing this bit.
+  *         Active only during device exit from powerdown mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fastsettl_mode_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.fastsettl_mode_xl= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing
+  *         this bit. Active only during device exit from powerdown mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fastsettl_mode_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.fastsettl_mode_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of slope_fds in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                          iis3dwb_slope_fds_t val)
+{
+  iis3dwb_slope_en_t int_cfg0;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_SLOPE_EN, (uint8_t*)&int_cfg0, 1);
+  if(ret == 0){
+    int_cfg0.slope_fds= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_SLOPE_EN,
+                              (uint8_t*)&int_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of slope_fds in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                          iis3dwb_slope_fds_t *val)
+{
+  iis3dwb_slope_en_t int_cfg0;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_SLOPE_EN, (uint8_t*)&int_cfg0, 1);
+  switch (int_cfg0.slope_fds){
+    case IIS3DWB_USE_SLOPE:
+      *val = IIS3DWB_USE_SLOPE;
+      break;
+    case IIS3DWB_USE_HPF:
+      *val = IIS3DWB_USE_HPF;
+      break;
+    default:
+      *val = IIS3DWB_USE_SLOPE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_ main_serial_interface
+  * @brief      This section groups all the functions concerning main
+  *             serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sdo_pu_en in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
+                                   iis3dwb_sdo_pu_en_t val)
+{
+  iis3dwb_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+  if(ret == 0){
+    pin_ctrl.sdo_pu_en= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sdo_pu_en in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
+                                   iis3dwb_sdo_pu_en_t *val)
+{
+  iis3dwb_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+
+  switch (pin_ctrl.sdo_pu_en){
+    case IIS3DWB_PULL_UP_DISC:
+      *val = IIS3DWB_PULL_UP_DISC;
+      break;
+    case IIS3DWB_PULL_UP_CONNECT:
+      *val = IIS3DWB_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = IIS3DWB_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_spi_mode_set(stmdev_ctx_t *ctx, iis3dwb_sim_t val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_spi_mode_get(stmdev_ctx_t *ctx, iis3dwb_sim_t *val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.sim){
+    case IIS3DWB_SPI_4_WIRE:
+      *val = IIS3DWB_SPI_4_WIRE;
+      break;
+    case IIS3DWB_SPI_3_WIRE:
+      *val = IIS3DWB_SPI_3_WIRE;
+      break;
+    default:
+      *val = IIS3DWB_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_i2c_interface_set(stmdev_ctx_t *ctx,
+                                    iis3dwb_i2c_disable_t val)
+{
+  iis3dwb_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_i2c_interface_get(stmdev_ctx_t *ctx,
+                                    iis3dwb_i2c_disable_t *val)
+{
+  iis3dwb_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+
+  switch (ctrl4_c.i2c_disable){
+    case IIS3DWB_I2C_ENABLE:
+      *val = IIS3DWB_I2C_ENABLE;
+      break;
+    case IIS3DWB_I2C_DISABLE:
+      *val = IIS3DWB_I2C_DISABLE;
+      break;
+    default:
+      *val = IIS3DWB_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i3c_disable in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_i3c_disable_set(stmdev_ctx_t *ctx, iis3dwb_i3c_disable_t val)
+{
+  iis3dwb_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.i3c_disable = ((uint8_t)val & 0x80U) >> 7;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i3c_disable in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_i3c_disable_get(stmdev_ctx_t *ctx, iis3dwb_i3c_disable_t *val)
+{
+  iis3dwb_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+
+  switch (ctrl9_xl.i3c_disable){
+    case IIS3DWB_I3C_DISABLE:
+      *val = IIS3DWB_I3C_DISABLE;
+      break;
+    case IIS3DWB_I3C_ENABLE:
+      *val = IIS3DWB_I3C_ENABLE;
+      break;
+    default:
+      *val = IIS3DWB_I3C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_interrupt_pins
+  * @brief      This section groups all the functions that manage
+  *             interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief   Select the signal that need to route on int1 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL,MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                     iis3dwb_pin_int1_route_t *val)
+{
+  int32_t ret;
+  
+  ret = iis3dwb_write_reg(ctx, IIS3DWB_INT1_CTRL,
+                            (uint8_t*)&val->int1_ctrl, 1);
+  if(ret == 0){
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_MD1_CFG,
+                              (uint8_t*)&val->md1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL, MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                     iis3dwb_pin_int1_route_t *val)
+{
+  int32_t ret;
+  
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_INT1_CTRL,
+                           (uint8_t*)&val->int1_ctrl, 1);
+  if(ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_MD1_CFG,
+                             (uint8_t*)&val->md1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                     iis3dwb_pin_int2_route_t *val)
+{
+  int32_t ret;
+
+
+  ret = iis3dwb_write_reg(ctx, IIS3DWB_INT2_CTRL,
+                            (uint8_t*)&val->int2_ctrl, 1);
+
+  if(ret == 0){
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_MD2_CFG,
+                              (uint8_t*)&val->md2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B.[get]
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                     iis3dwb_pin_int2_route_t *val)
+{
+  int32_t ret;
+
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_INT2_CTRL,
+                             (uint8_t*)&val->int2_ctrl, 1);
+  if(ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_MD2_CFG,
+                             (uint8_t*)&val->md2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_pin_mode_set(stmdev_ctx_t *ctx, iis3dwb_pp_od_t val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_pin_mode_get(stmdev_ctx_t *ctx, iis3dwb_pp_od_t *val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.pp_od){
+    case IIS3DWB_PUSH_PULL:
+      *val = IIS3DWB_PUSH_PULL;
+      break;
+    case IIS3DWB_OPEN_DRAIN:
+      *val = IIS3DWB_OPEN_DRAIN;
+      break;
+    default:
+      *val = IIS3DWB_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_pin_polarity_set(stmdev_ctx_t *ctx,
+                                   iis3dwb_h_lactive_t val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_pin_polarity_get(stmdev_ctx_t *ctx,
+                                   iis3dwb_h_lactive_t *val)
+{
+  iis3dwb_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.h_lactive){
+    case IIS3DWB_ACTIVE_HIGH:
+      *val = IIS3DWB_ACTIVE_HIGH;
+      break;
+    case IIS3DWB_ACTIVE_LOW:
+      *val = IIS3DWB_ACTIVE_LOW;
+      break;
+    default:
+      *val = IIS3DWB_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_Wake_Up_event
+  * @brief      This section groups all the functions that manage the
+  *             Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[set]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_ths_w in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_wkup_ths_weight_set(stmdev_ctx_t *ctx,
+                                      iis3dwb_wake_ths_w_t val)
+{
+  iis3dwb_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_ths_w= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[get]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wake_ths_w in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_wkup_ths_weight_get(stmdev_ctx_t *ctx,
+                                      iis3dwb_wake_ths_w_t *val)
+{
+  iis3dwb_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+
+  switch (wake_up_dur.wake_ths_w){
+    case IIS3DWB_LSb_FS_DIV_64:
+      *val = IIS3DWB_LSb_FS_DIV_64;
+      break;
+    case IIS3DWB_LSb_FS_DIV_256:
+      *val = IIS3DWB_LSb_FS_DIV_256;
+      break;
+    default:
+      *val = IIS3DWB_LSb_FS_DIV_64;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event( 1LSb = 1 / ODR ).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_wu in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.usr_off_on_wu= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event( 1LSb = 1 / ODR ).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_wu in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  iis3dwb_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.usr_off_on_wu;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_ Activity/Inactivity_detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.(1 LSb = 512 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   IIS3DWB_fifo
+  * @brief      This section group all the functions concerning
+  *             the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  iis3dwb_fifo_ctrl1_t fifo_ctrl1;
+  iis3dwb_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl1.wtm = (uint8_t)(0x00FFU & val);
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_FIFO_CTRL1,
+                              (uint8_t*)&fifo_ctrl1, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl2.wtm = (uint8_t)(( 0x0100U & val ) >> 8);
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  iis3dwb_fifo_ctrl1_t fifo_ctrl1;
+  iis3dwb_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL1,
+                             (uint8_t*)&fifo_ctrl1, 1);
+  }
+  *val = fifo_ctrl2.wtm;
+  *val = *val << 8;
+  *val += fifo_ctrl1.wtm;
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_wtm in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.stop_on_wtm= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_wtm in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdr_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_xl_batch_set(stmdev_ctx_t *ctx,
+                                    iis3dwb_bdr_xl_t val)
+{
+  iis3dwb_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.bdr_xl= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdr_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_xl_batch_get(stmdev_ctx_t *ctx,
+                                    iis3dwb_bdr_xl_t *val)
+{
+  iis3dwb_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.bdr_xl){
+    case IIS3DWB_XL_NOT_BATCHED:
+      *val = IIS3DWB_XL_NOT_BATCHED;
+      break;
+    case IIS3DWB_XL_BATCHED_AT_26k7Hz:
+      *val = IIS3DWB_XL_BATCHED_AT_26k7Hz;
+      break;
+    default:
+      *val = IIS3DWB_XL_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_mode in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_mode_set(stmdev_ctx_t *ctx,
+                                iis3dwb_fifo_mode_t val)
+{
+  iis3dwb_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.fifo_mode= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_mode in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_mode_get(stmdev_ctx_t *ctx,
+                                iis3dwb_fifo_mode_t *val)
+{
+  iis3dwb_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.fifo_mode){
+    case IIS3DWB_BYPASS_MODE:
+      *val = IIS3DWB_BYPASS_MODE;
+      break;
+    case IIS3DWB_FIFO_MODE:
+      *val = IIS3DWB_FIFO_MODE;
+      break;
+    case IIS3DWB_STREAM_TO_FIFO_MODE:
+      *val = IIS3DWB_STREAM_TO_FIFO_MODE;
+      break;
+    case IIS3DWB_BYPASS_TO_STREAM_MODE:
+      *val = IIS3DWB_BYPASS_TO_STREAM_MODE;
+      break;
+    case IIS3DWB_STREAM_MODE:
+      *val = IIS3DWB_STREAM_MODE;
+      break;
+    case IIS3DWB_BYPASS_TO_FIFO_MODE:
+      *val = IIS3DWB_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = IIS3DWB_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_t_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_temp_batch_set(stmdev_ctx_t *ctx,
+                                      iis3dwb_odr_t_batch_t val)
+{
+  iis3dwb_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.odr_t_batch= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_t_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_temp_batch_get(stmdev_ctx_t *ctx,
+                                      iis3dwb_odr_t_batch_t *val)
+{
+  iis3dwb_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.odr_t_batch){
+    case IIS3DWB_TEMP_NOT_BATCHED:
+      *val = IIS3DWB_TEMP_NOT_BATCHED;
+      break;
+    case IIS3DWB_TEMP_BATCHED_AT_104Hz:
+      *val = IIS3DWB_TEMP_BATCHED_AT_104Hz;
+      break;
+    default:
+      *val = IIS3DWB_TEMP_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_ts_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
+                                                iis3dwb_odr_ts_batch_t val)
+{
+  iis3dwb_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.odr_ts_batch= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_ts_batch in reg
+  *                                 FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
+                                                iis3dwb_odr_ts_batch_t *val)
+{
+  iis3dwb_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.odr_ts_batch){
+    case IIS3DWB_NO_DECIMATION:
+      *val = IIS3DWB_NO_DECIMATION;
+      break;
+    case IIS3DWB_DEC_1:
+      *val = IIS3DWB_DEC_1;
+      break;
+    case IIS3DWB_DEC_8:
+      *val = IIS3DWB_DEC_8;
+      break;
+    case IIS3DWB_DEC_32:
+      *val = IIS3DWB_DEC_32;
+      break;
+    default:
+      *val = IIS3DWB_NO_DECIMATION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.rst_counter_bdr= (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  *val = counter_bdr_reg1.rst_counter_bdr;
+
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of cnt_bdr_th in reg COUNTER_BDR_REG2
+  *                and COUNTER_BDR_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_batch_counter_threshold_set(stmdev_ctx_t *ctx,
+                                              uint16_t val)
+{
+  iis3dwb_counter_bdr_reg2_t counter_bdr_reg1;
+  iis3dwb_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0){
+    counter_bdr_reg1.cnt_bdr_th = (uint8_t)((0x0700U & val) >> 8);
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_COUNTER_BDR_REG1, (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  if (ret == 0){
+    counter_bdr_reg2.cnt_bdr_th = (uint8_t)(0x00FFU & val);
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_COUNTER_BDR_REG2,
+                              (uint8_t*)&counter_bdr_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of cnt_bdr_th in reg COUNTER_BDR_REG2
+  *                and COUNTER_BDR_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_batch_counter_threshold_get(stmdev_ctx_t *ctx,
+                                              uint16_t *val)
+{
+  iis3dwb_counter_bdr_reg1_t counter_bdr_reg1;
+  iis3dwb_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_COUNTER_BDR_REG2,
+                             (uint8_t*)&counter_bdr_reg2, 1);
+  }
+
+  *val = counter_bdr_reg1.cnt_bdr_th;
+  *val = *val << 8;
+  *val += counter_bdr_reg2.cnt_bdr_th;
+  return ret;
+}
+
+/**
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  iis3dwb_fifo_status1_t fifo_status1;
+  iis3dwb_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_STATUS1,
+                           (uint8_t*)&fifo_status1, 1);
+  if (ret == 0){
+    ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_STATUS2,
+                             (uint8_t*)&fifo_status2, 1);
+    *val = fifo_status2.diff_fifo;
+    *val = *val << 8;
+    *val += fifo_status1.diff_fifo;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Registers FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_status_get(stmdev_ctx_t *ctx,
+                                  iis3dwb_fifo_status2_t *val)
+{
+  int32_t ret;
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_STATUS2, (uint8_t*)val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO full status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.fifo_full_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  fifo_over_run_latched in
+  *                reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2. fifo_ovr_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.fifo_wtm_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  Identifies the sensor in FIFO_DATA_OUT.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tag_sensor in reg FIFO_DATA_OUT_TAG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
+                                      iis3dwb_fifo_tag_t *val)
+{
+  iis3dwb_fifo_data_out_tag_t fifo_data_out_tag;
+  int32_t ret;
+
+  ret = iis3dwb_read_reg(ctx, IIS3DWB_FIFO_DATA_OUT_TAG,
+                           (uint8_t*)&fifo_data_out_tag, 1);
+
+  switch (fifo_data_out_tag.tag_sensor){
+    case IIS3DWB_XL_NC_TAG:
+      *val = IIS3DWB_XL_NC_TAG;
+      break;
+    case IIS3DWB_TEMPERATURE_TAG:
+      *val = IIS3DWB_TEMPERATURE_TAG;
+      break;
+    case IIS3DWB_TIMESTAMP_TAG:
+      *val = IIS3DWB_TIMESTAMP_TAG;
+      break;
+    case IIS3DWB_CFG_CHANGE_TAG:
+      *val = IIS3DWB_CFG_CHANGE_TAG;
+      break;
+    default:
+      *val = IIS3DWB_CFG_CHANGE_TAG;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/iis3dwb_STdC/driver/iis3dwb_reg.h
+++ b/sensor/stmemsc/iis3dwb_STdC/driver/iis3dwb_reg.h
@@ -1,0 +1,795 @@
+/*
+ ******************************************************************************
+ * @file    iis3dwb_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          iis3dwb_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef IIS3DWB_REGS_H
+#define IIS3DWB_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup IIS3DWB
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup IIS3DWB Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define IIS3DWB_I2C_ADD_L                    0xD5U
+#define IIS3DWB_I2C_ADD_H                    0xD7U
+
+/** Device Identification (Who am I) **/
+#define IIS3DWB_ID                           0x7BU
+
+/**
+  * @}
+  *
+  */
+
+#define IIS3DWB_PIN_CTRL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t sdo_pu_en                : 1;
+  uint8_t not_used_02              : 1;
+} iis3dwb_pin_ctrl_t;
+
+#define IIS3DWB_FIFO_CTRL1                   0x07U
+typedef struct {
+  uint8_t wtm                      : 8;
+} iis3dwb_fifo_ctrl1_t;
+
+#define IIS3DWB_FIFO_CTRL2                   0x08U
+typedef struct {
+  uint8_t wtm                      : 1;
+  uint8_t not_used_01              : 6;
+  uint8_t stop_on_wtm              : 1;
+} iis3dwb_fifo_ctrl2_t;
+
+#define IIS3DWB_FIFO_CTRL3                   0x09U
+typedef struct {
+  uint8_t bdr_xl                   : 4;
+  uint8_t not_used_01              : 4;
+} iis3dwb_fifo_ctrl3_t;
+
+#define IIS3DWB_FIFO_CTRL4                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t odr_t_batch              : 2;
+  uint8_t odr_ts_batch             : 2;
+} iis3dwb_fifo_ctrl4_t;
+
+#define IIS3DWB_COUNTER_BDR_REG1             0x0BU
+typedef struct {
+  uint8_t cnt_bdr_th               : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t rst_counter_bdr          : 1;
+  uint8_t dataready_pulsed         : 1;
+} iis3dwb_counter_bdr_reg1_t;
+
+#define IIS3DWB_COUNTER_BDR_REG2             0x0CU
+typedef struct {
+  uint8_t cnt_bdr_th               : 8;
+} iis3dwb_counter_bdr_reg2_t;
+
+#define IIS3DWB_INT1_CTRL                    0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fifo_th             : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_fifo_full           : 1;
+  uint8_t int1_cnt_bdr             : 1;
+  uint8_t not_used_02              : 1;
+} iis3dwb_int1_ctrl_t;
+
+#define IIS3DWB_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fifo_th             : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_fifo_full           : 1;
+  uint8_t int2_cnt_bdr             : 1;
+  uint8_t not_used_02              : 1;
+} iis3dwb_int2_ctrl_t;
+
+#define IIS3DWB_WHO_AM_I                     0x0FU
+#define IIS3DWB_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf2_xl_en               : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t not_used_02              : 1;  
+  uint8_t xl_en                    : 3;
+} iis3dwb_ctrl1_xl_t;
+
+#define IIS3DWB_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} iis3dwb_ctrl3_c_t;
+
+#define IIS3DWB_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t _1ax_to_3regout          : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t not_used_03              : 2;
+} iis3dwb_ctrl4_c_t;
+
+#define IIS3DWB_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t not_used_01              : 3;
+  uint8_t rounding                 : 2;
+  uint8_t not_used_02              : 1;
+} iis3dwb_ctrl5_c_t;
+
+#define IIS3DWB_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t xl_axis_sel              : 2;
+  uint8_t not_used_01              : 1;  
+  uint8_t usr_off_w                : 1;
+  uint8_t not_used_02              : 4;
+} iis3dwb_ctrl6_c_t;
+
+#define IIS3DWB_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t fds                      : 1;
+  uint8_t fastsettl_mode_xl        : 1;
+  uint8_t hp_ref_mode_xl           : 1;
+  uint8_t hpcf_xl                  : 3;
+} iis3dwb_ctrl8_xl_t;
+
+#define IIS3DWB_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t i3c_disable              : 1;
+  uint8_t not_used_02              : 6;
+} iis3dwb_ctrl9_xl_t;
+
+#define IIS3DWB_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t timestamp_en             : 1;
+  uint8_t not_used_02              : 2;
+} iis3dwb_ctrl10_c_t;
+
+#define IIS3DWB_ALL_INT_SRC                  0x1AU
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t not_used_02              : 3;
+  uint8_t sleep_change             : 1;
+  uint8_t not_used_03              : 1;
+  uint8_t timestamp_endcount       : 1;
+} iis3dwb_all_int_src_t;
+
+#define IIS3DWB_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state_ia           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t sleep_change             : 1;
+  uint8_t not_used_02              : 1;
+} iis3dwb_wake_up_src_t;
+
+#define IIS3DWB_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_02              : 5;
+} iis3dwb_status_reg_t;
+
+#define IIS3DWB_OUT_TEMP_L                   0x20U
+#define IIS3DWB_OUT_TEMP_H                   0x21U
+#define IIS3DWB_OUTX_L_A                     0x28U
+#define IIS3DWB_OUTX_H_A                     0x29U
+#define IIS3DWB_OUTY_L_A                     0x2AU
+#define IIS3DWB_OUTY_H_A                     0x2BU
+#define IIS3DWB_OUTZ_L_A                     0x2CU
+#define IIS3DWB_OUTZ_H_A                     0x2DU
+#define IIS3DWB_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;
+} iis3dwb_fifo_status1_t;
+
+#define IIS3DWB_FIFO_STATUS2                 0x3BU
+typedef struct {
+  uint8_t diff_fifo                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t over_run_latched         : 1;
+  uint8_t counter_bdr_ia           : 1;
+  uint8_t fifo_full_ia             : 1;
+  uint8_t fifo_ovr_ia              : 1;
+  uint8_t fifo_wtm_ia              : 1;
+} iis3dwb_fifo_status2_t;
+
+#define IIS3DWB_TIMESTAMP0                   0x40U
+#define IIS3DWB_TIMESTAMP1                   0x41U
+#define IIS3DWB_TIMESTAMP2                   0x42U
+#define IIS3DWB_TIMESTAMP3                   0x43U
+#define IIS3DWB_SLOPE_EN                     0x56U
+typedef struct {
+  uint8_t not_used_01              : 4;
+  uint8_t slope_fds                : 1;
+  uint8_t not_used_02              : 3;
+} iis3dwb_slope_en_t;
+
+#define IIS3DWB_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t usr_off_on_wu            : 1;
+  uint8_t not_used_01              : 1;
+} iis3dwb_wake_up_ths_t;
+
+#define IIS3DWB_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t wake_ths_w               : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t not_used_01              : 1;
+} iis3dwb_wake_up_dur_t;
+
+#define IIS3DWB_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t int1_wu                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int1_sleep_change        : 1;
+} iis3dwb_md1_cfg_t;
+
+#define IIS3DWB_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_timestamp           : 1;
+  uint8_t not_used_01              : 4;
+  uint8_t int2_wu                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_sleep_change        : 1;
+} iis3dwb_md2_cfg_t;
+
+#define IIS3DWB_INTERNAL_FREQ_FINE           0x63U
+typedef struct {
+  uint8_t freq_fine                : 8;
+} iis3dwb_internal_freq_fine_t;
+
+#define IIS3DWB_X_OFS_USR                    0x73U
+#define IIS3DWB_Y_OFS_USR                    0x74U
+#define IIS3DWB_Z_OFS_USR                    0x75U
+#define IIS3DWB_FIFO_DATA_OUT_TAG            0x78U
+typedef struct {
+  uint8_t tag_parity               : 1;
+  uint8_t tag_cnt                  : 2;
+  uint8_t tag_sensor               : 5;
+} iis3dwb_fifo_data_out_tag_t;
+
+#define IIS3DWB_FIFO_DATA_OUT_X_L            0x79U
+#define IIS3DWB_FIFO_DATA_OUT_X_H            0x7AU
+#define IIS3DWB_FIFO_DATA_OUT_Y_L            0x7BU
+#define IIS3DWB_FIFO_DATA_OUT_Y_H            0x7CU
+#define IIS3DWB_FIFO_DATA_OUT_Z_L            0x7DU
+#define IIS3DWB_FIFO_DATA_OUT_Z_H            0x7EU
+
+/**
+  * @defgroup IIS3DWB_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  iis3dwb_pin_ctrl_t                      pin_ctrl;
+  iis3dwb_fifo_ctrl1_t                    fifo_ctrl1;
+  iis3dwb_fifo_ctrl2_t                    fifo_ctrl2;
+  iis3dwb_fifo_ctrl3_t                    fifo_ctrl3;
+  iis3dwb_fifo_ctrl4_t                    fifo_ctrl4;
+  iis3dwb_counter_bdr_reg1_t              counter_bdr_reg1;
+  iis3dwb_counter_bdr_reg2_t              counter_bdr_reg2;
+  iis3dwb_int1_ctrl_t                     int1_ctrl;
+  iis3dwb_int2_ctrl_t                     int2_ctrl;
+  iis3dwb_ctrl1_xl_t                      ctrl1_xl;
+  iis3dwb_ctrl3_c_t                       ctrl3_c;
+  iis3dwb_ctrl4_c_t                       ctrl4_c;
+  iis3dwb_ctrl5_c_t                       ctrl5_c;
+  iis3dwb_ctrl6_c_t                       ctrl6_c;
+  iis3dwb_ctrl8_xl_t                      ctrl8_xl;
+  iis3dwb_ctrl9_xl_t                      ctrl9_xl;
+  iis3dwb_ctrl10_c_t                      ctrl10_c;
+  iis3dwb_all_int_src_t                   all_int_src;
+  iis3dwb_wake_up_src_t                   wake_up_src;
+  iis3dwb_status_reg_t                    status_reg;
+  iis3dwb_fifo_status1_t                  fifo_status1;
+  iis3dwb_fifo_status2_t                  fifo_status2;
+  iis3dwb_slope_en_t                      slope_en;
+  iis3dwb_wake_up_ths_t                   wake_up_ths;
+  iis3dwb_wake_up_dur_t                   wake_up_dur;
+  iis3dwb_md1_cfg_t                       md1_cfg;
+  iis3dwb_md2_cfg_t                       md2_cfg;
+  iis3dwb_internal_freq_fine_t            internal_freq_fine;
+  iis3dwb_fifo_data_out_tag_t             fifo_data_out_tag;
+  bitwise_t                               bitwise;
+  uint8_t                                 byte;
+} iis3dwb_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t iis3dwb_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t iis3dwb_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t iis3dwb_from_fs2g_to_mg(int16_t lsb);
+extern float_t iis3dwb_from_fs4g_to_mg(int16_t lsb);
+extern float_t iis3dwb_from_fs8g_to_mg(int16_t lsb);
+extern float_t iis3dwb_from_fs16g_to_mg(int16_t lsb);
+extern float_t iis3dwb_from_lsb_to_celsius(int16_t lsb);
+extern float_t iis3dwb_from_lsb_to_nsec(int32_t lsb);
+
+typedef enum {
+  IIS3DWB_2g   = 0,
+  IIS3DWB_16g  = 1, /* if XL_FS_MODE = ‘1’ -> IIS3DWB_2g */
+  IIS3DWB_4g   = 2,
+  IIS3DWB_8g   = 3,
+} iis3dwb_fs_xl_t;
+int32_t iis3dwb_xl_full_scale_set(stmdev_ctx_t *ctx, iis3dwb_fs_xl_t val);
+int32_t iis3dwb_xl_full_scale_get(stmdev_ctx_t *ctx, iis3dwb_fs_xl_t *val);
+
+typedef enum {
+  IIS3DWB_XL_ODR_OFF    = 0,
+  IIS3DWB_XL_ODR_26k7Hz = 5,
+} iis3dwb_odr_xl_t;
+int32_t iis3dwb_xl_data_rate_set(stmdev_ctx_t *ctx, iis3dwb_odr_xl_t val);
+int32_t iis3dwb_xl_data_rate_get(stmdev_ctx_t *ctx, iis3dwb_odr_xl_t *val);
+
+int32_t iis3dwb_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DWB_LSb_1mg  = 0,
+  IIS3DWB_LSb_16mg = 1,
+} iis3dwb_usr_off_w_t;
+int32_t iis3dwb_xl_offset_weight_set(stmdev_ctx_t *ctx,
+                                     iis3dwb_usr_off_w_t val);
+int32_t iis3dwb_xl_offset_weight_get(stmdev_ctx_t *ctx,
+                                     iis3dwb_usr_off_w_t *val);
+
+typedef enum {
+  IIS3DWB_ENABLE_ALL  = 0,
+  IIS3DWB_ONLY_X_ON_ONE_OUT_REG      = 0x01,
+  IIS3DWB_ONLY_Y_ON_ONE_OUT_REG      = 0x02,
+  IIS3DWB_ONLY_Z_ON_ONE_OUT_REG      = 0x03,
+  IIS3DWB_ONLY_X_ON_ALL_OUT_REG      = 0x11,
+  IIS3DWB_ONLY_Y_ON_ALL_OUT_REG      = 0x12,
+  IIS3DWB_ONLY_Z_ON_ALL_OUT_REG      = 0x13,
+} iis3dwb_xl_axis_sel_t;
+int32_t iis3dwb_xl_axis_selection_set(stmdev_ctx_t *ctx,
+                                      iis3dwb_xl_axis_sel_t val);
+int32_t iis3dwb_xl_axis_selection_get(stmdev_ctx_t *ctx,
+                                      iis3dwb_xl_axis_sel_t *val);
+
+typedef struct {
+  iis3dwb_all_int_src_t       all_int_src;
+  iis3dwb_wake_up_src_t       wake_up_src;
+  iis3dwb_status_reg_t        status_reg;
+  } iis3dwb_all_sources_t;
+int32_t iis3dwb_all_sources_get(stmdev_ctx_t *ctx,
+                                iis3dwb_all_sources_t *val);
+
+int32_t iis3dwb_status_reg_get(stmdev_ctx_t *ctx,
+                               iis3dwb_status_reg_t *val);
+
+int32_t iis3dwb_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis3dwb_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dwb_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis3dwb_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dwb_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t iis3dwb_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dwb_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  IIS3DWB_NO_ROUND      = 0,
+  IIS3DWB_ROUND         = 1,
+} iis3dwb_rounding_t;
+int32_t iis3dwb_rounding_mode_set(stmdev_ctx_t *ctx,
+                                  iis3dwb_rounding_t val);
+int32_t iis3dwb_rounding_mode_get(stmdev_ctx_t *ctx,
+                                  iis3dwb_rounding_t *val);
+
+int32_t iis3dwb_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dwb_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dwb_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dwb_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DWB_DRDY_LATCHED = 0,
+  IIS3DWB_DRDY_PULSED  = 1,
+} iis3dwb_dataready_pulsed_t;
+int32_t iis3dwb_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                    iis3dwb_dataready_pulsed_t val);
+int32_t iis3dwb_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                    iis3dwb_dataready_pulsed_t *val);
+
+int32_t iis3dwb_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t iis3dwb_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DWB_XL_ST_DISABLE  = 0,
+  IIS3DWB_XL_ST_POSITIVE = 1,
+  IIS3DWB_XL_ST_NEGATIVE = 2,
+} iis3dwb_st_xl_t;
+int32_t iis3dwb_xl_self_test_set(stmdev_ctx_t *ctx, iis3dwb_st_xl_t val);
+int32_t iis3dwb_xl_self_test_get(stmdev_ctx_t *ctx, iis3dwb_st_xl_t *val);
+
+int32_t iis3dwb_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_filter_settling_mask_set(stmdev_ctx_t *ctx,
+                                         uint8_t val);
+int32_t iis3dwb_filter_settling_mask_get(stmdev_ctx_t *ctx,
+                                         uint8_t *val);
+
+typedef enum {
+  IIS3DWB_SLOPE_ODR_DIV_4           = 0x30,
+  IIS3DWB_HP_ODR_DIV_10             = 0x11,
+  IIS3DWB_HP_ODR_DIV_20             = 0x12,
+  IIS3DWB_HP_ODR_DIV_45             = 0x13,
+  IIS3DWB_HP_ODR_DIV_100            = 0x14,
+  IIS3DWB_HP_ODR_DIV_200            = 0x15,
+  IIS3DWB_HP_ODR_DIV_400            = 0x16,
+  IIS3DWB_HP_ODR_DIV_800            = 0x17,
+  IIS3DWB_LP_5kHz                   = 0x00,
+  IIS3DWB_LP_ODR_DIV_4              = 0x80,
+  IIS3DWB_LP_ODR_DIV_10             = 0x81,
+  IIS3DWB_LP_ODR_DIV_20             = 0x82,
+  IIS3DWB_LP_ODR_DIV_45             = 0x83,
+  IIS3DWB_LP_ODR_DIV_100            = 0x84,
+  IIS3DWB_LP_ODR_DIV_200            = 0x85,
+  IIS3DWB_LP_ODR_DIV_400            = 0x86,
+  IIS3DWB_LP_ODR_DIV_800            = 0x87,
+} iis3dwb_hp_slope_xl_en_t;
+int32_t iis3dwb_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
+                                      iis3dwb_hp_slope_xl_en_t val);
+int32_t iis3dwb_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
+                                      iis3dwb_hp_slope_xl_en_t *val);
+
+int32_t iis3dwb_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DWB_USE_SLOPE = 0,
+  IIS3DWB_USE_HPF   = 1,
+} iis3dwb_slope_fds_t;
+int32_t iis3dwb_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                        iis3dwb_slope_fds_t val);
+int32_t iis3dwb_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                        iis3dwb_slope_fds_t *val);
+
+typedef enum {
+  IIS3DWB_PULL_UP_DISC       = 0,
+  IIS3DWB_PULL_UP_CONNECT    = 1,
+} iis3dwb_sdo_pu_en_t;
+int32_t iis3dwb_sdo_sa0_mode_set(stmdev_ctx_t *ctx, iis3dwb_sdo_pu_en_t val);
+int32_t iis3dwb_sdo_sa0_mode_get(stmdev_ctx_t *ctx, iis3dwb_sdo_pu_en_t *val);
+
+typedef enum {
+  IIS3DWB_SPI_4_WIRE = 0,
+  IIS3DWB_SPI_3_WIRE = 1,
+} iis3dwb_sim_t;
+int32_t iis3dwb_spi_mode_set(stmdev_ctx_t *ctx, iis3dwb_sim_t val);
+int32_t iis3dwb_spi_mode_get(stmdev_ctx_t *ctx, iis3dwb_sim_t *val);
+
+typedef enum {
+  IIS3DWB_I2C_ENABLE  = 0,
+  IIS3DWB_I2C_DISABLE = 1,
+} iis3dwb_i2c_disable_t;
+int32_t iis3dwb_i2c_interface_set(stmdev_ctx_t *ctx,
+                                  iis3dwb_i2c_disable_t val);
+int32_t iis3dwb_i2c_interface_get(stmdev_ctx_t *ctx,
+                                  iis3dwb_i2c_disable_t *val);
+
+typedef enum {
+  IIS3DWB_I3C_DISABLE         = 0x01,
+  IIS3DWB_I3C_ENABLE          = 0x00,
+} iis3dwb_i3c_disable_t;
+int32_t iis3dwb_i3c_disable_set(stmdev_ctx_t *ctx,
+                                iis3dwb_i3c_disable_t val);
+int32_t iis3dwb_i3c_disable_get(stmdev_ctx_t *ctx,
+                                iis3dwb_i3c_disable_t *val);
+
+typedef struct {
+    iis3dwb_int1_ctrl_t          int1_ctrl;
+    iis3dwb_md1_cfg_t            md1_cfg;
+} iis3dwb_pin_int1_route_t;
+int32_t iis3dwb_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                   iis3dwb_pin_int1_route_t *val);
+int32_t iis3dwb_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                   iis3dwb_pin_int1_route_t *val);
+
+typedef struct {
+  iis3dwb_int2_ctrl_t          int2_ctrl;
+  iis3dwb_md2_cfg_t            md2_cfg;
+} iis3dwb_pin_int2_route_t;
+int32_t iis3dwb_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                   iis3dwb_pin_int2_route_t *val);
+int32_t iis3dwb_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                   iis3dwb_pin_int2_route_t *val);
+
+typedef enum {
+  IIS3DWB_PUSH_PULL   = 0,
+  IIS3DWB_OPEN_DRAIN  = 1,
+} iis3dwb_pp_od_t;
+int32_t iis3dwb_pin_mode_set(stmdev_ctx_t *ctx, iis3dwb_pp_od_t val);
+int32_t iis3dwb_pin_mode_get(stmdev_ctx_t *ctx, iis3dwb_pp_od_t *val);
+
+typedef enum {
+  IIS3DWB_ACTIVE_HIGH = 0,
+  IIS3DWB_ACTIVE_LOW  = 1,
+} iis3dwb_h_lactive_t;
+int32_t iis3dwb_pin_polarity_set(stmdev_ctx_t *ctx, iis3dwb_h_lactive_t val);
+int32_t iis3dwb_pin_polarity_get(stmdev_ctx_t *ctx, iis3dwb_h_lactive_t *val);
+
+int32_t iis3dwb_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DWB_LSb_FS_DIV_64       = 0,
+  IIS3DWB_LSb_FS_DIV_256      = 1,
+} iis3dwb_wake_ths_w_t;
+int32_t iis3dwb_wkup_ths_weight_set(stmdev_ctx_t *ctx,
+                                    iis3dwb_wake_ths_w_t val);
+int32_t iis3dwb_wkup_ths_weight_get(stmdev_ctx_t *ctx,
+                                    iis3dwb_wake_ths_w_t *val);
+
+int32_t iis3dwb_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t iis3dwb_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t iis3dwb_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DWB_XL_NOT_BATCHED          =  0,
+  IIS3DWB_XL_BATCHED_AT_26k7Hz    = 10,
+} iis3dwb_bdr_xl_t;
+int32_t iis3dwb_fifo_xl_batch_set(stmdev_ctx_t *ctx, iis3dwb_bdr_xl_t val);
+int32_t iis3dwb_fifo_xl_batch_get(stmdev_ctx_t *ctx, iis3dwb_bdr_xl_t *val);
+
+typedef enum {
+  IIS3DWB_BYPASS_MODE             = 0,
+  IIS3DWB_FIFO_MODE               = 1,
+  IIS3DWB_STREAM_TO_FIFO_MODE     = 3,
+  IIS3DWB_BYPASS_TO_STREAM_MODE   = 4,
+  IIS3DWB_STREAM_MODE             = 6,
+  IIS3DWB_BYPASS_TO_FIFO_MODE     = 7,
+} iis3dwb_fifo_mode_t;
+int32_t iis3dwb_fifo_mode_set(stmdev_ctx_t *ctx, iis3dwb_fifo_mode_t val);
+int32_t iis3dwb_fifo_mode_get(stmdev_ctx_t *ctx, iis3dwb_fifo_mode_t *val);
+
+typedef enum {
+  IIS3DWB_TEMP_NOT_BATCHED        = 0,
+  IIS3DWB_TEMP_BATCHED_AT_104Hz   = 3,
+} iis3dwb_odr_t_batch_t;
+int32_t iis3dwb_fifo_temp_batch_set(stmdev_ctx_t *ctx,
+                                    iis3dwb_odr_t_batch_t val);
+int32_t iis3dwb_fifo_temp_batch_get(stmdev_ctx_t *ctx,
+                                    iis3dwb_odr_t_batch_t *val);
+
+typedef enum {
+  IIS3DWB_NO_DECIMATION = 0,
+  IIS3DWB_DEC_1         = 1,
+  IIS3DWB_DEC_8         = 2,
+  IIS3DWB_DEC_32        = 3,
+} iis3dwb_odr_ts_batch_t;
+int32_t iis3dwb_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
+                                              iis3dwb_odr_ts_batch_t val);
+int32_t iis3dwb_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
+                                              iis3dwb_odr_ts_batch_t *val);
+
+int32_t iis3dwb_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_batch_counter_threshold_set(stmdev_ctx_t *ctx,
+                                            uint16_t val);
+int32_t iis3dwb_batch_counter_threshold_get(stmdev_ctx_t *ctx,
+                                            uint16_t *val);
+
+int32_t iis3dwb_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t iis3dwb_fifo_status_get(stmdev_ctx_t *ctx,
+                                iis3dwb_fifo_status2_t *val);
+
+int32_t iis3dwb_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t iis3dwb_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  IIS3DWB_XL_NC_TAG = 2,
+  IIS3DWB_TEMPERATURE_TAG,
+  IIS3DWB_TIMESTAMP_TAG,
+  IIS3DWB_CFG_CHANGE_TAG,
+  IIS3DWB_XL_NC_T_2_TAG,
+  IIS3DWB_XL_NC_T_1_TAG,
+} iis3dwb_fifo_tag_t;
+int32_t iis3dwb_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
+				                    iis3dwb_fifo_tag_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IIS3DWB_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism303dac_STdC/driver/ism303dac_reg.c
+++ b/sensor/stmemsc/ism303dac_STdC/driver/ism303dac_reg.c
@@ -1,2822 +1,3557 @@
 /*
  ******************************************************************************
  * @file    ism303dac_reg.c
- * @author  MEMS Software Solution Team
- * @date    20-December-2017
+ * @author  Sensors Software Solution Team
  * @brief   ISM303DAC driver file
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "ism303dac_reg.h"
 
 /**
-  * @addtogroup  ism303dac
-  * @brief  This file provides a set of functions needed to drive the
-  *         ism303dac enanced inertial module.
+  * @defgroup  ISM303DAC
+  * @brief     This file provides a set of functions needed to drive the
+  *            ism303dac enhanced inertial module.
   * @{
+  *
   */
 
 /**
-  * @addtogroup  interfaces_functions
-  * @brief  This section provide a set of functions used to read and write
-  *         a generic register of the device.
+  * @defgroup  ISM303DAC_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
   * @{
+  *
   */
 
 /**
   * @brief  Read generic device register
   *
-  * @param  ism303dac_ctx_t* ctx: read / write interface definitions
-  * @param  uint8_t reg: register to read
-  * @param  uint8_t* data: pointer to buffer that store the data read
-  * @param  uint16_t len: number of consecutive register to read
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t ism303dac_read_reg(ism303dac_ctx_t* ctx, uint8_t reg, uint8_t* data,
-                          uint16_t len)
+int32_t ism303dac_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
 {
-  return ctx->read_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @brief  Write generic device register
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t reg: register to write
-  * @param  uint8_t* data: pointer to data to write in register reg
-  * @param  uint16_t len: number of consecutive register to write
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
-*/
-int32_t ism303dac_write_reg(ism303dac_ctx_t* ctx, uint8_t reg, uint8_t* data,
-                           uint16_t len)
+  */
+int32_t ism303dac_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
 {
-  return ctx->write_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  data_generation_c
-  * @brief   This section groups all the functions concerning data generation
+  * @defgroup    ISM303DAC_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
   * @{
+  *
   */
 
-/**
-  * @brief  all_sources: [get] Read all the interrupt/status flag of
-  *                            the device.
-  *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_all_sources: FIFO_SRC, STATUS_DUP, WAKE_UP_SRC,
-  *                               TAP_SRC, 6D_SRC, FUNC_CK_GATE, FUNC_SRC.
-  *
-  */
-int32_t ism303dac_xl_all_sources_get(ism303dac_ctx_t *ctx,
-                                 ism303dac_xl_all_sources_t *val)
+float_t ism303dac_from_fs2g_to_mg(int16_t lsb)
 {
-  int32_t mm_error;
+  return ((float_t)lsb * 0.061f);
+}
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A,
-                               &(val->byte[0]), 1);
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_STATUS_DUP_A,
-                               &(val->byte[1]), 4);
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FUNC_SRC_A,
-                               &(val->byte[5]), 1);
+float_t ism303dac_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
 
-  return mm_error;
+float_t ism303dac_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t ism303dac_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t ism303dac_from_lsb_to_mG(int16_t lsb)
+{
+  return ((float_t)lsb * 1.5f);
+}
+
+float_t ism303dac_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
 }
 
 /**
-  * @brief  block_data_update: [set] Blockdataupdate.
-  *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of bdu in reg CTRL1
+  * @}
   *
   */
-int32_t ism303dac_xl_block_data_update_set(ism303dac_ctx_t *ctx, uint8_t val)
+
+/**
+  * @defgroup  ISM303DAC_data_generation_c
+  * @brief     This section groups all the functions concerning data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get FIFO_SRC, STATUS_DUP, WAKE_UP_SRC, TAP_SRC, 6D_SRC,
+  *                FUNC_CK_GATE, FUNC_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism303dac_xl_all_sources_get(stmdev_ctx_t *ctx,
+                                     ism303dac_xl_all_sources_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
-  reg.ctrl1_a.bdu = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A,
+                           (uint8_t*)&(val->fifo_src_a), 1);
+  if(ret == 0){
+    ret = ism303dac_read_reg(ctx, ISM303DAC_STATUS_DUP_A,
+                             (uint8_t*)&(val->status_dup_a), 1);
+  }
+  if(ret == 0){
+    ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_SRC_A,
+                             (uint8_t*)&(val->wake_up_src_a), 1);
+  }
+  if(ret == 0){
+    ret = ism303dac_read_reg(ctx, ISM303DAC_TAP_SRC_A,
+                             (uint8_t*)&(val->tap_src_a), 1);
+  }
+  if(ret == 0){
+    ret = ism303dac_read_reg(ctx, ISM303DAC_6D_SRC_A,
+                             (uint8_t*)&(val->_6d_src_a), 1);
+  }
+  if(ret == 0){
+    ret = ism303dac_read_reg(ctx, ISM303DAC_FUNC_SRC_A,
+                             (uint8_t*)&(val->func_src_a), 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [get] Blockdataupdate.
+  * @brief  Block data update.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of bdu in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_block_data_update_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
-  *val = reg.ctrl1_a.bdu;
-
-  return mm_error;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  if(ret == 0){
+    ctrl1_a.bdu = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A,(uint8_t*)&ctrl1_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [set] Blockdataupdate.
+  * @brief  Block data update.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of bdu in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_block_data_update_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.bdu = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  *val = ctrl1_a.bdu;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [get] Blockdataupdate.
+  * @brief  Block data update.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of bdu in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_block_data_update_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  *val = reg.cfg_reg_c_m.bdu;
 
-  return mm_error;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.bdu = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  data_format: [set]  Big/Little Endian data selection.
+  * @brief  Block data update.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_ble_t: change the values of ble in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CFG_REG_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_data_format_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
+
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection.[set]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of ble in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism303dac_mg_data_format_set(stmdev_ctx_t *ctx,
                                      ism303dac_mg_ble_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.ble = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_c_m.ble = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  data_format: [get]  Big/Little Endian data selection.
+  * @brief  Big/Little Endian data selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_ble_t: Get the values of ble in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of ble in reg CFG_REG_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_data_format_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_mg_ble_t *val)
+int32_t ism303dac_mg_data_format_get(stmdev_ctx_t *ctx,
+                                     ism303dac_mg_ble_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  *val = (ism303dac_mg_ble_t) reg.cfg_reg_c_m.ble;
-
-  return mm_error;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  switch (cfg_reg_c_m.ble){
+    case ISM303DAC_MG_LSB_AT_LOW_ADD:
+      *val = ISM303DAC_MG_LSB_AT_LOW_ADD;
+      break;
+    case ISM303DAC_MG_MSB_AT_LOW_ADD:
+      *val = ISM303DAC_MG_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = ISM303DAC_MG_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_full_scale: [set]   Accelerometer full-scale selection.
+  * @brief  Accelerometer full-scale selection.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_fs_t: change the values of fs in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_full_scale_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_full_scale_set(stmdev_ctx_t *ctx,
                                     ism303dac_xl_fs_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
-  reg.ctrl1_a.fs = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl1_a.fs = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_full_scale: [get]   Accelerometer full-scale selection.
+  * @brief  Accelerometer full-scale selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_fs_t: Get the values of fs in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_full_scale_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_full_scale_get(stmdev_ctx_t *ctx,
                                     ism303dac_xl_fs_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
-  *val = (ism303dac_xl_fs_t) reg.ctrl1_a.fs;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
 
-  return mm_error;
+  switch (ctrl1_a.fs){
+    case ISM303DAC_XL_2g:
+      *val = ISM303DAC_XL_2g;
+      break;
+    case ISM303DAC_XL_16g:
+      *val = ISM303DAC_XL_16g;
+      break;
+    case ISM303DAC_XL_4g:
+      *val = ISM303DAC_XL_4g;
+      break;
+    case ISM303DAC_XL_8g:
+      *val = ISM303DAC_XL_8g;
+      break;
+    default:
+      *val = ISM303DAC_XL_2g;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  xl_data_rate: [set]  Accelerometer data rate selection.
+  * @brief  Accelerometer data rate selection.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_odr_t: change the values of odr in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_data_rate_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_data_rate_set(stmdev_ctx_t *ctx,
                                    ism303dac_xl_odr_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
-  reg.ctrl1_a.odr = val & 0x0F;
-  reg.ctrl1_a.hf_odr = (val & 0x10) >> 4;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl1_a.odr = (uint8_t)val & 0x0FU;
+    ctrl1_a.hf_odr = ((uint8_t)val & 0x10U) >> 4;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_data_rate: [get]  Accelerometer data rate selection.
+  * @brief  Accelerometer data rate selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_odr_t: Get the values of odr in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_data_rate_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_data_rate_get(stmdev_ctx_t *ctx,
                                    ism303dac_xl_odr_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, &reg.byte, 1);
-  *val = (ism303dac_xl_odr_t) ((reg.ctrl1_a.hf_odr << 4) + reg.ctrl1_a.odr);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
 
-  return mm_error;
+  switch ((ctrl1_a.hf_odr << 4) + ctrl1_a.odr){
+    case ISM303DAC_XL_ODR_OFF:
+      *val = ISM303DAC_XL_ODR_OFF;
+      break;
+    case ISM303DAC_XL_ODR_1Hz_LP:
+      *val = ISM303DAC_XL_ODR_1Hz_LP;
+      break;
+    case ISM303DAC_XL_ODR_12Hz5_LP:
+      *val = ISM303DAC_XL_ODR_12Hz5_LP;
+      break;
+    case ISM303DAC_XL_ODR_25Hz_LP:
+      *val = ISM303DAC_XL_ODR_25Hz_LP;
+      break;
+    case ISM303DAC_XL_ODR_50Hz_LP:
+      *val = ISM303DAC_XL_ODR_50Hz_LP;
+      break;
+    case ISM303DAC_XL_ODR_100Hz_LP:
+      *val = ISM303DAC_XL_ODR_100Hz_LP;
+      break;
+    case ISM303DAC_XL_ODR_200Hz_LP:
+      *val = ISM303DAC_XL_ODR_200Hz_LP;
+      break;
+    case ISM303DAC_XL_ODR_400Hz_LP:
+      *val = ISM303DAC_XL_ODR_400Hz_LP;
+      break;
+    case ISM303DAC_XL_ODR_800Hz_LP:
+      *val = ISM303DAC_XL_ODR_800Hz_LP;
+      break;
+    case ISM303DAC_XL_ODR_12Hz5_HR:
+      *val = ISM303DAC_XL_ODR_12Hz5_HR;
+      break;
+    case ISM303DAC_XL_ODR_25Hz_HR:
+      *val = ISM303DAC_XL_ODR_25Hz_HR;
+      break;
+    case ISM303DAC_XL_ODR_50Hz_HR:
+      *val = ISM303DAC_XL_ODR_50Hz_HR;
+      break;
+    case ISM303DAC_XL_ODR_100Hz_HR:
+      *val = ISM303DAC_XL_ODR_100Hz_HR;
+      break;
+    case ISM303DAC_XL_ODR_200Hz_HR:
+      *val = ISM303DAC_XL_ODR_200Hz_HR;
+      break;
+    case ISM303DAC_XL_ODR_400Hz_HR:
+      *val = ISM303DAC_XL_ODR_400Hz_HR;
+      break;
+    case ISM303DAC_XL_ODR_800Hz_HR:
+      *val = ISM303DAC_XL_ODR_800Hz_HR;
+      break;
+    case ISM303DAC_XL_ODR_1k6Hz_HF:
+      *val = ISM303DAC_XL_ODR_1k6Hz_HF;
+      break;
+    case ISM303DAC_XL_ODR_3k2Hz_HF:
+      *val = ISM303DAC_XL_ODR_3k2Hz_HF;
+      break;
+    case ISM303DAC_XL_ODR_6k4Hz_HF:
+      *val = ISM303DAC_XL_ODR_6k4Hz_HF;
+      break;
+    default:
+      *val = ISM303DAC_XL_ODR_OFF;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  status_reg: [get]  The STATUS_REG register.
+  * @brief  The STATUS_REG register.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_status_reg_t: registers STATUS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_status_reg_get(ism303dac_ctx_t *ctx,
-                                   ism303dac_status_a_t *val)
+int32_t ism303dac_xl_status_reg_get(stmdev_ctx_t *ctx,
+                                    ism303dac_status_a_t *val)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_STATUS_A, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_STATUS_A, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  status: [get]  Info about device status.
+  * @brief  Info about device status.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_status_reg_t: registers STATUS_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_status_get(ism303dac_ctx_t *ctx,
-                               ism303dac_status_reg_m_t *val)
+int32_t ism303dac_mg_status_get(stmdev_ctx_t *ctx,
+                                ism303dac_status_reg_m_t *val)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  xl_flag_data_ready: [get]  Accelerometer new data available.
+  * @brief  Accelerometer new data available.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of drdy in reg STATUS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_flag_data_ready_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_status_a_t status_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_STATUS_A, &reg.byte, 1);
-  *val = reg.status_a.drdy;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_STATUS_A, (uint8_t*)&status_a, 1);
+  *val = status_a.drdy;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  mag_data_ready: [get]  Magnetic set of data available.
+  * @brief  Magnetic set of data available.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of zyxda in reg STATUS_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxda in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_data_ready_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_status_reg_m_t status_reg_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M, &reg.byte, 1);
-  *val = reg.status_reg_m.zyxda;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M,
+                           (uint8_t*)&status_reg_m, 1);
+  *val = status_reg_m.zyxda;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  mag_data_ovr: [get]  Magnetic set of data overrun.
+  * @brief  Magnetic set of data overrun.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of zyxor in reg STATUS_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxor in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_data_ovr_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_status_reg_m_t status_reg_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M, &reg.byte, 1);
-  *val = reg.status_reg_m.zyxor;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_STATUS_REG_M,
+                           (uint8_t*)&status_reg_m, 1);
+  *val = status_reg_m.zyxor;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  mag_user_offset: [set]  These registers comprise a 3 group of
-  *                                 16-bit number and represent hard-iron
-  *                                 offset in order to compensate environmental
-  *                                 effects. Data format is the same of
-  *                                 output data raw: two’s complement with
-  *                                 1LSb = 1.5mG. These values act on the
-  *                                 magnetic output data value in order to
-  *                                 delete the environmental offset.
+  * @brief  These registers comprise a 3 group of 16-bit number and represent
+  *         hard-iron offset in order to compensate environmental effects.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG. These values act on the magnetic output data value
+  *         in order to delete the environmental offset.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that contains data to write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_user_offset_set(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_mg_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_write_reg(ctx, ISM303DAC_OFFSET_X_REG_L_M, buff, 6);
+  int32_t ret;
+  ret = ism303dac_write_reg(ctx, ISM303DAC_OFFSET_X_REG_L_M, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  mag_user_offset: [get]  These registers comprise a 3 group of
-  *                                 16-bit number and represent hard-iron
-  *                                 offset in order to compensate environmental
-  *                                 effects. Data format is the same of
-  *                                 output data raw: two’s complement with
-  *                                 1LSb = 1.5mG. These values act on the
-  *                                 magnetic output data value in order to
-  *                                 delete the environmental offset.
+  * @brief  These registers comprise a 3 group of 16-bit number and represent
+  *         hard-iron offset in order to compensate environmental effects.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG. These values act on the magnetic output data value
+  *         in order to delete the environmental offset.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_user_offset_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_mg_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_OFFSET_X_REG_L_M, buff, 6);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_OFFSET_X_REG_L_M, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  operating_mode: [set]  Operating mode selection.
+  * @brief  Operating mode selection.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_md_t: change the values of md in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of md in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_operating_mode_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_operating_mode_set(stmdev_ctx_t *ctx,
                                        ism303dac_mg_md_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.md = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_a_m.md = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  operating_mode: [get]  Operating mode selection.
+  * @brief  Operating mode selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_md_t: Get the values of md in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of md in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_operating_mode_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_operating_mode_get(stmdev_ctx_t *ctx,
                                        ism303dac_mg_md_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  *val = (ism303dac_mg_md_t) reg.cfg_reg_a_m.md;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
 
-  return mm_error;
+  switch (cfg_reg_a_m.md){
+    case ISM303DAC_MG_CONTINUOUS_MODE:
+      *val = ISM303DAC_MG_CONTINUOUS_MODE;
+      break;
+    case ISM303DAC_MG_SINGLE_TRIGGER:
+      *val = ISM303DAC_MG_SINGLE_TRIGGER;
+      break;
+    case ISM303DAC_MG_POWER_DOWN:
+      *val = ISM303DAC_MG_POWER_DOWN;
+      break;
+    default:
+      *val = ISM303DAC_MG_CONTINUOUS_MODE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  data_rate: [set]  Output data rate selection.
+  * @brief  Output data rate selection.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_odr_t: change the values of odr in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_data_rate_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_data_rate_set(stmdev_ctx_t *ctx,
                                    ism303dac_mg_odr_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.odr = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_a_m.odr = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  data_rate: [get]  Output data rate selection.
+  * @brief  Output data rate selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_odr_t: Get the values of odr in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_data_rate_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_data_rate_get(stmdev_ctx_t *ctx,
                                    ism303dac_mg_odr_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  *val = (ism303dac_mg_odr_t) reg.cfg_reg_a_m.odr;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
 
-  return mm_error;
+  switch (cfg_reg_a_m.odr){
+    case ISM303DAC_MG_ODR_10Hz:
+      *val = ISM303DAC_MG_ODR_10Hz;
+      break;
+    case ISM303DAC_MG_ODR_20Hz:
+      *val = ISM303DAC_MG_ODR_20Hz;
+      break;
+    case ISM303DAC_MG_ODR_50Hz:
+      *val = ISM303DAC_MG_ODR_50Hz;
+      break;
+    case ISM303DAC_MG_ODR_100Hz:
+      *val = ISM303DAC_MG_ODR_100Hz;
+      break;
+    default:
+      *val = ISM303DAC_MG_ODR_10Hz;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  power_mode: [set]  Enables high-resolution/low-power mode.
+  * @brief  Enables high-resolution/low-power mode.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_lp_t: change the values of lp in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of lp in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_power_mode_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_power_mode_set(stmdev_ctx_t *ctx,
                                     ism303dac_mg_lp_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.lp = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_a_m.lp = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  power_mode: [get]  Enables high-resolution/low-power mode.
+  * @brief  Enables high-resolution/low-power mode.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_lp_t: Get the values of lp in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lp in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_power_mode_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_power_mode_get(stmdev_ctx_t *ctx,
                                     ism303dac_mg_lp_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  *val = (ism303dac_mg_lp_t) reg.cfg_reg_a_m.lp;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
 
-  return mm_error;
+  switch (cfg_reg_a_m.lp){
+    case ISM303DAC_MG_HIGH_RESOLUTION:
+      *val = ISM303DAC_MG_HIGH_RESOLUTION;
+      break;
+    case ISM303DAC_MG_LOW_POWER:
+      *val = ISM303DAC_MG_LOW_POWER;
+      break;
+    default:
+      *val = ISM303DAC_MG_HIGH_RESOLUTION;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  offset_temp_comp: [set]  Enables the magnetometer temperature
-  *                                  compensation.
+  * @brief  Enables the magnetometer temperature compensation.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of comp_temp_en in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of comp_temp_en in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_offset_temp_comp_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_mg_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.comp_temp_en = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_a_m.comp_temp_en = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  offset_temp_comp: [get]  Enables the magnetometer temperature
-  *                                  compensation.
+  * @brief  Enables the magnetometer temperature compensation.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of comp_temp_en in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of comp_temp_en in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_offset_temp_comp_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  *val = reg.cfg_reg_a_m.comp_temp_en;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.comp_temp_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @brief  set_rst_mode: [set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_set_rst_t: change the values of set_rst in
-  *                            reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of set_rst in reg CFG_REG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_set_rst_mode_set(ism303dac_ctx_t *ctx,
-                                     ism303dac_mg_set_rst_t val)
+int32_t ism303dac_mg_set_rst_mode_set(stmdev_ctx_t *ctx,
+                                      ism303dac_mg_set_rst_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
-  reg.cfg_reg_b_m.set_rst = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_b_m.set_rst = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                              (uint8_t*)&cfg_reg_b_m, 1);
+  }
+  return ret;
 }
 
 /**
   * @brief  set_rst_mode: [get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_set_rst_t: Get the values of set_rst in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of set_rst in reg CFG_REG_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_set_rst_mode_get(ism303dac_ctx_t *ctx,
-                                     ism303dac_mg_set_rst_t *val)
+int32_t ism303dac_mg_set_rst_mode_get(stmdev_ctx_t *ctx,
+                                      ism303dac_mg_set_rst_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
-  *val = (ism303dac_mg_set_rst_t) reg.cfg_reg_b_m.set_rst;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
 
-  return mm_error;
+  switch (cfg_reg_b_m.set_rst){
+    case ISM303DAC_MG_SET_SENS_ODR_DIV_63:
+      *val = ISM303DAC_MG_SET_SENS_ODR_DIV_63;
+      break;
+    case ISM303DAC_MG_SENS_OFF_CANC_EVERY_ODR:
+      *val = ISM303DAC_MG_SENS_OFF_CANC_EVERY_ODR;
+      break;
+    case ISM303DAC_MG_SET_SENS_ONLY_AT_POWER_ON:
+      *val = ISM303DAC_MG_SET_SENS_ONLY_AT_POWER_ON;
+      break;
+    default:
+      *val = ISM303DAC_MG_SET_SENS_ODR_DIV_63;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief   set_rst_sensor_single: [set] Enables offset cancellation
-  *                                       in single measurement mode.
-  *                                       The OFF_CANC bit must be set
-  *                                       to 1 when enabling offset
-  *                                       cancellation in single measurement
-  *                                       mode this means a call function:
-  *                                       set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
-  *                                       is need.
+  * @brief  Enables offset cancellation in single measurement mode.
+  *         The OFF_CANC bit must be set to 1 when enabling offset cancellation
+  *         in single measurement mode this means a call function: set_rst_mode
+  *         (SENS_OFF_CANC_EVERY_ODR) is need.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of off_canc_one_shot in
-  *                      reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of off_canc_one_shot in reg CFG_REG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_set_rst_sensor_single_set(ism303dac_ctx_t *ctx,
-                                              uint8_t val)
+int32_t ism303dac_mg_set_rst_sensor_single_set(stmdev_ctx_t *ctx,
+                                               uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
-  reg.cfg_reg_b_m.off_canc_one_shot = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_b_m.off_canc_one_shot = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                              (uint8_t*)&cfg_reg_b_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief   set_rst_sensor_single: [get] Enables offset cancellation
-  *                                       in single measurement mode.
-  *                                       The OFF_CANC bit must be set to
-  *                                       1 when enabling offset cancellation
-  *                                       in single measurement mode this
-  *                                       means a call function:
-  *                                       set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
-  *                                       is need.
+  * @brief  Enables offset cancellation in single measurement mode.
+  *         The OFF_CANC bit must be set to 1 when enabling offset cancellation
+  *         in single measurement mode this means a call function: set_rst_mode
+  *         (SENS_OFF_CANC_EVERY_ODR) is need.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of off_canc_one_shot in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of off_canc_one_shot in reg CFG_REG_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_set_rst_sensor_single_get(ism303dac_ctx_t *ctx,
-                                              uint8_t *val)
+int32_t ism303dac_mg_set_rst_sensor_single_get(stmdev_ctx_t *ctx,
+                                               uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
-  *val = reg.cfg_reg_b_m.off_canc_one_shot;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  *val = cfg_reg_b_m.off_canc_one_shot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Dataoutput
+  * @defgroup  ISM303DAC_Dataoutput
   * @brief   This section groups all the data output functions.
   * @{
+  *
   */
 
 /**
-  * @brief   acceleration_module_raw: [get]   Module output value (8-bit).
+  * @brief  Module output value (8-bit).[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_acceleration_module_raw_get(ism303dac_ctx_t *ctx,
-                                             uint8_t *buff)
+int32_t ism303dac_acceleration_module_raw_get(stmdev_ctx_t *ctx,
+                                              uint8_t *buff)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_MODULE_8BIT_A, buff, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_MODULE_8BIT_A, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  temperature_raw: [get] Temperature data output register (r).
-  *                                L and H registers together express a 16-bit
-  *                                word in two’s complement.
+  * @brief  Temperature data output register (r). L and H registers together
+  *         express a 16-bit word in two’s complement.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_temperature_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_xl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_OUT_T_A, buff, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_OUT_T_A, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  acceleration_raw: [get] Linear acceleration output register.
-  *                                 The value is expressed as a 16-bit word
-  *                                 in two’s complement.
+  * @brief  Linear acceleration output register. The value is expressed as a
+  *         16-bit word in two’s complement.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_acceleration_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_OUT_X_L_A, buff, 6);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_OUT_X_L_A, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  magnetic_raw: [get]  Magnetic output value.
+  * @brief  Magnetic output value.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_magnetic_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_OUTX_L_REG_M, buff, 6);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_OUTX_L_REG_M, buff, 6);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  common
-  * @brief   This section groups common usefull functions.
+  * @defgroup  ISM303DAC_common
+  * @brief   This section groups common useful functions.
   * @{
+  *
   */
 
 /**
-  * @brief  device_id: [get] DeviceWhoamI.
+  * @brief  DeviceWhoamI.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_device_id_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_xl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_WHO_AM_I_A, buff, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WHO_AM_I_A, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  device_id: [get] DeviceWhoamI.
+  * @brief  DeviceWhoamI.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_device_id_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_mg_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_WHO_AM_I_M, buff, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WHO_AM_I_M, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  auto_increment: [set] Register address automatically
-  *                               incremented during a multiple byte
-  *                               access with a serial interface.
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of if_add_inc in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_add_inc in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_auto_increment_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.if_add_inc = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl2_a.if_add_inc = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  auto_increment: [get] Register address automatically incremented
-  *                               during a multiple byte access with a
-  *                               serial interface.
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of if_add_inc in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_add_inc in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_auto_increment_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  *val = reg.ctrl2_a.if_add_inc;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  *val = ctrl2_a.if_add_inc;
 
-  return mm_error;
+  return ret;
 }
 
 
 /**
-  * @brief  reset: [set] Software reset. Restore the default values in
-  *                      user registers.
+  * @brief  Software reset. Restore the default values in user registers.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of soft_reset in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of soft_reset in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_reset_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.soft_reset = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl2_a.soft_reset = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  reset: [get] Software reset. Restore the default values in
-  *                      user registers.
+  * @brief  Software reset. Restore the default values in user registers.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of soft_reset in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of soft_reset in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_reset_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  *val = reg.ctrl2_a.soft_reset;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  *val = ctrl2_a.soft_reset;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  reset: [set]  Software reset. Restore the default values in
-  *                       user registers.
+  * @brief  Software reset. Restore the default values in user registers.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of soft_rst in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of soft_rst in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_reset_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_mg_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.soft_rst = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_a_m.soft_rst = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  reset: [get]  Software reset. Restore the default values
-  *                       in user registers.
+  * @brief  Software reset. Restore the default values in user registers.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of soft_rst in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of soft_rst in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_reset_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  *val = reg.cfg_reg_a_m.soft_rst;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.soft_rst;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot: [set] Reboot memory content. Reload the calibration
-  *                     parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of boot in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_boot_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.boot = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl2_a.boot = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  boot: [get] Reboot memory content. Reload the calibration
-  *                     parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of boot in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_boot_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  *val = reg.ctrl2_a.boot;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  *val = ctrl2_a.boot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot: [set]  Reboot memory content. Reload the calibration
-  *                      parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of reboot in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of reboot in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_boot_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_mg_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.reboot = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_a_m.reboot = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                              (uint8_t*)&cfg_reg_a_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  boot: [get]  Reboot memory content. Reload the
-  *                      calibration parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of reboot in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of reboot in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_boot_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M, &reg.byte, 1);
-  *val = reg.cfg_reg_a_m.reboot;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_A_M,
+                           (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.reboot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @brief  xl_self_test: [set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_st_t: change the values of st in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of st in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_self_test_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_self_test_set(stmdev_ctx_t *ctx,
                                    ism303dac_xl_st_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.st = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl3_a.st = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
+  return ret;
 }
 
 /**
   * @brief  xl_self_test: [get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_st_t: Get the values of st in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_self_test_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_self_test_get(stmdev_ctx_t *ctx,
                                    ism303dac_xl_st_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  *val = (ism303dac_xl_st_t) reg.ctrl3_a.st;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
 
-  return mm_error;
+  switch (ctrl3_a.st){
+    case ISM303DAC_XL_ST_DISABLE:
+      *val = ISM303DAC_XL_ST_DISABLE;
+      break;
+    case ISM303DAC_XL_ST_POSITIVE:
+      *val = ISM303DAC_XL_ST_POSITIVE;
+      break;
+    case ISM303DAC_XL_ST_NEGATIVE:
+      *val = ISM303DAC_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = ISM303DAC_XL_ST_DISABLE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  self_test: [set] Selftest.
+  * @brief  Selftest.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of self_test in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of self_test in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_self_test_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_mg_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.self_test = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_c_m.self_test = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  self_test: [get] Selftest.
+  * @brief  Selftest.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of self_test in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of self_test in reg CFG_REG_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_self_test_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  *val = reg.cfg_reg_c_m.self_test;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.self_test;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @brief  data_ready_mode: [set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_drdy_pulsed_t: change the values of drdy_pulsed in
-  *                                 reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_pulsed in reg CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_data_ready_mode_set(ism303dac_ctx_t *ctx,
-                                     ism303dac_xl_drdy_pulsed_t val)
+int32_t ism303dac_xl_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                         ism303dac_xl_drdy_pulsed_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
-  reg.ctrl5_a.drdy_pulsed = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl5_a.drdy_pulsed = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  }
+  return ret;
 }
 
 /**
   * @brief  data_ready_mode: [get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_drdy_pulsed_t: Get the values of drdy_pulsed in
-  *                                    reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_pulsed in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_data_ready_mode_get(ism303dac_ctx_t *ctx,
-                                     ism303dac_xl_drdy_pulsed_t *val)
+int32_t ism303dac_xl_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                         ism303dac_xl_drdy_pulsed_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
-  *val = (ism303dac_xl_drdy_pulsed_t) reg.ctrl5_a.drdy_pulsed;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
 
-  return mm_error;
+  switch (ctrl5_a.drdy_pulsed){
+    case ISM303DAC_XL_DRDY_LATCHED:
+      *val = ISM303DAC_XL_DRDY_LATCHED;
+      break;
+    case ISM303DAC_XL_DRDY_PULSED:
+      *val = ISM303DAC_XL_DRDY_PULSED;
+      break;
+    default:
+      *val = ISM303DAC_XL_DRDY_LATCHED;
+      break;
+  }
+
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Filters
+  * @defgroup  ISM303DAC_Filters
   * @brief   This section group all the functions concerning the filters
   *          configuration.
   * @{
+  *
   */
 
 /**
-  * @brief  xl_hp_path: [set] High-pass filter data selection on output
-  *                           register and FIFO.
+  * @brief  High-pass filter data selection on output register and FIFO.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_fds_slope_t: change the values of fds_slope in
-  *                                  reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of fds_slope in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_hp_path_set(ism303dac_ctx_t *ctx,
-                                ism303dac_xl_fds_slope_t val)
+int32_t ism303dac_xl_hp_path_set(stmdev_ctx_t *ctx,
+                                 ism303dac_xl_fds_slope_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.fds_slope = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl2_a.fds_slope = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_hp_path: [get] High-pass filter data selection on output
-  *                           register and FIFO.
+  * @brief  High-pass filter data selection on output register and FIFO.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_fds_slope_t: Get the values of fds_slope in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fds_slope in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_hp_path_get(ism303dac_ctx_t *ctx,
-                                ism303dac_xl_fds_slope_t *val)
+int32_t ism303dac_xl_hp_path_get(stmdev_ctx_t *ctx,
+                                 ism303dac_xl_fds_slope_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  *val = (ism303dac_xl_fds_slope_t) reg.ctrl2_a.fds_slope;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
 
-  return mm_error;
+  switch (ctrl2_a.fds_slope){
+    case ISM303DAC_XL_HP_INTERNAL_ONLY:
+      *val = ISM303DAC_XL_HP_INTERNAL_ONLY;
+      break;
+    case ISM303DAC_XL_HP_ON_OUTPUTS:
+      *val = ISM303DAC_XL_HP_ON_OUTPUTS;
+      break;
+    default:
+      *val = ISM303DAC_XL_HP_INTERNAL_ONLY;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  low_pass_bandwidth: [set]  Low-pass bandwidth selection.
+  * @brief  Low-pass bandwidth selection.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_lpf_t: change the values of lpf in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf in reg CFG_REG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_low_pass_bandwidth_set(ism303dac_ctx_t *ctx,
-                                       ism303dac_mg_lpf_t val)
+int32_t ism303dac_mg_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
+                                            ism303dac_mg_lpf_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
-  reg.cfg_reg_b_m.lpf = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_b_m.lpf = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                              (uint8_t*)&cfg_reg_b_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  low_pass_bandwidth: [get]  Low-pass bandwidth selection.
+  * @brief  Low-pass bandwidth selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_lpf_t: Get the values of lpf in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lpf in reg CFG_REG_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_low_pass_bandwidth_get(ism303dac_ctx_t *ctx,
-                                       ism303dac_mg_lpf_t *val)
+int32_t ism303dac_mg_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
+                                            ism303dac_mg_lpf_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
-  *val = (ism303dac_mg_lpf_t) reg.cfg_reg_b_m.lpf;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
 
-  return mm_error;
+  switch (cfg_reg_b_m.lpf){
+    case ISM303DAC_MG_ODR_DIV_2:
+      *val = ISM303DAC_MG_ODR_DIV_2;
+      break;
+    case ISM303DAC_MG_ODR_DIV_4:
+      *val = ISM303DAC_MG_ODR_DIV_4;
+      break;
+    default:
+      *val = ISM303DAC_MG_ODR_DIV_2;
+      break;
+  }
+
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   Auxiliary_interface
+  * @defgroup  ISM303DAC_ Auxiliary_interface
   * @brief   This section groups all the functions concerning auxiliary
   *          interface.
   * @{
+  *
   */
 
 /**
-  * @brief  spi_mode: [set]  SPI Serial Interface Mode selection.
+  * @brief  SPI Serial Interface Mode selection.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_sim_t: change the values of sim in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_spi_mode_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_spi_mode_set(stmdev_ctx_t *ctx,
                                   ism303dac_xl_sim_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.sim = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl2_a.sim = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  spi_mode: [get]  SPI Serial Interface Mode selection.
+  * @brief  SPI Serial Interface Mode selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_sim_t: Get the values of sim in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_spi_mode_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_spi_mode_get(stmdev_ctx_t *ctx,
                                   ism303dac_xl_sim_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  *val = (ism303dac_xl_sim_t) reg.ctrl2_a.sim;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
 
-  return mm_error;
+  switch (ctrl2_a.sim){
+    case ISM303DAC_XL_SPI_4_WIRE:
+      *val = ISM303DAC_XL_SPI_4_WIRE;
+      break;
+    case ISM303DAC_XL_SPI_3_WIRE:
+      *val = ISM303DAC_XL_SPI_3_WIRE;
+      break;
+    default:
+      *val = ISM303DAC_XL_SPI_4_WIRE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [set]  Disable / Enable I2C interface.
+  * @brief  Disable / Enable I2C interface.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_i2c_disable_t: change the values of i2c_disable
-  *                                 in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_disable in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_i2c_interface_set(ism303dac_ctx_t *ctx,
-                                   ism303dac_xl_i2c_disable_t val)
+int32_t ism303dac_xl_i2c_interface_set(stmdev_ctx_t *ctx,
+                                       ism303dac_xl_i2c_disable_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.i2c_disable = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl2_a.i2c_disable = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [get]  Disable / Enable I2C interface.
+  * @brief  Disable / Enable I2C interface.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_i2c_disable_t: Get the values of i2c_disable in
-  *                                 reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_disable in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_i2c_interface_get(ism303dac_ctx_t *ctx,
-                                   ism303dac_xl_i2c_disable_t *val)
+int32_t ism303dac_xl_i2c_interface_get(stmdev_ctx_t *ctx,
+                                       ism303dac_xl_i2c_disable_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, &reg.byte, 1);
-  *val = (ism303dac_xl_i2c_disable_t) reg.ctrl2_a.i2c_disable;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
 
-  return mm_error;
+  switch (ctrl2_a.i2c_disable){
+    case ISM303DAC_XL_I2C_ENABLE:
+      *val = ISM303DAC_XL_I2C_ENABLE;
+      break;
+    case ISM303DAC_XL_I2C_DISABLE:
+      *val = ISM303DAC_XL_I2C_DISABLE;
+      break;
+    default:
+      *val = ISM303DAC_XL_I2C_ENABLE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [set]  Enable/Disable I2C interface.
+  * @brief  Enable/Disable I2C interface.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_i2c_dis_t: change the values of i2c_dis in
-  *                                reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_dis in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_i2c_interface_set(ism303dac_ctx_t *ctx,
-                                      ism303dac_mg_i2c_dis_t val)
+int32_t ism303dac_mg_i2c_interface_set(stmdev_ctx_t *ctx,
+                                       ism303dac_mg_i2c_dis_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.i2c_dis = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_c_m.i2c_dis = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [get]  Enable/Disable I2C interface.
+  * @brief  Enable/Disable I2C interface.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_i2c_dis_t: Get the values of i2c_dis in
-  *                                 reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_dis in reg CFG_REG_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_i2c_interface_get(ism303dac_ctx_t *ctx,
-                                      ism303dac_mg_i2c_dis_t *val)
+int32_t ism303dac_mg_i2c_interface_get(stmdev_ctx_t *ctx,
+                                       ism303dac_mg_i2c_dis_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  *val = (ism303dac_mg_i2c_dis_t) reg.cfg_reg_c_m.i2c_dis;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
 
-  return mm_error;
+  switch (cfg_reg_c_m.i2c_dis){
+    case ISM303DAC_MG_I2C_ENABLE:
+      *val = ISM303DAC_MG_I2C_ENABLE;
+      break;
+    case ISM303DAC_MG_I2C_DISABLE:
+      *val = ISM303DAC_MG_I2C_DISABLE;
+      break;
+    default:
+      *val = ISM303DAC_MG_I2C_ENABLE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  cs_mode: [set]  Connect/Disconnects pull-up in if_cs pad.
+  * @brief  Connect/Disconnects pull-up in if_cs pad.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
+  * @param  ctx    read / write interface definitions.(ptr)
   * @param  ism303dac_xl_if_cs_pu_dis_t: change the values of if_cs_pu_dis
   *                                  in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_cs_mode_set(ism303dac_ctx_t *ctx,
-                             ism303dac_xl_if_cs_pu_dis_t val)
+int32_t ism303dac_xl_cs_mode_set(stmdev_ctx_t *ctx,
+                                 ism303dac_xl_if_cs_pu_dis_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
-  reg.fifo_ctrl_a.if_cs_pu_dis = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                           (uint8_t*)&fifo_ctrl_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    fifo_ctrl_a.if_cs_pu_dis = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                              (uint8_t*)&fifo_ctrl_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  cs_mode: [get]  Connect/Disconnects pull-up in if_cs pad.
+  * @brief  Connect/Disconnects pull-up in if_cs pad.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_if_cs_pu_dis_t: Get the values of if_cs_pu_dis in
-  *                                  reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_cs_pu_dis in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_cs_mode_get(ism303dac_ctx_t *ctx,
-                             ism303dac_xl_if_cs_pu_dis_t *val)
+int32_t ism303dac_xl_cs_mode_get(stmdev_ctx_t *ctx,
+                                 ism303dac_xl_if_cs_pu_dis_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
-  *val = (ism303dac_xl_if_cs_pu_dis_t) reg.fifo_ctrl_a.if_cs_pu_dis;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                           (uint8_t*)&fifo_ctrl_a, 1);
 
-  return mm_error;
+  switch (fifo_ctrl_a.if_cs_pu_dis){
+    case ISM303DAC_XL_PULL_UP_CONNECTED:
+      *val = ISM303DAC_XL_PULL_UP_CONNECTED;
+      break;
+    case ISM303DAC_XL_PULL_UP_DISCONNECTED:
+      *val = ISM303DAC_XL_PULL_UP_DISCONNECTED;
+      break;
+    default:
+      *val = ISM303DAC_XL_PULL_UP_CONNECTED;
+      break;
+  }
+
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   main_serial_interface
+  * @defgroup  ISM303DAC_ main_serial_interface
   * @brief   This section groups all the functions concerning main serial
   *          interface management (not auxiliary)
   * @{
+  *
   */
 
 /**
-  * @brief  pin_mode: [set]  Push-pull/open-drain selection on interrupt pad.
+  * @brief  Push-pull/open-drain selection on interrupt pad.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_pp_od_t: change the values of pp_od in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_pin_mode_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_pin_mode_set(stmdev_ctx_t *ctx,
                                   ism303dac_xl_pp_od_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.pp_od = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl3_a.pp_od = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_mode: [get]  Push-pull/open-drain selection on interrupt pad.
+  * @brief  Push-pull/open-drain selection on interrupt pad.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_pp_od_t: Get the values of pp_od in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_pin_mode_get(ism303dac_ctx_t *ctx,
-                                 ism303dac_xl_pp_od_t *val)
+int32_t ism303dac_xl_pin_mode_get(stmdev_ctx_t *ctx,
+                                  ism303dac_xl_pp_od_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  *val = (ism303dac_xl_pp_od_t) reg.ctrl3_a.pp_od;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
 
-  return mm_error;
+  switch (ctrl3_a.pp_od){
+    case ISM303DAC_XL_PUSH_PULL:
+      *val = ISM303DAC_XL_PUSH_PULL;
+      break;
+    case ISM303DAC_XL_OPEN_DRAIN:
+      *val = ISM303DAC_XL_OPEN_DRAIN;
+      break;
+    default:
+      *val = ISM303DAC_XL_PUSH_PULL;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  pin_polarity: [set]  Interrupt active-high/low.
+  * @brief  Interrupt active-high/low.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_h_lactive_t: change the values of h_lactive in
-  *                                  reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of h_lactive in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_pin_polarity_set(ism303dac_ctx_t *ctx,
-                                  ism303dac_xl_h_lactive_t val)
+int32_t ism303dac_xl_pin_polarity_set(stmdev_ctx_t *ctx,
+                                      ism303dac_xl_h_lactive_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.h_lactive = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl3_a.h_lactive = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_polarity: [get]  Interrupt active-high/low.
+  * @brief  Interrupt active-high/low.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_h_lactive_t: Get the values of h_lactive in
-  *                                   reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_pin_polarity_get(ism303dac_ctx_t *ctx,
-                                  ism303dac_xl_h_lactive_t *val)
+int32_t ism303dac_xl_pin_polarity_get(stmdev_ctx_t *ctx,
+                                      ism303dac_xl_h_lactive_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  *val = (ism303dac_xl_h_lactive_t) reg.ctrl3_a.h_lactive;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
 
-  return mm_error;
+  switch (ctrl3_a.h_lactive){
+    case ISM303DAC_XL_ACTIVE_HIGH:
+      *val = ISM303DAC_XL_ACTIVE_HIGH;
+      break;
+    case ISM303DAC_XL_ACTIVE_LOW:
+      *val = ISM303DAC_XL_ACTIVE_LOW;
+      break;
+    default:
+      *val = ISM303DAC_XL_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  int_notification: [set]  Latched/pulsed interrupt.
+  * @brief  Latched/pulsed interrupt.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_lir_t: change the values of lir in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_int_notification_set(ism303dac_ctx_t *ctx,
-                                      ism303dac_xl_lir_t val)
+int32_t ism303dac_xl_int_notification_set(stmdev_ctx_t *ctx,
+                                          ism303dac_xl_lir_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.lir = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl3_a.lir = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  int_notification: [get]  Latched/pulsed interrupt.
+  * @brief  Latched/pulsed interrupt.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_lir_t: Get the values of lir in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_int_notification_get(ism303dac_ctx_t *ctx,
-                                      ism303dac_xl_lir_t *val)
+int32_t ism303dac_xl_int_notification_get(stmdev_ctx_t *ctx,
+                                          ism303dac_xl_lir_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  *val = (ism303dac_xl_lir_t) reg.ctrl3_a.lir;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
 
-  return mm_error;
+  switch (ctrl3_a.lir){
+    case ISM303DAC_XL_INT_PULSED:
+      *val = ISM303DAC_XL_INT_PULSED;
+      break;
+    case ISM303DAC_XL_INT_LATCHED:
+      *val = ISM303DAC_XL_INT_LATCHED;
+      break;
+    default:
+      *val = ISM303DAC_XL_INT_PULSED;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  pin_int1_route: [set] Select the signal that need to route
-  *                               on int1 pad.
+  * @brief  Select the signal that need to route on int1 pad.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_pin_int1_route_t: union of registers from CTRL4 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change union of registers from CTRL4 to
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_pin_int1_route_set(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_pin_int1_route_t val)
+int32_t ism303dac_xl_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                        ism303dac_xl_pin_int1_route_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl4_a_t ctrl4_a;
+  ism303dac_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL4_A, &reg.byte, 1);
-  reg.ctrl4_a.int1_drdy         = val.int1_drdy;
-  reg.ctrl4_a.int1_fth          = val.int1_fth;
-  reg.ctrl4_a.int1_6d           = val.int1_6d;
-  reg.ctrl4_a.int1_tap          = val.int1_tap;
-  reg.ctrl4_a.int1_ff           = val.int1_ff;
-  reg.ctrl4_a.int1_wu           = val.int1_wu;
-  reg.ctrl4_a.int1_s_tap        = val.int1_s_tap;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL4_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL4_A, (uint8_t*)&ctrl4_a, 1);
+  if(ret == 0){
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_dur_a.int1_fss7   = val.int1_fss7;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+    ctrl4_a.int1_drdy         = val.int1_drdy;
+    ctrl4_a.int1_fth          = val.int1_fth;
+    ctrl4_a.int1_6d           = val.int1_6d;
+    ctrl4_a.int1_tap          = val.int1_tap;
+    ctrl4_a.int1_ff           = val.int1_ff;
+    ctrl4_a.int1_wu           = val.int1_wu;
+    ctrl4_a.int1_s_tap        = val.int1_s_tap;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL4_A, (uint8_t*)&ctrl4_a, 1);
+  }
+  if(ret == 0){
+    ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_DUR_A,
+                             (uint8_t*)&wake_up_dur_a, 1);
+  }
 
-  return mm_error;
+  if(ret == 0){
+    wake_up_dur_a.int1_fss7   = val.int1_fss7;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_int1_route: [get] Select the signal that need to route on
-  *                               int1 pad.
+  * @brief  Select the signal that need to route on int1 pad.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_pin_int1_route_t: union of registers from CTRL4 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from CTRL4 to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_pin_int1_route_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_pin_int1_route_t *val)
+int32_t ism303dac_xl_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                        ism303dac_xl_pin_int1_route_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl4_a_t ctrl4_a;
+  ism303dac_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL4_A, &reg.byte, 1);
-  val->int1_drdy          = reg.ctrl4_a.int1_drdy;
-  val->int1_fth           = reg.ctrl4_a.int1_fth;
-  val->int1_6d            = reg.ctrl4_a.int1_6d;
-  val->int1_tap           = reg.ctrl4_a.int1_tap;
-  val->int1_ff            = reg.ctrl4_a.int1_ff;
-  val->int1_wu            = reg.ctrl4_a.int1_wu;
-  val->int1_s_tap         = reg.ctrl4_a.int1_s_tap;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL4_A, (uint8_t*)&ctrl4_a, 1);
+  if(ret == 0){
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  val->int1_fss7 = reg.wake_up_dur_a.int1_fss7;
+    val->int1_drdy          = ctrl4_a.int1_drdy;
+    val->int1_fth           = ctrl4_a.int1_fth;
+    val->int1_6d            = ctrl4_a.int1_6d;
+    val->int1_tap           = ctrl4_a.int1_tap;
+    val->int1_ff            = ctrl4_a.int1_ff;
+    val->int1_wu            = ctrl4_a.int1_wu;
+    val->int1_s_tap         = ctrl4_a.int1_s_tap;
 
-  return mm_error;
+    ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  }
+
+  if(ret == 0){
+    val->int1_fss7 = wake_up_dur_a.int1_fss7;
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_int2_route: [set] Select the signal that need to route on
-  *                               int2 pad.
+  * @brief  Select the signal that need to route on int2 pad.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_pin_int2_route_t: union of registers from CTRL5 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change union of registers from CTRL5 to
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_pin_int2_route_set(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_pin_int2_route_t val)
+int32_t ism303dac_xl_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                        ism303dac_xl_pin_int2_route_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
-  reg.ctrl5_a.int2_boot       = val.int2_boot;
-  reg.ctrl5_a.int2_fth        = val.int2_fth;
-  reg.ctrl5_a.int2_drdy       = val.int2_drdy;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl5_a.int2_boot       = val.int2_boot;
+    ctrl5_a.int2_fth        = val.int2_fth;
+    ctrl5_a.int2_drdy       = val.int2_drdy;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_int2_route: [get] Select the signal that need to route on
-  *                               int2 pad.
+  * @brief  Select the signal that need to route on int2 pad.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_pin_int2_route_t: union of registers from CTRL5 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from CTRL5 to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_pin_int2_route_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_pin_int2_route_t *val)
+int32_t ism303dac_xl_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                        ism303dac_xl_pin_int2_route_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
-  val->int2_boot     = reg.ctrl5_a.int2_boot;
-  val->int2_fth      = reg.ctrl5_a.int2_fth;
-  val->int2_drdy     = reg.ctrl5_a.int2_drdy;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    val->int2_boot     = ctrl5_a.int2_boot;
+    val->int2_fth      = ctrl5_a.int2_fth;
+    val->int2_drdy     = ctrl5_a.int2_drdy;
+  }
+  return ret;
 }
 
 /**
-  * @brief  all_on_int1: [set] All interrupt signals become available on
-  *                            INT1 pin.
+  * @brief  All interrupt signals become available on INT1 pin.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int2_on_int1 in reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_all_on_int1_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
-  reg.ctrl5_a.int2_on_int1 = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl5_a.int2_on_int1 = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  all_on_int1: [get] All interrupt signals become available on
-  *                            INT1 pin.
+  * @brief  All interrupt signals become available on INT1 pin.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int2_on_int1 in reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_on_int1 in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_all_on_int1_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, &reg.byte, 1);
-  *val = reg.ctrl5_a.int2_on_int1;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  *val = ctrl5_a.int2_on_int1;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_pin: [set]  Data-ready signal on INT_DRDY pin.
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of drdy_on_pin in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_on_pin in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_drdy_on_pin_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_mg_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.int_mag = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_c_m.int_mag = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_pin: [get]  Data-ready signal on INT_DRDY pin.
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of drdy_on_pin in reg CFG_REG_C_M
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_on_pin in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_drdy_on_pin_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  *val = reg.cfg_reg_c_m.int_mag;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.int_mag;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_on_pin: [set]  Interrupt signal on INT_DRDY pin.
+  * @brief  Interrupt signal on INT_DRDY pin.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int_on_pin in reg CFG_REG_C_M
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of int_on_pin in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_int_on_pin_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_mg_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.int_mag_pin = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_c_m.int_mag_pin = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                              (uint8_t*)&cfg_reg_c_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  int_on_pin: [get]  Interrupt signal on INT_DRDY pin.
+  * @brief  Interrupt signal on INT_DRDY pin.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int_on_pin in reg CFG_REG_C_M
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_on_pin in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_int_on_pin_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_mg_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M, &reg.byte, 1);
-  *val = reg.cfg_reg_c_m.int_mag_pin;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_C_M,
+                           (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.int_mag_pin;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_gen_conf: [set]  Interrupt generator configuration register
+  * @brief  Interrupt generator configuration register.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_int_crtl_reg_m_t: registers INT_CRTL_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change registers INT_CRTL_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_int_gen_conf_set(ism303dac_ctx_t *ctx,
-                                 ism303dac_int_crtl_reg_m_t *val)
+int32_t ism303dac_mg_int_gen_conf_set(stmdev_ctx_t *ctx,
+                                      ism303dac_int_crtl_reg_m_t *val)
 {
-  return ism303dac_write_reg(ctx, ISM303DAC_INT_CRTL_REG_M, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = ism303dac_write_reg(ctx, ISM303DAC_INT_CRTL_REG_M,
+                            (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_gen_conf: [get]  Interrupt generator configuration register
+  * @brief  Interrupt generator configuration register.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_int_crtl_reg_m_t: registers INT_CRTL_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers INT_CRTL_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_int_gen_conf_get(ism303dac_ctx_t *ctx,
-                                 ism303dac_int_crtl_reg_m_t *val)
+int32_t ism303dac_mg_int_gen_conf_get(stmdev_ctx_t *ctx,
+                                      ism303dac_int_crtl_reg_m_t *val)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_INT_CRTL_REG_M, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_CRTL_REG_M, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_gen_source: [get]  Interrupt generator source register
+  * @brief  Interrupt generator source register.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_int_source_reg_m_t: registers INT_SOURCE_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers INT_SOURCE_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_int_gen_source_get(ism303dac_ctx_t *ctx,
-                                   ism303dac_int_source_reg_m_t *val)
+int32_t ism303dac_mg_int_gen_source_get(stmdev_ctx_t *ctx,
+                                        ism303dac_int_source_reg_m_t *val)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_INT_SOURCE_REG_M, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_SOURCE_REG_M, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_gen_treshold: [set]  User-defined threshold value for xl
-  *                                  interrupt event on generator.
-  *                                  Data format is the same of output
-  *                                  data raw: two’s complement with
-  *                                  1LSb = 1.5mG.
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_int_gen_treshold_set(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_mg_int_gen_treshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_write_reg(ctx, ISM303DAC_INT_THS_L_REG_M, buff, 2);
+  int32_t ret;
+  ret = ism303dac_write_reg(ctx, ISM303DAC_INT_THS_L_REG_M, buff, 2);
+  return ret;
 }
 
 /**
-  * @brief  int_gen_treshold: [get]  User-defined threshold value for
-  *                                  xl interrupt event on generator.
-  *                                  Data format is the same of output
-  *                                  data raw: two’s complement with
-  *                                  1LSb = 1.5mG.
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_int_gen_treshold_get(ism303dac_ctx_t *ctx, uint8_t *buff)
+int32_t ism303dac_mg_int_gen_treshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_INT_THS_L_REG_M, buff, 2);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_THS_L_REG_M, buff, 2);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  interrupt_pins
+  * @defgroup  ISM303DAC_interrupt_pins
   * @brief   This section groups all the functions that manage interrup pins
   * @{
+  *
   */
-
-
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Wake_Up_event
+  * @defgroup  ISM303DAC_Wake_Up_event
   * @brief   This section groups all the functions that manage the Wake Up
   *          event generation.
   * @{
+  *
   */
 
 /**
-  * @brief  offset_int_conf: [set]  The interrupt block recognition checks
-  *                                 data after/before the hard-iron correction
-  *                                 to discover the interrupt.
+  * @brief  The interrupt block recognition checks data after/before the
+  *         hard-iron correction to discover the interrupt.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_int_on_dataoff_t: change the values of int_on_dataoff
-  *                                       in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of int_on_dataoff in reg CFG_REG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_offset_int_conf_set(ism303dac_ctx_t *ctx,
-                                    ism303dac_mg_int_on_dataoff_t val)
+int32_t ism303dac_mg_offset_int_conf_set(stmdev_ctx_t *ctx,
+                                         ism303dac_mg_int_on_dataoff_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
-  reg.cfg_reg_b_m.int_on_dataoff = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
 
-  return mm_error;
+    cfg_reg_b_m.int_on_dataoff = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                              (uint8_t*)&cfg_reg_b_m, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  offset_int_conf: [get]  The interrupt block recognition checks
-  *                                 data after/before the hard-iron correction
-  *                                 to discover the interrupt.
+  * @brief  The interrupt block recognition checks data after/before the
+  *         hard-iron correction to discover the interrupt.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_mg_int_on_dataoff_t: Get the values of int_on_dataoff in
-  *                                   reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_on_dataoff in reg CFG_REG_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_mg_offset_int_conf_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_mg_int_on_dataoff_t *val)
+int32_t ism303dac_mg_offset_int_conf_get(stmdev_ctx_t *ctx,
+                                         ism303dac_mg_int_on_dataoff_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M, &reg.byte, 1);
-  *val = (ism303dac_mg_int_on_dataoff_t) reg.cfg_reg_b_m.int_on_dataoff;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CFG_REG_B_M,
+                           (uint8_t*)&cfg_reg_b_m, 1);
 
-  return mm_error;
+  switch (cfg_reg_b_m.int_on_dataoff){
+    case ISM303DAC_MG_CHECK_BEFORE:
+      *val = ISM303DAC_MG_CHECK_BEFORE;
+      break;
+    case ISM303DAC_MG_CHECK_AFTER:
+      *val = ISM303DAC_MG_CHECK_AFTER;
+      break;
+    default:
+      *val = ISM303DAC_MG_CHECK_BEFORE;
+      break;
+  }
+
+  return ret;
 }
 
   /**
-  * @brief  wkup_threshold: [set]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  * @brief  Threshold for wakeup [1 LSb = FS_XL / 64].[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of wu_ths in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of wu_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_wkup_threshold_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_ths_a.wu_ths = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                           (uint8_t*)&wake_up_ths_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    wake_up_ths_a.wu_ths = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                              (uint8_t*)&wake_up_ths_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  wkup_threshold: [get]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  * @brief  Threshold for wakeup [1 LSb = FS_XL / 64].[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of wu_ths in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of wu_ths in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_wkup_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = reg.wake_up_ths_a.wu_ths;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                           (uint8_t*)&wake_up_ths_a, 1);
+  *val = wake_up_ths_a.wu_ths;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  wkup_dur: [set]  Wakeup duration [1 LSb = 1 / ODR].
+  * @brief  Wakeup duration [1 LSb = 1 / ODR].[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of wu_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of wu_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_wkup_dur_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_dur_a.wu_dur = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                           (uint8_t*)&wake_up_dur_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    wake_up_dur_a.wu_dur = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                              (uint8_t*)&wake_up_dur_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  wkup_dur: [get]  Wakeup duration [1 LSb = 1 / ODR].
+  * @brief  Wakeup duration [1 LSb = 1 / ODR].[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of wu_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of wu_dur in reg WAKE_UP_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_wkup_dur_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = reg.wake_up_dur_a.wu_dur;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_DUR_A,
+                           (uint8_t*)&wake_up_dur_a, 1);
+  *val = wake_up_dur_a.wu_dur;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   Activity/Inactivity_detection
+  * @defgroup  ISM303DAC_ Activity/Inactivity_detection
   * @brief   This section groups all the functions concerning
   *          activity/inactivity detection.
   * @{
+  *
   */
+
 /**
-  * @brief  sleep_mode: [set]  Enables gyroscope Sleep mode.
+  * @brief  Enables gyroscope Sleep mode.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sleep_on in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_on in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_sleep_mode_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_ths_a.sleep_on = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                           (uint8_t*)&wake_up_ths_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    wake_up_ths_a.sleep_on = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                              (uint8_t*)&wake_up_ths_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  sleep_mode: [get]  Enables gyroscope Sleep mode.
+  * @brief  Enables gyroscope Sleep mode.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sleep_on in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_on in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_sleep_mode_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = reg.wake_up_ths_a.sleep_on;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                           (uint8_t*)&wake_up_ths_a, 1);
+  *val = wake_up_ths_a.sleep_on;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  act_sleep_dur: [set] Duration to go in sleep mode
-  *                              [1 LSb = 512 / ODR].
+  * @brief  Duration to go in sleep mode [1 LSb = 512 / ODR].[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sleep_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_act_sleep_dur_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_dur_a.sleep_dur = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                           (uint8_t*)&wake_up_dur_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    wake_up_dur_a.sleep_dur = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                              (uint8_t*)&wake_up_dur_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  act_sleep_dur: [get] Duration to go in sleep mode
-  *                              [1 LSb = 512 / ODR].
+  * @brief  Duration to go in sleep mode [1 LSb = 512 / ODR].[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sleep_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_dur in reg WAKE_UP_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_act_sleep_dur_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = reg.wake_up_dur_a.sleep_dur;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_DUR_A,
+                           (uint8_t*)&wake_up_dur_a, 1);
+  *val = wake_up_dur_a.sleep_dur;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  tap_generator
+  * @defgroup  ISM303DAC_tap_generator
   * @brief   This section groups all the functions that manage the tap and
   *          double tap event generation.
   * @{
+  *
   */
 
 /**
-  * @brief  tap_detection_on_z: [set]  Enable Z direction in tap recognition.
+  * @brief  Enable Z direction in tap recognition.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_z_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_z_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_detection_on_z_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_z_set(stmdev_ctx_t *ctx,
                                             uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.tap_z_en = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl3_a.tap_z_en = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_z: [get]  Enable Z direction in tap recognition.
+  * @brief  Enable Z direction in tap recognition.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_z_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_z_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_detection_on_z_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_z_get(stmdev_ctx_t *ctx,
                                             uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  *val = reg.ctrl3_a.tap_z_en;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  *val = ctrl3_a.tap_z_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_y: [set]  Enable Y direction in tap recognition.
+  * @brief  Enable Y direction in tap recognition.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_y_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_y_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_detection_on_y_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_y_set(stmdev_ctx_t *ctx,
                                             uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.tap_y_en = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl3_a.tap_y_en = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_y: [get]  Enable Y direction in tap recognition.
+  * @brief  Enable Y direction in tap recognition.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_y_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_y_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_detection_on_y_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_y_get(stmdev_ctx_t *ctx,
                                             uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  *val = reg.ctrl3_a.tap_y_en;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  *val = ctrl3_a.tap_y_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_x: [set]  Enable X direction in tap recognition.
+  * @brief  Enable X direction in tap recognition.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_x_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_x_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_detection_on_x_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.tap_x_en = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    ctrl3_a.tap_x_en = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_x: [get]  Enable X direction in tap recognition.
+  * @brief  Enable X direction in tap recognition.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_x_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_x_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_detection_on_x_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_x_get(stmdev_ctx_t *ctx,
                                             uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, &reg.byte, 1);
-  *val = reg.ctrl3_a.tap_x_en;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  *val = ctrl3_a.tap_x_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_threshold: [set] Threshold for tap recognition
-  *                              [1 LSb = FS/32].
+  * @brief  Threshold for tap recognition [1 LSb = FS/32].[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_threshold_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
-  reg.tap_6d_ths_a.tap_ths = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                           (uint8_t*)&tap_6d_ths_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    tap_6d_ths_a.tap_ths = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                              (uint8_t*)&tap_6d_ths_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_threshold: [get] Threshold for tap recognition
-  *                              [1 LSb = FS/32].
+  * @brief  Threshold for tap recognition [1 LSb = FS/32].[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_ths in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
-  *val = reg.tap_6d_ths_a.tap_ths;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                           (uint8_t*)&tap_6d_ths_a, 1);
+  *val = tap_6d_ths_a.tap_ths;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_shock: [set] Maximum duration is the maximum time of
-  *                          an overthreshold signal detection to be
-  *                          recognized as a tap event. The default value
-  *                          of these bits is 00b which corresponds to
-  *                          4*ODR_XL time. If the SHOCK[1:0] bits are set
-  *                          to a different value, 1LSB corresponds to
-  *                          8*ODR_XL time.
+  * @brief  Maximum duration is the maximum time of an overthreshold
+  *         signal detection to be recognized as a tap event. The default
+  *         value of these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of shock in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of shock in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_shock_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
-  reg.int_dur_a.shock = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    int_dur_a.shock = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A,
+                              (uint8_t*)&int_dur_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_shock: [get] Maximum duration is the maximum time of an
-  *                          overthreshold signal detection to be recognized
-  *                          as a tap event. The default value of these bits
-  *                          is 00b which corresponds to 4*ODR_XL time.
-  *                          If the SHOCK[1:0] bits are set to a different
-                             value, 1LSB corresponds to 8*ODR_XL time.
+  * @brief  Maximum duration is the maximum time of an overthreshold
+  *         signal detection to be recognized as a tap event. The default
+  *         value of these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of shock in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of shock in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_shock_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
-  *val = reg.int_dur_a.shock;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  *val = int_dur_a.shock;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_quiet: [set] Quiet time is the time after the first
-  *                          detected tap in which there must not be any
-  *                          overthreshold event. The default value of these
-  *                          bits is 00b which corresponds to 2*ODR_XL time.
-  *                          If the QUIET[1:0] bits are set to a different
-  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event. The default value of these
+  *         bits is 00b which corresponds to 2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value,
+  *         1LSB corresponds to 4*ODR_XL time.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of quiet in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of quiet in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_quiet_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
-  reg.int_dur_a.quiet = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    int_dur_a.quiet = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A,
+                              (uint8_t*)&int_dur_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_quiet: [get] Quiet time is the time after the first detected
-  *                          tap in which there must not be any overthreshold
-  *                          event. The default value of these bits is 00b
-  *                          which corresponds to 2*ODR_XL time.
-  *                          If the QUIET[1:0] bits are set to a different
-  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  * @brief Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event. The default value of these
+  *         bits is 00b which corresponds to 2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value,
+  *         1LSB corresponds to 4*ODR_XL time.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of quiet in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of quiet in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_quiet_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
-  *val = reg.int_dur_a.quiet;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  *val = int_dur_a.quiet;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_dur: [set] When double tap recognition is enabled, this
-  *                        register expresses the maximum time between two
-  *                        consecutive detected taps to determine a double
-  *                        tap event. The default value of these bits is
-  *                        0000b which corresponds to 16*ODR_XL time.
-  *                        If the DUR[3:0] bits are set to a different value,
-  *                        1LSB corresponds to 32*ODR_XL time.
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event. The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,
+  *         1LSB corresponds to 32*ODR_XL time.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of lat in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of lat in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_dur_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
-  reg.int_dur_a.lat = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    int_dur_a.lat = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_INT_DUR_A,
+                              (uint8_t*)&int_dur_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_dur: [get] When double tap recognition is enabled,
-  *                        this register expresses the maximum time
-  *                        between two consecutive detected taps to
-  *                        determine a double tap event. The default
-  *                        value of these bits is 0000b which corresponds
-  *                        to 16*ODR_XL time. If the DUR[3:0] bits are set
-  *                        to a different value, 1LSB corresponds to
-  *                        32*ODR_XL time.
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event. The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,
+  *         1LSB corresponds to 32*ODR_XL time.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of lat in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lat in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_dur_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, &reg.byte, 1);
-  *val = reg.int_dur_a.lat;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  *val = int_dur_a.lat;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_mode: [set]  Single/double-tap event enable/disable.
+  * @brief  Single/double-tap event enable/disable.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_single_double_tap_t: change the values of
-  *                                       single_double_tap in regWAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of single_double_tap in regWAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_mode_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_mode_set(stmdev_ctx_t *ctx,
                               ism303dac_xl_single_double_tap_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_ths_a.single_double_tap = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                           (uint8_t*)&wake_up_ths_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    wake_up_ths_a.single_double_tap = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                              (uint8_t*)&wake_up_ths_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_mode: [get]  Single/double-tap event enable/disable.
+  * @brief  Single/double-tap event enable/disable.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_single_double_tap_t: Get the values of
-  *                                        single_double_tap in
-  *                                        reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of single_double_tap in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_mode_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_mode_get(stmdev_ctx_t *ctx,
                               ism303dac_xl_single_double_tap_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = (ism303dac_xl_single_double_tap_t)reg.wake_up_ths_a.single_double_tap;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
+                           (uint8_t*)&wake_up_ths_a, 1);
 
-  return mm_error;
+  switch (wake_up_ths_a.single_double_tap){
+    case ISM303DAC_XL_ONLY_SINGLE:
+      *val = ISM303DAC_XL_ONLY_SINGLE;
+      break;
+    case ISM303DAC_XL_ONLY_DOUBLE:
+      *val = ISM303DAC_XL_ONLY_DOUBLE;
+      break;
+    default:
+      *val = ISM303DAC_XL_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  tap_src: [get]  TAP source register
+  * @brief  TAP source register[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_tap_src_t: registers TAP_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers TAP_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_tap_src_get(ism303dac_ctx_t *ctx,
-                                ism303dac_tap_src_a_t *val)
+int32_t ism303dac_xl_tap_src_get(stmdev_ctx_t *ctx,
+                                 ism303dac_tap_src_a_t *val)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_TAP_SRC_A, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_TAP_SRC_A, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   Six_position_detection(6D/4D)
+  * @defgroup  ISM303DAC_ Six_position_detection(6D/4D)
   * @brief   This section groups all the functions concerning six
   *          position detection (6D).
   * @{
+  *
   */
 
 /**
-  * @brief  6d_threshold: [set]  Threshold for 4D/6D function.
+  * @brief  Threshold for 4D/6D function.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_6d_ths_t: change the values of 6d_ths in
-  *                                reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of 6d_ths in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_6d_threshold_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_6d_threshold_set(stmdev_ctx_t *ctx,
                                      ism303dac_xl_6d_ths_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
-  reg.tap_6d_ths_a._6d_ths = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                           (uint8_t*)&tap_6d_ths_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    tap_6d_ths_a._6d_ths = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                              (uint8_t*)&tap_6d_ths_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  6d_threshold: [get]  Threshold for 4D/6D function.
+  * @brief  Threshold for 4D/6D function.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_6d_ths_t: Get the values of 6d_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of 6d_ths in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_6d_threshold_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_6d_threshold_get(stmdev_ctx_t *ctx,
                                      ism303dac_xl_6d_ths_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
-  *val = (ism303dac_xl_6d_ths_t) reg.tap_6d_ths_a._6d_ths;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                           (uint8_t*)&tap_6d_ths_a, 1);
 
-  return mm_error;
+  switch (tap_6d_ths_a._6d_ths){
+    case ISM303DAC_XL_DEG_80:
+      *val = ISM303DAC_XL_DEG_80;
+      break;
+    case ISM303DAC_XL_DEG_70:
+      *val = ISM303DAC_XL_DEG_70;
+      break;
+    case ISM303DAC_XL_DEG_60:
+      *val = ISM303DAC_XL_DEG_60;
+      break;
+    case ISM303DAC_XL_DEG_50:
+      *val = ISM303DAC_XL_DEG_50;
+      break;
+    default:
+      *val = ISM303DAC_XL_DEG_80;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  4d_mode: [set]  4D orientation detection enable.
+  * @brief  4D orientation detection enable.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of 4d_en in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of 4d_en in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_4d_mode_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
-  reg.tap_6d_ths_a._4d_en = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                           (uint8_t*)&tap_6d_ths_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    tap_6d_ths_a._4d_en = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                              (uint8_t*)&tap_6d_ths_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  4d_mode: [get]  4D orientation detection enable.
+  * @brief  4D orientation detection enable.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of 4d_en in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of 4d_en in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_4d_mode_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A, &reg.byte, 1);
-  *val = reg.tap_6d_ths_a._4d_en;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_TAP_6D_THS_A,
+                           (uint8_t*)&tap_6d_ths_a, 1);
+  *val = tap_6d_ths_a._4d_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  6d_src: [get]  6D source register.
+  * @brief  6D source register.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_6d_src_t: union of registers from 6D_SRC to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from 6D_SRC to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_6d_src_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_6d_src_get(stmdev_ctx_t *ctx,
                                 ism303dac_6d_src_a_t *val)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_6D_SRC_A, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_6D_SRC_A, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  free_fall
+  * @defgroup  ISM303DAC_free_fall
   * @brief   This section group all the functions concerning the
   *          free fall detection.
   * @{
+  *
   */
 
 /**
-  * @brief  ff_dur: [set]  Free-fall duration [1 LSb = 1 / ODR].
+  * @brief  Free-fall duration [1 LSb = 1 / ODR].[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of ff_dur in reg
-  *                      WAKE_UP_DUR/FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_ff_dur_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg[2];
-  int32_t mm_error;
+  ism303dac_wake_up_dur_a_t wake_up_dur_a;
+  ism303dac_free_fall_a_t free_fall_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
-                                &reg[0].byte, 2);
-  reg[1].free_fall_a.ff_dur = 0x1F & val;
-  reg[0].wake_up_dur_a.ff_dur = (val & 0x20) >> 5;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
-                                 &reg[0].byte, 2);
-
-  return mm_error;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_DUR_A,
+                           (uint8_t*)&wake_up_dur_a, 1);
+  if(ret == 0){
+    wake_up_dur_a.ff_dur = (val & 0x20U) >> 5;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_WAKE_UP_DUR_A,
+                              (uint8_t*)&wake_up_dur_a, 1);
+  }
+  if(ret == 0){
+  	ret = ism303dac_read_reg(ctx, ISM303DAC_FREE_FALL_A,
+                             (uint8_t*)&free_fall_a, 1);
+  }
+  if(ret == 0){
+    free_fall_a.ff_dur = val & 0x1FU;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_FREE_FALL_A,
+                              (uint8_t*)&free_fall_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  ff_dur: [get]  Free-fall duration [1 LSb = 1 / ODR].
+  * @brief  Free-fall duration [1 LSb = 1 / ODR].[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_ff_dur_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg[2];
-  int32_t mm_error;
+  ism303dac_wake_up_dur_a_t wake_up_dur_a;
+  ism303dac_free_fall_a_t free_fall_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_THS_A,
-                                &reg[0].byte, 2);
-  *val = (reg[0].wake_up_dur_a.ff_dur << 5) + reg[1].free_fall_a.ff_dur;
-
-  return mm_error;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_WAKE_UP_DUR_A,
+                           (uint8_t*)&wake_up_dur_a, 1);
+  if(ret == 0){
+    ret = ism303dac_read_reg(ctx, ISM303DAC_FREE_FALL_A,
+                             (uint8_t*)&free_fall_a, 1);
+  }
+  *val = (wake_up_dur_a.ff_dur << 5) + free_fall_a.ff_dur;
+  return ret;
 }
 
 /**
-  * @brief  ff_threshold: [set]  Free-fall threshold [1 LSB = 31.25 mg].
+  * @brief  Free-fall threshold [1 LSB = 31.25 mg].[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of ff_ths in reg FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_ff_threshold_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_ff_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_free_fall_a_t free_fall_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FREE_FALL_A, &reg.byte, 1);
-  reg.free_fall_a.ff_ths = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FREE_FALL_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FREE_FALL_A,
+                           (uint8_t*)&free_fall_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    free_fall_a.ff_ths = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_FREE_FALL_A,
+                              (uint8_t*)&free_fall_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  ff_threshold: [get]  Free-fall threshold [1 LSB = 31.25 mg].
+  * @brief  Free-fall threshold [1 LSB = 31.25 mg].[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ff_ths in reg FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_ths in reg FREE_FALL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_ff_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_ff_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_free_fall_a_t free_fall_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FREE_FALL_A, &reg.byte, 1);
-  *val = reg.free_fall_a.ff_ths;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FREE_FALL_A,
+                           (uint8_t*)&free_fall_a, 1);
+  *val = free_fall_a.ff_ths;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Fifo
+  * @defgroup  ISM303DAC_Fifo
   * @brief   This section group all the functions concerning the fifo usage
   * @{
+  *
   */
 
 /**
-  * @brief   fifo_xl_module_batch: [set]  Module routine result is send to
-  *          FIFO instead of X,Y,Z acceleration data
+  * @brief   Module routine result is send to
+  *          FIFO instead of X,Y,Z acceleration data.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of module_to_fifo in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of module_to_fifo in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_xl_module_batch_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_fifo_xl_module_batch_set(stmdev_ctx_t *ctx,
                                               uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
-  reg.fifo_ctrl_a.module_to_fifo = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                           (uint8_t*)&fifo_ctrl_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    fifo_ctrl_a.module_to_fifo = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                              (uint8_t*)&fifo_ctrl_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief   fifo_xl_module_batch: [get]  Module routine result is send to
-  *                                       FIFO instead of X,Y,Z acceleration
-  *                                       data
+  * @brief   Module routine result is send to FIFO instead of X,Y,Z
+  *          acceleration data[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of module_to_fifo in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of module_to_fifo in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_xl_module_batch_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_fifo_xl_module_batch_get(stmdev_ctx_t *ctx,
                                              uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
-  *val = reg.fifo_ctrl_a.module_to_fifo;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                           (uint8_t*)&fifo_ctrl_a, 1);
+  *val = fifo_ctrl_a.module_to_fifo;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [set]  FIFO mode selection.
+  * @brief  FIFO mode selection.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_fmode_t: change the values of fmode in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of fmode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_mode_set(ism303dac_ctx_t *ctx,
-                                  ism303dac_xl_fmode_t val)
+int32_t ism303dac_xl_fifo_mode_set(stmdev_ctx_t *ctx,
+                                   ism303dac_xl_fmode_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
-  reg.fifo_ctrl_a.fmode = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                           (uint8_t*)&fifo_ctrl_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    fifo_ctrl_a.fmode = (uint8_t)val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                              (uint8_t*)&fifo_ctrl_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [get]  FIFO mode selection.
+  * @brief  FIFO mode selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_fmode_t: Get the values of fmode in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fmode in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_mode_get(ism303dac_ctx_t *ctx,
-                                  ism303dac_xl_fmode_t *val)
+int32_t ism303dac_xl_fifo_mode_get(stmdev_ctx_t *ctx,
+                                   ism303dac_xl_fmode_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A, &reg.byte, 1);
-  *val = (ism303dac_xl_fmode_t) reg.fifo_ctrl_a.fmode;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_CTRL_A,
+                           (uint8_t*)&fifo_ctrl_a, 1);
 
-  return mm_error;
+  switch (fifo_ctrl_a.fmode){
+    case ISM303DAC_XL_BYPASS_MODE:
+      *val = ISM303DAC_XL_BYPASS_MODE;
+      break;
+    case ISM303DAC_XL_FIFO_MODE:
+      *val = ISM303DAC_XL_FIFO_MODE;
+      break;
+    case ISM303DAC_XL_STREAM_TO_FIFO_MODE:
+      *val = ISM303DAC_XL_STREAM_TO_FIFO_MODE;
+      break;
+    case ISM303DAC_XL_BYPASS_TO_STREAM_MODE:
+      *val = ISM303DAC_XL_BYPASS_TO_STREAM_MODE;
+      break;
+    case ISM303DAC_XL_STREAM_MODE:
+      *val = ISM303DAC_XL_STREAM_MODE;
+      break;
+    default:
+      *val = ISM303DAC_XL_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of fifo_watermark in reg FIFO_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_watermark in reg FIFO_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_watermark_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FIFO_THS_A, &val, 1);
+  ret = ism303dac_write_reg(ctx, ISM303DAC_FIFO_THS_A, &val, 1);
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_watermark in reg FIFO_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_watermark in reg FIFO_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_watermark_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_THS_A, val, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_THS_A, val, 1);
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_full_flag: [get]  FIFO full, 256 unread samples.
+  * @brief  FIFO full, 256 unread samples.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of diff in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of diff in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_full_flag_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_src_a_t fifo_src_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, &reg.byte, 1);
-  *val = reg.fifo_src_a.diff;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A,
+                           (uint8_t*)&fifo_src_a, 1);
+  *val = fifo_src_a.diff;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_flag: [get]  FIFO overrun status.
+  * @brief  FIFO overrun status.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_ovr in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_ovr in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_ovr_flag_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_src_a_t fifo_src_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, &reg.byte, 1);
-  *val = reg.fifo_src_a.fifo_ovr;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A,
+                           (uint8_t*)&fifo_src_a, 1);
+  *val = fifo_src_a.fifo_ovr;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_wtm_flag: [get]  FIFO threshold status.
+  * @brief  FIFO threshold status.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fth in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_wtm_flag_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_fifo_src_a_t fifo_src_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, &reg.byte, 1);
-  *val = reg.fifo_src_a.fth;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A,
+                           (uint8_t*)&fifo_src_a, 1);
+  *val = fifo_src_a.fth;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_data_level: [get] The number of unread samples
-  *                                stored in FIFO.
+  * @brief  The number of unread samples stored in FIFO.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint16_t: change the values of diff in reg FIFO_SAMPLES
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of diff in reg FIFO_SAMPLES.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_data_level_get(ism303dac_ctx_t *ctx, uint16_t *val)
+int32_t ism303dac_xl_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
-  ism303dac_reg_t reg[2];
-  int32_t mm_error;
+  ism303dac_fifo_src_a_t       fifo_src_a;
+  ism303dac_fifo_samples_a_t   fifo_samples_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, &reg[0].byte, 2);
-  *val = (reg[1].fifo_src_a.diff << 7) + reg[0].byte;
-
-  return mm_error;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A,
+                           (uint8_t*)&fifo_src_a, 1);
+  if(ret == 0){
+    ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SAMPLES_A,
+                             (uint8_t*)&fifo_samples_a, 1);
+    *val = fifo_src_a.diff;
+    *val = *val << 7;
+    *val += fifo_samples_a.diff;
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_src: [get] FIFO_SRCregister.
+  * @brief  FIFO_SRCregister.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  ism303dac_xl_fifo_src_t: registers FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_fifo_src_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_fifo_src_get(stmdev_ctx_t *ctx,
                                  ism303dac_fifo_src_a_t *val)
 {
-  return ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FIFO_SRC_A, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  module
+  * @defgroup  ISM303DAC_module
   * @brief   This section groups all the functions that manage
   *          module calculation
   * @{
+  *
   */
 
 /**
-  * @brief  module_sens: [set]  Module processing enable.
+  * @brief  Module processing enable.[set]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of module_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of module_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_module_sens_set(ism303dac_ctx_t *ctx, uint8_t val)
+int32_t ism303dac_xl_module_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FUNC_CTRL_A, &reg.byte, 1);
-  reg.func_ctrl_a.module_on = val;
-  mm_error = ism303dac_write_reg(ctx, ISM303DAC_FUNC_CTRL_A, &reg.byte, 1);
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FUNC_CTRL_A,
+                           (uint8_t*)&func_ctrl_a, 1);
+  if(ret == 0){
 
-  return mm_error;
+    func_ctrl_a.module_on = val;
+    ret = ism303dac_write_reg(ctx, ISM303DAC_FUNC_CTRL_A,
+                              (uint8_t*)&func_ctrl_a, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  module_sens: [get]  Module processing enable.
+  * @brief  Module processing enable.[get]
   *
-  * @param  ism303dac_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of module_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of module_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism303dac_xl_module_sens_get(ism303dac_ctx_t *ctx, uint8_t *val)
+int32_t ism303dac_xl_module_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  ism303dac_reg_t reg;
-  int32_t mm_error;
+  ism303dac_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = ism303dac_read_reg(ctx, ISM303DAC_FUNC_CTRL_A, &reg.byte, 1);
-  *val = reg.func_ctrl_a.module_on;
+  ret = ism303dac_read_reg(ctx, ISM303DAC_FUNC_CTRL_A,
+                           (uint8_t*)&func_ctrl_a, 1);
+  *val = func_ctrl_a.module_on;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
   * @}
+  *
   */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism303dac_STdC/driver/ism303dac_reg.h
+++ b/sensor/stmemsc/ism303dac_STdC/driver/ism303dac_reg.h
@@ -1,42 +1,26 @@
 /*
  ******************************************************************************
  * @file    ism303dac_reg.h
- * @author  MEMS Software Solution Team
- * @date    20-December-2017
+ * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
  *          ism303dac_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __ISM303DAC_DRIVER__H
-#define __ISM303DAC_DRIVER__H
+#ifndef ISM303DAC_REGS_H
+#define ISM303DAC_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -51,33 +35,13 @@
   *
   */
 
-/** @defgroup ISM303DAC_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -93,68 +57,84 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
-/** @defgroup ism303dac_interface
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
   * @{
+  *
   */
 
-typedef int32_t (*ism303dac_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*ism303dac_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
-
 typedef struct {
-  /** Component mandatory fields **/
-  ism303dac_write_ptr  write_reg;
-  ism303dac_read_ptr   read_reg;
-  /** Customizable optional pointer **/
-  void *handle;
-} ism303dac_ctx_t;
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
 
 /**
   * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
   */
 
 /** @defgroup ism303dac_Infos
   * @{
+  *
   */
-  /** I2C Device Address 8 bit format **/
-#define ISM303DAC_I2C_ADD_XL     0x3B
-#define ISM303DAC_I2C_ADD_MG       0x3D
+
+/** I2C Device Address 8 bit format **/
+#define ISM303DAC_I2C_ADD_XL       0x3BU
+#define ISM303DAC_I2C_ADD_MG       0x3DU
 
 /** Device Identification (Who am I) **/
-#define ISM303DAC_ID_XL            0x43
-#define ISM303DAC_ID_MG            0x40
+#define ISM303DAC_ID_XL            0x43U
+#define ISM303DAC_ID_MG            0x40U
 
 /**
   * @}
+  *
   */
 
-/**
-  * @defgroup ism303dac_Sensitivity
-  * @{
-  */
-
-#define ISM303DAC_FROM_FS_2g_TO_mg(lsb)    (float)(lsb *  61.0f) / 1000.0f
-#define ISM303DAC_FROM_FS_4g_TO_mg(lsb)    (float)(lsb * 122.0f) / 1000.0f
-#define ISM303DAC_FROM_FS_8g_TO_mg(lsb)    (float)(lsb * 244.0f) / 1000.0f
-#define ISM303DAC_FROM_FS_16g_TO_mg(lsb)   (float)(lsb * 488.0f) / 1000.0f
-
-#define ISM303DAC_FROM_LSB_TO_mG(lsb)      (float)(lsb * 1.5f)
-
-#define ISM303DAC_FROM_LSB_TO_degC(lsb) ((float)((int16_t)lsb>>8)*1.0f + 25.0f)
-
-/**
-  * @}
-  */
-
-#define ISM303DAC_MODULE_8BIT_A           0x0C
-#define ISM303DAC_WHO_AM_I_A              0x0F
-#define ISM303DAC_CTRL1_A                 0x20
+#define ISM303DAC_MODULE_8BIT_A           0x0CU
+#define ISM303DAC_WHO_AM_I_A              0x0FU
+#define ISM303DAC_CTRL1_A                 0x20U
 typedef struct {
   uint8_t bdu                 : 1;
   uint8_t hf_odr              : 1;
@@ -162,7 +142,7 @@ typedef struct {
   uint8_t odr                 : 4;
 } ism303dac_ctrl1_a_t;
 
-#define ISM303DAC_CTRL2_A                 0x21
+#define ISM303DAC_CTRL2_A                 0x21U
 typedef struct {
   uint8_t sim                 : 1;
   uint8_t i2c_disable         : 1;
@@ -173,7 +153,7 @@ typedef struct {
   uint8_t boot                : 1;
 } ism303dac_ctrl2_a_t;
 
-#define ISM303DAC_CTRL3_A                 0x22
+#define ISM303DAC_CTRL3_A                 0x22U
 typedef struct {
   uint8_t pp_od               : 1;
   uint8_t h_lactive           : 1;
@@ -184,7 +164,7 @@ typedef struct {
   uint8_t st                  : 2;
 } ism303dac_ctrl3_a_t;
 
-#define ISM303DAC_CTRL4_A                 0x23
+#define ISM303DAC_CTRL4_A                 0x23U
 typedef struct {
   uint8_t int1_drdy           : 1;
   uint8_t int1_fth            : 1;
@@ -196,7 +176,7 @@ typedef struct {
   uint8_t not_used_01         : 1;
 } ism303dac_ctrl4_a_t;
 
-#define ISM303DAC_CTRL5_A                 0x24
+#define ISM303DAC_CTRL5_A                 0x24U
 typedef struct {
   uint8_t int2_drdy           : 1;
   uint8_t int2_fth            : 1;
@@ -206,7 +186,7 @@ typedef struct {
   uint8_t drdy_pulsed         : 1;
 } ism303dac_ctrl5_a_t;
 
-#define ISM303DAC_FIFO_CTRL_A             0x25
+#define ISM303DAC_FIFO_CTRL_A             0x25U
 typedef struct {
   uint8_t if_cs_pu_dis        : 1;
   uint8_t not_used_01         : 2;
@@ -215,8 +195,8 @@ typedef struct {
   uint8_t fmode               : 3;
 } ism303dac_fifo_ctrl_a_t;
 
-#define ISM303DAC_OUT_T_A                 0x26
-#define ISM303DAC_STATUS_A                0x27
+#define ISM303DAC_OUT_T_A                 0x26U
+#define ISM303DAC_STATUS_A                0x27U
 typedef struct {
   uint8_t drdy                : 1;
   uint8_t ff_ia               : 1;
@@ -228,14 +208,14 @@ typedef struct {
   uint8_t fifo_ths            : 1;
 } ism303dac_status_a_t;
 
-#define ISM303DAC_OUT_X_L_A               0x28
-#define ISM303DAC_OUT_X_H_A               0x29
-#define ISM303DAC_OUT_Y_L_A               0x2A
-#define ISM303DAC_OUT_Y_H_A               0x2B
-#define ISM303DAC_OUT_Z_L_A               0x2C
-#define ISM303DAC_OUT_Z_H_A               0x2D
-#define ISM303DAC_FIFO_THS_A              0x2E
-#define ISM303DAC_FIFO_SRC_A              0x2F
+#define ISM303DAC_OUT_X_L_A               0x28U
+#define ISM303DAC_OUT_X_H_A               0x29U
+#define ISM303DAC_OUT_Y_L_A               0x2AU
+#define ISM303DAC_OUT_Y_H_A               0x2BU
+#define ISM303DAC_OUT_Z_L_A               0x2CU
+#define ISM303DAC_OUT_Z_H_A               0x2DU
+#define ISM303DAC_FIFO_THS_A              0x2EU
+#define ISM303DAC_FIFO_SRC_A              0x2FU
 typedef struct {
   uint8_t not_used_01         : 5;
   uint8_t diff                : 1;
@@ -243,29 +223,33 @@ typedef struct {
   uint8_t fth                 : 1;
 } ism303dac_fifo_src_a_t;
 
-#define ISM303DAC_FIFO_SAMPLES_A          0x30
-#define ISM303DAC_TAP_6D_THS_A            0x31
+#define ISM303DAC_FIFO_SAMPLES_A          0x30U
+typedef struct {
+  uint8_t diff                : 8;
+} ism303dac_fifo_samples_a_t;
+
+#define ISM303DAC_TAP_6D_THS_A            0x31U
 typedef struct {
   uint8_t tap_ths             : 5;
   uint8_t _6d_ths             : 2;
   uint8_t _4d_en              : 1;
 } ism303dac_tap_6d_ths_a_t;
 
-#define ISM303DAC_INT_DUR_A               0x32
+#define ISM303DAC_INT_DUR_A               0x32U
 typedef struct {
   uint8_t shock               : 2;
   uint8_t quiet               : 2;
   uint8_t lat                 : 4;
 } ism303dac_int_dur_a_t;
 
-#define ISM303DAC_WAKE_UP_THS_A           0x33
+#define ISM303DAC_WAKE_UP_THS_A           0x33U
 typedef struct {
   uint8_t wu_ths              : 6;
   uint8_t sleep_on            : 1;
   uint8_t single_double_tap   : 1;
 } ism303dac_wake_up_ths_a_t;
 
-#define ISM303DAC_WAKE_UP_DUR_A           0x34
+#define ISM303DAC_WAKE_UP_DUR_A           0x34U
 typedef struct {
   uint8_t sleep_dur           : 4;
   uint8_t int1_fss7           : 1;
@@ -273,13 +257,13 @@ typedef struct {
   uint8_t ff_dur              : 1;
 } ism303dac_wake_up_dur_a_t;
 
-#define ISM303DAC_FREE_FALL_A             0x35
+#define ISM303DAC_FREE_FALL_A             0x35U
 typedef struct {
   uint8_t ff_ths              : 3;
   uint8_t ff_dur              : 5;
 } ism303dac_free_fall_a_t;
 
-#define ISM303DAC_STATUS_DUP_A            0x36
+#define ISM303DAC_STATUS_DUP_A            0x36U
 typedef struct {
   uint8_t drdy                : 1;
   uint8_t ff_ia               : 1;
@@ -291,7 +275,7 @@ typedef struct {
   uint8_t ovr                 : 1;
 } ism303dac_status_dup_a_t;
 
-#define ISM303DAC_WAKE_UP_SRC_A           0x37
+#define ISM303DAC_WAKE_UP_SRC_A           0x37U
 typedef struct {
   uint8_t z_wu                : 1;
   uint8_t y_wu                : 1;
@@ -302,7 +286,7 @@ typedef struct {
   uint8_t not_used_01         : 2;
 } ism303dac_wake_up_src_a_t;
 
-#define ISM303DAC_TAP_SRC_A               0x38
+#define ISM303DAC_TAP_SRC_A               0x38U
 typedef struct {
   uint8_t z_tap               : 1;
   uint8_t y_tap               : 1;
@@ -314,7 +298,7 @@ typedef struct {
   uint8_t not_used_01         : 1;
 } ism303dac_tap_src_a_t;
 
-#define ISM303DAC_6D_SRC_A                0x39
+#define ISM303DAC_6D_SRC_A                0x39U
 typedef struct {
   uint8_t xl                  : 1;
   uint8_t xh                  : 1;
@@ -326,28 +310,28 @@ typedef struct {
   uint8_t not_used_01         : 1;
 } ism303dac_6d_src_a_t;
 
-#define ISM303DAC_FUNC_SRC_A              0x3E
+#define ISM303DAC_FUNC_SRC_A              0x3EU
 typedef struct {
   uint8_t not_used_01         : 1;
   uint8_t module_ready        : 1;
   uint8_t not_used_02         : 6;
 } ism303dac_func_src_a_t;
 
-#define ISM303DAC_FUNC_CTRL_A             0x3F
+#define ISM303DAC_FUNC_CTRL_A             0x3FU
 typedef struct {
   uint8_t not_used_01         : 5;
   uint8_t module_on           : 1;
   uint8_t not_used_02         : 2;
 } ism303dac_func_ctrl_a_t;
 
-#define ISM303DAC_OFFSET_X_REG_L_M          0x45
-#define ISM303DAC_OFFSET_X_REG_H_M          0x46
-#define ISM303DAC_OFFSET_Y_REG_L_M          0x47
-#define ISM303DAC_OFFSET_Y_REG_H_M          0x48
-#define ISM303DAC_OFFSET_Z_REG_L_M          0x49
-#define ISM303DAC_OFFSET_Z_REG_H_M          0x4A
-#define ISM303DAC_WHO_AM_I_M                0x4F
-#define ISM303DAC_CFG_REG_A_M               0x60
+#define ISM303DAC_OFFSET_X_REG_L_M          0x45U
+#define ISM303DAC_OFFSET_X_REG_H_M          0x46U
+#define ISM303DAC_OFFSET_Y_REG_L_M          0x47U
+#define ISM303DAC_OFFSET_Y_REG_H_M          0x48U
+#define ISM303DAC_OFFSET_Z_REG_L_M          0x49U
+#define ISM303DAC_OFFSET_Z_REG_H_M          0x4AU
+#define ISM303DAC_WHO_AM_I_M                0x4FU
+#define ISM303DAC_CFG_REG_A_M               0x60U
 typedef struct {
   uint8_t md                     : 2;
   uint8_t odr                    : 2;
@@ -357,7 +341,7 @@ typedef struct {
   uint8_t comp_temp_en           : 1;
 } ism303dac_cfg_reg_a_m_t;
 
-#define ISM303DAC_CFG_REG_B_M               0x61
+#define ISM303DAC_CFG_REG_B_M               0x61U
 typedef struct {
   uint8_t lpf                    : 1;
   uint8_t set_rst                : 2; /* off_canc + set_freq */
@@ -366,7 +350,7 @@ typedef struct {
   uint8_t not_used_01            : 3;
 } ism303dac_cfg_reg_b_m_t;
 
-#define ISM303DAC_CFG_REG_C_M               0x62
+#define ISM303DAC_CFG_REG_C_M               0x62U
 typedef struct {
   uint8_t int_mag                : 1;
   uint8_t self_test              : 1;
@@ -378,7 +362,7 @@ typedef struct {
   uint8_t not_used_02            : 1;
 } ism303dac_cfg_reg_c_m_t;
 
-#define ISM303DAC_INT_CRTL_REG_M            0x63
+#define ISM303DAC_INT_CRTL_REG_M            0x63U
 typedef struct {
   uint8_t ien                    : 1;
   uint8_t iel                    : 1;
@@ -389,7 +373,7 @@ typedef struct {
   uint8_t xien                   : 1;
 } ism303dac_int_crtl_reg_m_t;
 
-#define ISM303DAC_INT_SOURCE_REG_M          0x64
+#define ISM303DAC_INT_SOURCE_REG_M          0x64U
 typedef struct {
   uint8_t _int                    : 1;
   uint8_t mroi                   : 1;
@@ -401,9 +385,9 @@ typedef struct {
   uint8_t p_th_s_x               : 1;
 } ism303dac_int_source_reg_m_t;
 
-#define ISM303DAC_INT_THS_L_REG_M           0x65
-#define ISM303DAC_INT_THS_H_REG_M           0x66
-#define ISM303DAC_STATUS_REG_M              0x67
+#define ISM303DAC_INT_THS_L_REG_M           0x65U
+#define ISM303DAC_INT_THS_H_REG_M           0x66U
+#define ISM303DAC_STATUS_REG_M              0x67U
 typedef struct {
   uint8_t xda                    : 1;
   uint8_t yda                    : 1;
@@ -415,13 +399,25 @@ typedef struct {
   uint8_t zyxor                  : 1;
 } ism303dac_status_reg_m_t;
 
-#define ISM303DAC_OUTX_L_REG_M              0x68
-#define ISM303DAC_OUTX_H_REG_M              0x69
-#define ISM303DAC_OUTY_L_REG_M              0x6A
-#define ISM303DAC_OUTY_H_REG_M              0x6B
-#define ISM303DAC_OUTZ_L_REG_M              0x6C
-#define ISM303DAC_OUTZ_H_REG_M              0x6D
+#define ISM303DAC_OUTX_L_REG_M              0x68U
+#define ISM303DAC_OUTX_H_REG_M              0x69U
+#define ISM303DAC_OUTY_L_REG_M              0x6AU
+#define ISM303DAC_OUTY_H_REG_M              0x6BU
+#define ISM303DAC_OUTZ_L_REG_M              0x6CU
+#define ISM303DAC_OUTZ_H_REG_M              0x6DU
 
+/**
+  * @defgroup ISM303DAC_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
 typedef union{
   ism303dac_ctrl1_a_t                      ctrl1_a;
   ism303dac_ctrl2_a_t                      ctrl2_a;
@@ -431,6 +427,7 @@ typedef union{
   ism303dac_fifo_ctrl_a_t                  fifo_ctrl_a;
   ism303dac_status_a_t                     status_a;
   ism303dac_fifo_src_a_t                   fifo_src_a;
+  ism303dac_fifo_samples_a_t               fifo_samples_a;
   ism303dac_tap_6d_ths_a_t                 tap_6d_ths_a;
   ism303dac_int_dur_a_t                    int_dur_a;
   ism303dac_wake_up_ths_a_t                wake_up_ths_a;
@@ -448,58 +445,69 @@ typedef union{
   ism303dac_int_crtl_reg_m_t               int_crtl_reg_m;
   ism303dac_int_source_reg_m_t             int_source_reg_m;
   ism303dac_status_reg_m_t                 status_reg_m;
-  bitwise_t                               bitwise;
-  uint8_t                                 byte;
+  bitwise_t                                bitwise;
+  uint8_t                                  byte;
 } ism303dac_reg_t;
-int32_t ism303dac_read_reg(ism303dac_ctx_t *ctx, uint8_t reg, uint8_t* data,
-                          uint16_t len);
-int32_t ism303dac_write_reg(ism303dac_ctx_t *ctx, uint8_t reg, uint8_t* data,
-                           uint16_t len);
 
-typedef union {
-  struct {
+/**
+  * @}
+  *
+  */
+
+int32_t ism303dac_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+int32_t ism303dac_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len);
+
+extern float_t ism303dac_from_fs2g_to_mg(int16_t lsb);
+extern float_t ism303dac_from_fs4g_to_mg(int16_t lsb);
+extern float_t ism303dac_from_fs8g_to_mg(int16_t lsb);
+extern float_t ism303dac_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t ism303dac_from_lsb_to_mG(int16_t lsb);
+
+extern float_t ism303dac_from_lsb_to_celsius(int16_t lsb);
+
+typedef struct {
   ism303dac_fifo_src_a_t       fifo_src_a;
   ism303dac_status_dup_a_t     status_dup_a;
   ism303dac_wake_up_src_a_t    wake_up_src_a;
   ism303dac_tap_src_a_t        tap_src_a;
   ism303dac_6d_src_a_t         _6d_src_a;
   ism303dac_func_src_a_t       func_src_a;
-  } reg;
-  uint8_t byte[6];
 } ism303dac_xl_all_sources_t;
-int32_t ism303dac_xl_all_sources_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_all_sources_t *val);
+int32_t ism303dac_xl_all_sources_get(stmdev_ctx_t *ctx,
+                                     ism303dac_xl_all_sources_t *val);
 
-
-int32_t ism303dac_xl_block_data_update_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_block_data_update_set(stmdev_ctx_t *ctx,
                                            uint8_t val);
-int32_t ism303dac_xl_block_data_update_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_block_data_update_get(stmdev_ctx_t *ctx,
                                            uint8_t *val);
 
-int32_t ism303dac_mg_block_data_update_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_block_data_update_set(stmdev_ctx_t *ctx,
                                            uint8_t val);
-int32_t ism303dac_mg_block_data_update_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_block_data_update_get(stmdev_ctx_t *ctx,
                                            uint8_t *val);
 
 typedef enum {
   ISM303DAC_MG_LSB_AT_LOW_ADD  = 0,
   ISM303DAC_MG_MSB_AT_LOW_ADD  = 1,
 } ism303dac_mg_ble_t;
-int32_t ism303dac_mg_data_format_set(ism303dac_ctx_t *ctx,
-                                    ism303dac_mg_ble_t val);
-int32_t ism303dac_mg_data_format_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_mg_ble_t *val);
+int32_t ism303dac_mg_data_format_set(stmdev_ctx_t *ctx,
+                                     ism303dac_mg_ble_t val);
+int32_t ism303dac_mg_data_format_get(stmdev_ctx_t *ctx,
+                                     ism303dac_mg_ble_t *val);
 
 typedef enum {
-  ISM303DAC_XL_2g = 0,
+  ISM303DAC_XL_2g  = 0,
   ISM303DAC_XL_16g = 1,
-  ISM303DAC_XL_4g = 2,
-  ISM303DAC_XL_8g = 3,
+  ISM303DAC_XL_4g  = 2,
+  ISM303DAC_XL_8g  = 3,
 } ism303dac_xl_fs_t;
-int32_t ism303dac_xl_full_scale_set(ism303dac_ctx_t *ctx,
-                                   ism303dac_xl_fs_t val);
-int32_t ism303dac_xl_full_scale_get(ism303dac_ctx_t *ctx,
-                                   ism303dac_xl_fs_t *val);
+int32_t ism303dac_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                    ism303dac_xl_fs_t val);
+int32_t ism303dac_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                    ism303dac_xl_fs_t *val);
 
 typedef enum {
   ISM303DAC_XL_ODR_OFF         = 0x00,
@@ -522,34 +530,34 @@ typedef enum {
   ISM303DAC_XL_ODR_3k2Hz_HF    = 0x16,
   ISM303DAC_XL_ODR_6k4Hz_HF    = 0x17,
 } ism303dac_xl_odr_t;
-int32_t ism303dac_xl_data_rate_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_data_rate_set(stmdev_ctx_t *ctx,
                                    ism303dac_xl_odr_t val);
-int32_t ism303dac_xl_data_rate_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_data_rate_get(stmdev_ctx_t *ctx,
                                    ism303dac_xl_odr_t *val);
 
-int32_t ism303dac_xl_status_reg_get(ism303dac_ctx_t *ctx,
-                                   ism303dac_status_a_t *val);
+int32_t ism303dac_xl_status_reg_get(stmdev_ctx_t *ctx,
+                                    ism303dac_status_a_t *val);
 
-int32_t ism303dac_mg_status_get(ism303dac_ctx_t *ctx,
-                               ism303dac_status_reg_m_t *val);
+int32_t ism303dac_mg_status_get(stmdev_ctx_t *ctx,
+                                ism303dac_status_reg_m_t *val);
 
-int32_t ism303dac_xl_flag_data_ready_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_mg_data_ready_get(ism303dac_ctx_t *ctx, uint8_t *val);
-int32_t ism303dac_mg_data_ovr_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_mg_user_offset_set(ism303dac_ctx_t *ctx, uint8_t *buff);
-int32_t ism303dac_mg_user_offset_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+int32_t ism303dac_mg_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism303dac_mg_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   ISM303DAC_MG_CONTINUOUS_MODE  = 0,
   ISM303DAC_MG_SINGLE_TRIGGER   = 1,
   ISM303DAC_MG_POWER_DOWN       = 2,
 } ism303dac_mg_md_t;
-int32_t ism303dac_mg_operating_mode_set(ism303dac_ctx_t *ctx,
-                                       ism303dac_mg_md_t val);
-int32_t ism303dac_mg_operating_mode_get(ism303dac_ctx_t *ctx,
-                                       ism303dac_mg_md_t *val);
+int32_t ism303dac_mg_operating_mode_set(stmdev_ctx_t *ctx,
+                                        ism303dac_mg_md_t val);
+int32_t ism303dac_mg_operating_mode_get(stmdev_ctx_t *ctx,
+                                        ism303dac_mg_md_t *val);
 
 typedef enum {
   ISM303DAC_MG_ODR_10Hz   = 0,
@@ -557,169 +565,169 @@ typedef enum {
   ISM303DAC_MG_ODR_50Hz   = 2,
   ISM303DAC_MG_ODR_100Hz  = 3,
 } ism303dac_mg_odr_t;
-int32_t ism303dac_mg_data_rate_set(ism303dac_ctx_t *ctx,
-                                  ism303dac_mg_odr_t val);
-int32_t ism303dac_mg_data_rate_get(ism303dac_ctx_t *ctx,
-                                  ism303dac_mg_odr_t *val);
+int32_t ism303dac_mg_data_rate_set(stmdev_ctx_t *ctx,
+                                   ism303dac_mg_odr_t val);
+int32_t ism303dac_mg_data_rate_get(stmdev_ctx_t *ctx,
+                                   ism303dac_mg_odr_t *val);
 
 typedef enum {
   ISM303DAC_MG_HIGH_RESOLUTION  = 0,
   ISM303DAC_MG_LOW_POWER        = 1,
 } ism303dac_mg_lp_t;
-int32_t ism303dac_mg_power_mode_set(ism303dac_ctx_t *ctx,
-                                   ism303dac_mg_lp_t val);
-int32_t ism303dac_mg_power_mode_get(ism303dac_ctx_t *ctx,
-                                   ism303dac_mg_lp_t *val);
+int32_t ism303dac_mg_power_mode_set(stmdev_ctx_t *ctx,
+                                    ism303dac_mg_lp_t val);
+int32_t ism303dac_mg_power_mode_get(stmdev_ctx_t *ctx,
+                                    ism303dac_mg_lp_t *val);
 
-int32_t ism303dac_mg_offset_temp_comp_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_mg_offset_temp_comp_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM303DAC_MG_SET_SENS_ODR_DIV_63        = 0,
   ISM303DAC_MG_SENS_OFF_CANC_EVERY_ODR    = 1,
   ISM303DAC_MG_SET_SENS_ONLY_AT_POWER_ON  = 2,
 } ism303dac_mg_set_rst_t;
-int32_t ism303dac_mg_set_rst_mode_set(ism303dac_ctx_t *ctx,
-                                 ism303dac_mg_set_rst_t val);
-int32_t ism303dac_mg_set_rst_mode_get(ism303dac_ctx_t *ctx,
-                                 ism303dac_mg_set_rst_t *val);
+int32_t ism303dac_mg_set_rst_mode_set(stmdev_ctx_t *ctx,
+                                      ism303dac_mg_set_rst_t val);
+int32_t ism303dac_mg_set_rst_mode_get(stmdev_ctx_t *ctx,
+                                      ism303dac_mg_set_rst_t *val);
 
-int32_t ism303dac_mg_set_rst_sensor_single_set(ism303dac_ctx_t *ctx,
-                                          uint8_t val);
-int32_t ism303dac_mg_set_rst_sensor_single_get(ism303dac_ctx_t *ctx,
-                                          uint8_t *val);
+int32_t ism303dac_mg_set_rst_sensor_single_set(stmdev_ctx_t *ctx,
+                                               uint8_t val);
+int32_t ism303dac_mg_set_rst_sensor_single_get(stmdev_ctx_t *ctx,
+                                               uint8_t *val);
 
-int32_t ism303dac_acceleration_module_raw_get(ism303dac_ctx_t *ctx,
-                                             uint8_t *buff);
+int32_t ism303dac_acceleration_module_raw_get(stmdev_ctx_t *ctx,
+                                              uint8_t *buff);
 
-int32_t ism303dac_magnetic_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+int32_t ism303dac_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism303dac_xl_temperature_raw_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_temperature_raw_get(stmdev_ctx_t *ctx,
                                          uint8_t *buff);
 
-int32_t ism303dac_acceleration_raw_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+int32_t ism303dac_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism303dac_xl_device_id_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+int32_t ism303dac_xl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism303dac_mg_device_id_get(ism303dac_ctx_t *ctx, uint8_t *buff);
+int32_t ism303dac_mg_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism303dac_xl_auto_increment_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_auto_increment_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_reset_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_reset_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_mg_reset_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_mg_reset_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_boot_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_boot_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_mg_boot_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_mg_boot_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM303DAC_XL_ST_DISABLE     = 0,
   ISM303DAC_XL_ST_POSITIVE    = 1,
   ISM303DAC_XL_ST_NEGATIVE    = 2,
 } ism303dac_xl_st_t;
-int32_t ism303dac_xl_self_test_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_self_test_set(stmdev_ctx_t *ctx,
                                    ism303dac_xl_st_t val);
-int32_t ism303dac_xl_self_test_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_self_test_get(stmdev_ctx_t *ctx,
                                    ism303dac_xl_st_t *val);
 
-int32_t ism303dac_mg_self_test_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_mg_self_test_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_self_test_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_self_test_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM303DAC_XL_DRDY_LATCHED   = 0,
   ISM303DAC_XL_DRDY_PULSED    = 1,
 } ism303dac_xl_drdy_pulsed_t;
-int32_t ism303dac_xl_data_ready_mode_set(ism303dac_ctx_t *ctx,
-                                     ism303dac_xl_drdy_pulsed_t val);
-int32_t ism303dac_xl_data_ready_mode_get(ism303dac_ctx_t *ctx,
-                                     ism303dac_xl_drdy_pulsed_t *val);
+int32_t ism303dac_xl_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                         ism303dac_xl_drdy_pulsed_t val);
+int32_t ism303dac_xl_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                         ism303dac_xl_drdy_pulsed_t *val);
 
 typedef enum {
   ISM303DAC_XL_HP_INTERNAL_ONLY  = 0,
   ISM303DAC_XL_HP_ON_OUTPUTS     = 1,
 } ism303dac_xl_fds_slope_t;
-int32_t ism303dac_xl_hp_path_set(ism303dac_ctx_t *ctx,
-                                ism303dac_xl_fds_slope_t val);
-int32_t ism303dac_xl_hp_path_get(ism303dac_ctx_t *ctx,
-                                ism303dac_xl_fds_slope_t *val);
+int32_t ism303dac_xl_hp_path_set(stmdev_ctx_t *ctx,
+                                 ism303dac_xl_fds_slope_t val);
+int32_t ism303dac_xl_hp_path_get(stmdev_ctx_t *ctx,
+                                 ism303dac_xl_fds_slope_t *val);
 
 typedef enum {
   ISM303DAC_MG_ODR_DIV_2  = 0,
   ISM303DAC_MG_ODR_DIV_4  = 1,
 } ism303dac_mg_lpf_t;
-int32_t ism303dac_mg_low_pass_bandwidth_set(ism303dac_ctx_t *ctx,
-                                       ism303dac_mg_lpf_t val);
-int32_t ism303dac_mg_low_pass_bandwidth_get(ism303dac_ctx_t *ctx,
-                                       ism303dac_mg_lpf_t *val);
+int32_t ism303dac_mg_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
+                                            ism303dac_mg_lpf_t val);
+int32_t ism303dac_mg_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
+                                            ism303dac_mg_lpf_t *val);
 
 typedef enum {
   ISM303DAC_XL_SPI_4_WIRE   = 0,
   ISM303DAC_XL_SPI_3_WIRE   = 1,
 } ism303dac_xl_sim_t;
-int32_t ism303dac_xl_spi_mode_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_spi_mode_set(stmdev_ctx_t *ctx,
                                   ism303dac_xl_sim_t val);
-int32_t ism303dac_xl_spi_mode_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_spi_mode_get(stmdev_ctx_t *ctx,
                                   ism303dac_xl_sim_t *val);
 
 typedef enum {
   ISM303DAC_XL_I2C_ENABLE   = 0,
   ISM303DAC_XL_I2C_DISABLE  = 1,
 } ism303dac_xl_i2c_disable_t;
-int32_t ism303dac_xl_i2c_interface_set(ism303dac_ctx_t *ctx,
-                                   ism303dac_xl_i2c_disable_t val);
-int32_t ism303dac_xl_i2c_interface_get(ism303dac_ctx_t *ctx,
-                                   ism303dac_xl_i2c_disable_t *val);
+int32_t ism303dac_xl_i2c_interface_set(stmdev_ctx_t *ctx,
+                                       ism303dac_xl_i2c_disable_t val);
+int32_t ism303dac_xl_i2c_interface_get(stmdev_ctx_t *ctx,
+                                       ism303dac_xl_i2c_disable_t *val);
 
 typedef enum {
   ISM303DAC_MG_I2C_ENABLE   = 0,
   ISM303DAC_MG_I2C_DISABLE  = 1,
 } ism303dac_mg_i2c_dis_t;
-int32_t ism303dac_mg_i2c_interface_set(ism303dac_ctx_t *ctx,
-                                  ism303dac_mg_i2c_dis_t val);
-int32_t ism303dac_mg_i2c_interface_get(ism303dac_ctx_t *ctx,
-                                  ism303dac_mg_i2c_dis_t *val);
+int32_t ism303dac_mg_i2c_interface_set(stmdev_ctx_t *ctx,
+                                       ism303dac_mg_i2c_dis_t val);
+int32_t ism303dac_mg_i2c_interface_get(stmdev_ctx_t *ctx,
+                                       ism303dac_mg_i2c_dis_t *val);
 
 typedef enum {
   ISM303DAC_XL_PULL_UP_CONNECTED     = 0,
   ISM303DAC_XL_PULL_UP_DISCONNECTED  = 1,
 } ism303dac_xl_if_cs_pu_dis_t;
-int32_t ism303dac_xl_cs_mode_set(ism303dac_ctx_t *ctx,
-                             ism303dac_xl_if_cs_pu_dis_t val);
-int32_t ism303dac_xl_cs_mode_get(ism303dac_ctx_t *ctx,
-                             ism303dac_xl_if_cs_pu_dis_t *val);
+int32_t ism303dac_xl_cs_mode_set(stmdev_ctx_t *ctx,
+                                 ism303dac_xl_if_cs_pu_dis_t val);
+int32_t ism303dac_xl_cs_mode_get(stmdev_ctx_t *ctx,
+                                 ism303dac_xl_if_cs_pu_dis_t *val);
 
 typedef enum {
   ISM303DAC_XL_PUSH_PULL   = 0,
   ISM303DAC_XL_OPEN_DRAIN  = 1,
 } ism303dac_xl_pp_od_t;
-int32_t ism303dac_xl_pin_mode_set(ism303dac_ctx_t *ctx,
-                                 ism303dac_xl_pp_od_t val);
-int32_t ism303dac_xl_pin_mode_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_pin_mode_set(stmdev_ctx_t *ctx,
+                                  ism303dac_xl_pp_od_t val);
+int32_t ism303dac_xl_pin_mode_get(stmdev_ctx_t *ctx,
                                  ism303dac_xl_pp_od_t *val);
 
 typedef enum {
   ISM303DAC_XL_ACTIVE_HIGH  = 0,
   ISM303DAC_XL_ACTIVE_LOW   = 1,
 } ism303dac_xl_h_lactive_t;
-int32_t ism303dac_xl_pin_polarity_set(ism303dac_ctx_t *ctx,
-                                  ism303dac_xl_h_lactive_t val);
-int32_t ism303dac_xl_pin_polarity_get(ism303dac_ctx_t *ctx,
-                                  ism303dac_xl_h_lactive_t *val);
+int32_t ism303dac_xl_pin_polarity_set(stmdev_ctx_t *ctx,
+                                      ism303dac_xl_h_lactive_t val);
+int32_t ism303dac_xl_pin_polarity_get(stmdev_ctx_t *ctx,
+                                      ism303dac_xl_h_lactive_t *val);
 
 typedef enum {
   ISM303DAC_XL_INT_PULSED   = 0,
   ISM303DAC_XL_INT_LATCHED  = 1,
 } ism303dac_xl_lir_t;
-int32_t ism303dac_xl_int_notification_set(ism303dac_ctx_t *ctx,
-                                      ism303dac_xl_lir_t val);
-int32_t ism303dac_xl_int_notification_get(ism303dac_ctx_t *ctx,
-                                      ism303dac_xl_lir_t *val);
+int32_t ism303dac_xl_int_notification_set(stmdev_ctx_t *ctx,
+                                          ism303dac_xl_lir_t val);
+int32_t ism303dac_xl_int_notification_get(stmdev_ctx_t *ctx,
+                                          ism303dac_xl_lir_t *val);
 
 typedef struct{
   uint8_t int1_drdy               : 1;
@@ -731,101 +739,101 @@ typedef struct{
   uint8_t int1_s_tap              : 1;
   uint8_t int1_fss7               : 1;
 } ism303dac_xl_pin_int1_route_t;
-int32_t ism303dac_xl_pin_int1_route_set(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_pin_int1_route_t val);
-int32_t ism303dac_xl_pin_int1_route_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_pin_int1_route_t *val);
+int32_t ism303dac_xl_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                        ism303dac_xl_pin_int1_route_t val);
+int32_t ism303dac_xl_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                        ism303dac_xl_pin_int1_route_t *val);
 
 typedef struct{
   uint8_t int2_boot               : 1;
   uint8_t int2_fth                : 1;
   uint8_t int2_drdy               : 1;
 } ism303dac_xl_pin_int2_route_t;
-int32_t ism303dac_xl_pin_int2_route_set(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_pin_int2_route_t val);
-int32_t ism303dac_xl_pin_int2_route_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_xl_pin_int2_route_t *val);
+int32_t ism303dac_xl_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                        ism303dac_xl_pin_int2_route_t val);
+int32_t ism303dac_xl_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                        ism303dac_xl_pin_int2_route_t *val);
 
-int32_t ism303dac_xl_all_on_int1_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_all_on_int1_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_mg_drdy_on_pin_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_mg_drdy_on_pin_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_mg_int_on_pin_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_mg_int_on_pin_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_mg_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_mg_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_mg_int_gen_conf_set(ism303dac_ctx_t *ctx,
-                                 ism303dac_int_crtl_reg_m_t *val);
-int32_t ism303dac_mg_int_gen_conf_get(ism303dac_ctx_t *ctx,
-                                 ism303dac_int_crtl_reg_m_t *val);
+int32_t ism303dac_mg_int_gen_conf_set(stmdev_ctx_t *ctx,
+                                      ism303dac_int_crtl_reg_m_t *val);
+int32_t ism303dac_mg_int_gen_conf_get(stmdev_ctx_t *ctx,
+                                      ism303dac_int_crtl_reg_m_t *val);
 
-int32_t ism303dac_mg_int_gen_source_get(ism303dac_ctx_t *ctx,
-                                   ism303dac_int_source_reg_m_t *val);
+int32_t ism303dac_mg_int_gen_source_get(stmdev_ctx_t *ctx,
+                                        ism303dac_int_source_reg_m_t *val);
 
-int32_t ism303dac_mg_int_gen_treshold_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_int_gen_treshold_set(stmdev_ctx_t *ctx,
                                           uint8_t *buff);
-int32_t ism303dac_mg_int_gen_treshold_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_mg_int_gen_treshold_get(stmdev_ctx_t *ctx,
                                           uint8_t *buff);
 
 typedef enum {
   ISM303DAC_MG_CHECK_BEFORE  = 0,
   ISM303DAC_MG_CHECK_AFTER   = 1,
 } ism303dac_mg_int_on_dataoff_t;
-int32_t ism303dac_mg_offset_int_conf_set(ism303dac_ctx_t *ctx,
-                                    ism303dac_mg_int_on_dataoff_t val);
-int32_t ism303dac_mg_offset_int_conf_get(ism303dac_ctx_t *ctx,
-                                    ism303dac_mg_int_on_dataoff_t *val);
+int32_t ism303dac_mg_offset_int_conf_set(stmdev_ctx_t *ctx,
+                                         ism303dac_mg_int_on_dataoff_t val);
+int32_t ism303dac_mg_offset_int_conf_get(stmdev_ctx_t *ctx,
+                                         ism303dac_mg_int_on_dataoff_t *val);
 
-int32_t ism303dac_xl_wkup_threshold_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_wkup_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_wkup_dur_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_wkup_dur_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_sleep_mode_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_sleep_mode_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_act_sleep_dur_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_act_sleep_dur_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_tap_detection_on_z_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_z_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t ism303dac_xl_tap_detection_on_z_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_z_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
-int32_t ism303dac_xl_tap_detection_on_y_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_y_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t ism303dac_xl_tap_detection_on_y_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_y_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
-int32_t ism303dac_xl_tap_detection_on_x_set(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_x_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t ism303dac_xl_tap_detection_on_x_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_detection_on_x_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
-int32_t ism303dac_xl_tap_threshold_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_tap_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_tap_shock_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_tap_shock_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_tap_quiet_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_tap_quiet_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_tap_dur_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_tap_dur_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM303DAC_XL_ONLY_SINGLE  = 0,
   ISM303DAC_XL_ONLY_DOUBLE  = 1,
 } ism303dac_xl_single_double_tap_t;
-int32_t ism303dac_xl_tap_mode_set(ism303dac_ctx_t *ctx,
-                              ism303dac_xl_single_double_tap_t val);
-int32_t ism303dac_xl_tap_mode_get(ism303dac_ctx_t *ctx,
-                              ism303dac_xl_single_double_tap_t *val);
+int32_t ism303dac_xl_tap_mode_set(stmdev_ctx_t *ctx,
+                                  ism303dac_xl_single_double_tap_t val);
+int32_t ism303dac_xl_tap_mode_get(stmdev_ctx_t *ctx,
+                                  ism303dac_xl_single_double_tap_t *val);
 
-int32_t ism303dac_xl_tap_src_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_tap_src_get(stmdev_ctx_t *ctx,
                                 ism303dac_tap_src_a_t *val);
 
 typedef enum {
@@ -834,27 +842,27 @@ typedef enum {
   ISM303DAC_XL_DEG_60   = 2,
   ISM303DAC_XL_DEG_50   = 3,
 } ism303dac_xl_6d_ths_t;
-int32_t ism303dac_xl_6d_threshold_set(ism303dac_ctx_t *ctx,
-                                     ism303dac_xl_6d_ths_t val);
-int32_t ism303dac_xl_6d_threshold_get(ism303dac_ctx_t *ctx,
-                                     ism303dac_xl_6d_ths_t *val);
+int32_t ism303dac_xl_6d_threshold_set(stmdev_ctx_t *ctx,
+                                      ism303dac_xl_6d_ths_t val);
+int32_t ism303dac_xl_6d_threshold_get(stmdev_ctx_t *ctx,
+                                      ism303dac_xl_6d_ths_t *val);
 
-int32_t ism303dac_xl_4d_mode_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_4d_mode_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_6d_src_get(ism303dac_ctx_t *ctx,
+int32_t ism303dac_xl_6d_src_get(stmdev_ctx_t *ctx,
                                 ism303dac_6d_src_a_t *val);
 
-int32_t ism303dac_xl_ff_dur_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_ff_dur_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_ff_threshold_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_ff_threshold_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_ff_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_ff_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_fifo_xl_module_batch_set(ism303dac_ctx_t *ctx,
-                                             uint8_t val);
-int32_t ism303dac_xl_fifo_xl_module_batch_get(ism303dac_ctx_t *ctx,
-                                             uint8_t *val);
+int32_t ism303dac_xl_fifo_xl_module_batch_set(stmdev_ctx_t *ctx,
+                                              uint8_t val);
+int32_t ism303dac_xl_fifo_xl_module_batch_get(stmdev_ctx_t *ctx,
+                                              uint8_t *val);
 
 typedef enum {
   ISM303DAC_XL_BYPASS_MODE            = 0,
@@ -863,36 +871,42 @@ typedef enum {
   ISM303DAC_XL_BYPASS_TO_STREAM_MODE  = 4,
   ISM303DAC_XL_STREAM_MODE            = 6,
 } ism303dac_xl_fmode_t;
-int32_t ism303dac_xl_fifo_mode_set(ism303dac_ctx_t *ctx,
-                                  ism303dac_xl_fmode_t val);
-int32_t ism303dac_xl_fifo_mode_get(ism303dac_ctx_t *ctx,
-                                  ism303dac_xl_fmode_t *val);
+int32_t ism303dac_xl_fifo_mode_set(stmdev_ctx_t *ctx,
+                                   ism303dac_xl_fmode_t val);
+int32_t ism303dac_xl_fifo_mode_get(stmdev_ctx_t *ctx,
+                                   ism303dac_xl_fmode_t *val);
 
-int32_t ism303dac_xl_fifo_watermark_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_fifo_watermark_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_fifo_full_flag_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_fifo_ovr_flag_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_fifo_wtm_flag_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism303dac_xl_fifo_data_level_get(ism303dac_ctx_t *ctx, uint16_t *val);
+int32_t ism303dac_xl_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t ism303dac_xl_fifo_src_get(ism303dac_ctx_t *ctx,
-                                 ism303dac_fifo_src_a_t *val);
+int32_t ism303dac_xl_fifo_src_get(stmdev_ctx_t *ctx,
+                                  ism303dac_fifo_src_a_t *val);
 
-int32_t ism303dac_xl_module_sens_set(ism303dac_ctx_t *ctx, uint8_t val);
-int32_t ism303dac_xl_module_sens_get(ism303dac_ctx_t *ctx, uint8_t *val);
+int32_t ism303dac_xl_module_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism303dac_xl_module_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}
+  *
+  */
+
+/**
+  *@}
+  *
   */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /*__ISM303DAC_DRIVER__H */
+#endif /* ISM303DAC_REGS_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.c
+++ b/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.c
@@ -1,0 +1,9845 @@
+/*
+ ******************************************************************************
+ * @file    ism330dhcx_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   ISM330DHCX driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "ism330dhcx_reg.h"
+
+/**
+  * @defgroup    ISM330DHCX
+  * @brief       This file provides a set of functions needed to drive the
+  *              ism330dhcx enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    ISM330DHCX_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ism330dhcx_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t ism330dhcx_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                             uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    ISM330DHCX_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t ism330dhcx_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t ism330dhcx_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t ism330dhcx_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t ism330dhcx_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t ism330dhcx_from_fs125dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 4.375f);
+}
+
+float_t ism330dhcx_from_fs250dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 8.75f);
+}
+
+float_t ism330dhcx_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 17.50f);
+}
+
+float_t ism330dhcx_from_fs1000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 35.0f);
+}
+
+float_t ism330dhcx_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t ism330dhcx_from_fs4000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 140.0f);
+}
+
+float_t ism330dhcx_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+float_t ism330dhcx_from_lsb_to_nsec(int32_t lsb)
+{
+  return ((float_t)lsb * 25000.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM9DS1_Data_generation
+  * @brief      This section groups all the functions concerning data
+  *             generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer full-scale selection[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_fs_xl_t val)
+{
+  ism330dhcx_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL1_XL,
+                               (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_fs_xl_t *val)
+{
+  ism330dhcx_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.fs_xl){
+    case ISM330DHCX_2g:
+      *val = ISM330DHCX_2g;
+      break;
+    case ISM330DHCX_16g:
+      *val = ISM330DHCX_16g;
+      break;
+    case ISM330DHCX_4g:
+      *val = ISM330DHCX_4g;
+      break;
+    case ISM330DHCX_8g:
+      *val = ISM330DHCX_8g;
+      break;
+    default:
+      *val = ISM330DHCX_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_data_rate_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_odr_xl_t val)
+{
+  ism330dhcx_odr_xl_t odr_xl =  val;
+  ism330dhcx_emb_fsm_enable_t fsm_enable;
+  ism330dhcx_fsm_odr_t fsm_odr;
+  uint8_t mlc_enable;
+  ism330dhcx_mlc_odr_t mlc_odr;
+  ism330dhcx_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  /* Check the Finite State Machine data rate constraints */
+  ret =  ism330dhcx_fsm_enable_get(ctx, &fsm_enable);
+  if (ret == 0) {
+    if ( (fsm_enable.fsm_enable_a.fsm1_en  |
+          fsm_enable.fsm_enable_a.fsm2_en  |
+          fsm_enable.fsm_enable_a.fsm3_en  |
+          fsm_enable.fsm_enable_a.fsm4_en  |
+          fsm_enable.fsm_enable_a.fsm5_en  |
+          fsm_enable.fsm_enable_a.fsm6_en  |
+          fsm_enable.fsm_enable_a.fsm7_en  |
+          fsm_enable.fsm_enable_a.fsm8_en  |
+          fsm_enable.fsm_enable_b.fsm9_en  |
+          fsm_enable.fsm_enable_b.fsm10_en |
+          fsm_enable.fsm_enable_b.fsm11_en |
+          fsm_enable.fsm_enable_b.fsm12_en |
+          fsm_enable.fsm_enable_b.fsm13_en |
+          fsm_enable.fsm_enable_b.fsm14_en |
+          fsm_enable.fsm_enable_b.fsm15_en |
+          fsm_enable.fsm_enable_b.fsm16_en ) == PROPERTY_ENABLE ){
+
+      ret =  ism330dhcx_fsm_data_rate_get(ctx, &fsm_odr);
+      if (ret == 0) {
+        switch (fsm_odr) {
+          case ISM330DHCX_ODR_FSM_12Hz5:
+
+            if (val == ISM330DHCX_XL_ODR_OFF){
+              odr_xl = ISM330DHCX_XL_ODR_12Hz5;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case ISM330DHCX_ODR_FSM_26Hz:
+
+            if (val == ISM330DHCX_XL_ODR_OFF){
+              odr_xl = ISM330DHCX_XL_ODR_26Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_12Hz5){
+              odr_xl = ISM330DHCX_XL_ODR_26Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case ISM330DHCX_ODR_FSM_52Hz:
+
+            if (val == ISM330DHCX_XL_ODR_OFF){
+              odr_xl = ISM330DHCX_XL_ODR_52Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_12Hz5){
+              odr_xl = ISM330DHCX_XL_ODR_52Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_26Hz){
+              odr_xl = ISM330DHCX_XL_ODR_52Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case ISM330DHCX_ODR_FSM_104Hz:
+
+            if (val == ISM330DHCX_XL_ODR_OFF){
+              odr_xl = ISM330DHCX_XL_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_12Hz5){
+              odr_xl = ISM330DHCX_XL_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_26Hz){
+              odr_xl = ISM330DHCX_XL_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_52Hz){
+              odr_xl = ISM330DHCX_XL_ODR_104Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          default:
+            odr_xl = val;
+            break;
+        }
+      }
+    }
+  }
+
+  /* Check the Machine Learning Core data rate constraints */
+  mlc_enable = PROPERTY_DISABLE;
+  if (ret == 0) {
+    ret =  ism330dhcx_mlc_get(ctx, &mlc_enable);
+    if ( mlc_enable == PROPERTY_ENABLE ){
+
+      ret =  ism330dhcx_mlc_data_rate_get(ctx, &mlc_odr);
+      if (ret == 0) {
+        switch (mlc_odr) {
+          case ISM330DHCX_ODR_PRGS_12Hz5:
+
+            if (val == ISM330DHCX_XL_ODR_OFF){
+              odr_xl = ISM330DHCX_XL_ODR_12Hz5;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case ISM330DHCX_ODR_PRGS_26Hz:
+            if (val == ISM330DHCX_XL_ODR_OFF){
+              odr_xl = ISM330DHCX_XL_ODR_26Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_12Hz5){
+              odr_xl = ISM330DHCX_XL_ODR_26Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case ISM330DHCX_ODR_PRGS_52Hz:
+
+            if (val == ISM330DHCX_XL_ODR_OFF){
+              odr_xl = ISM330DHCX_XL_ODR_52Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_12Hz5){
+              odr_xl = ISM330DHCX_XL_ODR_52Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_26Hz){
+              odr_xl = ISM330DHCX_XL_ODR_52Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case ISM330DHCX_ODR_PRGS_104Hz:
+            if (val == ISM330DHCX_XL_ODR_OFF){
+              odr_xl = ISM330DHCX_XL_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_12Hz5){
+              odr_xl = ISM330DHCX_XL_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_26Hz){
+              odr_xl = ISM330DHCX_XL_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_XL_ODR_52Hz){
+              odr_xl = ISM330DHCX_XL_ODR_104Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          default:
+            odr_xl = val;
+            break;
+        }
+      }
+    }
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  if(ret == 0){
+    ctrl1_xl.odr_xl= (uint8_t)odr_xl;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL1_XL,
+                               (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_data_rate_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_xl_t *val)
+{
+  ism330dhcx_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.odr_xl){
+    case ISM330DHCX_XL_ODR_OFF:
+      *val = ISM330DHCX_XL_ODR_OFF;
+      break;
+    case ISM330DHCX_XL_ODR_12Hz5:
+      *val = ISM330DHCX_XL_ODR_12Hz5;
+      break;
+    case ISM330DHCX_XL_ODR_26Hz:
+      *val = ISM330DHCX_XL_ODR_26Hz;
+      break;
+    case ISM330DHCX_XL_ODR_52Hz:
+      *val = ISM330DHCX_XL_ODR_52Hz;
+      break;
+    case ISM330DHCX_XL_ODR_104Hz:
+      *val = ISM330DHCX_XL_ODR_104Hz;
+      break;
+    case ISM330DHCX_XL_ODR_208Hz:
+      *val = ISM330DHCX_XL_ODR_208Hz;
+      break;
+    case ISM330DHCX_XL_ODR_417Hz:
+      *val = ISM330DHCX_XL_ODR_417Hz;
+      break;
+    case ISM330DHCX_XL_ODR_833Hz:
+      *val = ISM330DHCX_XL_ODR_833Hz;
+      break;
+    case ISM330DHCX_XL_ODR_1667Hz:
+      *val = ISM330DHCX_XL_ODR_1667Hz;
+      break;
+    case ISM330DHCX_XL_ODR_3333Hz:
+      *val = ISM330DHCX_XL_ODR_3333Hz;
+      break;
+    case ISM330DHCX_XL_ODR_6667Hz:
+      *val = ISM330DHCX_XL_ODR_6667Hz;
+      break;
+    case ISM330DHCX_XL_ODR_6Hz5:
+      *val = ISM330DHCX_XL_ODR_6Hz5;
+      break;
+    default:
+      *val = ISM330DHCX_XL_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_full_scale_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_fs_g_t val)
+{
+  ism330dhcx_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.fs_g= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_full_scale_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_fs_g_t *val)
+{
+  ism330dhcx_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.fs_g){
+    case ISM330DHCX_125dps:
+      *val = ISM330DHCX_125dps;
+      break;
+    case ISM330DHCX_250dps:
+      *val = ISM330DHCX_250dps;
+      break;
+    case ISM330DHCX_500dps:
+      *val = ISM330DHCX_500dps;
+      break;
+    case ISM330DHCX_1000dps:
+      *val = ISM330DHCX_1000dps;
+      break;
+    case ISM330DHCX_2000dps:
+      *val = ISM330DHCX_2000dps;
+      break;
+    case ISM330DHCX_4000dps:
+      *val = ISM330DHCX_4000dps;
+      break;
+    default:
+      *val = ISM330DHCX_125dps;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_data_rate_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_odr_g_t val)
+{
+  ism330dhcx_odr_g_t odr_gy =  val;
+  ism330dhcx_emb_fsm_enable_t fsm_enable;
+  ism330dhcx_fsm_odr_t fsm_odr;
+  uint8_t mlc_enable;
+  ism330dhcx_mlc_odr_t mlc_odr;
+  ism330dhcx_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  /* Check the Finite State Machine data rate constraints */
+  ret =  ism330dhcx_fsm_enable_get(ctx, &fsm_enable);
+  if (ret == 0) {
+    if ( (fsm_enable.fsm_enable_a.fsm1_en  |
+          fsm_enable.fsm_enable_a.fsm2_en  |
+          fsm_enable.fsm_enable_a.fsm3_en  |
+          fsm_enable.fsm_enable_a.fsm4_en  |
+          fsm_enable.fsm_enable_a.fsm5_en  |
+          fsm_enable.fsm_enable_a.fsm6_en  |
+          fsm_enable.fsm_enable_a.fsm7_en  |
+          fsm_enable.fsm_enable_a.fsm8_en  |
+          fsm_enable.fsm_enable_b.fsm9_en  |
+          fsm_enable.fsm_enable_b.fsm10_en |
+          fsm_enable.fsm_enable_b.fsm11_en |
+          fsm_enable.fsm_enable_b.fsm12_en |
+          fsm_enable.fsm_enable_b.fsm13_en |
+          fsm_enable.fsm_enable_b.fsm14_en |
+          fsm_enable.fsm_enable_b.fsm15_en |
+          fsm_enable.fsm_enable_b.fsm16_en ) == PROPERTY_ENABLE ){
+
+      ret =  ism330dhcx_fsm_data_rate_get(ctx, &fsm_odr);
+      if (ret == 0) {
+        switch (fsm_odr) {
+          case ISM330DHCX_ODR_FSM_12Hz5:
+
+            if (val == ISM330DHCX_GY_ODR_OFF){
+              odr_gy = ISM330DHCX_GY_ODR_12Hz5;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case ISM330DHCX_ODR_FSM_26Hz:
+
+            if (val == ISM330DHCX_GY_ODR_OFF){
+              odr_gy = ISM330DHCX_GY_ODR_26Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_12Hz5){
+              odr_gy = ISM330DHCX_GY_ODR_26Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case ISM330DHCX_ODR_FSM_52Hz:
+
+            if (val == ISM330DHCX_GY_ODR_OFF){
+              odr_gy = ISM330DHCX_GY_ODR_52Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_12Hz5){
+              odr_gy = ISM330DHCX_GY_ODR_52Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_26Hz){
+              odr_gy = ISM330DHCX_GY_ODR_52Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case ISM330DHCX_ODR_FSM_104Hz:
+
+            if (val == ISM330DHCX_GY_ODR_OFF){
+              odr_gy = ISM330DHCX_GY_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_12Hz5){
+              odr_gy = ISM330DHCX_GY_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_26Hz){
+              odr_gy = ISM330DHCX_GY_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_52Hz){
+              odr_gy = ISM330DHCX_GY_ODR_104Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          default:
+            odr_gy = val;
+            break;
+        }
+      }
+    }
+  }
+
+  /* Check the Machine Learning Core data rate constraints */
+  mlc_enable = PROPERTY_DISABLE;
+  if (ret == 0) {
+    ret =  ism330dhcx_mlc_get(ctx, &mlc_enable);
+    if ( mlc_enable == PROPERTY_ENABLE ){
+
+      ret =  ism330dhcx_mlc_data_rate_get(ctx, &mlc_odr);
+      if (ret == 0) {
+        switch (mlc_odr) {
+          case ISM330DHCX_ODR_PRGS_12Hz5:
+
+            if (val == ISM330DHCX_GY_ODR_OFF){
+              odr_gy = ISM330DHCX_GY_ODR_12Hz5;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case ISM330DHCX_ODR_PRGS_26Hz:
+
+            if (val == ISM330DHCX_GY_ODR_OFF){
+              odr_gy = ISM330DHCX_GY_ODR_26Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_12Hz5){
+              odr_gy = ISM330DHCX_GY_ODR_26Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case ISM330DHCX_ODR_PRGS_52Hz:
+
+            if (val == ISM330DHCX_GY_ODR_OFF){
+              odr_gy = ISM330DHCX_GY_ODR_52Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_12Hz5){
+              odr_gy = ISM330DHCX_GY_ODR_52Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_26Hz){
+              odr_gy = ISM330DHCX_GY_ODR_52Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case ISM330DHCX_ODR_PRGS_104Hz:
+
+            if (val == ISM330DHCX_GY_ODR_OFF){
+              odr_gy = ISM330DHCX_GY_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_12Hz5){
+              odr_gy = ISM330DHCX_GY_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_26Hz){
+              odr_gy = ISM330DHCX_GY_ODR_104Hz;
+
+            } else if (val == ISM330DHCX_GY_ODR_52Hz){
+              odr_gy = ISM330DHCX_GY_ODR_104Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          default:
+            odr_gy = val;
+            break;
+        }
+      }
+    }
+  }
+  if (ret == 0) {
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  if(ret == 0){
+   ctrl2_g.odr_g= (uint8_t)odr_gy;
+   ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_data_rate_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_odr_g_t *val)
+{
+  ism330dhcx_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.odr_g){
+    case ISM330DHCX_GY_ODR_OFF:
+      *val = ISM330DHCX_GY_ODR_OFF;
+      break;
+    case ISM330DHCX_GY_ODR_12Hz5:
+      *val = ISM330DHCX_GY_ODR_12Hz5;
+      break;
+    case ISM330DHCX_GY_ODR_26Hz:
+      *val = ISM330DHCX_GY_ODR_26Hz;
+      break;
+    case ISM330DHCX_GY_ODR_52Hz:
+      *val = ISM330DHCX_GY_ODR_52Hz;
+      break;
+    case ISM330DHCX_GY_ODR_104Hz:
+      *val = ISM330DHCX_GY_ODR_104Hz;
+      break;
+    case ISM330DHCX_GY_ODR_208Hz:
+      *val = ISM330DHCX_GY_ODR_208Hz;
+      break;
+    case ISM330DHCX_GY_ODR_417Hz:
+      *val = ISM330DHCX_GY_ODR_417Hz;
+      break;
+    case ISM330DHCX_GY_ODR_833Hz:
+      *val = ISM330DHCX_GY_ODR_833Hz;
+      break;
+    case ISM330DHCX_GY_ODR_1667Hz:
+      *val = ISM330DHCX_GY_ODR_1667Hz;
+      break;
+    case ISM330DHCX_GY_ODR_3333Hz:
+      *val = ISM330DHCX_GY_ODR_3333Hz;
+      break;
+    case ISM330DHCX_GY_ODR_6667Hz:
+      *val = ISM330DHCX_GY_ODR_6667Hz;
+      break;
+    default:
+      *val = ISM330DHCX_GY_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_offset_weight_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_usr_off_w_t val)
+{
+  ism330dhcx_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.usr_off_w= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_offset_weight_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_usr_off_w_t *val)
+{
+  ism330dhcx_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.usr_off_w){
+    case ISM330DHCX_LSb_1mg:
+      *val = ISM330DHCX_LSb_1mg;
+      break;
+    case ISM330DHCX_LSb_16mg:
+      *val = ISM330DHCX_LSb_16mg;
+      break;
+    default:
+      *val = ISM330DHCX_LSb_1mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer power mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_power_mode_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_xl_hm_mode_t val)
+{
+  ism330dhcx_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.xl_hm_mode = (uint8_t)val & 0x01U;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer power mode[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_power_mode_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_xl_hm_mode_t *val)
+{
+  ism330dhcx_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.xl_hm_mode){
+    case ISM330DHCX_HIGH_PERFORMANCE_MD:
+      *val = ISM330DHCX_HIGH_PERFORMANCE_MD;
+      break;
+    case ISM330DHCX_LOW_NORMAL_POWER_MD:
+      *val = ISM330DHCX_LOW_NORMAL_POWER_MD;
+      break;
+    default:
+      *val = ISM330DHCX_HIGH_PERFORMANCE_MD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode for gyroscope.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_power_mode_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_g_hm_mode_t val)
+{
+  ism330dhcx_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.g_hm_mode= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  gy_power_mode: [get]  Operating mode for gyroscope.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_power_mode_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_g_hm_mode_t *val)
+{
+  ism330dhcx_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.g_hm_mode){
+    case ISM330DHCX_GY_HIGH_PERFORMANCE:
+      *val = ISM330DHCX_GY_HIGH_PERFORMANCE;
+      break;
+    case ISM330DHCX_GY_NORMAL:
+      *val = ISM330DHCX_GY_NORMAL;
+      break;
+    default:
+      *val = ISM330DHCX_GY_HIGH_PERFORMANCE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt flag of the device.
+  *[get]
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers ALL_INT_SRC; WAKE_UP_SRC;
+  *                              TAP_SRC; D6D_SRC; STATUS_REG;
+  *                              EMB_FUNC_STATUS; FSM_STATUS_A/B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_all_sources_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_ALL_INT_SRC,
+                           (uint8_t*)&val->all_int_src, 1);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_SRC,
+                             (uint8_t*)&val->wake_up_src, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_SRC,
+                             (uint8_t*)&val->tap_src, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_D6D_SRC,
+                             (uint8_t*)&val->d6d_src, 1);
+  }
+  if(ret == 0){
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG,
+                           (uint8_t*)&val->status_reg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_STATUS,
+                             (uint8_t*)&val->emb_func_status, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_STATUS_A,
+                             (uint8_t*)&val->fsm_status_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_STATUS_B,
+                             (uint8_t*)&val->fsm_status_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get register STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_status_reg_get(stmdev_ctx_t *ctx,
+                                  ism330dhcx_status_reg_t *val)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_temp_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  ism330dhcx_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_write_reg(ctx, ISM330DHCX_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_write_reg(ctx, ISM330DHCX_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_write_reg(ctx, ISM330DHCX_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enables user offset on out.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_out in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.usr_off_on_out= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL7_G,
+                               (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Get user offset on out flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get values of usr_off_on_out in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  *val = ctrl7_g.usr_off_on_out;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_Timestamp
+  * @brief      This section groups all the functions that manage the
+  *             timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.timestamp_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL10_C,
+                              (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp first data output register (r).
+  *         The value is expressed as a 32-bit word and the bit resolution
+  *         is 25 μs.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TIMESTAMP0, buff, 4);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_Data output
+  * @brief      This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read of the output registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_rounding_mode_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_rounding_t val)
+{
+  ism330dhcx_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL5_C,
+                               (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_rounding_mode_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_rounding_t *val)
+{
+  ism330dhcx_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.rounding){
+    case ISM330DHCX_NO_ROUND:
+      *val = ISM330DHCX_NO_ROUND;
+      break;
+    case ISM330DHCX_ROUND_XL:
+      *val = ISM330DHCX_ROUND_XL;
+      break;
+    case ISM330DHCX_ROUND_GY:
+      *val = ISM330DHCX_ROUND_GY;
+      break;
+    case ISM330DHCX_ROUND_GY_XL:
+      *val = ISM330DHCX_ROUND_GY_XL;
+      break;
+    default:
+      *val = ISM330DHCX_NO_ROUND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r).
+  *         L and H registers together express a 16-bit word in two’s
+  *         complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit
+  *         word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as a
+  *         16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_OUTX_L_A, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  FIFO data output.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_DATA_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Step counter output register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STEP_COUNTER_L, buff, 2);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_steps_reset(stmdev_ctx_t *ctx)
+{
+  ism330dhcx_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_SRC,
+                             (uint8_t*)&emb_func_src, 1);
+  }
+  if(ret == 0){
+    emb_func_src.pedo_rst_step = PROPERTY_ENABLE;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_SRC,
+                              (uint8_t*)&emb_func_src, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_common
+  * @brief      This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate)
+  *         with respect to the typical.[set]
+  *         Step:  0.15%. 8-bit format, 2's complement.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_internal_freq_fine_t internal_freq_fine;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INTERNAL_FREQ_FINE,
+                            (uint8_t*)&internal_freq_fine, 1);
+  if(ret == 0){
+    internal_freq_fine.freq_fine= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INTERNAL_FREQ_FINE,
+                               (uint8_t*)&internal_freq_fine, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate)
+  *         with respect to the typical.[get]
+  *         Step:  0.15%. 8-bit format, 2's complement.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_internal_freq_fine_t internal_freq_fine;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INTERNAL_FREQ_FINE,
+                            (uint8_t*)&internal_freq_fine, 1);
+  *val = internal_freq_fine.freq_fine;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of reg_access in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mem_bank_set(stmdev_ctx_t *ctx,
+                                ism330dhcx_reg_access_t val)
+{
+  ism330dhcx_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FUNC_CFG_ACCESS,
+                           (uint8_t*)&func_cfg_access, 1);
+  if(ret == 0){
+    func_cfg_access.reg_access= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FUNC_CFG_ACCESS,
+                              (uint8_t*)&func_cfg_access, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of reg_access in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mem_bank_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_reg_access_t *val)
+{
+  ism330dhcx_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FUNC_CFG_ACCESS,
+                           (uint8_t*)&func_cfg_access, 1);
+  switch (func_cfg_access.reg_access){
+    case ISM330DHCX_USER_BANK:
+      *val = ISM330DHCX_USER_BANK;
+      break;
+    case ISM330DHCX_SENSOR_HUB_BANK:
+      *val = ISM330DHCX_SENSOR_HUB_BANK;
+      break;
+    case ISM330DHCX_EMBEDDED_FUNC_BANK:
+      *val = ISM330DHCX_EMBEDDED_FUNC_BANK;
+      break;
+    default:
+      *val = ISM330DHCX_USER_BANK;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write a line(byte) in a page.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  add    Page line address
+  * @param  val    Value to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_ln_pg_write_byte(stmdev_ctx_t *ctx, uint16_t add,
+                                   uint8_t *val)
+{
+  ism330dhcx_page_rw_t page_rw;
+  ism330dhcx_page_sel_t page_sel;
+  ism330dhcx_page_address_t page_address;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x02U; /* page_write enable */
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_sel.page_sel = (uint8_t)((add >> 8) & 0x0FU);
+    page_sel.not_used_01 = 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_address.page_addr = (uint8_t)(add & 0xFFU);
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_ADDRESS,
+                              (uint8_t*)&page_address, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_VALUE, val, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_RW,
+                              (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x00; /* page_write disable */
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_RW,
+                               (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write buffer in a page.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buf    Page line address.(ptr)
+  * @param  val    Value to write.
+  * @param  len    buffer lengh.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_ln_pg_write(stmdev_ctx_t *ctx, uint16_t add,
+                               uint8_t *buf, uint8_t len)
+{
+  ism330dhcx_page_rw_t page_rw;
+  ism330dhcx_page_sel_t page_sel;
+  ism330dhcx_page_address_t page_address;
+  int32_t ret;
+  uint8_t msb, lsb;
+  uint8_t i ;
+
+  msb = (uint8_t)((add >> 8) & 0x0FU);
+  lsb = (uint8_t)(add & 0xFFU);
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x02U; /* page_write enable*/
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_RW,
+                               (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_sel.page_sel = msb;
+    page_sel.not_used_01 = 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_address.page_addr = lsb;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_ADDRESS,
+                              (uint8_t*)&page_address, 1);
+  }
+  for (i = 0; i < len; i++){
+    if(ret == 0){
+      ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_VALUE, &buf[i], 1);
+      if(ret == 0){
+        /* Check if page wrap */
+        if (lsb == 0x00U){
+          msb++;
+          ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_SEL,
+                                   (uint8_t*)&page_sel, 1);
+        }
+        lsb++;
+      }
+      if(ret == 0){
+        page_sel.page_sel = msb;
+        page_sel.not_used_01 = 1;
+        ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_SEL,
+                                  (uint8_t*)&page_sel, 1);
+      }
+    }
+  }
+
+  if(ret == 0){
+    page_sel.page_sel = 0;
+    page_sel.not_used_01 = 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x00U; /* page_write disable */
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read a line(byte) in a page.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  add    Page line address.
+  * @param  val    Read value.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t add,
+                                  uint8_t *val)
+{
+  ism330dhcx_page_rw_t page_rw;
+  ism330dhcx_page_sel_t page_sel;
+  ism330dhcx_page_address_t page_address;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x01U; /* page_read enable*/
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_RW,
+                               (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_sel.page_sel = (uint8_t)((add >> 8) & 0x0FU);
+    page_sel.not_used_01 = 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_address.page_addr = (uint8_t)(add & 0x00FFU);
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_ADDRESS,
+                              (uint8_t*)&page_address, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_VALUE, val, 2);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x00U; /* page_read disable */
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dataready_pulsed in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                      ism330dhcx_dataready_pulsed_t val)
+{
+  ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.dataready_pulsed= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dataready_pulsed in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                      ism330dhcx_dataready_pulsed_t *val)
+{
+  ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  switch (counter_bdr_reg1.dataready_pulsed){
+    case ISM330DHCX_DRDY_LATCHED:
+      *val = ISM330DHCX_DRDY_LATCHED;
+      break;
+    case ISM330DHCX_DRDY_PULSED:
+      *val = ISM330DHCX_DRDY_PULSED;
+      break;
+    default:
+      *val = ISM330DHCX_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_C,
+                               (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.boot;
+
+  return ret;
+}
+
+
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_self_test_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_xl_t val)
+{
+  ism330dhcx_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_self_test_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_xl_t *val)
+{
+  ism330dhcx_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_xl){
+    case ISM330DHCX_XL_ST_DISABLE:
+      *val = ISM330DHCX_XL_ST_DISABLE;
+      break;
+    case ISM330DHCX_XL_ST_POSITIVE:
+      *val = ISM330DHCX_XL_ST_POSITIVE;
+      break;
+    case ISM330DHCX_XL_ST_NEGATIVE:
+      *val = ISM330DHCX_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = ISM330DHCX_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_self_test_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_g_t val)
+{
+  ism330dhcx_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_g= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_self_test_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_g_t *val)
+{
+  ism330dhcx_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_g){
+    case ISM330DHCX_GY_ST_DISABLE:
+      *val = ISM330DHCX_GY_ST_DISABLE;
+      break;
+    case ISM330DHCX_GY_ST_POSITIVE:
+      *val = ISM330DHCX_GY_ST_POSITIVE;
+      break;
+    case ISM330DHCX_GY_ST_NEGATIVE:
+      *val = ISM330DHCX_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = ISM330DHCX_GY_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_filters
+  * @brief      This section group all the functions concerning the
+  *             filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf2_xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf2_xl_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf2_xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  *val = ctrl1_xl.lpf2_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0] in CTRL6_C.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf1_sel_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_filter_lp1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.lpf1_sel_g= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0] in CTRL6_C.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf1_sel_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_filter_lp1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.lpf1_sel_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_filter_settling_mask_get(stmdev_ctx_t *ctx,
+                                           uint8_t *val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass filter 1 bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ftype in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_ftype_t val)
+{
+  ism330dhcx_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.ftype= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass filter 1 bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ftype in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_ftype_t *val)
+{
+  ism330dhcx_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.ftype){
+    case ISM330DHCX_ULTRA_LIGHT:
+      *val = ISM330DHCX_ULTRA_LIGHT;
+      break;
+    case ISM330DHCX_VERY_LIGHT:
+      *val = ISM330DHCX_VERY_LIGHT;
+      break;
+    case ISM330DHCX_LIGHT:
+      *val = ISM330DHCX_LIGHT;
+      break;
+    case ISM330DHCX_MEDIUM:
+      *val = ISM330DHCX_MEDIUM;
+      break;
+    case ISM330DHCX_STRONG:
+      *val = ISM330DHCX_STRONG;
+      break;
+    case ISM330DHCX_VERY_STRONG:
+      *val = ISM330DHCX_VERY_STRONG;
+      break;
+    case ISM330DHCX_AGGRESSIVE:
+      *val = ISM330DHCX_AGGRESSIVE;
+      break;
+    case ISM330DHCX_XTREME:
+      *val = ISM330DHCX_XTREME;
+      break;
+    default:
+      *val = ISM330DHCX_ULTRA_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_lp2_on_6d_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.low_pass_on_6d= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_lp2_on_6d_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.low_pass_on_6d;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection
+  *         on output.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_hp_slope_xl_en_t val)
+{
+  ism330dhcx_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.hp_slope_xl_en = (((uint8_t)val & 0x10U) >> 4);
+    ctrl8_xl.hp_ref_mode_xl = (((uint8_t)val & 0x20U) >> 5);
+    ctrl8_xl.hpcf_xl = (uint8_t)val & 0x07U;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection on
+  *         output.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_hp_slope_xl_en_t *val)
+{
+  ism330dhcx_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  switch (( (ctrl8_xl.hp_ref_mode_xl << 5) +(ctrl8_xl.hp_slope_xl_en << 4) +
+             ctrl8_xl.hpcf_xl )){
+    case ISM330DHCX_HP_PATH_DISABLE_ON_OUT:
+      *val = ISM330DHCX_HP_PATH_DISABLE_ON_OUT;
+      break;
+    case ISM330DHCX_SLOPE_ODR_DIV_4:
+      *val = ISM330DHCX_SLOPE_ODR_DIV_4;
+      break;
+    case ISM330DHCX_HP_ODR_DIV_10:
+      *val = ISM330DHCX_HP_ODR_DIV_10;
+      break;
+    case ISM330DHCX_HP_ODR_DIV_20:
+      *val = ISM330DHCX_HP_ODR_DIV_20;
+      break;
+    case ISM330DHCX_HP_ODR_DIV_45:
+      *val = ISM330DHCX_HP_ODR_DIV_45;
+      break;
+    case ISM330DHCX_HP_ODR_DIV_100:
+      *val = ISM330DHCX_HP_ODR_DIV_100;
+      break;
+    case ISM330DHCX_HP_ODR_DIV_200:
+      *val = ISM330DHCX_HP_ODR_DIV_200;
+      break;
+    case ISM330DHCX_HP_ODR_DIV_400:
+      *val = ISM330DHCX_HP_ODR_DIV_400;
+      break;
+    case ISM330DHCX_HP_ODR_DIV_800:
+      *val = ISM330DHCX_HP_ODR_DIV_800;
+      break;
+    case ISM330DHCX_HP_REF_MD_ODR_DIV_10:
+      *val = ISM330DHCX_HP_REF_MD_ODR_DIV_10;
+      break;
+    case ISM330DHCX_HP_REF_MD_ODR_DIV_20:
+      *val = ISM330DHCX_HP_REF_MD_ODR_DIV_20;
+      break;
+    case ISM330DHCX_HP_REF_MD_ODR_DIV_45:
+      *val = ISM330DHCX_HP_REF_MD_ODR_DIV_45;
+      break;
+    case ISM330DHCX_HP_REF_MD_ODR_DIV_100:
+      *val = ISM330DHCX_HP_REF_MD_ODR_DIV_100;
+      break;
+    case ISM330DHCX_HP_REF_MD_ODR_DIV_200:
+      *val = ISM330DHCX_HP_REF_MD_ODR_DIV_200;
+      break;
+    case ISM330DHCX_HP_REF_MD_ODR_DIV_400:
+      *val = ISM330DHCX_HP_REF_MD_ODR_DIV_400;
+      break;
+    case ISM330DHCX_HP_REF_MD_ODR_DIV_800:
+      *val = ISM330DHCX_HP_REF_MD_ODR_DIV_800;
+      break;
+    case ISM330DHCX_LP_ODR_DIV_10:
+      *val = ISM330DHCX_LP_ODR_DIV_10;
+      break;
+    case ISM330DHCX_LP_ODR_DIV_20:
+      *val = ISM330DHCX_LP_ODR_DIV_20;
+      break;
+    case ISM330DHCX_LP_ODR_DIV_45:
+      *val = ISM330DHCX_LP_ODR_DIV_45;
+      break;
+    case ISM330DHCX_LP_ODR_DIV_100:
+      *val = ISM330DHCX_LP_ODR_DIV_100;
+      break;
+    case ISM330DHCX_LP_ODR_DIV_200:
+      *val = ISM330DHCX_LP_ODR_DIV_200;
+      break;
+    case ISM330DHCX_LP_ODR_DIV_400:
+      *val = ISM330DHCX_LP_ODR_DIV_400;
+      break;
+    case ISM330DHCX_LP_ODR_DIV_800:
+      *val = ISM330DHCX_LP_ODR_DIV_800;
+      break;
+    default:
+      *val = ISM330DHCX_HP_PATH_DISABLE_ON_OUT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing this bit.
+  *         Active only during device exit from powerdown mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fastsettl_mode_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.fastsettl_mode_xl= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing
+  *         this bit. Active only during device exit from powerdown mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fastsettl_mode_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.fastsettl_mode_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of slope_fds in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                          ism330dhcx_slope_fds_t val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.slope_fds= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of slope_fds in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                          ism330dhcx_slope_fds_t *val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  switch (tap_cfg0.slope_fds){
+    case ISM330DHCX_USE_SLOPE:
+      *val = ISM330DHCX_USE_SLOPE;
+      break;
+    case ISM330DHCX_USE_HPF:
+      *val = ISM330DHCX_USE_HPF;
+      break;
+    default:
+      *val = ISM330DHCX_USE_SLOPE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital high-pass filter. The filter is enabled
+  *         only if the gyro is in HP mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_en_g and hp_en_g in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                          ism330dhcx_hpm_g_t val)
+{
+  ism330dhcx_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hp_en_g = (((uint8_t)val & 0x80U) >> 7);
+    ctrl7_g.hpm_g = (uint8_t)val & 0x03U;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Enables gyroscope digital high-pass filter. The filter is
+  *           enabled only if the gyro is in HP mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_en_g and hp_en_g in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                          ism330dhcx_hpm_g_t *val)
+{
+  ism330dhcx_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  switch ((ctrl7_g.hp_en_g << 7) + ctrl7_g.hpm_g){
+    case ISM330DHCX_HP_FILTER_NONE:
+      *val = ISM330DHCX_HP_FILTER_NONE;
+      break;
+    case ISM330DHCX_HP_FILTER_16mHz:
+      *val = ISM330DHCX_HP_FILTER_16mHz;
+      break;
+    case ISM330DHCX_HP_FILTER_65mHz:
+      *val = ISM330DHCX_HP_FILTER_65mHz;
+      break;
+    case ISM330DHCX_HP_FILTER_260mHz:
+      *val = ISM330DHCX_HP_FILTER_260mHz;
+      break;
+    case ISM330DHCX_HP_FILTER_1Hz04:
+      *val = ISM330DHCX_HP_FILTER_1Hz04;
+      break;
+    default:
+      *val = ISM330DHCX_HP_FILTER_NONE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_ Auxiliary_interface
+  * @brief      This section groups all the functions concerning
+  *             auxiliary interface.
+  * @{
+  *
+  */
+
+/**
+  * @brief  On auxiliary interface connect/disconnect SDO and OCS
+  *         internal pull-up.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ois_pu_dis in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_sdo_ocs_mode_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_ois_pu_dis_t val)
+{
+  ism330dhcx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+  if(ret == 0){
+    pin_ctrl.ois_pu_dis= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PIN_CTRL,
+                              (uint8_t*)&pin_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  On auxiliary interface connect/disconnect SDO and OCS
+  *         internal pull-up.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ois_pu_dis in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_sdo_ocs_mode_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_ois_pu_dis_t *val)
+{
+  ism330dhcx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+
+  switch (pin_ctrl.ois_pu_dis){
+    case ISM330DHCX_AUX_PULL_UP_DISC:
+      *val = ISM330DHCX_AUX_PULL_UP_DISC;
+      break;
+    case ISM330DHCX_AUX_PULL_UP_CONNECT:
+      *val = ISM330DHCX_AUX_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  OIS chain on aux interface power on mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ois_on in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_pw_on_ctrl_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_ois_on_t val)
+{
+  ism330dhcx_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.ois_on_en = (uint8_t)val & 0x01U;
+    ctrl7_g.ois_on = (uint8_t)val & 0x01U;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  OIS chain on aux interface power on mode[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ois_on in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_pw_on_ctrl_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_ois_on_t *val)
+{
+  ism330dhcx_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  switch (ctrl7_g.ois_on){
+    case ISM330DHCX_AUX_ON:
+      *val = ISM330DHCX_AUX_ON;
+      break;
+    case ISM330DHCX_AUX_ON_BY_AUX_INTERFACE:
+      *val = ISM330DHCX_AUX_ON_BY_AUX_INTERFACE;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_ON;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_SPIAux register is read by the auxiliary SPI.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  ism330dhcx_status_spiaux_t: registers STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_status_reg_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_status_spiaux_t *val)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_SPIAUX, (uint8_t*)val, 1);
+  return ret;
+}
+
+/**
+  * @brief  AUX accelerometer data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xlda in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  ism330dhcx_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_SPIAUX,
+                           (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  AUX gyroscope data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gda in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  ism330dhcx_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_SPIAUX,
+                           (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  High when the gyroscope output is in the settling phase.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gyro_settling in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_flag_settling_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  ism330dhcx_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_SPIAUX,
+                           (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.gyro_settling;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer self-test. Effective only if XL OIS chain is
+  *         enabled.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_xl_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_xl_self_test_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_st_xl_ois_t val)
+{
+  ism330dhcx_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.st_xl_ois= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer self-test. Effective only if XL OIS chain
+  *         is enabled.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_xl_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_xl_self_test_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_st_xl_ois_t *val)
+{
+  ism330dhcx_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+
+  switch (int_ois.st_xl_ois){
+    case ISM330DHCX_AUX_XL_DISABLE:
+      *val = ISM330DHCX_AUX_XL_DISABLE;
+      break;
+    case ISM330DHCX_AUX_XL_POS:
+      *val = ISM330DHCX_AUX_XL_POS;
+      break;
+    case ISM330DHCX_AUX_XL_NEG:
+      *val = ISM330DHCX_AUX_XL_NEG;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_XL_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_lh_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_den_polarity_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_den_lh_ois_t val)
+{
+  ism330dhcx_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.den_lh_ois= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT_OIS,
+                               (uint8_t*)&int_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_lh_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_den_polarity_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_den_lh_ois_t *val)
+{
+  ism330dhcx_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+
+  switch (int_ois.den_lh_ois){
+    case ISM330DHCX_AUX_DEN_ACTIVE_LOW:
+      *val = ISM330DHCX_AUX_DEN_ACTIVE_LOW;
+      break;
+    case ISM330DHCX_AUX_DEN_ACTIVE_HIGH:
+      *val = ISM330DHCX_AUX_DEN_ACTIVE_HIGH;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_DEN_ACTIVE_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lvl2_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_den_mode_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_lvl2_ois_t val)
+{
+  ism330dhcx_int_ois_t int_ois;
+  ism330dhcx_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.lvl2_ois = (uint8_t)val & 0x01U;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT_OIS,
+                               (uint8_t*)&int_ois, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+  if(ret == 0){
+    ctrl1_ois.lvl1_ois = ((uint8_t)val & 0x02U) >> 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lvl2_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_den_mode_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_lvl2_ois_t *val)
+{
+  ism330dhcx_int_ois_t int_ois;
+  ism330dhcx_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+
+  switch ((ctrl1_ois.lvl1_ois << 1) + int_ois.lvl2_ois){
+    case ISM330DHCX_AUX_DEN_DISABLE:
+      *val = ISM330DHCX_AUX_DEN_DISABLE;
+      break;
+    case ISM330DHCX_AUX_DEN_LEVEL_LATCH:
+      *val = ISM330DHCX_AUX_DEN_LEVEL_LATCH;
+      break;
+    case ISM330DHCX_AUX_DEN_LEVEL_TRIG:
+      *val = ISM330DHCX_AUX_DEN_LEVEL_TRIG;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin. This setting has
+  *         priority over all other INT2 settings.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_drdy_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.int2_drdy_ois= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin. This setting has
+  *         priority over all other INT2 settings.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_drdy_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_OIS, (uint8_t*)&int_ois, 1);
+  *val = int_ois.int2_drdy_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro in Mode 3 and Mode 4
+  *         (mode4_en = 1) and accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are available
+  *         through the SPI2 in registers OUTX_L_G (22h) through OUTZ_H_G(27h)
+  *         and STATUS_REG (1Eh) / STATUS_SPIAux, and LPF1 is dedicated to
+  *         this chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ois_en_spi2 in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_mode_set(stmdev_ctx_t *ctx,
+                               ism330dhcx_ois_en_spi2_t val)
+{
+  ism330dhcx_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                            (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.ois_en_spi2 = (uint8_t)val & 0x01U;
+    ctrl1_ois.mode4_en = ((uint8_t)val & 0x02U) >> 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro in Mode 3 and Mode 4
+  *         (mode4_en = 1) and accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are available
+  *         through the SPI2 in registers OUTX_L_G (22h) through OUTZ_H_G(27h)
+  *         and STATUS_REG (1Eh) / STATUS_SPIAux, and LPF1 is dedicated to
+  *         this chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ois_en_spi2 in
+  *                                reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_mode_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_ois_en_spi2_t *val)
+{
+  ism330dhcx_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                            (uint8_t*)&ctrl1_ois, 1);
+
+  switch (((ctrl1_ois.mode4_en << 1) + ctrl1_ois.ois_en_spi2)){
+    case ISM330DHCX_AUX_DISABLE:
+      *val = ISM330DHCX_AUX_DISABLE;
+      break;
+    case ISM330DHCX_MODE_3_GY:
+      *val = ISM330DHCX_MODE_3_GY;
+      break;
+    case ISM330DHCX_MODE_4_GY_XL:
+      *val = ISM330DHCX_MODE_4_GY_XL;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_g_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_fs_g_ois_t val)
+{
+  ism330dhcx_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                            (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.fs_g_ois = (uint8_t)val & 0x03U;
+    ctrl1_ois.fs_125_ois = ( (uint8_t)val & 0x04U ) >> 2;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_g_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
+                                         ism330dhcx_fs_g_ois_t *val)
+{
+  ism330dhcx_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                            (uint8_t*)&ctrl1_ois, 1);
+
+  switch ( ( ctrl1_ois.fs_125_ois << 2 ) + ctrl1_ois.fs_g_ois ){
+    case ISM330DHCX_250dps_AUX:
+      *val = ISM330DHCX_250dps_AUX;
+      break;
+    case ISM330DHCX_125dps_AUX:
+      *val = ISM330DHCX_125dps_AUX;
+      break;
+    case ISM330DHCX_500dps_AUX:
+      *val = ISM330DHCX_500dps_AUX;
+      break;
+    case ISM330DHCX_1000dps_AUX:
+      *val = ISM330DHCX_1000dps_AUX;
+      break;
+    case ISM330DHCX_2000dps_AUX:
+      *val = ISM330DHCX_2000dps_AUX;
+      break;
+    default:
+      *val = ISM330DHCX_250dps_AUX;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_spi_mode_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sim_ois_t val)
+{
+  ism330dhcx_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                            (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.sim_ois= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_spi_mode_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sim_ois_t *val)
+{
+  ism330dhcx_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL1_OIS,
+                            (uint8_t*)&ctrl1_ois, 1);
+
+  switch (ctrl1_ois.sim_ois){
+    case ISM330DHCX_AUX_SPI_4_WIRE:
+      *val = ISM330DHCX_AUX_SPI_4_WIRE;
+      break;
+    case ISM330DHCX_AUX_SPI_3_WIRE:
+      *val = ISM330DHCX_AUX_SPI_3_WIRE;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope digital LPF1 filter bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ftype_ois in reg CTRL2_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                           ism330dhcx_ftype_ois_t val)
+{
+  ism330dhcx_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_OIS,
+                            (uint8_t*)&ctrl2_ois, 1);
+  if(ret == 0){
+    ctrl2_ois.ftype_ois= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL2_OIS,
+                              (uint8_t*)&ctrl2_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope digital LPF1 filter bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ftype_ois in reg CTRL2_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                           ism330dhcx_ftype_ois_t *val)
+{
+  ism330dhcx_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_OIS,
+                            (uint8_t*)&ctrl2_ois, 1);
+
+  switch (ctrl2_ois.ftype_ois){
+    case ISM330DHCX_351Hz39:
+      *val = ISM330DHCX_351Hz39;
+      break;
+    case ISM330DHCX_236Hz63:
+      *val = ISM330DHCX_236Hz63;
+      break;
+    case ISM330DHCX_172Hz70:
+      *val = ISM330DHCX_172Hz70;
+      break;
+    case ISM330DHCX_937Hz91:
+      *val = ISM330DHCX_937Hz91;
+      break;
+    default:
+      *val = ISM330DHCX_351Hz39;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain digital high-pass filter cutoff.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hpm_ois in reg CTRL2_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_hp_bandwidth_set(stmdev_ctx_t *ctx,
+                                           ism330dhcx_hpm_ois_t val)
+{
+  ism330dhcx_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_OIS,
+                            (uint8_t*)&ctrl2_ois, 1);
+  if(ret == 0){
+    ctrl2_ois.hpm_ois = (uint8_t)val & 0x03U;
+    ctrl2_ois.hp_en_ois = ((uint8_t)val & 0x10U) >> 4;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL2_OIS,
+                              (uint8_t*)&ctrl2_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain digital high-pass filter cutoff.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpm_ois in reg CTRL2_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_hp_bandwidth_get(stmdev_ctx_t *ctx,
+                                           ism330dhcx_hpm_ois_t *val)
+{
+  ism330dhcx_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL2_OIS,
+                            (uint8_t*)&ctrl2_ois, 1);
+
+  switch ((ctrl2_ois.hp_en_ois << 4) + ctrl2_ois.hpm_ois){
+    case ISM330DHCX_AUX_HP_DISABLE:
+      *val = ISM330DHCX_AUX_HP_DISABLE;
+      break;
+    case ISM330DHCX_AUX_HP_Hz016:
+      *val = ISM330DHCX_AUX_HP_Hz016;
+      break;
+    case ISM330DHCX_AUX_HP_Hz065:
+      *val = ISM330DHCX_AUX_HP_Hz065;
+      break;
+    case ISM330DHCX_AUX_HP_Hz260:
+      *val = ISM330DHCX_AUX_HP_Hz260;
+      break;
+    case ISM330DHCX_AUX_HP_1Hz040:
+      *val = ISM330DHCX_AUX_HP_1Hz040;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp. Enable: All OIS chain
+  *         outputs = 8000h during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full scale selected.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_ois_clampdis in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_clamp_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_st_ois_clampdis_t val)
+{
+  ism330dhcx_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                            (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.st_ois_clampdis= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp. Enable: All OIS chain
+  *         outputs = 8000h during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full scale selected.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_ois_clampdis in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_clamp_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_st_ois_clampdis_t *val)
+{
+  ism330dhcx_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                            (uint8_t*)&ctrl3_ois, 1);
+
+  switch (ctrl3_ois.st_ois_clampdis){
+    case ISM330DHCX_ENABLE_CLAMP:
+      *val = ISM330DHCX_ENABLE_CLAMP;
+      break;
+    case ISM330DHCX_DISABLE_CLAMP:
+      *val = ISM330DHCX_DISABLE_CLAMP;
+      break;
+    default:
+      *val = ISM330DHCX_ENABLE_CLAMP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_self_test_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_st_ois_t val)
+{
+  ism330dhcx_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                            (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.st_ois= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_gy_self_test_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_st_ois_t *val)
+{
+  ism330dhcx_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                            (uint8_t*)&ctrl3_ois, 1);
+
+  switch (ctrl3_ois.st_ois){
+    case ISM330DHCX_AUX_GY_DISABLE:
+      *val = ISM330DHCX_AUX_GY_DISABLE;
+      break;
+    case ISM330DHCX_AUX_GY_POS:
+      *val = ISM330DHCX_AUX_GY_POS;
+      break;
+    case ISM330DHCX_AUX_GY_NEG:
+      *val = ISM330DHCX_AUX_GY_NEG;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_GY_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of filter_xl_conf_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_xl_bandwidth_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_filter_xl_conf_ois_t val)
+{
+  ism330dhcx_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                            (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.filter_xl_conf_ois= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of filter_xl_conf_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_xl_bandwidth_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_filter_xl_conf_ois_t *val)
+{
+  ism330dhcx_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                            (uint8_t*)&ctrl3_ois, 1);
+
+  switch (ctrl3_ois.filter_xl_conf_ois){
+    case ISM330DHCX_631Hz:
+      *val = ISM330DHCX_631Hz;
+      break;
+    case ISM330DHCX_295Hz:
+      *val = ISM330DHCX_295Hz;
+      break;
+    case ISM330DHCX_140Hz:
+      *val = ISM330DHCX_140Hz;
+      break;
+    case ISM330DHCX_68Hz2:
+      *val = ISM330DHCX_68Hz2;
+      break;
+    case ISM330DHCX_33Hz6:
+      *val = ISM330DHCX_33Hz6;
+      break;
+    case ISM330DHCX_16Hz7:
+      *val = ISM330DHCX_16Hz7;
+      break;
+    case ISM330DHCX_8Hz3:
+      *val = ISM330DHCX_8Hz3;
+      break;
+    case ISM330DHCX_4Hz11:
+      *val = ISM330DHCX_4Hz11;
+      break;
+    default:
+      *val = ISM330DHCX_631Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_xl_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_fs_xl_ois_t val)
+{
+  ism330dhcx_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                            (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.fs_xl_ois= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_xl_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_fs_xl_ois_t *val)
+{
+  ism330dhcx_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_OIS,
+                            (uint8_t*)&ctrl3_ois, 1);
+
+  switch (ctrl3_ois.fs_xl_ois){
+    case ISM330DHCX_AUX_2g:
+      *val = ISM330DHCX_AUX_2g;
+      break;
+    case ISM330DHCX_AUX_16g:
+      *val = ISM330DHCX_AUX_16g;
+      break;
+    case ISM330DHCX_AUX_4g:
+      *val = ISM330DHCX_AUX_4g;
+      break;
+    case ISM330DHCX_AUX_8g:
+      *val = ISM330DHCX_AUX_8g;
+      break;
+    default:
+      *val = ISM330DHCX_AUX_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_ main_serial_interface
+  * @brief      This section groups all the functions concerning main
+  *             serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sdo_pu_en in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_sdo_pu_en_t val)
+{
+  ism330dhcx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PIN_CTRL,
+                            (uint8_t*)&pin_ctrl, 1);
+  if(ret == 0){
+    pin_ctrl.sdo_pu_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PIN_CTRL,
+                               (uint8_t*)&pin_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sdo_pu_en in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sdo_pu_en_t *val)
+{
+  ism330dhcx_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PIN_CTRL,
+                            (uint8_t*)&pin_ctrl, 1);
+
+  switch (pin_ctrl.sdo_pu_en){
+    case ISM330DHCX_PULL_UP_DISC:
+      *val = ISM330DHCX_PULL_UP_DISC;
+      break;
+    case ISM330DHCX_PULL_UP_CONNECT:
+      *val = ISM330DHCX_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = ISM330DHCX_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_spi_mode_set(stmdev_ctx_t *ctx, ism330dhcx_sim_t val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_C,
+                               (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_spi_mode_get(stmdev_ctx_t *ctx, ism330dhcx_sim_t *val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.sim){
+    case ISM330DHCX_SPI_4_WIRE:
+      *val = ISM330DHCX_SPI_4_WIRE;
+      break;
+    case ISM330DHCX_SPI_3_WIRE:
+      *val = ISM330DHCX_SPI_3_WIRE;
+      break;
+    default:
+      *val = ISM330DHCX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_i2c_interface_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_i2c_disable_t val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL4_C,
+                               (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_i2c_interface_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_i2c_disable_t *val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+
+  switch (ctrl4_c.i2c_disable){
+    case ISM330DHCX_I2C_ENABLE:
+      *val = ISM330DHCX_I2C_ENABLE;
+      break;
+    case ISM330DHCX_I2C_DISABLE:
+      *val = ISM330DHCX_I2C_DISABLE;
+      break;
+    default:
+      *val = ISM330DHCX_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_interrupt_pins
+  * @brief      This section groups all the functions that manage
+  *             interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief   Select the signal that need to route on int1 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL,MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_pin_int1_route_t *val)
+{
+  ism330dhcx_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MLC_INT1,
+                              (uint8_t*)&val->mlc_int1, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_INT1,
+                              (uint8_t*)&val->emb_func_int1, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FSM_INT1_A,
+                              (uint8_t*)&val->fsm_int1_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FSM_INT1_B,
+                              (uint8_t*)&val->fsm_int1_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  if(ret == 0){
+    if ((val->emb_func_int1.int1_fsm_lc |
+         val->emb_func_int1.int1_sig_mot |
+         val->emb_func_int1.int1_step_detector |
+         val->emb_func_int1.int1_tilt |
+         val->fsm_int1_a.int1_fsm1 |
+         val->fsm_int1_a.int1_fsm2 |
+         val->fsm_int1_a.int1_fsm3 |
+         val->fsm_int1_a.int1_fsm4 |
+         val->fsm_int1_a.int1_fsm5 |
+         val->fsm_int1_a.int1_fsm6 |
+         val->fsm_int1_a.int1_fsm7 |
+         val->fsm_int1_a.int1_fsm8 |
+         val->fsm_int1_b.int1_fsm9 |
+         val->fsm_int1_b.int1_fsm10 |
+         val->fsm_int1_b.int1_fsm11 |
+         val->fsm_int1_b.int1_fsm12 |
+         val->fsm_int1_b.int1_fsm13 |
+         val->fsm_int1_b.int1_fsm14 |
+         val->fsm_int1_b.int1_fsm15 |
+         val->fsm_int1_b.int1_fsm16 |
+         val->mlc_int1.int1_mlc1 |
+         val->mlc_int1.int1_mlc2 |
+         val->mlc_int1.int1_mlc3 |
+         val->mlc_int1.int1_mlc4 |
+         val->mlc_int1.int1_mlc5 |
+         val->mlc_int1.int1_mlc6 |
+         val->mlc_int1.int1_mlc7 |
+         val->mlc_int1.int1_mlc8) != PROPERTY_DISABLE){
+      val->md1_cfg.int1_emb_func = PROPERTY_ENABLE;
+    }
+    else{
+      val->md1_cfg.int1_emb_func = PROPERTY_DISABLE;
+    }
+  ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT1_CTRL,
+                            (uint8_t*)&val->int1_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MD1_CFG,
+                              (uint8_t*)&val->md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2,
+                              (uint8_t*)&tap_cfg2, 1);
+    if ((val->int1_ctrl.den_drdy_flag |
+         val->int1_ctrl.int1_boot |
+         val->int1_ctrl.int1_cnt_bdr |
+         val->int1_ctrl.int1_drdy_g |
+         val->int1_ctrl.int1_drdy_xl |
+         val->int1_ctrl.int1_fifo_full |
+         val->int1_ctrl.int1_fifo_ovr |
+         val->int1_ctrl.int1_fifo_th |
+         val->md1_cfg.int1_shub |
+         val->md1_cfg.int1_6d |
+         val->md1_cfg.int1_double_tap |
+         val->md1_cfg.int1_ff |
+         val->md1_cfg.int1_wu |
+         val->md1_cfg.int1_single_tap |
+         val->md1_cfg.int1_sleep_change)!= PROPERTY_DISABLE){
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG2,
+                              (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL, MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_pin_int1_route_t *val)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MLC_INT1,
+                             (uint8_t*)&val->mlc_int1, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_INT1,
+                             (uint8_t*)&val->emb_func_int1, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_INT1_A,
+                             (uint8_t*)&val->fsm_int1_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_INT1_B,
+                             (uint8_t*)&val->fsm_int1_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT1_CTRL,
+                             (uint8_t*)&val->int1_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MD1_CFG,
+                             (uint8_t*)&val->md1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_pin_int2_route_t *val)
+{
+  ism330dhcx_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MLC_INT2,
+                            (uint8_t*)&val->mlc_int2, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_INT2,
+                              (uint8_t*)&val->emb_func_int2, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FSM_INT2_A,
+                              (uint8_t*)&val->fsm_int2_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FSM_INT2_B,
+                              (uint8_t*)&val->fsm_int2_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  if(ret == 0){
+    if ((val->emb_func_int2.int2_step_detector |
+         val->emb_func_int2.int2_tilt |
+         val->emb_func_int2.int2_sig_mot |
+         val->emb_func_int2.int2_fsm_lc |
+         val->fsm_int2_a.int2_fsm1 |
+         val->fsm_int2_a.int2_fsm2 |
+         val->fsm_int2_a.int2_fsm3 |
+         val->fsm_int2_a.int2_fsm4 |
+         val->fsm_int2_a.int2_fsm5 |
+         val->fsm_int2_a.int2_fsm6 |
+         val->fsm_int2_a.int2_fsm7 |
+         val->fsm_int2_a.int2_fsm8 |
+         val->fsm_int2_b.int2_fsm9 |
+         val->fsm_int2_b.int2_fsm10 |
+         val->fsm_int2_b.int2_fsm11 |
+         val->fsm_int2_b.int2_fsm12 |
+         val->fsm_int2_b.int2_fsm13 |
+         val->fsm_int2_b.int2_fsm14 |
+         val->fsm_int2_b.int2_fsm15 |
+         val->fsm_int2_b.int2_fsm16 |
+         val->mlc_int2.int2_mlc1 |
+         val->mlc_int2.int2_mlc2 |
+         val->mlc_int2.int2_mlc3 |
+         val->mlc_int2.int2_mlc4 |
+         val->mlc_int2.int2_mlc5 |
+         val->mlc_int2.int2_mlc6 |
+         val->mlc_int2.int2_mlc7 |
+         val->mlc_int2.int2_mlc8) != PROPERTY_DISABLE){
+      val->md2_cfg.int2_emb_func = PROPERTY_ENABLE;
+    }
+    else{
+      val->md2_cfg.int2_emb_func = PROPERTY_DISABLE;
+    }
+  ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT2_CTRL,
+                            (uint8_t*)&val->int2_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MD2_CFG,
+                              (uint8_t*)&val->md2_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2,
+                             (uint8_t*)&tap_cfg2, 1);
+  }
+  if(ret == 0){
+    if ((val->int2_ctrl.int2_drdy_xl |
+         val->int2_ctrl.int2_drdy_g |
+         val->int2_ctrl.int2_drdy_temp |
+         val->int2_ctrl.int2_fifo_th |
+         val->int2_ctrl.int2_fifo_ovr |
+         val->int2_ctrl.int2_fifo_full |
+         val->int2_ctrl.int2_cnt_bdr |
+         val->md2_cfg.int2_6d |
+         val->md2_cfg.int2_double_tap |
+         val->md2_cfg.int2_ff |
+         val->md2_cfg.int2_wu |
+         val->md2_cfg.int2_single_tap |
+         val->md2_cfg.int2_sleep_change) != PROPERTY_DISABLE){
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG2,
+                              (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B.[get]
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_pin_int2_route_t *val)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+      ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MLC_INT2,
+                            (uint8_t*)&val->mlc_int2, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_INT2,
+                             (uint8_t*)&val->emb_func_int2, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_INT2_A,
+                             (uint8_t*)&val->fsm_int2_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_INT2_B,
+                             (uint8_t*)&val->fsm_int2_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT2_CTRL,
+                             (uint8_t*)&val->int2_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MD2_CFG,
+                             (uint8_t*)&val->md2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pin_mode_set(stmdev_ctx_t *ctx, ism330dhcx_pp_od_t val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pin_mode_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_pp_od_t *val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.pp_od){
+    case ISM330DHCX_PUSH_PULL:
+      *val = ISM330DHCX_PUSH_PULL;
+      break;
+    case ISM330DHCX_OPEN_DRAIN:
+      *val = ISM330DHCX_OPEN_DRAIN;
+      break;
+    default:
+      *val = ISM330DHCX_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pin_polarity_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_h_lactive_t val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL3_C,
+                               (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pin_polarity_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_h_lactive_t *val)
+{
+  ism330dhcx_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.h_lactive){
+    case ISM330DHCX_ACTIVE_HIGH:
+      *val = ISM330DHCX_ACTIVE_HIGH;
+      break;
+    case ISM330DHCX_ACTIVE_LOW:
+      *val = ISM330DHCX_ACTIVE_LOW;
+      break;
+    default:
+      *val = ISM330DHCX_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL4_C,
+                               (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals notification mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_int_notification_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_lir_t val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  ism330dhcx_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.lir = (uint8_t)val & 0x01U;
+    tap_cfg0.int_clr_on_read = (uint8_t)val & 0x01U;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.emb_func_lir = ((uint8_t)val & 0x02U) >> 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_PAGE_RW,
+                               (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals notification mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_int_notification_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_lir_t *val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  ism330dhcx_page_rw_t page_rw;
+  int32_t ret;
+
+  *val = ISM330DHCX_ALL_INT_PULSED;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0,
+                            (uint8_t*)&tap_cfg0, 1);
+
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_PAGE_RW,
+                              (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  switch ((page_rw.emb_func_lir << 1) + tap_cfg0.lir){
+    case ISM330DHCX_ALL_INT_PULSED:
+      *val = ISM330DHCX_ALL_INT_PULSED;
+      break;
+    case ISM330DHCX_BASE_LATCHED_EMB_PULSED:
+      *val = ISM330DHCX_BASE_LATCHED_EMB_PULSED;
+      break;
+    case ISM330DHCX_BASE_PULSED_EMB_LATCHED:
+      *val = ISM330DHCX_BASE_PULSED_EMB_LATCHED;
+      break;
+    case ISM330DHCX_ALL_INT_LATCHED:
+      *val = ISM330DHCX_ALL_INT_LATCHED;
+      break;
+    default:
+      *val = ISM330DHCX_ALL_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_Wake_Up_event
+  * @brief      This section groups all the functions that manage the
+  *             Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[set]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_ths_w in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_wkup_ths_weight_set(stmdev_ctx_t *ctx,
+                                      ism330dhcx_wake_ths_w_t val)
+{
+  ism330dhcx_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_ths_w= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[get]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wake_ths_w in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_wkup_ths_weight_get(stmdev_ctx_t *ctx,
+                                      ism330dhcx_wake_ths_w_t *val)
+{
+  ism330dhcx_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+
+  switch (wake_up_dur.wake_ths_w){
+    case ISM330DHCX_LSb_FS_DIV_64:
+      *val = ISM330DHCX_LSb_FS_DIV_64;
+      break;
+    case ISM330DHCX_LSb_FS_DIV_256:
+      *val = ISM330DHCX_LSb_FS_DIV_256;
+      break;
+    default:
+      *val = ISM330DHCX_LSb_FS_DIV_64;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event( 1LSb = 1 / ODR ).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_wu in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx,
+                                             uint8_t val)
+{
+  ism330dhcx_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.usr_off_on_wu= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event( 1LSb = 1 / ODR ).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_wu in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  ism330dhcx_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.usr_off_on_wu;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_ Activity/Inactivity_detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.sleep_g= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.sleep_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of sleep change on INT pins
+  *         (only if INT1_SLEEP_CHANGE or INT2_SLEEP_CHANGE bits
+  *         are enabled).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_status_on_int in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_act_pin_notification_set(stmdev_ctx_t *ctx,
+                                           ism330dhcx_sleep_status_on_int_t val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0. sleep_status_on_int= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of sleep change on INT pins
+  *         (only if INT1_SLEEP_CHANGE or INT2_SLEEP_CHANGE bits
+  *         are enabled).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_status_on_int in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_act_pin_notification_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_sleep_status_on_int_t *val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  switch (tap_cfg0. sleep_status_on_int){
+    case ISM330DHCX_DRIVE_SLEEP_CHG_EVENT:
+      *val = ISM330DHCX_DRIVE_SLEEP_CHG_EVENT;
+      break;
+    case ISM330DHCX_DRIVE_SLEEP_STATUS:
+      *val = ISM330DHCX_DRIVE_SLEEP_STATUS;
+      break;
+    default:
+      *val = ISM330DHCX_DRIVE_SLEEP_CHG_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of inact_en in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_act_mode_set(stmdev_ctx_t *ctx,
+                                ism330dhcx_inact_en_t val)
+{
+  ism330dhcx_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+  if(ret == 0){
+    tap_cfg2.inact_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG2,
+                               (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of inact_en in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_act_mode_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_inact_en_t *val)
+{
+  ism330dhcx_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+
+  switch (tap_cfg2.inact_en){
+    case ISM330DHCX_XL_AND_GY_NOT_AFFECTED:
+      *val = ISM330DHCX_XL_AND_GY_NOT_AFFECTED;
+      break;
+    case ISM330DHCX_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = ISM330DHCX_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case ISM330DHCX_XL_12Hz5_GY_SLEEP:
+      *val = ISM330DHCX_XL_12Hz5_GY_SLEEP;
+      break;
+    case ISM330DHCX_XL_12Hz5_GY_PD:
+      *val = ISM330DHCX_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = ISM330DHCX_XL_AND_GY_NOT_AFFECTED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.(1 LSb = 512 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_tap_generator
+  * @brief      This section groups all the functions that manage the
+  *             tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.tap_z_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  *val = tap_cfg0.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.tap_y_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  *val = tap_cfg0.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.tap_x_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  *val = tap_cfg0.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  X-axis tap recognition threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_x in reg TAP_CFG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+  if(ret == 0){
+    tap_cfg1.tap_ths_x= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG1,
+                              (uint8_t*)&tap_cfg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X-axis tap recognition threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_x in reg TAP_CFG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+  *val = tap_cfg1.tap_ths_x;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_priority in reg TAP_CFG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_axis_priority_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_tap_priority_t val)
+{
+  ism330dhcx_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+  if(ret == 0){
+    tap_cfg1.tap_priority= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG1,
+                               (uint8_t*)&tap_cfg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_priority in reg TAP_CFG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_axis_priority_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_tap_priority_t *val)
+{
+  ism330dhcx_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+
+  switch (tap_cfg1.tap_priority){
+    case ISM330DHCX_XYZ:
+      *val = ISM330DHCX_XYZ;
+      break;
+    case ISM330DHCX_YXZ:
+      *val = ISM330DHCX_YXZ;
+      break;
+    case ISM330DHCX_XZY:
+      *val = ISM330DHCX_XZY;
+      break;
+    case ISM330DHCX_ZYX:
+      *val = ISM330DHCX_ZYX;
+      break;
+    case ISM330DHCX_YZX:
+      *val = ISM330DHCX_YZX;
+      break;
+    case ISM330DHCX_ZXY:
+      *val = ISM330DHCX_ZXY;
+      break;
+    default:
+      *val = ISM330DHCX_XYZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y-axis tap recognition threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_y in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+  if(ret == 0){
+    tap_cfg2.tap_ths_y= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_CFG2,
+                              (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y-axis tap recognition threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_y in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+  *val = tap_cfg2.tap_ths_y;
+
+  return ret;
+}
+
+/**
+  * @brief  Z-axis recognition threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_z in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.tap_ths_z= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z-axis recognition threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_z in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.tap_ths_z;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value of
+  *         these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.shock= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT_DUR2,
+                              (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value of
+  *         these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.quiet= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT_DUR2,
+                              (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses
+  *         the maximum time between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value, 1LSB
+  *         corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.dur= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_INT_DUR2,
+                              (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine
+  *         a double tap event. The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time. If the DUR[3:0] bits are set to
+  *         a different value, 1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_mode_set(stmdev_ctx_t *ctx,
+                               ism330dhcx_single_double_tap_t val)
+{
+  ism330dhcx_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.single_double_tap= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tap_mode_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_single_double_tap_t *val)
+{
+  ism330dhcx_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+
+  switch (wake_up_ths.single_double_tap){
+    case ISM330DHCX_ONLY_SINGLE:
+      *val = ISM330DHCX_ONLY_SINGLE;
+      break;
+    case ISM330DHCX_BOTH_SINGLE_DOUBLE:
+      *val = ISM330DHCX_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = ISM330DHCX_ONLY_SINGLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_ Six_position_detection(6D/4D)
+  * @brief      This section groups all the functions concerning six
+  *             position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_6d_threshold_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sixd_ths_t val)
+{
+  ism330dhcx_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.sixd_ths= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_6d_threshold_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sixd_ths_t *val)
+{
+  ism330dhcx_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+
+  switch (tap_ths_6d.sixd_ths){
+    case ISM330DHCX_DEG_80:
+      *val = ISM330DHCX_DEG_80;
+      break;
+    case ISM330DHCX_DEG_70:
+      *val = ISM330DHCX_DEG_70;
+      break;
+    case ISM330DHCX_DEG_60:
+      *val = ISM330DHCX_DEG_60;
+      break;
+    case ISM330DHCX_DEG_50:
+      *val = ISM330DHCX_DEG_50;
+      break;
+    default:
+      *val = ISM330DHCX_DEG_80;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.d4d_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_free_fall
+  * @brief      This section group all the functions concerning the free
+  *             fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_ff_threshold_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_ff_ths_t val)
+{
+  ism330dhcx_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FREE_FALL,
+                            (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FREE_FALL,
+                              (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_ff_threshold_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_ff_ths_t *val)
+{
+  ism330dhcx_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FREE_FALL,
+                            (uint8_t*)&free_fall, 1);
+
+  switch (free_fall.ff_ths){
+    case ISM330DHCX_FF_TSH_156mg:
+      *val = ISM330DHCX_FF_TSH_156mg;
+      break;
+    case ISM330DHCX_FF_TSH_219mg:
+      *val = ISM330DHCX_FF_TSH_219mg;
+      break;
+    case ISM330DHCX_FF_TSH_250mg:
+      *val = ISM330DHCX_FF_TSH_250mg;
+      break;
+    case ISM330DHCX_FF_TSH_312mg:
+      *val = ISM330DHCX_FF_TSH_312mg;
+      break;
+    case ISM330DHCX_FF_TSH_344mg:
+      *val = ISM330DHCX_FF_TSH_344mg;
+      break;
+    case ISM330DHCX_FF_TSH_406mg:
+      *val = ISM330DHCX_FF_TSH_406mg;
+      break;
+    case ISM330DHCX_FF_TSH_469mg:
+      *val = ISM330DHCX_FF_TSH_469mg;
+      break;
+    case ISM330DHCX_FF_TSH_500mg:
+      *val = ISM330DHCX_FF_TSH_500mg;
+      break;
+    default:
+      *val = ISM330DHCX_FF_TSH_156mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_dur in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_wake_up_dur_t wake_up_dur;
+  ism330dhcx_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.ff_dur = (val & 0x20U) >> 5;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FREE_FALL,
+                             (uint8_t*)&free_fall, 1);
+  }
+  if(ret == 0){
+    free_fall.ff_dur = val & 0x1FU;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FREE_FALL,
+                              (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_dur in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_wake_up_dur_t wake_up_dur;
+  ism330dhcx_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FREE_FALL,
+                             (uint8_t*)&free_fall, 1);
+  }
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_fifo
+  * @brief      This section group all the functions concerning
+  *             the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  ism330dhcx_fifo_ctrl1_t fifo_ctrl1;
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl1.wtm = (uint8_t)(0x00FFU & val);
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL1,
+                              (uint8_t*)&fifo_ctrl1, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl2.wtm = (uint8_t)(( 0x0100U & val ) >> 8);
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  ism330dhcx_fifo_ctrl1_t fifo_ctrl1;
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL1,
+                             (uint8_t*)&fifo_ctrl1, 1);
+  }
+  *val = fifo_ctrl2.wtm;
+  *val = *val << 8;
+  *val += fifo_ctrl1.wtm;
+  return ret;
+}
+
+/**
+  * @brief  Enable and configure compression algo.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of uncoptr_rate in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_compression_algo_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_uncoptr_rate_t val)
+{
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  ism330dhcx_emb_func_en_b_t emb_func_en_b;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    emb_func_en_b.fifo_compr_en = ((uint8_t)val & 0x04U) >> 2;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                              (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                             (uint8_t*)&fifo_ctrl2, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl2.fifo_compr_rt_en = ((uint8_t)val & 0x04U) >> 2;
+    fifo_ctrl2.uncoptr_rate = (uint8_t)val & 0x03U;
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable and configure compression algo.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of uncoptr_rate in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_compression_algo_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_uncoptr_rate_t *val)
+{
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+
+  switch (( fifo_ctrl2.fifo_compr_rt_en << 2) + fifo_ctrl2.uncoptr_rate ){
+    case ISM330DHCX_CMP_DISABLE:
+      *val = ISM330DHCX_CMP_DISABLE;
+      break;
+    case ISM330DHCX_CMP_ALWAYS:
+      *val = ISM330DHCX_CMP_ALWAYS;
+      break;
+    case ISM330DHCX_CMP_8_TO_1:
+      *val = ISM330DHCX_CMP_8_TO_1;
+      break;
+    case ISM330DHCX_CMP_16_TO_1:
+      *val = ISM330DHCX_CMP_16_TO_1;
+      break;
+    case ISM330DHCX_CMP_32_TO_1:
+      *val = ISM330DHCX_CMP_32_TO_1;
+      break;
+    default:
+      *val = ISM330DHCX_CMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odrchg_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
+                                                uint8_t val)
+{
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.odrchg_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odrchg_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
+                                                uint8_t *val)
+{
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.odrchg_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_compr_rt_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_compression_algo_real_time_set(stmdev_ctx_t *ctx,
+                                                 uint8_t val)
+{
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.fifo_compr_rt_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_compr_rt_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_compression_algo_real_time_get(stmdev_ctx_t *ctx,
+                                                 uint8_t *val)
+{
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.fifo_compr_rt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_wtm in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.stop_on_wtm= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_wtm in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdr_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_xl_batch_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_bdr_xl_t val)
+{
+  ism330dhcx_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.bdr_xl= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdr_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_xl_batch_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_bdr_xl_t *val)
+{
+  ism330dhcx_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.bdr_xl){
+    case ISM330DHCX_XL_NOT_BATCHED:
+      *val = ISM330DHCX_XL_NOT_BATCHED;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_12Hz5:
+      *val = ISM330DHCX_XL_BATCHED_AT_12Hz5;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_26Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_26Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_52Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_52Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_104Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_104Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_208Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_208Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_417Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_417Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_833Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_833Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_1667Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_1667Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_3333Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_3333Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_6667Hz:
+      *val = ISM330DHCX_XL_BATCHED_AT_6667Hz;
+      break;
+    case ISM330DHCX_XL_BATCHED_AT_6Hz5:
+      *val = ISM330DHCX_XL_BATCHED_AT_6Hz5;
+      break;
+    default:
+      *val = ISM330DHCX_XL_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdr_gy in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_gy_batch_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_bdr_gy_t val)
+{
+  ism330dhcx_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.bdr_gy= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdr_gy in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_gy_batch_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_bdr_gy_t *val)
+{
+  ism330dhcx_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.bdr_gy){
+    case ISM330DHCX_GY_NOT_BATCHED:
+      *val = ISM330DHCX_GY_NOT_BATCHED;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_12Hz5:
+      *val = ISM330DHCX_GY_BATCHED_AT_12Hz5;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_26Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_26Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_52Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_52Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_104Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_104Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_208Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_208Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_417Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_417Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_833Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_833Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_1667Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_1667Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_3333Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_3333Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_AT_6667Hz:
+      *val = ISM330DHCX_GY_BATCHED_AT_6667Hz;
+      break;
+    case ISM330DHCX_GY_BATCHED_6Hz5:
+      *val = ISM330DHCX_GY_BATCHED_6Hz5;
+      break;
+    default:
+      *val = ISM330DHCX_GY_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_mode in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_mode_set(stmdev_ctx_t *ctx,
+                                ism330dhcx_fifo_mode_t val)
+{
+  ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.fifo_mode= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_mode in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_mode_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_fifo_mode_t *val)
+{
+  ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.fifo_mode){
+    case ISM330DHCX_BYPASS_MODE:
+      *val = ISM330DHCX_BYPASS_MODE;
+      break;
+    case ISM330DHCX_FIFO_MODE:
+      *val = ISM330DHCX_FIFO_MODE;
+      break;
+    case ISM330DHCX_STREAM_TO_FIFO_MODE:
+      *val = ISM330DHCX_STREAM_TO_FIFO_MODE;
+      break;
+    case ISM330DHCX_BYPASS_TO_STREAM_MODE:
+      *val = ISM330DHCX_BYPASS_TO_STREAM_MODE;
+      break;
+    case ISM330DHCX_STREAM_MODE:
+      *val = ISM330DHCX_STREAM_MODE;
+      break;
+    case ISM330DHCX_BYPASS_TO_FIFO_MODE:
+      *val = ISM330DHCX_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = ISM330DHCX_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_t_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_temp_batch_set(stmdev_ctx_t *ctx,
+                                      ism330dhcx_odr_t_batch_t val)
+{
+  ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.odr_t_batch= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_t_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_temp_batch_get(stmdev_ctx_t *ctx,
+                                      ism330dhcx_odr_t_batch_t *val)
+{
+  ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.odr_t_batch){
+    case ISM330DHCX_TEMP_NOT_BATCHED:
+      *val = ISM330DHCX_TEMP_NOT_BATCHED;
+      break;
+    case ISM330DHCX_TEMP_BATCHED_AT_52Hz:
+      *val = ISM330DHCX_TEMP_BATCHED_AT_52Hz;
+      break;
+    case ISM330DHCX_TEMP_BATCHED_AT_12Hz5:
+      *val = ISM330DHCX_TEMP_BATCHED_AT_12Hz5;
+      break;
+    case ISM330DHCX_TEMP_BATCHED_AT_1Hz6:
+      *val = ISM330DHCX_TEMP_BATCHED_AT_1Hz6;
+      break;
+    default:
+      *val = ISM330DHCX_TEMP_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_ts_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
+                                                ism330dhcx_odr_ts_batch_t val)
+{
+  ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.odr_ts_batch= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_ts_batch in reg
+  *                                 FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
+                                                ism330dhcx_odr_ts_batch_t *val)
+{
+  ism330dhcx_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.odr_ts_batch){
+    case ISM330DHCX_NO_DECIMATION:
+      *val = ISM330DHCX_NO_DECIMATION;
+      break;
+    case ISM330DHCX_DEC_1:
+      *val = ISM330DHCX_DEC_1;
+      break;
+    case ISM330DHCX_DEC_8:
+      *val = ISM330DHCX_DEC_8;
+      break;
+    case ISM330DHCX_DEC_32:
+      *val = ISM330DHCX_DEC_32;
+      break;
+    default:
+      *val = ISM330DHCX_NO_DECIMATION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *         between XL and gyro.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of trig_counter_bdr in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_cnt_event_batch_set(stmdev_ctx_t *ctx,
+                                           ism330dhcx_trig_counter_bdr_t val)
+{
+  ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.trig_counter_bdr= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *          between XL and gyro.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of trig_counter_bdr
+  *                in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_cnt_event_batch_get(stmdev_ctx_t *ctx,
+                                           ism330dhcx_trig_counter_bdr_t *val)
+{
+  ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+
+  switch (counter_bdr_reg1.trig_counter_bdr){
+    case ISM330DHCX_XL_BATCH_EVENT:
+      *val = ISM330DHCX_XL_BATCH_EVENT;
+      break;
+    case ISM330DHCX_GYRO_BATCH_EVENT:
+      *val = ISM330DHCX_GYRO_BATCH_EVENT;
+      break;
+    default:
+      *val = ISM330DHCX_XL_BATCH_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to '1'.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.rst_counter_bdr= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to '1'.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  *val = counter_bdr_reg1.rst_counter_bdr;
+
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of cnt_bdr_th in reg COUNTER_BDR_REG2
+  *                and COUNTER_BDR_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_batch_counter_threshold_set(stmdev_ctx_t *ctx,
+                                              uint16_t val)
+{
+  ism330dhcx_counter_bdr_reg2_t counter_bdr_reg1;
+  ism330dhcx_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0){
+    counter_bdr_reg1.cnt_bdr_th = (uint8_t)((0x0700U & val) >> 8);
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                               (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  if (ret == 0){
+    counter_bdr_reg2.cnt_bdr_th = (uint8_t)(0x00FFU & val);
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_COUNTER_BDR_REG2,
+                              (uint8_t*)&counter_bdr_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of cnt_bdr_th in reg COUNTER_BDR_REG2
+  *                and COUNTER_BDR_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_batch_counter_threshold_get(stmdev_ctx_t *ctx,
+                                              uint16_t *val)
+{
+  ism330dhcx_counter_bdr_reg1_t counter_bdr_reg1;
+  ism330dhcx_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_COUNTER_BDR_REG2,
+                             (uint8_t*)&counter_bdr_reg2, 1);
+  }
+
+  *val = counter_bdr_reg1.cnt_bdr_th;
+  *val = *val << 8;
+  *val += counter_bdr_reg2.cnt_bdr_th;
+  return ret;
+}
+
+/**
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  ism330dhcx_fifo_status1_t fifo_status1;
+  ism330dhcx_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS1,
+                           (uint8_t*)&fifo_status1, 1);
+  if (ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
+                             (uint8_t*)&fifo_status2, 1);
+    *val = fifo_status2.diff_fifo;
+    *val = *val << 8;
+    *val += fifo_status1.diff_fifo;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Registers FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_status_get(stmdev_ctx_t *ctx,
+                                  ism330dhcx_fifo_status2_t *val)
+{
+  int32_t ret;
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2, (uint8_t*)val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO full status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.fifo_full_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  fifo_over_run_latched in
+  *                reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2. fifo_ovr_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.fifo_wtm_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  Identifies the sensor in FIFO_DATA_OUT.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tag_sensor in reg FIFO_DATA_OUT_TAG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
+                                      ism330dhcx_fifo_tag_t *val)
+{
+  ism330dhcx_fifo_data_out_tag_t fifo_data_out_tag;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FIFO_DATA_OUT_TAG,
+                           (uint8_t*)&fifo_data_out_tag, 1);
+
+  switch (fifo_data_out_tag.tag_sensor){
+    case ISM330DHCX_GYRO_NC_TAG:
+      *val = ISM330DHCX_GYRO_NC_TAG;
+      break;
+    case ISM330DHCX_XL_NC_TAG:
+      *val = ISM330DHCX_XL_NC_TAG;
+      break;
+    case ISM330DHCX_TEMPERATURE_TAG:
+      *val = ISM330DHCX_TEMPERATURE_TAG;
+      break;
+    case ISM330DHCX_TIMESTAMP_TAG:
+      *val = ISM330DHCX_TIMESTAMP_TAG;
+      break;
+    case ISM330DHCX_CFG_CHANGE_TAG:
+      *val = ISM330DHCX_CFG_CHANGE_TAG;
+      break;
+    case ISM330DHCX_XL_NC_T_2_TAG:
+      *val = ISM330DHCX_XL_NC_T_2_TAG;
+      break;
+    case ISM330DHCX_XL_NC_T_1_TAG:
+      *val = ISM330DHCX_XL_NC_T_1_TAG;
+      break;
+    case ISM330DHCX_XL_2XC_TAG:
+      *val = ISM330DHCX_XL_2XC_TAG;
+      break;
+    case ISM330DHCX_XL_3XC_TAG:
+      *val = ISM330DHCX_XL_3XC_TAG;
+      break;
+    case ISM330DHCX_GYRO_NC_T_2_TAG:
+      *val = ISM330DHCX_GYRO_NC_T_2_TAG;
+      break;
+    case ISM330DHCX_GYRO_NC_T_1_TAG:
+      *val = ISM330DHCX_GYRO_NC_T_1_TAG;
+      break;
+    case ISM330DHCX_GYRO_2XC_TAG:
+      *val = ISM330DHCX_GYRO_2XC_TAG;
+      break;
+    case ISM330DHCX_GYRO_3XC_TAG:
+      *val = ISM330DHCX_GYRO_3XC_TAG;
+      break;
+    case ISM330DHCX_SENSORHUB_SLAVE0_TAG:
+      *val = ISM330DHCX_SENSORHUB_SLAVE0_TAG;
+      break;
+    case ISM330DHCX_SENSORHUB_SLAVE1_TAG:
+      *val = ISM330DHCX_SENSORHUB_SLAVE1_TAG;
+      break;
+    case ISM330DHCX_SENSORHUB_SLAVE2_TAG:
+      *val = ISM330DHCX_SENSORHUB_SLAVE2_TAG;
+      break;
+    case ISM330DHCX_SENSORHUB_SLAVE3_TAG:
+      *val = ISM330DHCX_SENSORHUB_SLAVE3_TAG;
+      break;
+    case ISM330DHCX_STEP_CPUNTER_TAG:
+      *val = ISM330DHCX_STEP_CPUNTER_TAG;
+      break;
+    case ISM330DHCX_GAME_ROTATION_TAG:
+      *val = ISM330DHCX_GAME_ROTATION_TAG;
+      break;
+    case ISM330DHCX_GEOMAG_ROTATION_TAG:
+      *val = ISM330DHCX_GEOMAG_ROTATION_TAG;
+      break;
+    case ISM330DHCX_ROTATION_TAG:
+      *val = ISM330DHCX_ROTATION_TAG;
+      break;
+    case ISM330DHCX_SENSORHUB_NACK_TAG:
+      *val = ISM330DHCX_SENSORHUB_NACK_TAG;
+      break;
+    default:
+      *val = ISM330DHCX_SENSORHUB_NACK_TAG;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching of pedometer embedded function values.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gbias_fifo_en in
+  *                reg ISM330DHCX_EMB_FUNC_FIFO_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_emb_func_fifo_cfg_t emb_func_fifo_cfg;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+     ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_FIFO_CFG,
+                              (uint8_t*)&emb_func_fifo_cfg, 1);
+  }
+  if(ret == 0){
+    emb_func_fifo_cfg.pedo_fifo_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_FIFO_CFG,
+                              (uint8_t*)&emb_func_fifo_cfg, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching of pedometer embedded function values.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pedo_fifo_en in reg
+  *                ISM330DHCX_EMB_FUNC_FIFO_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_emb_func_fifo_cfg_t emb_func_fifo_cfg;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_FIFO_CFG,
+                             (uint8_t*)&emb_func_fifo_cfg, 1);
+    *val = emb_func_fifo_cfg.pedo_fifo_en;
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of first slave.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_0_en in reg SLV0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_batch_slave_0_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    slv0_config. batch_ext_sens_0_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV0_CONFIG,
+                              (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of first slave.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_0_en in
+  *                reg SLV0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_batch_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    *val = slv0_config. batch_ext_sens_0_en;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of second slave.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_1_en in
+  *                reg SLV1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_batch_slave_1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_slv1_config_t slv1_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV1_CONFIG,
+                             (uint8_t*)&slv1_config, 1);
+  }
+  if(ret == 0){
+    slv1_config. batch_ext_sens_1_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV1_CONFIG,
+                              (uint8_t*)&slv1_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of second slave.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_1_en in
+  *                reg SLV1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_batch_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_slv1_config_t slv1_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV1_CONFIG,
+                             (uint8_t*)&slv1_config, 1);
+    *val = slv1_config. batch_ext_sens_1_en;
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of third slave.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_2_en in
+  *                reg SLV2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_batch_slave_2_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_slv2_config_t slv2_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV2_CONFIG,
+                             (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    slv2_config. batch_ext_sens_2_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV2_CONFIG,
+                              (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of third slave.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_2_en in
+  *                reg SLV2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_batch_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_slv2_config_t slv2_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV2_CONFIG,
+                             (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    *val = slv2_config. batch_ext_sens_2_en;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of fourth slave.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_3_en in
+  *                reg SLV3_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_batch_slave_3_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_slv3_config_t slv3_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV3_CONFIG,
+                             (uint8_t*)&slv3_config, 1);
+  }
+  if(ret == 0){
+    slv3_config. batch_ext_sens_3_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV3_CONFIG,
+                              (uint8_t*)&slv3_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of fourth slave.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_3_en in
+  *                reg SLV3_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_batch_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_slv3_config_t slv3_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV3_CONFIG,
+                             (uint8_t*)&slv3_config, 1);
+    *val = slv3_config. batch_ext_sens_3_en;
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_DEN_functionality
+  * @brief      This section groups all the functions concerning
+  *             DEN functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DEN functionality marking mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_mode_set(stmdev_ctx_t *ctx, ism330dhcx_den_mode_t val)
+{
+  ism330dhcx_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.den_mode= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_mode_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_den_mode_t *val)
+{
+  ism330dhcx_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.den_mode){
+    case ISM330DHCX_DEN_DISABLE:
+      *val = ISM330DHCX_DEN_DISABLE;
+      break;
+    case ISM330DHCX_LEVEL_FIFO:
+      *val = ISM330DHCX_LEVEL_FIFO;
+      break;
+    case ISM330DHCX_LEVEL_LETCHED:
+      *val = ISM330DHCX_LEVEL_LETCHED;
+      break;
+    case ISM330DHCX_LEVEL_TRIGGER:
+      *val = ISM330DHCX_LEVEL_TRIGGER;
+      break;
+    case ISM330DHCX_EDGE_TRIGGER:
+      *val = ISM330DHCX_EDGE_TRIGGER;
+      break;
+    default:
+      *val = ISM330DHCX_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_lh in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_polarity_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_den_lh_t val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_lh= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_lh in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_polarity_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_den_lh_t *val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+
+  switch (ctrl9_xl.den_lh){
+    case ISM330DHCX_DEN_ACT_LOW:
+      *val = ISM330DHCX_DEN_ACT_LOW;
+      break;
+    case ISM330DHCX_DEN_ACT_HIGH:
+      *val = ISM330DHCX_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = ISM330DHCX_DEN_ACT_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_xl_g in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_enable_set(stmdev_ctx_t *ctx,
+                                 ism330dhcx_den_xl_g_t val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_xl_g= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_xl_g in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_enable_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_den_xl_g_t *val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+
+  switch (ctrl9_xl.den_xl_g){
+    case ISM330DHCX_STAMP_IN_GY_DATA:
+      *val = ISM330DHCX_STAMP_IN_GY_DATA;
+      break;
+    case ISM330DHCX_STAMP_IN_XL_DATA:
+      *val = ISM330DHCX_STAMP_IN_XL_DATA;
+      break;
+    case ISM330DHCX_STAMP_IN_GY_XL_DATA:
+      *val = ISM330DHCX_STAMP_IN_GY_XL_DATA;
+      break;
+    default:
+      *val = ISM330DHCX_STAMP_IN_GY_DATA;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_z= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_y= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_x= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_CTRL9_XL,
+                               (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = ism330dhcx_read_reg(ctx, ISM330DHCX_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_Pedometer
+  * @brief      This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable pedometer algorithm.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pedo_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                             (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    emb_func_en_a.pedo_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                              (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer algorithm.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pedo_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                             (uint8_t*)&emb_func_en_a, 1);
+    *val = emb_func_en_a.pedo_en;
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer algorithm working mode.[set]
+  *
+  * @param  ctx    read / write interface definitions
+  * @param  val    Change the values of:
+  *                   - pedo_fpr_adf_dis in reg ADV_PEDO
+  *                   - pedo_adv_en in reg EMB_FUNC_EN_B
+  *                   - ad_det_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_mode_set(stmdev_ctx_t *ctx,
+                                 ism330dhcx_pedo_mode_t val)
+{
+  ism330dhcx_adv_pedo_t adv_pedo;
+  ism330dhcx_emb_func_en_b_t emb_func_en_b;
+  ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_ADV_PEDO,
+                              (uint8_t*)&adv_pedo, 1);
+  }
+  if(ret == 0){
+    adv_pedo.pedo_fpr_adf_dis = (~((uint8_t)val) & 0x01U);
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_ADV_PEDO,
+                               (uint8_t*)&adv_pedo, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                           (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    emb_func_en_b.mlc_en = (uint8_t)val & 0x01U;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                            (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                  (uint8_t*)&pedo_cmd_reg);
+    pedo_cmd_reg.fp_rejection_en = ((uint8_t)val & 0x01U);
+    pedo_cmd_reg.ad_det_en = ((uint8_t)val & 0x02U)>>1;
+  }
+  if(ret == 0){
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer algorithm working mode.[get]
+  *
+  * @param  ctx    read / write interface definitions
+  * @param  val    Get the values of:
+  *                   - pedo_fpr_adf_dis in reg ADV_PEDO
+  *                   - pedo_adv_en in reg EMB_FUNC_EN_B
+  *                   - ad_det_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_mode_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_pedo_mode_t *val)
+{
+  ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                (uint8_t*)&pedo_cmd_reg);
+
+  switch ((pedo_cmd_reg.ad_det_en << 1) | pedo_cmd_reg.fp_rejection_en){
+    case ISM330DHCX_PEDO_BASE:
+      *val = ISM330DHCX_PEDO_BASE;
+      break;
+    case ISM330DHCX_PEDO_BASE_FALSE_STEP_REJ:
+      *val = ISM330DHCX_PEDO_BASE_FALSE_STEP_REJ;
+      break;
+    case ISM330DHCX_PEDO_ADV_FALSE_STEP_REJ:
+      *val = ISM330DHCX_PEDO_ADV_FALSE_STEP_REJ;
+      break;
+    default:
+      *val = ISM330DHCX_PEDO_BASE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for step detection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_step_det in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_step_detect_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_STATUS,
+                             (uint8_t*)&emb_func_status, 1);
+    *val = emb_func_status.is_step_det;
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_debounce_steps_set(stmdev_ctx_t *ctx,
+                                           uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_DEB_STEPS_CONF,
+                                    buff);
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_debounce_steps_get(stmdev_ctx_t *ctx,
+                                           uint8_t *buff)
+{
+  int32_t ret;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_DEB_STEPS_CONF,
+                                   buff);
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_SC_DELTAT_L,
+                                    &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_SC_DELTAT_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_SC_DELTAT_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_SC_DELTAT_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the advanced detection feature.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ad_det_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_adv_detection_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+
+  if(ret == 0){
+    pedo_cmd_reg.ad_det_en= (uint8_t)val;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                      (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the advanced detection feature.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ad_det_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_adv_detection_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+  *val = pedo_cmd_reg.ad_det_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the false-positive rejection feature.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fp_rejection_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_false_step_rejection_set(stmdev_ctx_t *ctx,
+                                                uint8_t val)
+{
+  ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+
+  if(ret == 0){
+    pedo_cmd_reg.fp_rejection_en= (uint8_t)val;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                      (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the false-positive rejection feature.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fp_rejection_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_false_step_rejection_get(stmdev_ctx_t *ctx,
+                                                 uint8_t *val)
+{
+  ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+  *val = pedo_cmd_reg.fp_rejection_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Set when user wants to generate interrupt on count overflow
+  *         event/every step.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of carry_count_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_int_mode_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_carry_count_en_t val)
+{
+  ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+
+  if(ret == 0){
+    pedo_cmd_reg.carry_count_en= (uint8_t)val;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                      (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Set when user wants to generate interrupt on count overflow
+  *         event/every step.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of carry_count_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_pedo_int_mode_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_carry_count_en_t *val)
+{
+  ism330dhcx_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+
+  switch (pedo_cmd_reg.carry_count_en){
+    case ISM330DHCX_EVERY_STEP:
+      *val = ISM330DHCX_EVERY_STEP;
+      break;
+    case ISM330DHCX_COUNT_OVERFLOW:
+      *val = ISM330DHCX_COUNT_OVERFLOW;
+      break;
+    default:
+      *val = ISM330DHCX_EVERY_STEP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_significant_motion
+  * @brief      This section groups all the functions that manage the
+  *             significant motion detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable significant motion detection function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sign_motion_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                              (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    emb_func_en_a.sign_motion_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                               (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable significant motion detection function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sign_motion_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                              (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_en_a.sign_motion_en;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for significant motion detection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_sigmot in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_motion_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                              uint8_t *val)
+{
+  ism330dhcx_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_STATUS,
+                              (uint8_t*)&emb_func_status, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_status.is_sigmot;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_tilt_detection
+  * @brief      This section groups all the functions that manage the tilt
+  *             event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tilt_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                              (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    emb_func_en_a.tilt_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                               (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tilt_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_A,
+                              (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_en_a.tilt_en;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for tilt detection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_tilt in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_tilt_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  ism330dhcx_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_STATUS,
+                             (uint8_t*)&emb_func_status, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_status.is_tilt;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_ magnetometer_sensor
+  * @brief      This section groups all the functions that manage additional
+  *             magnetometer sensor.
+  * @{
+  *
+  */
+
+/**
+  * @brief  External magnetometer sensitivity value register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_sensitivity_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SENSITIVITY_L,
+                                   &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SENSITIVITY_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer sensitivity value register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_sensitivity_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SENSITIVITY_L,
+                                   &buff[i]);
+
+if(ret == 0){
+  i++;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SENSITIVITY_H,
+                                   &buff[i]);
+}
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFX_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFX_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_OFFZ_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFX_L, &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFX_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_OFFZ_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft-iron (3x3 symmetric) matrix correction register (r/w).
+  *         The value is expressed as half-precision floating-point format:
+  *         SEEEEEFFFFFFFFFF
+  *         S: 1 sign bit;
+  *         E: 5 exponent bits;
+  *         F: 10 fraction bits).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_XX_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_XX_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_XY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_XY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_XZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_XZ_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_YY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_YY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_YZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_YZ_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_ZZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_SI_ZZ_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft-iron (3x3 symmetric) matrix correction register (r/w).
+  *         The value is expressed as half-precision floating-point format:
+  *         SEEEEEFFFFFFFFFF
+  *         S: 1 sign bit;
+  *         E: 5 exponent bits;
+  *         F: 10 fraction bits).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_XX_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_XX_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_XY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_XY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_XZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_XZ_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_YY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_YY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_YZ_L, &buff[i]);
+    }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_YZ_H, &buff[i]);
+    }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_ZZ_L, &buff[i]);
+    }
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_SI_ZZ_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Z-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of mag_z_axis in reg MAG_CFG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_z_orient_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_z_axis_t val)
+{
+  ism330dhcx_mag_cfg_a_t mag_cfg_a;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_A,
+                                  (uint8_t*)&mag_cfg_a);
+
+  if(ret == 0){
+    mag_cfg_a.mag_z_axis= (uint8_t)val;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_CFG_A,
+                                     (uint8_t*)&mag_cfg_a);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Z-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of mag_z_axis in reg MAG_CFG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_z_orient_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_z_axis_t *val)
+{
+  ism330dhcx_mag_cfg_a_t mag_cfg_a;
+  int32_t ret;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_A,
+                                  (uint8_t*)&mag_cfg_a);
+
+  switch (mag_cfg_a.mag_z_axis){
+    case ISM330DHCX_Z_EQ_Y:
+      *val = ISM330DHCX_Z_EQ_Y;
+      break;
+    case ISM330DHCX_Z_EQ_MIN_Y:
+      *val = ISM330DHCX_Z_EQ_MIN_Y;
+      break;
+    case ISM330DHCX_Z_EQ_X:
+      *val = ISM330DHCX_Z_EQ_X;
+      break;
+    case ISM330DHCX_Z_EQ_MIN_X:
+      *val = ISM330DHCX_Z_EQ_MIN_X;
+      break;
+    case ISM330DHCX_Z_EQ_MIN_Z:
+      *val = ISM330DHCX_Z_EQ_MIN_Z;
+      break;
+    case ISM330DHCX_Z_EQ_Z:
+      *val = ISM330DHCX_Z_EQ_Z;
+      break;
+    default:
+      *val = ISM330DHCX_Z_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Y-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of mag_y_axis in
+  *                               reg MAG_CFG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_y_orient_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_y_axis_t val)
+{
+  ism330dhcx_mag_cfg_a_t mag_cfg_a;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_A,
+                                  (uint8_t*)&mag_cfg_a);
+  if(ret == 0){
+    mag_cfg_a.mag_y_axis= (uint8_t)val;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_CFG_A,
+                                     (uint8_t*)&mag_cfg_a);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Y-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of mag_y_axis in reg MAG_CFG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_y_orient_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_y_axis_t *val)
+{
+  ism330dhcx_mag_cfg_a_t mag_cfg_a;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_A,
+                                  (uint8_t*)&mag_cfg_a);
+
+  switch (mag_cfg_a.mag_y_axis){
+    case ISM330DHCX_Y_EQ_Y:
+      *val = ISM330DHCX_Y_EQ_Y;
+      break;
+    case ISM330DHCX_Y_EQ_MIN_Y:
+      *val = ISM330DHCX_Y_EQ_MIN_Y;
+      break;
+    case ISM330DHCX_Y_EQ_X:
+      *val = ISM330DHCX_Y_EQ_X;
+      break;
+    case ISM330DHCX_Y_EQ_MIN_X:
+      *val = ISM330DHCX_Y_EQ_MIN_X;
+      break;
+    case ISM330DHCX_Y_EQ_MIN_Z:
+      *val = ISM330DHCX_Y_EQ_MIN_Z;
+      break;
+    case ISM330DHCX_Y_EQ_Z:
+      *val = ISM330DHCX_Y_EQ_Z;
+      break;
+    default:
+      *val = ISM330DHCX_Y_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+   * @brief  Magnetometer X-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of mag_x_axis in reg MAG_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_x_orient_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_x_axis_t val)
+{
+  ism330dhcx_mag_cfg_b_t mag_cfg_b;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_B,
+                                  (uint8_t*)&mag_cfg_b);
+  if(ret == 0){
+    mag_cfg_b.mag_x_axis= (uint8_t)val;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_MAG_CFG_B,
+                                     (uint8_t*)&mag_cfg_b);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer X-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of mag_x_axis in reg MAG_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_mag_x_orient_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_x_axis_t *val)
+{
+  ism330dhcx_mag_cfg_b_t mag_cfg_b;
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_MAG_CFG_B,
+                                  (uint8_t*)&mag_cfg_b);
+
+  switch (mag_cfg_b.mag_x_axis){
+    case ISM330DHCX_X_EQ_Y:
+      *val = ISM330DHCX_X_EQ_Y;
+      break;
+    case ISM330DHCX_X_EQ_MIN_Y:
+      *val = ISM330DHCX_X_EQ_MIN_Y;
+      break;
+    case ISM330DHCX_X_EQ_X:
+      *val = ISM330DHCX_X_EQ_X;
+      break;
+    case ISM330DHCX_X_EQ_MIN_X:
+      *val = ISM330DHCX_X_EQ_MIN_X;
+      break;
+    case ISM330DHCX_X_EQ_MIN_Z:
+      *val = ISM330DHCX_X_EQ_MIN_Z;
+      break;
+    case ISM330DHCX_X_EQ_Z:
+      *val = ISM330DHCX_X_EQ_Z;
+      break;
+    default:
+      *val = ISM330DHCX_X_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_finite_state_machine
+  * @brief      This section groups all the functions that manage the
+  *             state_machine.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt status bit for FSM long counter timeout interrupt
+  *         event.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_fsm_lc in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_long_cnt_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                               uint8_t *val)
+{
+  ism330dhcx_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_STATUS,
+                             (uint8_t*)&emb_func_status, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_status.is_fsm_lc;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_en in reg EMB_FUNC_EN_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_emb_fsm_en_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  ism330dhcx_emb_func_en_b_t emb_func_en_b;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    emb_func_en_b.fsm_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                              (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fsm_en in reg EMB_FUNC_EN_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_emb_fsm_en_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  ism330dhcx_emb_func_en_b_t emb_func_en_b;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_en_b.fsm_en;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                              (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_enable_set(stmdev_ctx_t *ctx,
+                                 ism330dhcx_emb_fsm_enable_t *val)
+{
+  ism330dhcx_emb_func_en_b_t emb_func_en_b;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FSM_ENABLE_A,
+                              (uint8_t*)&val->fsm_enable_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FSM_ENABLE_B,
+                              (uint8_t*)&val->fsm_enable_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    if ( (val->fsm_enable_a.fsm1_en |
+          val->fsm_enable_a.fsm2_en |
+          val->fsm_enable_a.fsm3_en |
+          val->fsm_enable_a.fsm4_en |
+          val->fsm_enable_a.fsm5_en |
+          val->fsm_enable_a.fsm6_en |
+          val->fsm_enable_a.fsm7_en |
+          val->fsm_enable_a.fsm8_en |
+          val->fsm_enable_b.fsm9_en |
+          val->fsm_enable_b.fsm10_en |
+          val->fsm_enable_b.fsm11_en |
+          val->fsm_enable_b.fsm12_en |
+          val->fsm_enable_b.fsm13_en |
+          val->fsm_enable_b.fsm14_en |
+          val->fsm_enable_b.fsm15_en |
+          val->fsm_enable_b.fsm16_en ) != PROPERTY_DISABLE){
+      emb_func_en_b.fsm_en = PROPERTY_ENABLE;
+    }
+    else{
+      emb_func_en_b.fsm_en = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                              (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_enable_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_emb_fsm_enable_t *val)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_ENABLE_A,
+                             (uint8_t*)&val->fsm_enable_a, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_ENABLE_B,
+                             (uint8_t*)&val->fsm_enable_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_long_cnt_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FSM_LONG_COUNTER_L, buff, 2);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_long_cnt_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_LONG_COUNTER_L, buff, 2);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Clear FSM long counter value.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_lc_clr in reg
+  *                FSM_LONG_COUNTER_CLEAR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_long_clr_set(stmdev_ctx_t *ctx,
+                               ism330dhcx_fsm_lc_clr_t val)
+{
+  ism330dhcx_fsm_long_counter_clear_t fsm_long_counter_clear;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_LONG_COUNTER_CLEAR,
+                             (uint8_t*)&fsm_long_counter_clear, 1);
+  }
+  if(ret == 0){
+     fsm_long_counter_clear.fsm_lc_clr= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_FSM_LONG_COUNTER_CLEAR,
+                              (uint8_t*)&fsm_long_counter_clear, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Clear FSM long counter value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fsm_lc_clr in reg  FSM_LONG_COUNTER_CLEAR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_long_clr_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_fsm_lc_clr_t *val)
+{
+  ism330dhcx_fsm_long_counter_clear_t fsm_long_counter_clear;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_LONG_COUNTER_CLEAR,
+                             (uint8_t*)&fsm_long_counter_clear, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  switch (fsm_long_counter_clear.fsm_lc_clr){
+    case ISM330DHCX_LC_NORMAL:
+      *val = ISM330DHCX_LC_NORMAL;
+      break;
+    case ISM330DHCX_LC_CLEAR:
+      *val = ISM330DHCX_LC_CLEAR;
+      break;
+    case ISM330DHCX_LC_CLEAR_DONE:
+      *val = ISM330DHCX_LC_CLEAR_DONE;
+      break;
+    default:
+      *val = ISM330DHCX_LC_NORMAL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_OUTS1 to FSM_OUTS16
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_out_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_fsm_out_t *val)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_FSM_OUTS1,
+                             (uint8_t*)&val->fsm_outs1, 16);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_data_rate_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_fsm_odr_t val)
+{
+  ism330dhcx_emb_func_odr_cfg_b_t emb_func_odr_cfg_b;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_ODR_CFG_B,
+                             (uint8_t*)&emb_func_odr_cfg_b, 1);
+  }
+  if(ret == 0){
+    emb_func_odr_cfg_b.not_used_01 = 3; /* set default values */
+    emb_func_odr_cfg_b.not_used_02 = 1; /* set default values */
+    emb_func_odr_cfg_b.fsm_odr= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_ODR_CFG_B,
+                              (uint8_t*)&emb_func_odr_cfg_b, 1);
+ }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_data_rate_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_fsm_odr_t *val)
+{
+  ism330dhcx_emb_func_odr_cfg_b_t emb_func_odr_cfg_b;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_ODR_CFG_B,
+                             (uint8_t*)&emb_func_odr_cfg_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  switch (emb_func_odr_cfg_b.fsm_odr){
+    case ISM330DHCX_ODR_FSM_12Hz5:
+      *val = ISM330DHCX_ODR_FSM_12Hz5;
+      break;
+    case ISM330DHCX_ODR_FSM_26Hz:
+      *val = ISM330DHCX_ODR_FSM_26Hz;
+      break;
+    case ISM330DHCX_ODR_FSM_52Hz:
+      *val = ISM330DHCX_ODR_FSM_52Hz;
+      break;
+    case ISM330DHCX_ODR_FSM_104Hz:
+      *val = ISM330DHCX_ODR_FSM_104Hz;
+      break;
+    default:
+      *val = ISM330DHCX_ODR_FSM_12Hz5;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_init in reg FSM_INIT
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_INIT_B,
+                             (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    emb_func_init_b.fsm_init= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_INIT_B,
+                              (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_init in reg FSM_INIT
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_INIT_B,
+                             (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_init_b.fsm_init;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value, the FSM
+  *         generates an interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_long_cnt_int_value_set(stmdev_ctx_t *ctx,
+                                          uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_LC_TIMEOUT_L,
+                                    &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_LC_TIMEOUT_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value, the FSM generates
+  *         an interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_long_cnt_int_value_get(stmdev_ctx_t *ctx,
+                                          uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_LC_TIMEOUT_L,
+                                   &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_LC_TIMEOUT_H,
+                                    &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_number_of_programs_set(stmdev_ctx_t *ctx,
+                                             uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_PROGRAMS, buff);
+
+  if(ret == 0){
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_PROGRAMS + 0x01U,
+                                     buff);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_number_of_programs_get(stmdev_ctx_t *ctx,
+                                             uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_PROGRAMS, buff);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w). First available address is
+  *         0x033C.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_start_address_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_START_ADD_L, &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_write_byte(ctx, ISM330DHCX_FSM_START_ADD_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w). First available address
+  *         is 0x033C.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_fsm_start_address_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_START_ADD_L, &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = ism330dhcx_ln_pg_read_byte(ctx, ISM330DHCX_FSM_START_ADD_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @addtogroup  Machine Learning Core
+  * @brief   This section group all the functions concerning the
+  *          usage of Machine Learning Core
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable Machine Learning Core.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mlc_en in
+  *                  reg EMB_FUNC_EN_B and mlc_init
+  *                  in EMB_FUNC_INIT_B
+  *
+  */
+int32_t ism330dhcx_mlc_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_emb_func_en_b_t reg;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                              (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.mlc_en = val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                               (uint8_t*)&reg, 1);
+  }
+  if ((val != PROPERTY_DISABLE) && (ret == 0)){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_INIT_B,
+                                 (uint8_t*)&reg, 1);
+    if (ret == 0) {
+      reg.mlc_en = val;
+      ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_INIT_B,
+                                  (uint8_t*)&reg, 1);
+    }
+  }
+  if (ret == 0) {
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Machine Learning Core.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of mlc_en in
+  *                  reg EMB_FUNC_EN_B
+  *
+  */
+int32_t ism330dhcx_mlc_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_emb_func_en_b_t reg;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_EN_B,
+                              (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+    *val  = reg.mlc_en;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core status register[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register MLC_STATUS_MAINPAGE
+  *
+  */
+int32_t ism330dhcx_mlc_status_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_mlc_status_mainpage_t *val)
+{
+  return ism330dhcx_read_reg(ctx, ISM330DHCX_MLC_STATUS_MAINPAGE,
+                           (uint8_t*) val, 1);
+}
+
+/**
+  * @brief  Machine Learning Core data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      get the values of mlc_odr in
+  *                  reg EMB_FUNC_ODR_CFG_C
+  *
+  */
+int32_t ism330dhcx_mlc_data_rate_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_mlc_odr_t val)
+{
+  ism330dhcx_emb_func_odr_cfg_c_t reg;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_ODR_CFG_C,
+                            (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    reg.mlc_odr = (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_EMB_FUNC_ODR_CFG_C,
+                               (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Machine Learning Core data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mlc_odr in
+  *                  reg EMB_FUNC_ODR_CFG_C
+  *
+  */
+int32_t ism330dhcx_mlc_data_rate_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mlc_odr_t *val)
+{
+  ism330dhcx_emb_func_odr_cfg_c_t reg;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_EMBEDDED_FUNC_BANK);
+  if (ret == 0) {
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_EMB_FUNC_ODR_CFG_C,
+                              (uint8_t*)&reg, 1);
+  }
+  if (ret == 0) {
+    switch (reg.mlc_odr) {
+      case ISM330DHCX_ODR_PRGS_12Hz5:
+        *val = ISM330DHCX_ODR_PRGS_12Hz5;
+        break;
+      case ISM330DHCX_ODR_PRGS_26Hz:
+        *val = ISM330DHCX_ODR_PRGS_26Hz;
+        break;
+      case ISM330DHCX_ODR_PRGS_52Hz:
+        *val = ISM330DHCX_ODR_PRGS_52Hz;
+        break;
+      case ISM330DHCX_ODR_PRGS_104Hz:
+        *val = ISM330DHCX_ODR_PRGS_104Hz;
+        break;
+      default:
+        *val = ISM330DHCX_ODR_PRGS_12Hz5;
+        break;
+    }
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   ISM330DHCX_Sensor_hub
+  * @brief      This section groups all the functions that manage the
+  *             sensor hub.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sensor hub output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from SENSOR_HUB_1 to SENSOR_HUB_18
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_read_data_raw_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_emb_sh_read_t *val)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SENSOR_HUB_1,
+                              (uint8_t*)val, 18);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of aux_sens_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_slave_connected_set(stmdev_ctx_t *ctx,
+                                          ism330dhcx_aux_sens_on_t val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.aux_sens_on= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                               (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of aux_sens_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_slave_connected_get(stmdev_ctx_t *ctx,
+                                          ism330dhcx_aux_sens_on_t *val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  switch (master_config.aux_sens_on){
+    case ISM330DHCX_SLV_0:
+      *val = ISM330DHCX_SLV_0;
+      break;
+    case ISM330DHCX_SLV_0_1:
+      *val = ISM330DHCX_SLV_0_1;
+      break;
+    case ISM330DHCX_SLV_0_1_2:
+      *val = ISM330DHCX_SLV_0_1_2;
+      break;
+    case ISM330DHCX_SLV_0_1_2_3:
+      *val = ISM330DHCX_SLV_0_1_2_3;
+      break;
+    default:
+      *val = ISM330DHCX_SLV_0;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.master_on= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    *val = master_config.master_on;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of shub_pu_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_pin_mode_set(stmdev_ctx_t *ctx,
+                                  ism330dhcx_shub_pu_en_t val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.shub_pu_en= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of shub_pu_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_pin_mode_get(stmdev_ctx_t *ctx,
+                                  ism330dhcx_shub_pu_en_t *val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  switch (master_config.shub_pu_en){
+    case ISM330DHCX_EXT_PULL_UP:
+      *val = ISM330DHCX_EXT_PULL_UP;
+      break;
+    case ISM330DHCX_INTERNAL_PULL_UP:
+      *val = ISM330DHCX_INTERNAL_PULL_UP;
+      break;
+    default:
+      *val = ISM330DHCX_EXT_PULL_UP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.pass_through_mode= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    *val = master_config.pass_through_mode;
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_syncro_mode_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_start_config_t val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.start_config= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_syncro_mode_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_start_config_t *val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  switch (master_config.start_config){
+    case ISM330DHCX_EXT_ON_INT2_PIN:
+      *val = ISM330DHCX_EXT_ON_INT2_PIN;
+      break;
+    case ISM330DHCX_XL_GY_DRDY:
+      *val = ISM330DHCX_XL_GY_DRDY;
+      break;
+    default:
+      *val = ISM330DHCX_EXT_ON_INT2_PIN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of write_once in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_write_mode_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_write_once_t val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.write_once= (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of write_once in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_write_mode_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_write_once_t *val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  switch (master_config.write_once){
+    case ISM330DHCX_EACH_SH_CYCLE:
+      *val = ISM330DHCX_EACH_SH_CYCLE;
+      break;
+    case ISM330DHCX_ONLY_FIRST_CYCLE:
+      *val = ISM330DHCX_ONLY_FIRST_CYCLE;
+      break;
+    default:
+      *val = ISM330DHCX_EACH_SH_CYCLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Master logic and output registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_reset_set(stmdev_ctx_t *ctx)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.rst_master_regs = PROPERTY_ENABLE;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.rst_master_regs = PROPERTY_DISABLE;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Master logic and output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_master_regs in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  ism330dhcx_master_config_t master_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+    *val = master_config.rst_master_regs;
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the master communicates.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of shub_odr in reg SLV0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_data_rate_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_shub_odr_t val)
+{
+  ism330dhcx_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    slv0_config.shub_odr = (uint8_t)val;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV0_CONFIG,
+                              (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the master communicates.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of shub_odr in reg slv1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_data_rate_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_shub_odr_t *val)
+{
+  ism330dhcx_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  switch (slv0_config.shub_odr){
+    case ISM330DHCX_SH_ODR_104Hz:
+      *val = ISM330DHCX_SH_ODR_104Hz;
+      break;
+    case ISM330DHCX_SH_ODR_52Hz:
+      *val = ISM330DHCX_SH_ODR_52Hz;
+      break;
+    case ISM330DHCX_SH_ODR_26Hz:
+      *val = ISM330DHCX_SH_ODR_26Hz;
+      break;
+    case ISM330DHCX_SH_ODR_13Hz:
+      *val = ISM330DHCX_SH_ODR_13Hz;
+      break;
+    default:
+      *val = ISM330DHCX_SH_ODR_104Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv0_add;    8 bit i2c device address
+  *                - uint8_t slv0_subadd; 8 bit register device address
+  *                - uint8_t slv0_data;   8 bit data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_cfg_write(stmdev_ctx_t *ctx,
+                               ism330dhcx_sh_cfg_write_t *val)
+{
+  ism330dhcx_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    slv0_add.slave0 = (uint8_t) (val->slv0_add >> 1);
+    slv0_add.rw_0 = 0;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV0_ADD,
+                              (uint8_t*)&(slv0_add), 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV0_SUBADD,
+                              (uint8_t*)&(val->slv0_subadd), 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_DATAWRITE_SLV0,
+                              (uint8_t*)&(val->slv0_data), 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief Configure slave 0 for perform a write/read.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv_add;    8 bit i2c device address
+  *                - uint8_t slv_subadd; 8 bit register device address
+  *                - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sh_cfg_read_t *val)
+{
+  ism330dhcx_slv0_config_t slv0_config;
+  ism330dhcx_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    slv0_add.slave0 = (uint8_t) val->slv_add >> 1;
+    slv0_add.rw_0 = 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV0_ADD,
+                              (uint8_t*)&(slv0_add), 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV0_SUBADD,
+                              &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    slv0_config.slave0_numop = val->slv_len;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV0_CONFIG,
+                              (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write/read.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv_add;    8 bit i2c device address
+  *                - uint8_t slv_subadd; 8 bit register device address
+  *                - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sh_cfg_read_t *val)
+{
+  ism330dhcx_slv1_config_t slv1_config;
+  ism330dhcx_slv1_add_t slv1_add;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+  if(ret == 0){
+    slv1_add.slave1_add = (uint8_t) (val->slv_add >> 1);
+    slv1_add.r_1 = 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV1_ADD,
+                               (uint8_t*)&slv1_add, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV1_SUBADD,
+                              &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV1_CONFIG,
+                             (uint8_t*)&slv1_config, 1);
+  }
+  if(ret == 0){
+    slv1_config.slave1_numop = val->slv_len;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV1_CONFIG,
+                              (uint8_t*)&slv1_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+}
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 2 for perform a write/read.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv_add;    8 bit i2c device address
+  *                - uint8_t slv_subadd; 8 bit register device address
+  *                - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sh_cfg_read_t *val)
+{
+  ism330dhcx_slv2_config_t slv2_config;
+  ism330dhcx_slv2_add_t slv2_add;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    slv2_add.slave2_add = (uint8_t) (val->slv_add >> 1);
+    slv2_add.r_2 = 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV2_ADD,
+                              (uint8_t*)&slv2_add, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV2_SUBADD,
+                              (uint8_t*)&(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV2_CONFIG,
+                             (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    slv2_config.slave2_numop = val->slv_len;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV2_CONFIG,
+                              (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 3 for perform a write/read.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv_add;    8 bit i2c device address
+  *                - uint8_t slv_subadd; 8 bit register device address
+  *                - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sh_cfg_read_t *val)
+{
+  ism330dhcx_slv3_config_t slv3_config;
+  ism330dhcx_slv3_add_t slv3_add;
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    slv3_add.slave3_add = (uint8_t) (val->slv_add >> 1);
+    slv3_add.r_3 = 1;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV3_ADD,
+                              (uint8_t*)&slv3_add, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV3_SUBADD,
+                              &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_SLV3_CONFIG,
+                             (uint8_t*)&slv3_config, 1);
+  }
+  if(ret == 0){
+    slv3_config.slave3_numop = val->slv_len;
+    ret = ism330dhcx_write_reg(ctx, ISM330DHCX_SLV3_CONFIG,
+                              (uint8_t*)&slv3_config, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Registers from STATUS_MASTER
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t ism330dhcx_sh_status_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_status_master_t *val)
+{
+  int32_t ret;
+
+  ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = ism330dhcx_read_reg(ctx, ISM330DHCX_STATUS_MASTER,
+                              (uint8_t*)val, 1);
+  }
+  if(ret == 0){
+    ret = ism330dhcx_mem_bank_set(ctx, ISM330DHCX_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.h
+++ b/sensor/stmemsc/ism330dhcx_STdC/driver/ism330dhcx_reg.h
@@ -1,0 +1,2805 @@
+/*
+  ******************************************************************************
+ * @file    ism330dhcx_reg.h
+ * @author  Sensor Solutions Software Team
+ * @brief   This file contains all the functions prototypes for the
+ *          ism330dhcx_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef ISM330DHCX_REGS_H
+#define ISM330DHCX_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup ISM330DHCX
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup ISM330DHCX Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define ISM330DHCX_I2C_ADD_L                    0xD5U
+#define ISM330DHCX_I2C_ADD_H                    0xD7U
+
+/** Device Identification (Who am I) **/
+#define ISM330DHCX_ID                           0x6BU
+
+/**
+  * @}
+  *
+  */
+
+#define ISM330DHCX_FUNC_CFG_ACCESS              0x01U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t reg_access               : 2; /* shub_reg_access + func_cfg_access */
+} ism330dhcx_func_cfg_access_t;
+
+#define ISM330DHCX_PIN_CTRL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t sdo_pu_en                : 1;
+  uint8_t ois_pu_dis               : 1;
+} ism330dhcx_pin_ctrl_t;
+
+#define ISM330DHCX_FIFO_CTRL1                   0x07U
+typedef struct {
+  uint8_t wtm                      : 8;
+} ism330dhcx_fifo_ctrl1_t;
+
+#define ISM330DHCX_FIFO_CTRL2                   0x08U
+typedef struct {
+  uint8_t wtm                      : 1;
+  uint8_t uncoptr_rate             : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t odrchg_en                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t fifo_compr_rt_en         : 1;
+  uint8_t stop_on_wtm              : 1;
+} ism330dhcx_fifo_ctrl2_t;
+
+#define ISM330DHCX_FIFO_CTRL3                   0x09U
+typedef struct {
+  uint8_t bdr_xl                   : 4;
+  uint8_t bdr_gy                   : 4;
+} ism330dhcx_fifo_ctrl3_t;
+
+#define ISM330DHCX_FIFO_CTRL4                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t odr_t_batch              : 2;
+  uint8_t odr_ts_batch             : 2;
+} ism330dhcx_fifo_ctrl4_t;
+
+#define ISM330DHCX_COUNTER_BDR_REG1             0x0BU
+typedef struct {
+  uint8_t cnt_bdr_th               : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t trig_counter_bdr         : 1;
+  uint8_t rst_counter_bdr          : 1;
+  uint8_t dataready_pulsed         : 1;
+} ism330dhcx_counter_bdr_reg1_t;
+
+#define ISM330DHCX_COUNTER_BDR_REG2             0x0CU
+typedef struct {
+  uint8_t cnt_bdr_th               : 8;
+} ism330dhcx_counter_bdr_reg2_t;
+
+#define ISM330DHCX_INT1_CTRL                    0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fifo_th             : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_fifo_full           : 1;
+  uint8_t int1_cnt_bdr             : 1;
+  uint8_t den_drdy_flag            : 1;
+} ism330dhcx_int1_ctrl_t;
+
+#define ISM330DHCX_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fifo_th             : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_fifo_full           : 1;
+  uint8_t int2_cnt_bdr             : 1;
+  uint8_t not_used_01              : 1;
+} ism330dhcx_int2_ctrl_t;
+
+#define ISM330DHCX_WHO_AM_I                     0x0FU
+#define ISM330DHCX_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf2_xl_en               : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} ism330dhcx_ctrl1_xl_t;
+
+#define ISM330DHCX_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t fs_g                     : 4; /* fs_4000 + fs_125 + fs_g */
+  uint8_t odr_g                    : 4;
+} ism330dhcx_ctrl2_g_t;
+
+#define ISM330DHCX_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} ism330dhcx_ctrl3_c_t;
+
+#define ISM330DHCX_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep_g                  : 1;
+  uint8_t not_used_03              : 1;
+} ism330dhcx_ctrl4_c_t;
+
+#define ISM330DHCX_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t rounding                 : 2;
+  uint8_t not_used_02              : 1;
+} ism330dhcx_ctrl5_c_t;
+
+#define ISM330DHCX_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t ftype                    : 3;
+  uint8_t usr_off_w                : 1;
+  uint8_t xl_hm_mode               : 1;
+  uint8_t den_mode                 : 3;   /* trig_en + lvl1_en + lvl2_en */
+} ism330dhcx_ctrl6_c_t;
+
+#define ISM330DHCX_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t ois_on                   : 1;
+  uint8_t usr_off_on_out           : 1;
+  uint8_t ois_on_en                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t g_hm_mode                : 1;
+} ism330dhcx_ctrl7_g_t;
+
+#define ISM330DHCX_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t fastsettl_mode_xl        : 1;
+  uint8_t hp_ref_mode_xl           : 1;
+  uint8_t hpcf_xl                  : 3;
+} ism330dhcx_ctrl8_xl_t;
+
+#define ISM330DHCX_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t den_lh                   : 1;
+  uint8_t den_xl_g                 : 2;   /* den_xl_en + den_xl_g */
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} ism330dhcx_ctrl9_xl_t;
+
+#define ISM330DHCX_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t timestamp_en             : 1;
+  uint8_t not_used_02              : 2;
+} ism330dhcx_ctrl10_c_t;
+
+#define ISM330DHCX_ALL_INT_SRC                  0x1AU
+typedef struct {
+  uint8_t ff_ia                    : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t single_tap               : 1;
+  uint8_t double_tap               : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t sleep_change_ia          : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t timestamp_endcount       : 1;
+} ism330dhcx_all_int_src_t;
+
+#define ISM330DHCX_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state              : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t sleep_change_ia          : 1;
+  uint8_t not_used_01              : 1;
+} ism330dhcx_wake_up_src_t;
+
+#define ISM330DHCX_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_01              : 1;
+} ism330dhcx_tap_src_t;
+
+#define ISM330DHCX_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} ism330dhcx_d6d_src_t;
+
+#define ISM330DHCX_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} ism330dhcx_status_reg_t;
+
+#define ISM330DHCX_STATUS_SPIAUX                0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t gyro_settling            : 1;
+  uint8_t not_used_01              : 5;
+} ism330dhcx_status_spiaux_t;
+
+#define ISM330DHCX_OUT_TEMP_L                   0x20U
+#define ISM330DHCX_OUT_TEMP_H                   0x21U
+#define ISM330DHCX_OUTX_L_G                     0x22U
+#define ISM330DHCX_OUTX_H_G                     0x23U
+#define ISM330DHCX_OUTY_L_G                     0x24U
+#define ISM330DHCX_OUTY_H_G                     0x25U
+#define ISM330DHCX_OUTZ_L_G                     0x26U
+#define ISM330DHCX_OUTZ_H_G                     0x27U
+#define ISM330DHCX_OUTX_L_A                     0x28U
+#define ISM330DHCX_OUTX_H_A                     0x29U
+#define ISM330DHCX_OUTY_L_A                     0x2AU
+#define ISM330DHCX_OUTY_H_A                     0x2BU
+#define ISM330DHCX_OUTZ_L_A                     0x2CU
+#define ISM330DHCX_OUTZ_H_A                     0x2DU
+#define ISM330DHCX_EMB_FUNC_STATUS_MAINPAGE     0x35U
+typedef struct {
+  uint8_t not_used_01             : 3;
+  uint8_t is_step_det             : 1;
+  uint8_t is_tilt                 : 1;
+  uint8_t is_sigmot               : 1;
+  uint8_t not_used_02             : 1;
+  uint8_t is_fsm_lc               : 1;
+} ism330dhcx_emb_func_status_mainpage_t;
+
+#define ISM330DHCX_FSM_STATUS_A_MAINPAGE        0x36U
+typedef struct {
+  uint8_t is_fsm1                 : 1;
+  uint8_t is_fsm2                 : 1;
+  uint8_t is_fsm3                 : 1;
+  uint8_t is_fsm4                 : 1;
+  uint8_t is_fsm5                 : 1;
+  uint8_t is_fsm6                 : 1;
+  uint8_t is_fsm7                 : 1;
+  uint8_t is_fsm8                 : 1;
+} ism330dhcx_fsm_status_a_mainpage_t;
+
+#define ISM330DHCX_FSM_STATUS_B_MAINPAGE        0x37U
+typedef struct {
+  uint8_t is_fsm9                 : 1;
+  uint8_t is_fsm10                : 1;
+  uint8_t is_fsm11                : 1;
+  uint8_t is_fsm12                : 1;
+  uint8_t is_fsm13                : 1;
+  uint8_t is_fsm14                : 1;
+  uint8_t is_fsm15                : 1;
+  uint8_t is_fsm16                : 1;
+} ism330dhcx_fsm_status_b_mainpage_t;
+
+#define ISM330DHCX_MLC_STATUS_MAINPAGE     0x38U
+typedef struct {
+  uint8_t is_mlc1             : 1;
+  uint8_t is_mlc2             : 1;
+  uint8_t is_mlc3             : 1;
+  uint8_t is_mlc4             : 1;
+  uint8_t is_mlc5             : 1;
+  uint8_t is_mlc6             : 1;
+  uint8_t is_mlc7             : 1;
+  uint8_t is_mlc8             : 1;
+} ism330dhcx_mlc_status_mainpage_t;
+
+#define ISM330DHCX_STATUS_MASTER_MAINPAGE       0x39U
+typedef struct {
+  uint8_t sens_hub_endop          : 1;
+  uint8_t not_used_01             : 2;
+  uint8_t slave0_nack             : 1;
+  uint8_t slave1_nack             : 1;
+  uint8_t slave2_nack             : 1;
+  uint8_t slave3_nack             : 1;
+  uint8_t wr_once_done            : 1;
+} ism330dhcx_status_master_mainpage_t;
+
+#define ISM330DHCX_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;
+} ism330dhcx_fifo_status1_t;
+
+#define ISM330DHCX_FIFO_STATUS2                 0x3BU
+typedef struct {
+  uint8_t diff_fifo                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t over_run_latched         : 1;
+  uint8_t counter_bdr_ia           : 1;
+  uint8_t fifo_full_ia             : 1;
+  uint8_t fifo_ovr_ia              : 1;
+  uint8_t fifo_wtm_ia              : 1;
+} ism330dhcx_fifo_status2_t;
+
+#define ISM330DHCX_TIMESTAMP0                   0x40U
+#define ISM330DHCX_TIMESTAMP1                   0x41U
+#define ISM330DHCX_TIMESTAMP2                   0x42U
+#define ISM330DHCX_TIMESTAMP3                   0x43U
+#define ISM330DHCX_TAP_CFG0                     0x56U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t tap_z_en                 : 1;
+  uint8_t tap_y_en                 : 1;
+  uint8_t tap_x_en                 : 1;
+  uint8_t slope_fds                : 1;
+  uint8_t sleep_status_on_int      : 1;
+  uint8_t int_clr_on_read          : 1;
+  uint8_t not_used_01              : 1;
+} ism330dhcx_tap_cfg0_t;
+
+#define ISM330DHCX_TAP_CFG1                     0x57U
+typedef struct {
+  uint8_t tap_ths_x                : 5;
+  uint8_t tap_priority             : 3;
+} ism330dhcx_tap_cfg1_t;
+
+#define ISM330DHCX_TAP_CFG2                     0x58U
+typedef struct {
+  uint8_t tap_ths_y                : 5;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} ism330dhcx_tap_cfg2_t;
+
+#define ISM330DHCX_TAP_THS_6D                   0x59U
+typedef struct {
+  uint8_t tap_ths_z                : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} ism330dhcx_tap_ths_6d_t;
+
+#define ISM330DHCX_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} ism330dhcx_int_dur2_t;
+
+#define ISM330DHCX_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t usr_off_on_wu            : 1;
+  uint8_t single_double_tap        : 1;
+} ism330dhcx_wake_up_ths_t;
+
+#define ISM330DHCX_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t wake_ths_w               : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} ism330dhcx_wake_up_dur_t;
+
+#define ISM330DHCX_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} ism330dhcx_free_fall_t;
+
+#define ISM330DHCX_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t int1_shub                : 1;
+  uint8_t int1_emb_func            : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_sleep_change        : 1;
+} ism330dhcx_md1_cfg_t;
+
+#define ISM330DHCX_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_timestamp           : 1;
+  uint8_t int2_emb_func            : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_sleep_change        : 1;
+} ism330dhcx_md2_cfg_t;
+
+#define ISM330DHCX_INTERNAL_FREQ_FINE           0x63U
+typedef struct {
+  uint8_t freq_fine                : 8;
+} ism330dhcx_internal_freq_fine_t;
+
+#define ISM330DHCX_INT_OIS                      0x6FU
+typedef struct {
+  uint8_t st_xl_ois                : 2;
+  uint8_t not_used_01              : 3;
+  uint8_t den_lh_ois               : 1;
+  uint8_t lvl2_ois                 : 1;
+  uint8_t int2_drdy_ois            : 1;
+} ism330dhcx_int_ois_t;
+
+#define ISM330DHCX_CTRL1_OIS                    0x70U
+typedef struct {
+  uint8_t ois_en_spi2              : 1;
+  uint8_t fs_125_ois               : 1;
+  uint8_t fs_g_ois                 : 2;
+  uint8_t mode4_en                 : 1;
+  uint8_t sim_ois                  : 1;
+  uint8_t lvl1_ois                 : 1;
+  uint8_t not_used_01              : 1;
+} ism330dhcx_ctrl1_ois_t;
+
+#define ISM330DHCX_CTRL2_OIS                    0x71U
+typedef struct {
+  uint8_t hp_en_ois                : 1;
+  uint8_t ftype_ois                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_ois                  : 2;
+  uint8_t not_used_02              : 2;
+} ism330dhcx_ctrl2_ois_t;
+
+#define ISM330DHCX_CTRL3_OIS                    0x72U
+typedef struct {
+  uint8_t st_ois_clampdis          : 1;
+  uint8_t st_ois                   : 2;
+  uint8_t filter_xl_conf_ois       : 3;
+  uint8_t fs_xl_ois                : 2;
+} ism330dhcx_ctrl3_ois_t;
+
+#define ISM330DHCX_X_OFS_USR                    0x73U
+#define ISM330DHCX_Y_OFS_USR                    0x74U
+#define ISM330DHCX_Z_OFS_USR                    0x75U
+#define ISM330DHCX_FIFO_DATA_OUT_TAG            0x78U
+typedef struct {
+  uint8_t tag_parity               : 1;
+  uint8_t tag_cnt                  : 2;
+  uint8_t tag_sensor               : 5;
+} ism330dhcx_fifo_data_out_tag_t;
+
+#define ISM330DHCX_FIFO_DATA_OUT_X_L            0x79U
+#define ISM330DHCX_FIFO_DATA_OUT_X_H            0x7AU
+#define ISM330DHCX_FIFO_DATA_OUT_Y_L            0x7BU
+#define ISM330DHCX_FIFO_DATA_OUT_Y_H            0x7CU
+#define ISM330DHCX_FIFO_DATA_OUT_Z_L            0x7DU
+#define ISM330DHCX_FIFO_DATA_OUT_Z_H            0x7EU
+#define ISM330DHCX_PAGE_SEL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 4;
+  uint8_t page_sel                 : 4;
+} ism330dhcx_page_sel_t;
+
+#define ISM330DHCX_ADV_PEDO                     0x03U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t pedo_fpr_adf_dis         : 1;
+  uint8_t not_used_02              : 6;
+} ism330dhcx_adv_pedo_t;
+
+#define ISM330DHCX_EMB_FUNC_EN_A                0x04U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t pedo_en                  : 1;
+  uint8_t tilt_en                  : 1;
+  uint8_t sign_motion_en           : 1;
+  uint8_t not_used_02              : 2;
+} ism330dhcx_emb_func_en_a_t;
+
+#define ISM330DHCX_EMB_FUNC_EN_B                0x05U
+typedef struct {
+  uint8_t fsm_en                   : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t fifo_compr_en            : 1;
+  uint8_t mlc_en                   : 1;
+  uint8_t not_used_02              : 3;
+} ism330dhcx_emb_func_en_b_t;
+
+#define ISM330DHCX_PAGE_ADDRESS                 0x08U
+typedef struct {
+  uint8_t page_addr                : 8;
+} ism330dhcx_page_address_t;
+
+#define ISM330DHCX_PAGE_VALUE                   0x09U
+typedef struct {
+  uint8_t page_value               : 8;
+} ism330dhcx_page_value_t;
+
+#define ISM330DHCX_EMB_FUNC_INT1                0x0AU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t int1_step_detector       : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_sig_mot             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int1_fsm_lc              : 1;
+} ism330dhcx_emb_func_int1_t;
+
+#define ISM330DHCX_FSM_INT1_A                   0x0BU
+typedef struct {
+  uint8_t int1_fsm1                : 1;
+  uint8_t int1_fsm2                : 1;
+  uint8_t int1_fsm3                : 1;
+  uint8_t int1_fsm4                : 1;
+  uint8_t int1_fsm5                : 1;
+  uint8_t int1_fsm6                : 1;
+  uint8_t int1_fsm7                : 1;
+  uint8_t int1_fsm8                : 1;
+} ism330dhcx_fsm_int1_a_t;
+
+#define ISM330DHCX_FSM_INT1_B                   0x0CU
+typedef struct {
+  uint8_t int1_fsm9                : 1;
+  uint8_t int1_fsm10               : 1;
+  uint8_t int1_fsm11               : 1;
+  uint8_t int1_fsm12               : 1;
+  uint8_t int1_fsm13               : 1;
+  uint8_t int1_fsm14               : 1;
+  uint8_t int1_fsm15               : 1;
+  uint8_t int1_fsm16               : 1;
+} ism330dhcx_fsm_int1_b_t;
+
+#define ISM330DHCX_MLC_INT1                     0x0DU
+typedef struct {
+  uint8_t int1_mlc1                : 1;
+  uint8_t int1_mlc2                : 1;
+  uint8_t int1_mlc3                : 1;
+  uint8_t int1_mlc4                : 1;
+  uint8_t int1_mlc5                : 1;
+  uint8_t int1_mlc6                : 1;
+  uint8_t int1_mlc7                : 1;
+  uint8_t int1_mlc8                : 1;
+} ism330dhcx_mlc_int1_t;
+
+#define ISM330DHCX_EMB_FUNC_INT2                0x0EU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t int2_step_detector       : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_sig_mot             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_fsm_lc              : 1;
+} ism330dhcx_emb_func_int2_t;
+
+#define ISM330DHCX_FSM_INT2_A                   0x0FU
+typedef struct {
+  uint8_t int2_fsm1                : 1;
+  uint8_t int2_fsm2                : 1;
+  uint8_t int2_fsm3                : 1;
+  uint8_t int2_fsm4                : 1;
+  uint8_t int2_fsm5                : 1;
+  uint8_t int2_fsm6                : 1;
+  uint8_t int2_fsm7                : 1;
+  uint8_t int2_fsm8                : 1;
+} ism330dhcx_fsm_int2_a_t;
+
+#define ISM330DHCX_FSM_INT2_B                   0x10U
+typedef struct {
+  uint8_t int2_fsm9                : 1;
+  uint8_t int2_fsm10               : 1;
+  uint8_t int2_fsm11               : 1;
+  uint8_t int2_fsm12               : 1;
+  uint8_t int2_fsm13               : 1;
+  uint8_t int2_fsm14               : 1;
+  uint8_t int2_fsm15               : 1;
+  uint8_t int2_fsm16               : 1;
+} ism330dhcx_fsm_int2_b_t;
+
+#define ISM330DHCX_MLC_INT2                     0x11U
+typedef struct {
+  uint8_t int2_mlc1             : 1;
+  uint8_t int2_mlc2             : 1;
+  uint8_t int2_mlc3             : 1;
+  uint8_t int2_mlc4             : 1;
+  uint8_t int2_mlc5             : 1;
+  uint8_t int2_mlc6             : 1;
+  uint8_t int2_mlc7             : 1;
+  uint8_t int2_mlc8             : 1;
+} ism330dhcx_mlc_int2_t;
+
+#define ISM330DHCX_EMB_FUNC_STATUS              0x12U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t is_step_det              : 1;
+  uint8_t is_tilt                  : 1;
+  uint8_t is_sigmot                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t is_fsm_lc                : 1;
+} ism330dhcx_emb_func_status_t;
+
+#define ISM330DHCX_FSM_STATUS_A                 0x13U
+typedef struct {
+  uint8_t is_fsm1                  : 1;
+  uint8_t is_fsm2                  : 1;
+  uint8_t is_fsm3                  : 1;
+  uint8_t is_fsm4                  : 1;
+  uint8_t is_fsm5                  : 1;
+  uint8_t is_fsm6                  : 1;
+  uint8_t is_fsm7                  : 1;
+  uint8_t is_fsm8                  : 1;
+} ism330dhcx_fsm_status_a_t;
+
+#define ISM330DHCX_FSM_STATUS_B                 0x14U
+typedef struct {
+  uint8_t is_fsm9                  : 1;
+  uint8_t is_fsm10                 : 1;
+  uint8_t is_fsm11                 : 1;
+  uint8_t is_fsm12                 : 1;
+  uint8_t is_fsm13                 : 1;
+  uint8_t is_fsm14                 : 1;
+  uint8_t is_fsm15                 : 1;
+  uint8_t is_fsm16                 : 1;
+} ism330dhcx_fsm_status_b_t;
+
+#define ISM330DHCX_MLC_STATUS                   0x15U
+typedef struct {
+  uint8_t is_mlc1            : 1;
+  uint8_t is_mlc2            : 1;
+  uint8_t is_mlc3            : 1;
+  uint8_t is_mlc4            : 1;
+  uint8_t is_mlc5            : 1;
+  uint8_t is_mlc6            : 1;
+  uint8_t is_mlc7            : 1;
+  uint8_t is_mlc8            : 1;
+} ism330dhcx_mlc_status_t;
+
+#define ISM330DHCX_PAGE_RW                      0x17U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t page_rw                  : 2;  /* page_write + page_read */
+  uint8_t emb_func_lir             : 1;
+} ism330dhcx_page_rw_t;
+
+#define ISM330DHCX_EMB_FUNC_FIFO_CFG            0x44U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t pedo_fifo_en             : 1;
+  uint8_t not_used_02              : 1;
+} ism330dhcx_emb_func_fifo_cfg_t;
+
+#define ISM330DHCX_FSM_ENABLE_A                 0x46U
+typedef struct {
+  uint8_t fsm1_en                  : 1;
+  uint8_t fsm2_en                  : 1;
+  uint8_t fsm3_en                  : 1;
+  uint8_t fsm4_en                  : 1;
+  uint8_t fsm5_en                  : 1;
+  uint8_t fsm6_en                  : 1;
+  uint8_t fsm7_en                  : 1;
+  uint8_t fsm8_en                  : 1;
+} ism330dhcx_fsm_enable_a_t;
+
+#define ISM330DHCX_FSM_ENABLE_B                 0x47U
+typedef struct {
+  uint8_t fsm9_en                  : 1;
+  uint8_t fsm10_en                 : 1;
+  uint8_t fsm11_en                 : 1;
+  uint8_t fsm12_en                 : 1;
+  uint8_t fsm13_en                 : 1;
+  uint8_t fsm14_en                 : 1;
+  uint8_t fsm15_en                 : 1;
+  uint8_t fsm16_en                 : 1;
+} ism330dhcx_fsm_enable_b_t;
+
+#define ISM330DHCX_FSM_LONG_COUNTER_L           0x48U
+#define ISM330DHCX_FSM_LONG_COUNTER_H           0x49U
+#define ISM330DHCX_FSM_LONG_COUNTER_CLEAR       0x4AU
+typedef struct {
+  uint8_t fsm_lc_clr               : 2;  /* fsm_lc_cleared + fsm_lc_clear */
+  uint8_t not_used_01              : 6;
+} ism330dhcx_fsm_long_counter_clear_t;
+
+#define ISM330DHCX_FSM_OUTS1                    0x4CU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs1_t;
+
+#define ISM330DHCX_FSM_OUTS2                    0x4DU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs2_t;
+
+#define ISM330DHCX_FSM_OUTS3                    0x4EU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs3_t;
+
+#define ISM330DHCX_FSM_OUTS4                    0x4FU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs4_t;
+
+#define ISM330DHCX_FSM_OUTS5                    0x50U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs5_t;
+
+#define ISM330DHCX_FSM_OUTS6                    0x51U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs6_t;
+
+#define ISM330DHCX_FSM_OUTS7                    0x52U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs7_t;
+
+#define ISM330DHCX_FSM_OUTS8                    0x53U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs8_t;
+
+#define ISM330DHCX_FSM_OUTS9                    0x54U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs9_t;
+
+#define ISM330DHCX_FSM_OUTS10                   0x55U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs10_t;
+
+#define ISM330DHCX_FSM_OUTS11                   0x56U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs11_t;
+
+#define ISM330DHCX_FSM_OUTS12                   0x57U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs12_t;
+
+#define ISM330DHCX_FSM_OUTS13                   0x58U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs13_t;
+
+#define ISM330DHCX_FSM_OUTS14                   0x59U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs14_t;
+
+#define ISM330DHCX_FSM_OUTS15                   0x5AU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs15_t;
+
+#define ISM330DHCX_FSM_OUTS16                   0x5BU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} ism330dhcx_fsm_outs16_t;
+
+#define ISM330DHCX_EMB_FUNC_ODR_CFG_B           0x5FU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t fsm_odr                  : 2;
+  uint8_t not_used_02              : 3;
+} ism330dhcx_emb_func_odr_cfg_b_t;
+
+#define ISM330DHCX_EMB_FUNC_ODR_CFG_C           0x60U
+typedef struct {
+  uint8_t not_used_01             : 4;
+  uint8_t mlc_odr                 : 2;
+  uint8_t not_used_02             : 2;
+} ism330dhcx_emb_func_odr_cfg_c_t;
+
+#define ISM330DHCX_STEP_COUNTER_L               0x62U
+#define ISM330DHCX_STEP_COUNTER_H               0x63U
+#define ISM330DHCX_EMB_FUNC_SRC                 0x64U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t stepcounter_bit_set      : 1;
+  uint8_t step_overflow            : 1;
+  uint8_t step_count_delta_ia      : 1;
+  uint8_t step_detected            : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t pedo_rst_step            : 1;
+} ism330dhcx_emb_func_src_t;
+
+#define ISM330DHCX_EMB_FUNC_INIT_A              0x66U
+typedef struct {
+  uint8_t not_used_01               : 3;
+  uint8_t step_det_init             : 1;
+  uint8_t tilt_init                 : 1;
+  uint8_t sig_mot_init              : 1;
+  uint8_t not_used_02               : 2;
+} ism330dhcx_emb_func_init_a_t;
+
+#define ISM330DHCX_EMB_FUNC_INIT_B              0x67U
+typedef struct {
+  uint8_t fsm_init                 : 1;
+  uint8_t not_used_01              : 3;
+  uint8_t mlc_init                 : 1;
+  uint8_t not_used_02              : 3;
+} ism330dhcx_emb_func_init_b_t;
+
+#define ISM330DHCX_MLC0_SRC                     0x70U
+#define ISM330DHCX_MLC1_SRC                     0x71U
+#define ISM330DHCX_MLC2_SRC                     0x72U
+#define ISM330DHCX_MLC3_SRC                     0x73U
+#define ISM330DHCX_MLC4_SRC                     0x74U
+#define ISM330DHCX_MLC5_SRC                     0x75U
+#define ISM330DHCX_MLC6_SRC                     0x76U
+#define ISM330DHCX_MLC7_SRC                     0x77U
+#define ISM330DHCX_MAG_SENSITIVITY_L            0xBAU
+#define ISM330DHCX_MAG_SENSITIVITY_H            0xBBU
+#define ISM330DHCX_MAG_OFFX_L                   0xC0U
+#define ISM330DHCX_MAG_OFFX_H                   0xC1U
+#define ISM330DHCX_MAG_OFFY_L                   0xC2U
+#define ISM330DHCX_MAG_OFFY_H                   0xC3U
+#define ISM330DHCX_MAG_OFFZ_L                   0xC4U
+#define ISM330DHCX_MAG_OFFZ_H                   0xC5U
+#define ISM330DHCX_MAG_SI_XX_L                  0xC6U
+#define ISM330DHCX_MAG_SI_XX_H                  0xC7U
+#define ISM330DHCX_MAG_SI_XY_L                  0xC8U
+#define ISM330DHCX_MAG_SI_XY_H                  0xC9U
+#define ISM330DHCX_MAG_SI_XZ_L                  0xCAU
+#define ISM330DHCX_MAG_SI_XZ_H                  0xCBU
+#define ISM330DHCX_MAG_SI_YY_L                  0xCCU
+#define ISM330DHCX_MAG_SI_YY_H                  0xCDU
+#define ISM330DHCX_MAG_SI_YZ_L                  0xCEU
+#define ISM330DHCX_MAG_SI_YZ_H                  0xCFU
+#define ISM330DHCX_MAG_SI_ZZ_L                  0xD0U
+#define ISM330DHCX_MAG_SI_ZZ_H                  0xD1U
+#define ISM330DHCX_MAG_CFG_A                    0xD4U
+typedef struct {
+  uint8_t mag_z_axis               : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t mag_y_axis               : 3;
+  uint8_t not_used_02              : 1;
+} ism330dhcx_mag_cfg_a_t;
+
+#define ISM330DHCX_MAG_CFG_B                    0xD5U
+typedef struct {
+  uint8_t mag_x_axis               : 3;
+  uint8_t not_used_01              : 5;
+} ism330dhcx_mag_cfg_b_t;
+
+#define ISM330DHCX_FSM_LC_TIMEOUT_L             0x17AU
+#define ISM330DHCX_FSM_LC_TIMEOUT_H             0x17BU
+#define ISM330DHCX_FSM_PROGRAMS                 0x17CU
+#define ISM330DHCX_FSM_START_ADD_L              0x17EU
+#define ISM330DHCX_FSM_START_ADD_H              0x17FU
+#define ISM330DHCX_PEDO_CMD_REG                 0x183U
+typedef struct {
+  uint8_t ad_det_en                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t fp_rejection_en          : 1;
+  uint8_t carry_count_en           : 1;
+  uint8_t not_used_02              : 4;
+} ism330dhcx_pedo_cmd_reg_t;
+
+#define ISM330DHCX_PEDO_DEB_STEPS_CONF          0x184U
+#define ISM330DHCX_PEDO_SC_DELTAT_L             0x1D0U
+#define ISM330DHCX_PEDO_SC_DELTAT_H             0x1D1U
+#define ISM330DHCX_MLC_MAG_SENSITIVITY_L        0x1E8U
+#define ISM330DHCX_MLC_MAG_SENSITIVITY_H        0x1E9U
+#define ISM330DHCX_SENSOR_HUB_1                 0x02U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_1_t;
+
+#define ISM330DHCX_SENSOR_HUB_2                 0x03U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_2_t;
+
+#define ISM330DHCX_SENSOR_HUB_3                 0x04U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_3_t;
+
+#define ISM330DHCX_SENSOR_HUB_4                 0x05U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_4_t;
+
+#define ISM330DHCX_SENSOR_HUB_5                 0x06U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_5_t;
+
+#define ISM330DHCX_SENSOR_HUB_6                 0x07U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_6_t;
+
+#define ISM330DHCX_SENSOR_HUB_7                 0x08U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_7_t;
+
+#define ISM330DHCX_SENSOR_HUB_8                 0x09U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_8_t;
+
+#define ISM330DHCX_SENSOR_HUB_9                 0x0AU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_9_t;
+
+#define ISM330DHCX_SENSOR_HUB_10                0x0BU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_10_t;
+
+#define ISM330DHCX_SENSOR_HUB_11                0x0CU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_11_t;
+
+#define ISM330DHCX_SENSOR_HUB_12                0x0DU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_12_t;
+
+#define ISM330DHCX_SENSOR_HUB_13                0x0EU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_13_t;
+
+#define ISM330DHCX_SENSOR_HUB_14                0x0FU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_14_t;
+
+#define ISM330DHCX_SENSOR_HUB_15                0x10U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_15_t;
+
+#define ISM330DHCX_SENSOR_HUB_16                0x11U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_16_t;
+
+#define ISM330DHCX_SENSOR_HUB_17                0x12U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_17_t;
+
+#define ISM330DHCX_SENSOR_HUB_18                0x13U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} ism330dhcx_sensor_hub_18_t;
+
+#define ISM330DHCX_MASTER_CONFIG                0x14U
+typedef struct {
+  uint8_t aux_sens_on              : 2;
+  uint8_t master_on                : 1;
+  uint8_t shub_pu_en               : 1;
+  uint8_t pass_through_mode        : 1;
+  uint8_t start_config             : 1;
+  uint8_t write_once               : 1;
+  uint8_t rst_master_regs          : 1;
+} ism330dhcx_master_config_t;
+
+#define ISM330DHCX_SLV0_ADD                     0x15U
+typedef struct {
+  uint8_t rw_0                     : 1;
+  uint8_t slave0                   : 7;
+} ism330dhcx_slv0_add_t;
+
+#define ISM330DHCX_SLV0_SUBADD                  0x16U
+typedef struct {
+  uint8_t slave0_reg               : 8;
+} ism330dhcx_slv0_subadd_t;
+
+#define ISM330DHCX_SLV0_CONFIG                  0x17U
+typedef struct {
+  uint8_t slave0_numop             : 3;
+  uint8_t batch_ext_sens_0_en      : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t shub_odr                 : 2;
+} ism330dhcx_slv0_config_t;
+
+#define ISM330DHCX_SLV1_ADD                     0x18U
+typedef struct {
+  uint8_t r_1                      : 1;
+  uint8_t slave1_add               : 7;
+} ism330dhcx_slv1_add_t;
+
+#define ISM330DHCX_SLV1_SUBADD                  0x19U
+typedef struct {
+  uint8_t slave1_reg               : 8;
+} ism330dhcx_slv1_subadd_t;
+
+#define ISM330DHCX_SLV1_CONFIG                  0x1AU
+typedef struct {
+  uint8_t slave1_numop             : 3;
+  uint8_t batch_ext_sens_1_en      : 1;
+  uint8_t not_used_01              : 4;
+} ism330dhcx_slv1_config_t;
+
+#define ISM330DHCX_SLV2_ADD                     0x1BU
+typedef struct {
+  uint8_t r_2                      : 1;
+  uint8_t slave2_add               : 7;
+} ism330dhcx_slv2_add_t;
+
+#define ISM330DHCX_SLV2_SUBADD                  0x1CU
+typedef struct {
+  uint8_t slave2_reg               : 8;
+} ism330dhcx_slv2_subadd_t;
+
+#define ISM330DHCX_SLV2_CONFIG                  0x1DU
+typedef struct {
+  uint8_t slave2_numop             : 3;
+  uint8_t batch_ext_sens_2_en      : 1;
+  uint8_t not_used_01              : 4;
+} ism330dhcx_slv2_config_t;
+
+#define ISM330DHCX_SLV3_ADD                     0x1EU
+typedef struct {
+  uint8_t r_3                      : 1;
+  uint8_t slave3_add               : 7;
+} ism330dhcx_slv3_add_t;
+
+#define ISM330DHCX_SLV3_SUBADD                  0x1FU
+typedef struct {
+  uint8_t slave3_reg               : 8;
+} ism330dhcx_slv3_subadd_t;
+
+#define ISM330DHCX_SLV3_CONFIG                  0x20U
+typedef struct {
+  uint8_t slave3_numop             : 3;
+  uint8_t batch_ext_sens_3_en      : 1;
+  uint8_t not_used_01              : 4;
+} ism330dhcx_slv3_config_t;
+
+#define ISM330DHCX_DATAWRITE_SLV0  0x21U
+typedef struct {
+  uint8_t slave0_dataw             : 8;
+} ism330dhcx_datawrite_slv0_t;
+
+#define ISM330DHCX_STATUS_MASTER                0x22U
+typedef struct {
+  uint8_t sens_hub_endop           : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t slave0_nack              : 1;
+  uint8_t slave1_nack              : 1;
+  uint8_t slave2_nack              : 1;
+  uint8_t slave3_nack              : 1;
+  uint8_t wr_once_done             : 1;
+} ism330dhcx_status_master_t;
+
+/**
+  * @defgroup ISM330DHCX_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  ism330dhcx_func_cfg_access_t               func_cfg_access;
+  ism330dhcx_pin_ctrl_t                      pin_ctrl;
+  ism330dhcx_fifo_ctrl1_t                    fifo_ctrl1;
+  ism330dhcx_fifo_ctrl2_t                    fifo_ctrl2;
+  ism330dhcx_fifo_ctrl3_t                    fifo_ctrl3;
+  ism330dhcx_fifo_ctrl4_t                    fifo_ctrl4;
+  ism330dhcx_counter_bdr_reg1_t              counter_bdr_reg1;
+  ism330dhcx_counter_bdr_reg2_t              counter_bdr_reg2;
+  ism330dhcx_int1_ctrl_t                     int1_ctrl;
+  ism330dhcx_int2_ctrl_t                     int2_ctrl;
+  ism330dhcx_ctrl1_xl_t                      ctrl1_xl;
+  ism330dhcx_ctrl2_g_t                       ctrl2_g;
+  ism330dhcx_ctrl3_c_t                       ctrl3_c;
+  ism330dhcx_ctrl4_c_t                       ctrl4_c;
+  ism330dhcx_ctrl5_c_t                       ctrl5_c;
+  ism330dhcx_ctrl6_c_t                       ctrl6_c;
+  ism330dhcx_ctrl7_g_t                       ctrl7_g;
+  ism330dhcx_ctrl8_xl_t                      ctrl8_xl;
+  ism330dhcx_ctrl9_xl_t                      ctrl9_xl;
+  ism330dhcx_ctrl10_c_t                      ctrl10_c;
+  ism330dhcx_all_int_src_t                   all_int_src;
+  ism330dhcx_wake_up_src_t                   wake_up_src;
+  ism330dhcx_tap_src_t                       tap_src;
+  ism330dhcx_d6d_src_t                       d6d_src;
+  ism330dhcx_status_reg_t                    status_reg;
+  ism330dhcx_status_spiaux_t                 status_spiaux;
+  ism330dhcx_fifo_status1_t                  fifo_status1;
+  ism330dhcx_fifo_status2_t                  fifo_status2;
+  ism330dhcx_tap_cfg0_t                      tap_cfg0;
+  ism330dhcx_tap_cfg1_t                      tap_cfg1;
+  ism330dhcx_tap_cfg2_t                      tap_cfg2;
+  ism330dhcx_tap_ths_6d_t                    tap_ths_6d;
+  ism330dhcx_int_dur2_t                      int_dur2;
+  ism330dhcx_wake_up_ths_t                   wake_up_ths;
+  ism330dhcx_wake_up_dur_t                   wake_up_dur;
+  ism330dhcx_free_fall_t                     free_fall;
+  ism330dhcx_md1_cfg_t                       md1_cfg;
+  ism330dhcx_md2_cfg_t                       md2_cfg;
+  ism330dhcx_internal_freq_fine_t            internal_freq_fine;
+  ism330dhcx_int_ois_t                       int_ois;
+  ism330dhcx_ctrl1_ois_t                     ctrl1_ois;
+  ism330dhcx_ctrl2_ois_t                     ctrl2_ois;
+  ism330dhcx_ctrl3_ois_t                     ctrl3_ois;
+  ism330dhcx_fifo_data_out_tag_t             fifo_data_out_tag;
+  ism330dhcx_page_sel_t                      page_sel;
+  ism330dhcx_adv_pedo_t                      adv_pedo;
+  ism330dhcx_emb_func_en_a_t                 emb_func_en_a;
+  ism330dhcx_emb_func_en_b_t                 emb_func_en_b;
+  ism330dhcx_page_address_t                  page_address;
+  ism330dhcx_page_value_t                    page_value;
+  ism330dhcx_emb_func_int1_t                 emb_func_int1;
+  ism330dhcx_fsm_int1_a_t                    fsm_int1_a;
+  ism330dhcx_fsm_int1_b_t                    fsm_int1_b;
+  ism330dhcx_emb_func_int2_t                 emb_func_int2;
+  ism330dhcx_fsm_int2_a_t                    fsm_int2_a;
+  ism330dhcx_fsm_int2_b_t                    fsm_int2_b;
+  ism330dhcx_emb_func_status_t               emb_func_status;
+  ism330dhcx_fsm_status_a_t                  fsm_status_a;
+  ism330dhcx_fsm_status_b_t                  fsm_status_b;
+  ism330dhcx_page_rw_t                       page_rw;
+  ism330dhcx_emb_func_fifo_cfg_t	            emb_func_fifo_cfg;
+  ism330dhcx_fsm_enable_a_t                  fsm_enable_a;
+  ism330dhcx_fsm_enable_b_t                  fsm_enable_b;
+  ism330dhcx_fsm_long_counter_clear_t        fsm_long_counter_clear;
+  ism330dhcx_fsm_outs1_t                     fsm_outs1;
+  ism330dhcx_fsm_outs2_t                     fsm_outs2;
+  ism330dhcx_fsm_outs3_t                     fsm_outs3;
+  ism330dhcx_fsm_outs4_t                     fsm_outs4;
+  ism330dhcx_fsm_outs5_t                     fsm_outs5;
+  ism330dhcx_fsm_outs6_t                     fsm_outs6;
+  ism330dhcx_fsm_outs7_t                     fsm_outs7;
+  ism330dhcx_fsm_outs8_t                     fsm_outs8;
+  ism330dhcx_fsm_outs9_t                     fsm_outs9;
+  ism330dhcx_fsm_outs10_t                    fsm_outs10;
+  ism330dhcx_fsm_outs11_t                    fsm_outs11;
+  ism330dhcx_fsm_outs12_t                    fsm_outs12;
+  ism330dhcx_fsm_outs13_t                    fsm_outs13;
+  ism330dhcx_fsm_outs14_t                    fsm_outs14;
+  ism330dhcx_fsm_outs15_t                    fsm_outs15;
+  ism330dhcx_fsm_outs16_t                    fsm_outs16;
+  ism330dhcx_emb_func_odr_cfg_b_t            emb_func_odr_cfg_b;
+  ism330dhcx_emb_func_odr_cfg_c_t            emb_func_odr_cfg_c_t;
+  ism330dhcx_emb_func_src_t                  emb_func_src;
+  ism330dhcx_emb_func_init_a_t               emb_func_init_a;
+  ism330dhcx_emb_func_init_b_t               emb_func_init_b;
+  ism330dhcx_mag_cfg_a_t                     mag_cfg_a;
+  ism330dhcx_mag_cfg_b_t                     mag_cfg_b;
+  ism330dhcx_pedo_cmd_reg_t                  pedo_cmd_reg;
+  ism330dhcx_sensor_hub_1_t                  sensor_hub_1;
+  ism330dhcx_sensor_hub_2_t                  sensor_hub_2;
+  ism330dhcx_sensor_hub_3_t                  sensor_hub_3;
+  ism330dhcx_sensor_hub_4_t                  sensor_hub_4;
+  ism330dhcx_sensor_hub_5_t                  sensor_hub_5;
+  ism330dhcx_sensor_hub_6_t                  sensor_hub_6;
+  ism330dhcx_sensor_hub_7_t                  sensor_hub_7;
+  ism330dhcx_sensor_hub_8_t                  sensor_hub_8;
+  ism330dhcx_sensor_hub_9_t                  sensor_hub_9;
+  ism330dhcx_sensor_hub_10_t                 sensor_hub_10;
+  ism330dhcx_sensor_hub_11_t                 sensor_hub_11;
+  ism330dhcx_sensor_hub_12_t                 sensor_hub_12;
+  ism330dhcx_sensor_hub_13_t                 sensor_hub_13;
+  ism330dhcx_sensor_hub_14_t                 sensor_hub_14;
+  ism330dhcx_sensor_hub_15_t                 sensor_hub_15;
+  ism330dhcx_sensor_hub_16_t                 sensor_hub_16;
+  ism330dhcx_sensor_hub_17_t                 sensor_hub_17;
+  ism330dhcx_sensor_hub_18_t                 sensor_hub_18;
+  ism330dhcx_master_config_t                 master_config;
+  ism330dhcx_slv0_add_t                      slv0_add;
+  ism330dhcx_slv0_subadd_t                   slv0_subadd;
+  ism330dhcx_slv0_config_t                   slv0_config;
+  ism330dhcx_slv1_add_t                      slv1_add;
+  ism330dhcx_slv1_subadd_t                   slv1_subadd;
+  ism330dhcx_slv1_config_t                   slv1_config;
+  ism330dhcx_slv2_add_t                      slv2_add;
+  ism330dhcx_slv2_subadd_t                   slv2_subadd;
+  ism330dhcx_slv2_config_t                   slv2_config;
+  ism330dhcx_slv3_add_t                      slv3_add;
+  ism330dhcx_slv3_subadd_t                   slv3_subadd;
+  ism330dhcx_slv3_config_t                   slv3_config;
+  ism330dhcx_datawrite_slv0_t                datawrite_slv0;
+  ism330dhcx_status_master_t                 status_master;
+  bitwise_t                                 bitwise;
+  uint8_t                                   byte;
+} ism330dhcx_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t ism330dhcx_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+int32_t ism330dhcx_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len);
+
+extern float_t ism330dhcx_from_fs2g_to_mg(int16_t lsb);
+extern float_t ism330dhcx_from_fs4g_to_mg(int16_t lsb);
+extern float_t ism330dhcx_from_fs8g_to_mg(int16_t lsb);
+extern float_t ism330dhcx_from_fs16g_to_mg(int16_t lsb);
+extern float_t ism330dhcx_from_fs125dps_to_mdps(int16_t lsb);
+extern float_t ism330dhcx_from_fs250dps_to_mdps(int16_t lsb);
+extern float_t ism330dhcx_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t ism330dhcx_from_fs1000dps_to_mdps(int16_t lsb);
+extern float_t ism330dhcx_from_fs2000dps_to_mdps(int16_t lsb);
+extern float_t ism330dhcx_from_fs4000dps_to_mdps(int16_t lsb);
+extern float_t ism330dhcx_from_lsb_to_celsius(int16_t lsb);
+extern float_t ism330dhcx_from_lsb_to_nsec(int32_t lsb);
+
+typedef enum {
+  ISM330DHCX_2g   = 0,
+  ISM330DHCX_16g  = 1, /* if XL_FS_MODE = ‘1’ -> ISM330DHCX_2g */
+  ISM330DHCX_4g   = 2,
+  ISM330DHCX_8g   = 3,
+} ism330dhcx_fs_xl_t;
+int32_t ism330dhcx_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_fs_xl_t val);
+int32_t ism330dhcx_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_fs_xl_t *val);
+
+typedef enum {
+  ISM330DHCX_XL_ODR_OFF    = 0,
+  ISM330DHCX_XL_ODR_12Hz5  = 1,
+  ISM330DHCX_XL_ODR_26Hz   = 2,
+  ISM330DHCX_XL_ODR_52Hz   = 3,
+  ISM330DHCX_XL_ODR_104Hz  = 4,
+  ISM330DHCX_XL_ODR_208Hz  = 5,
+  ISM330DHCX_XL_ODR_417Hz  = 6,
+  ISM330DHCX_XL_ODR_833Hz  = 7,
+  ISM330DHCX_XL_ODR_1667Hz = 8,
+  ISM330DHCX_XL_ODR_3333Hz = 9,
+  ISM330DHCX_XL_ODR_6667Hz = 10,
+  ISM330DHCX_XL_ODR_6Hz5   = 11, /* (low power only) */
+} ism330dhcx_odr_xl_t;
+int32_t ism330dhcx_xl_data_rate_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_xl_t val);
+int32_t ism330dhcx_xl_data_rate_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_xl_t *val);
+
+typedef enum {
+  ISM330DHCX_125dps = 2,
+  ISM330DHCX_250dps = 0,
+  ISM330DHCX_500dps = 4,
+  ISM330DHCX_1000dps = 8,
+  ISM330DHCX_2000dps = 12,
+  ISM330DHCX_4000dps = 1,
+} ism330dhcx_fs_g_t;
+int32_t ism330dhcx_gy_full_scale_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_fs_g_t val);
+int32_t ism330dhcx_gy_full_scale_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_fs_g_t *val);
+
+typedef enum {
+  ISM330DHCX_GY_ODR_OFF    = 0,
+  ISM330DHCX_GY_ODR_12Hz5  = 1,
+  ISM330DHCX_GY_ODR_26Hz   = 2,
+  ISM330DHCX_GY_ODR_52Hz   = 3,
+  ISM330DHCX_GY_ODR_104Hz  = 4,
+  ISM330DHCX_GY_ODR_208Hz  = 5,
+  ISM330DHCX_GY_ODR_417Hz  = 6,
+  ISM330DHCX_GY_ODR_833Hz  = 7,
+  ISM330DHCX_GY_ODR_1667Hz = 8,
+  ISM330DHCX_GY_ODR_3333Hz = 9,
+  ISM330DHCX_GY_ODR_6667Hz = 10,
+} ism330dhcx_odr_g_t;
+int32_t ism330dhcx_gy_data_rate_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_g_t val);
+int32_t ism330dhcx_gy_data_rate_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_odr_g_t *val);
+
+int32_t ism330dhcx_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_LSb_1mg  = 0,
+  ISM330DHCX_LSb_16mg = 1,
+} ism330dhcx_usr_off_w_t;
+int32_t ism330dhcx_xl_offset_weight_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_usr_off_w_t val);
+int32_t ism330dhcx_xl_offset_weight_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_usr_off_w_t *val);
+
+typedef enum {
+  ISM330DHCX_HIGH_PERFORMANCE_MD  = 0,
+  ISM330DHCX_LOW_NORMAL_POWER_MD  = 1,
+} ism330dhcx_xl_hm_mode_t;
+int32_t ism330dhcx_xl_power_mode_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_xl_hm_mode_t val);
+int32_t ism330dhcx_xl_power_mode_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_xl_hm_mode_t *val);
+
+typedef enum {
+  ISM330DHCX_GY_HIGH_PERFORMANCE  = 0,
+  ISM330DHCX_GY_NORMAL            = 1,
+} ism330dhcx_g_hm_mode_t;
+int32_t ism330dhcx_gy_power_mode_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_g_hm_mode_t val);
+int32_t ism330dhcx_gy_power_mode_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_g_hm_mode_t *val);
+
+typedef struct {
+  ism330dhcx_all_int_src_t       all_int_src;
+  ism330dhcx_wake_up_src_t       wake_up_src;
+  ism330dhcx_tap_src_t           tap_src;
+  ism330dhcx_d6d_src_t           d6d_src;
+  ism330dhcx_status_reg_t        status_reg;
+  ism330dhcx_emb_func_status_t   emb_func_status;
+  ism330dhcx_fsm_status_a_t      fsm_status_a;
+  ism330dhcx_fsm_status_b_t      fsm_status_b;
+  } ism330dhcx_all_sources_t;
+int32_t ism330dhcx_all_sources_get(stmdev_ctx_t *ctx,
+                                  ism330dhcx_all_sources_t *val);
+
+int32_t ism330dhcx_status_reg_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_status_reg_t *val);
+
+int32_t ism330dhcx_xl_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                          uint8_t *val);
+
+int32_t ism330dhcx_gy_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                          uint8_t *val);
+
+int32_t ism330dhcx_temp_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t ism330dhcx_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  ISM330DHCX_NO_ROUND      = 0,
+  ISM330DHCX_ROUND_XL      = 1,
+  ISM330DHCX_ROUND_GY      = 2,
+  ISM330DHCX_ROUND_GY_XL   = 3,
+} ism330dhcx_rounding_t;
+int32_t ism330dhcx_rounding_mode_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_rounding_t val);
+int32_t ism330dhcx_rounding_mode_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_rounding_t *val);
+
+int32_t ism330dhcx_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_steps_reset(stmdev_ctx_t *ctx);
+
+typedef enum {
+  ISM330DHCX_USER_BANK           = 0,
+  ISM330DHCX_SENSOR_HUB_BANK     = 1,
+  ISM330DHCX_EMBEDDED_FUNC_BANK  = 2,
+} ism330dhcx_reg_access_t;
+int32_t ism330dhcx_mem_bank_set(stmdev_ctx_t *ctx,
+                                ism330dhcx_reg_access_t val);
+int32_t ism330dhcx_mem_bank_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_reg_access_t *val);
+
+int32_t ism330dhcx_ln_pg_write_byte(stmdev_ctx_t *ctx, uint16_t address,
+                                   uint8_t *val);
+int32_t ism330dhcx_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
+                              uint8_t *buf, uint8_t len);
+int32_t ism330dhcx_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t add,
+                                  uint8_t *val);
+int32_t ism330dhcx_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address,
+                             uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_DRDY_LATCHED = 0,
+  ISM330DHCX_DRDY_PULSED  = 1,
+} ism330dhcx_dataready_pulsed_t;
+int32_t ism330dhcx_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                      ism330dhcx_dataready_pulsed_t val);
+int32_t ism330dhcx_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                      ism330dhcx_dataready_pulsed_t *val);
+
+int32_t ism330dhcx_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_XL_ST_DISABLE  = 0,
+  ISM330DHCX_XL_ST_POSITIVE = 1,
+  ISM330DHCX_XL_ST_NEGATIVE = 2,
+} ism330dhcx_st_xl_t;
+int32_t ism330dhcx_xl_self_test_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_xl_t val);
+int32_t ism330dhcx_xl_self_test_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_xl_t *val);
+
+typedef enum {
+  ISM330DHCX_GY_ST_DISABLE  = 0,
+  ISM330DHCX_GY_ST_POSITIVE = 1,
+  ISM330DHCX_GY_ST_NEGATIVE = 3,
+} ism330dhcx_st_g_t;
+int32_t ism330dhcx_gy_self_test_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_g_t val);
+int32_t ism330dhcx_gy_self_test_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_g_t *val);
+
+int32_t ism330dhcx_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_gy_filter_lp1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_gy_filter_lp1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_filter_settling_mask_set(stmdev_ctx_t *ctx,
+                                           uint8_t val);
+int32_t ism330dhcx_filter_settling_mask_get(stmdev_ctx_t *ctx,
+                                           uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_ULTRA_LIGHT  = 0,
+  ISM330DHCX_VERY_LIGHT   = 1,
+  ISM330DHCX_LIGHT        = 2,
+  ISM330DHCX_MEDIUM       = 3,
+  ISM330DHCX_STRONG       = 4,
+  ISM330DHCX_VERY_STRONG  = 5,
+  ISM330DHCX_AGGRESSIVE   = 6,
+  ISM330DHCX_XTREME       = 7,
+} ism330dhcx_ftype_t;
+int32_t ism330dhcx_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_ftype_t val);
+int32_t ism330dhcx_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_ftype_t *val);
+
+int32_t ism330dhcx_xl_lp2_on_6d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_xl_lp2_on_6d_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_HP_PATH_DISABLE_ON_OUT    = 0x00,
+  ISM330DHCX_SLOPE_ODR_DIV_4           = 0x10,
+  ISM330DHCX_HP_ODR_DIV_10             = 0x11,
+  ISM330DHCX_HP_ODR_DIV_20             = 0x12,
+  ISM330DHCX_HP_ODR_DIV_45             = 0x13,
+  ISM330DHCX_HP_ODR_DIV_100            = 0x14,
+  ISM330DHCX_HP_ODR_DIV_200            = 0x15,
+  ISM330DHCX_HP_ODR_DIV_400            = 0x16,
+  ISM330DHCX_HP_ODR_DIV_800            = 0x17,
+  ISM330DHCX_HP_REF_MD_ODR_DIV_10      = 0x31,
+  ISM330DHCX_HP_REF_MD_ODR_DIV_20      = 0x32,
+  ISM330DHCX_HP_REF_MD_ODR_DIV_45      = 0x33,
+  ISM330DHCX_HP_REF_MD_ODR_DIV_100     = 0x34,
+  ISM330DHCX_HP_REF_MD_ODR_DIV_200     = 0x35,
+  ISM330DHCX_HP_REF_MD_ODR_DIV_400     = 0x36,
+  ISM330DHCX_HP_REF_MD_ODR_DIV_800     = 0x37,
+  ISM330DHCX_LP_ODR_DIV_10             = 0x01,
+  ISM330DHCX_LP_ODR_DIV_20             = 0x02,
+  ISM330DHCX_LP_ODR_DIV_45             = 0x03,
+  ISM330DHCX_LP_ODR_DIV_100            = 0x04,
+  ISM330DHCX_LP_ODR_DIV_200            = 0x05,
+  ISM330DHCX_LP_ODR_DIV_400            = 0x06,
+  ISM330DHCX_LP_ODR_DIV_800            = 0x07,
+} ism330dhcx_hp_slope_xl_en_t;
+int32_t ism330dhcx_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_hp_slope_xl_en_t val);
+int32_t ism330dhcx_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_hp_slope_xl_en_t *val);
+
+int32_t ism330dhcx_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_USE_SLOPE = 0,
+  ISM330DHCX_USE_HPF   = 1,
+} ism330dhcx_slope_fds_t;
+int32_t ism330dhcx_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                          ism330dhcx_slope_fds_t val);
+int32_t ism330dhcx_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                          ism330dhcx_slope_fds_t *val);
+
+typedef enum {
+  ISM330DHCX_HP_FILTER_NONE     = 0x00,
+  ISM330DHCX_HP_FILTER_16mHz    = 0x80,
+  ISM330DHCX_HP_FILTER_65mHz    = 0x81,
+  ISM330DHCX_HP_FILTER_260mHz   = 0x82,
+  ISM330DHCX_HP_FILTER_1Hz04    = 0x83,
+} ism330dhcx_hpm_g_t;
+int32_t ism330dhcx_gy_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                          ism330dhcx_hpm_g_t val);
+int32_t ism330dhcx_gy_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                          ism330dhcx_hpm_g_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_PULL_UP_DISC       = 0,
+  ISM330DHCX_AUX_PULL_UP_CONNECT    = 1,
+} ism330dhcx_ois_pu_dis_t;
+int32_t ism330dhcx_aux_sdo_ocs_mode_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_ois_pu_dis_t val);
+int32_t ism330dhcx_aux_sdo_ocs_mode_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_ois_pu_dis_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_ON                    = 1,
+  ISM330DHCX_AUX_ON_BY_AUX_INTERFACE   = 0,
+} ism330dhcx_ois_on_t;
+int32_t ism330dhcx_aux_pw_on_ctrl_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_ois_on_t val);
+int32_t ism330dhcx_aux_pw_on_ctrl_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_ois_on_t *val);
+
+int32_t ism330dhcx_aux_status_reg_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_status_spiaux_t *val);
+
+int32_t ism330dhcx_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t ism330dhcx_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t ism330dhcx_aux_gy_flag_settling_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_XL_DISABLE = 0,
+  ISM330DHCX_AUX_XL_POS     = 1,
+  ISM330DHCX_AUX_XL_NEG     = 2,
+} ism330dhcx_st_xl_ois_t;
+int32_t ism330dhcx_aux_xl_self_test_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_st_xl_ois_t val);
+int32_t ism330dhcx_aux_xl_self_test_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_st_xl_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_DEN_ACTIVE_LOW     = 0,
+  ISM330DHCX_AUX_DEN_ACTIVE_HIGH    = 1,
+} ism330dhcx_den_lh_ois_t;
+int32_t ism330dhcx_aux_den_polarity_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_den_lh_ois_t val);
+int32_t ism330dhcx_aux_den_polarity_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_den_lh_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_DEN_DISABLE         = 0,
+  ISM330DHCX_AUX_DEN_LEVEL_LATCH     = 3,
+  ISM330DHCX_AUX_DEN_LEVEL_TRIG      = 2,
+} ism330dhcx_lvl2_ois_t;
+int32_t ism330dhcx_aux_den_mode_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_lvl2_ois_t val);
+int32_t ism330dhcx_aux_den_mode_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_lvl2_ois_t *val);
+
+int32_t ism330dhcx_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_DISABLE  = 0,
+  ISM330DHCX_MODE_3_GY    = 1,
+  ISM330DHCX_MODE_4_GY_XL = 3,
+} ism330dhcx_ois_en_spi2_t;
+int32_t ism330dhcx_aux_mode_set(stmdev_ctx_t *ctx,
+                               ism330dhcx_ois_en_spi2_t val);
+int32_t ism330dhcx_aux_mode_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_ois_en_spi2_t *val);
+
+typedef enum {
+  ISM330DHCX_125dps_AUX  =  0x04,
+  ISM330DHCX_250dps_AUX  =  0x00,
+  ISM330DHCX_500dps_AUX  =  0x01,
+  ISM330DHCX_1000dps_AUX =  0x02,
+  ISM330DHCX_2000dps_AUX =  0x03,
+} ism330dhcx_fs_g_ois_t;
+int32_t ism330dhcx_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_fs_g_ois_t val);
+int32_t ism330dhcx_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_fs_g_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_SPI_4_WIRE = 0,
+  ISM330DHCX_AUX_SPI_3_WIRE = 1,
+} ism330dhcx_sim_ois_t;
+int32_t ism330dhcx_aux_spi_mode_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sim_ois_t val);
+int32_t ism330dhcx_aux_spi_mode_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sim_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_351Hz39 = 0,
+  ISM330DHCX_236Hz63 = 1,
+  ISM330DHCX_172Hz70 = 2,
+  ISM330DHCX_937Hz91 = 3,
+} ism330dhcx_ftype_ois_t;
+int32_t ism330dhcx_aux_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                           ism330dhcx_ftype_ois_t val);
+int32_t ism330dhcx_aux_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                           ism330dhcx_ftype_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_HP_DISABLE = 0x00,
+  ISM330DHCX_AUX_HP_Hz016   = 0x10,
+  ISM330DHCX_AUX_HP_Hz065   = 0x11,
+  ISM330DHCX_AUX_HP_Hz260   = 0x12,
+  ISM330DHCX_AUX_HP_1Hz040  = 0x13,
+} ism330dhcx_hpm_ois_t;
+int32_t ism330dhcx_aux_gy_hp_bandwidth_set(stmdev_ctx_t *ctx,
+                                          ism330dhcx_hpm_ois_t val);
+int32_t ism330dhcx_aux_gy_hp_bandwidth_get(stmdev_ctx_t *ctx,
+                                          ism330dhcx_hpm_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_ENABLE_CLAMP  = 0,
+  ISM330DHCX_DISABLE_CLAMP = 1,
+} ism330dhcx_st_ois_clampdis_t;
+int32_t ism330dhcx_aux_gy_clamp_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_ois_clampdis_t val);
+int32_t ism330dhcx_aux_gy_clamp_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_st_ois_clampdis_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_GY_DISABLE = 0,
+  ISM330DHCX_AUX_GY_POS     = 1,
+  ISM330DHCX_AUX_GY_NEG     = 3,
+} ism330dhcx_st_ois_t;
+int32_t ism330dhcx_aux_gy_self_test_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_st_ois_t val);
+int32_t ism330dhcx_aux_gy_self_test_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_st_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_631Hz = 0,
+  ISM330DHCX_295Hz = 1,
+  ISM330DHCX_140Hz = 2,
+  ISM330DHCX_68Hz2 = 3,
+  ISM330DHCX_33Hz6 = 4,
+  ISM330DHCX_16Hz7 = 5,
+  ISM330DHCX_8Hz3  = 6,
+  ISM330DHCX_4Hz11 = 7,
+} ism330dhcx_filter_xl_conf_ois_t;
+int32_t ism330dhcx_aux_xl_bandwidth_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_filter_xl_conf_ois_t val);
+int32_t ism330dhcx_aux_xl_bandwidth_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_filter_xl_conf_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_AUX_2g  = 0,
+  ISM330DHCX_AUX_16g = 1,
+  ISM330DHCX_AUX_4g  = 2,
+  ISM330DHCX_AUX_8g  = 3,
+} ism330dhcx_fs_xl_ois_t;
+int32_t ism330dhcx_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_fs_xl_ois_t val);
+int32_t ism330dhcx_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_fs_xl_ois_t *val);
+
+typedef enum {
+  ISM330DHCX_PULL_UP_DISC       = 0,
+  ISM330DHCX_PULL_UP_CONNECT    = 1,
+} ism330dhcx_sdo_pu_en_t;
+int32_t ism330dhcx_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sdo_pu_en_t val);
+int32_t ism330dhcx_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sdo_pu_en_t *val);
+
+typedef enum {
+  ISM330DHCX_SPI_4_WIRE = 0,
+  ISM330DHCX_SPI_3_WIRE = 1,
+} ism330dhcx_sim_t;
+int32_t ism330dhcx_spi_mode_set(stmdev_ctx_t *ctx, ism330dhcx_sim_t val);
+int32_t ism330dhcx_spi_mode_get(stmdev_ctx_t *ctx, ism330dhcx_sim_t *val);
+
+typedef enum {
+  ISM330DHCX_I2C_ENABLE  = 0,
+  ISM330DHCX_I2C_DISABLE = 1,
+} ism330dhcx_i2c_disable_t;
+int32_t ism330dhcx_i2c_interface_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_i2c_disable_t val);
+int32_t ism330dhcx_i2c_interface_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_i2c_disable_t *val);
+
+typedef struct {
+    ism330dhcx_int1_ctrl_t          int1_ctrl;
+    ism330dhcx_md1_cfg_t            md1_cfg;
+    ism330dhcx_emb_func_int1_t      emb_func_int1;
+    ism330dhcx_fsm_int1_a_t         fsm_int1_a;
+    ism330dhcx_fsm_int1_b_t         fsm_int1_b;
+    ism330dhcx_mlc_int1_t           mlc_int1;
+} ism330dhcx_pin_int1_route_t;
+int32_t ism330dhcx_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_pin_int1_route_t *val);
+int32_t ism330dhcx_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_pin_int1_route_t *val);
+
+typedef struct {
+  ism330dhcx_int2_ctrl_t          int2_ctrl;
+  ism330dhcx_md2_cfg_t            md2_cfg;
+  ism330dhcx_emb_func_int2_t      emb_func_int2;
+  ism330dhcx_fsm_int2_a_t         fsm_int2_a;
+  ism330dhcx_fsm_int2_b_t         fsm_int2_b;
+  ism330dhcx_mlc_int2_t           mlc_int2;
+} ism330dhcx_pin_int2_route_t;
+int32_t ism330dhcx_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_pin_int2_route_t *val);
+int32_t ism330dhcx_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_pin_int2_route_t *val);
+
+typedef enum {
+  ISM330DHCX_PUSH_PULL   = 0,
+  ISM330DHCX_OPEN_DRAIN  = 1,
+} ism330dhcx_pp_od_t;
+int32_t ism330dhcx_pin_mode_set(stmdev_ctx_t *ctx,
+                                ism330dhcx_pp_od_t val);
+int32_t ism330dhcx_pin_mode_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_pp_od_t *val);
+
+typedef enum {
+  ISM330DHCX_ACTIVE_HIGH = 0,
+  ISM330DHCX_ACTIVE_LOW  = 1,
+} ism330dhcx_h_lactive_t;
+int32_t ism330dhcx_pin_polarity_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_h_lactive_t val);
+int32_t ism330dhcx_pin_polarity_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_h_lactive_t *val);
+
+int32_t ism330dhcx_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_ALL_INT_PULSED            = 0,
+  ISM330DHCX_BASE_LATCHED_EMB_PULSED   = 1,
+  ISM330DHCX_BASE_PULSED_EMB_LATCHED   = 2,
+  ISM330DHCX_ALL_INT_LATCHED           = 3,
+} ism330dhcx_lir_t;
+int32_t ism330dhcx_int_notification_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_lir_t val);
+int32_t ism330dhcx_int_notification_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_lir_t *val);
+
+typedef enum {
+  ISM330DHCX_LSb_FS_DIV_64       = 0,
+  ISM330DHCX_LSb_FS_DIV_256      = 1,
+} ism330dhcx_wake_ths_w_t;
+int32_t ism330dhcx_wkup_ths_weight_set(stmdev_ctx_t *ctx,
+                                      ism330dhcx_wake_ths_w_t val);
+int32_t ism330dhcx_wkup_ths_weight_get(stmdev_ctx_t *ctx,
+                                      ism330dhcx_wake_ths_w_t *val);
+
+int32_t ism330dhcx_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx,
+                                            uint8_t val);
+int32_t ism330dhcx_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t ism330dhcx_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_DRIVE_SLEEP_CHG_EVENT = 0,
+  ISM330DHCX_DRIVE_SLEEP_STATUS    = 1,
+} ism330dhcx_sleep_status_on_int_t;
+int32_t ism330dhcx_act_pin_notification_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_sleep_status_on_int_t val);
+int32_t ism330dhcx_act_pin_notification_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_sleep_status_on_int_t *val);
+
+typedef enum {
+  ISM330DHCX_XL_AND_GY_NOT_AFFECTED      = 0,
+  ISM330DHCX_XL_12Hz5_GY_NOT_AFFECTED    = 1,
+  ISM330DHCX_XL_12Hz5_GY_SLEEP           = 2,
+  ISM330DHCX_XL_12Hz5_GY_PD              = 3,
+} ism330dhcx_inact_en_t;
+int32_t ism330dhcx_act_mode_set(stmdev_ctx_t *ctx,
+                               ism330dhcx_inact_en_t val);
+int32_t ism330dhcx_act_mode_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_inact_en_t *val);
+
+int32_t ism330dhcx_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_XYZ = 0,
+  ISM330DHCX_YXZ = 1,
+  ISM330DHCX_XZY = 2,
+  ISM330DHCX_ZYX = 3,
+  ISM330DHCX_YZX = 5,
+  ISM330DHCX_ZXY = 6,
+} ism330dhcx_tap_priority_t;
+int32_t ism330dhcx_tap_axis_priority_set(stmdev_ctx_t *ctx,
+                                        ism330dhcx_tap_priority_t val);
+int32_t ism330dhcx_tap_axis_priority_get(stmdev_ctx_t *ctx,
+                                        ism330dhcx_tap_priority_t *val);
+
+int32_t ism330dhcx_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_ONLY_SINGLE        = 0,
+  ISM330DHCX_BOTH_SINGLE_DOUBLE = 1,
+} ism330dhcx_single_double_tap_t;
+int32_t ism330dhcx_tap_mode_set(stmdev_ctx_t *ctx,
+                               ism330dhcx_single_double_tap_t val);
+int32_t ism330dhcx_tap_mode_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_single_double_tap_t *val);
+
+typedef enum {
+  ISM330DHCX_DEG_80  = 0,
+  ISM330DHCX_DEG_70  = 1,
+  ISM330DHCX_DEG_60  = 2,
+  ISM330DHCX_DEG_50  = 3,
+} ism330dhcx_sixd_ths_t;
+int32_t ism330dhcx_6d_threshold_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sixd_ths_t val);
+int32_t ism330dhcx_6d_threshold_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sixd_ths_t *val);
+
+int32_t ism330dhcx_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_FF_TSH_156mg = 0,
+  ISM330DHCX_FF_TSH_219mg = 1,
+  ISM330DHCX_FF_TSH_250mg = 2,
+  ISM330DHCX_FF_TSH_312mg = 3,
+  ISM330DHCX_FF_TSH_344mg = 4,
+  ISM330DHCX_FF_TSH_406mg = 5,
+  ISM330DHCX_FF_TSH_469mg = 6,
+  ISM330DHCX_FF_TSH_500mg = 7,
+} ism330dhcx_ff_ths_t;
+int32_t ism330dhcx_ff_threshold_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_ff_ths_t val);
+int32_t ism330dhcx_ff_threshold_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_ff_ths_t *val);
+
+int32_t ism330dhcx_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t ism330dhcx_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t ism330dhcx_compression_algo_init_set(stmdev_ctx_t *ctx,
+                                            uint8_t val);
+int32_t ism330dhcx_compression_algo_init_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_CMP_DISABLE  = 0x00,
+  ISM330DHCX_CMP_ALWAYS   = 0x04,
+  ISM330DHCX_CMP_8_TO_1   = 0x05,
+  ISM330DHCX_CMP_16_TO_1  = 0x06,
+  ISM330DHCX_CMP_32_TO_1  = 0x07,
+} ism330dhcx_uncoptr_rate_t;
+int32_t ism330dhcx_compression_algo_set(stmdev_ctx_t *ctx,
+                                       ism330dhcx_uncoptr_rate_t val);
+int32_t ism330dhcx_compression_algo_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_uncoptr_rate_t *val);
+
+int32_t ism330dhcx_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
+                                                uint8_t val);
+int32_t ism330dhcx_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
+                                                uint8_t *val);
+
+int32_t ism330dhcx_compression_algo_real_time_set(stmdev_ctx_t *ctx,
+                                                 uint8_t val);
+int32_t ism330dhcx_compression_algo_real_time_get(stmdev_ctx_t *ctx,
+                                                 uint8_t *val);
+
+int32_t ism330dhcx_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_XL_NOT_BATCHED     	=  0,
+  ISM330DHCX_XL_BATCHED_AT_12Hz5   =  1,
+  ISM330DHCX_XL_BATCHED_AT_26Hz    =  2,
+  ISM330DHCX_XL_BATCHED_AT_52Hz    =  3,
+  ISM330DHCX_XL_BATCHED_AT_104Hz   =  4,
+  ISM330DHCX_XL_BATCHED_AT_208Hz   =  5,
+  ISM330DHCX_XL_BATCHED_AT_417Hz   =  6,
+  ISM330DHCX_XL_BATCHED_AT_833Hz   =  7,
+  ISM330DHCX_XL_BATCHED_AT_1667Hz  =  8,
+  ISM330DHCX_XL_BATCHED_AT_3333Hz  =  9,
+  ISM330DHCX_XL_BATCHED_AT_6667Hz  = 10,
+  ISM330DHCX_XL_BATCHED_AT_6Hz5    = 11,
+} ism330dhcx_bdr_xl_t;
+int32_t ism330dhcx_fifo_xl_batch_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_bdr_xl_t val);
+int32_t ism330dhcx_fifo_xl_batch_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_bdr_xl_t *val);
+
+typedef enum {
+  ISM330DHCX_GY_NOT_BATCHED         = 0,
+  ISM330DHCX_GY_BATCHED_AT_12Hz5    = 1,
+  ISM330DHCX_GY_BATCHED_AT_26Hz     = 2,
+  ISM330DHCX_GY_BATCHED_AT_52Hz     = 3,
+  ISM330DHCX_GY_BATCHED_AT_104Hz    = 4,
+  ISM330DHCX_GY_BATCHED_AT_208Hz    = 5,
+  ISM330DHCX_GY_BATCHED_AT_417Hz    = 6,
+  ISM330DHCX_GY_BATCHED_AT_833Hz    = 7,
+  ISM330DHCX_GY_BATCHED_AT_1667Hz   = 8,
+  ISM330DHCX_GY_BATCHED_AT_3333Hz   = 9,
+  ISM330DHCX_GY_BATCHED_AT_6667Hz   = 10,
+  ISM330DHCX_GY_BATCHED_6Hz5        = 11,
+} ism330dhcx_bdr_gy_t;
+int32_t ism330dhcx_fifo_gy_batch_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_bdr_gy_t val);
+int32_t ism330dhcx_fifo_gy_batch_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_bdr_gy_t *val);
+
+typedef enum {
+  ISM330DHCX_BYPASS_MODE             = 0,
+  ISM330DHCX_FIFO_MODE               = 1,
+  ISM330DHCX_STREAM_TO_FIFO_MODE     = 3,
+  ISM330DHCX_BYPASS_TO_STREAM_MODE   = 4,
+  ISM330DHCX_STREAM_MODE             = 6,
+  ISM330DHCX_BYPASS_TO_FIFO_MODE     = 7,
+} ism330dhcx_fifo_mode_t;
+int32_t ism330dhcx_fifo_mode_set(stmdev_ctx_t *ctx,
+                                 ism330dhcx_fifo_mode_t val);
+int32_t ism330dhcx_fifo_mode_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_fifo_mode_t *val);
+
+typedef enum {
+  ISM330DHCX_TEMP_NOT_BATCHED        = 0,
+  ISM330DHCX_TEMP_BATCHED_AT_52Hz    = 1,
+  ISM330DHCX_TEMP_BATCHED_AT_12Hz5   = 2,
+  ISM330DHCX_TEMP_BATCHED_AT_1Hz6    = 3,
+} ism330dhcx_odr_t_batch_t;
+int32_t ism330dhcx_fifo_temp_batch_set(stmdev_ctx_t *ctx,
+                                      ism330dhcx_odr_t_batch_t val);
+int32_t ism330dhcx_fifo_temp_batch_get(stmdev_ctx_t *ctx,
+                                      ism330dhcx_odr_t_batch_t *val);
+
+typedef enum {
+  ISM330DHCX_NO_DECIMATION = 0,
+  ISM330DHCX_DEC_1         = 1,
+  ISM330DHCX_DEC_8         = 2,
+  ISM330DHCX_DEC_32        = 3,
+} ism330dhcx_odr_ts_batch_t;
+int32_t ism330dhcx_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
+                                                ism330dhcx_odr_ts_batch_t val);
+int32_t ism330dhcx_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
+                                                ism330dhcx_odr_ts_batch_t *val);
+
+typedef enum {
+  ISM330DHCX_XL_BATCH_EVENT   = 0,
+  ISM330DHCX_GYRO_BATCH_EVENT = 1,
+} ism330dhcx_trig_counter_bdr_t;
+int32_t ism330dhcx_fifo_cnt_event_batch_set(stmdev_ctx_t *ctx,
+                                           ism330dhcx_trig_counter_bdr_t val);
+int32_t ism330dhcx_fifo_cnt_event_batch_get(stmdev_ctx_t *ctx,
+                                           ism330dhcx_trig_counter_bdr_t *val);
+
+int32_t ism330dhcx_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_batch_counter_threshold_set(stmdev_ctx_t *ctx,
+                                              uint16_t val);
+int32_t ism330dhcx_batch_counter_threshold_get(stmdev_ctx_t *ctx,
+                                              uint16_t *val);
+
+int32_t ism330dhcx_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t ism330dhcx_fifo_status_get(stmdev_ctx_t *ctx,
+                                  ism330dhcx_fifo_status2_t *val);
+
+int32_t ism330dhcx_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_GYRO_NC_TAG    = 1,
+  ISM330DHCX_XL_NC_TAG,
+  ISM330DHCX_TEMPERATURE_TAG,
+  ISM330DHCX_TIMESTAMP_TAG,
+  ISM330DHCX_CFG_CHANGE_TAG,
+  ISM330DHCX_XL_NC_T_2_TAG,
+  ISM330DHCX_XL_NC_T_1_TAG,
+  ISM330DHCX_XL_2XC_TAG,
+  ISM330DHCX_XL_3XC_TAG,
+  ISM330DHCX_GYRO_NC_T_2_TAG,
+  ISM330DHCX_GYRO_NC_T_1_TAG,
+  ISM330DHCX_GYRO_2XC_TAG,
+  ISM330DHCX_GYRO_3XC_TAG,
+  ISM330DHCX_SENSORHUB_SLAVE0_TAG,
+  ISM330DHCX_SENSORHUB_SLAVE1_TAG,
+  ISM330DHCX_SENSORHUB_SLAVE2_TAG,
+  ISM330DHCX_SENSORHUB_SLAVE3_TAG,
+  ISM330DHCX_STEP_CPUNTER_TAG,
+  ISM330DHCX_GAME_ROTATION_TAG,
+  ISM330DHCX_GEOMAG_ROTATION_TAG,
+  ISM330DHCX_ROTATION_TAG,
+  ISM330DHCX_SENSORHUB_NACK_TAG	= 0x19,
+} ism330dhcx_fifo_tag_t;
+int32_t ism330dhcx_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
+                                      ism330dhcx_fifo_tag_t *val);
+
+int32_t ism330dhcx_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_sh_batch_slave_0_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_sh_batch_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_sh_batch_slave_1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_sh_batch_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_sh_batch_slave_2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_sh_batch_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_sh_batch_slave_3_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_sh_batch_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_DEN_DISABLE    = 0,
+  ISM330DHCX_LEVEL_FIFO     = 6,
+  ISM330DHCX_LEVEL_LETCHED  = 3,
+  ISM330DHCX_LEVEL_TRIGGER  = 2,
+  ISM330DHCX_EDGE_TRIGGER   = 4,
+} ism330dhcx_den_mode_t;
+int32_t ism330dhcx_den_mode_set(stmdev_ctx_t *ctx,
+                               ism330dhcx_den_mode_t val);
+int32_t ism330dhcx_den_mode_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_den_mode_t *val);
+
+typedef enum {
+  ISM330DHCX_DEN_ACT_LOW  = 0,
+  ISM330DHCX_DEN_ACT_HIGH = 1,
+} ism330dhcx_den_lh_t;
+int32_t ism330dhcx_den_polarity_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_den_lh_t val);
+int32_t ism330dhcx_den_polarity_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_den_lh_t *val);
+
+typedef enum {
+  ISM330DHCX_STAMP_IN_GY_DATA     = 0,
+  ISM330DHCX_STAMP_IN_XL_DATA     = 1,
+  ISM330DHCX_STAMP_IN_GY_XL_DATA  = 2,
+} ism330dhcx_den_xl_g_t;
+int32_t ism330dhcx_den_enable_set(stmdev_ctx_t *ctx,
+                                 ism330dhcx_den_xl_g_t val);
+int32_t ism330dhcx_den_enable_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_den_xl_g_t *val);
+
+int32_t ism330dhcx_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_PEDO_BASE                = 0x00,
+  ISM330DHCX_PEDO_BASE_FALSE_STEP_REJ = 0x01,
+  ISM330DHCX_PEDO_ADV_FALSE_STEP_REJ  = 0x03,
+} ism330dhcx_pedo_mode_t;
+int32_t ism330dhcx_pedo_mode_set(stmdev_ctx_t *ctx,
+                                 ism330dhcx_pedo_mode_t val);
+int32_t ism330dhcx_pedo_mode_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_pedo_mode_t *val);
+
+int32_t ism330dhcx_pedo_step_detect_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_pedo_debounce_steps_set(stmdev_ctx_t *ctx,
+                                           uint8_t *buff);
+int32_t ism330dhcx_pedo_debounce_steps_get(stmdev_ctx_t *ctx,
+                                           uint8_t *buff);
+
+int32_t ism330dhcx_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_pedo_adv_detection_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_pedo_adv_detection_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_pedo_false_step_rejection_set(stmdev_ctx_t *ctx,
+                                                 uint8_t val);
+int32_t ism330dhcx_pedo_false_step_rejection_get(stmdev_ctx_t *ctx,
+                                                 uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_EVERY_STEP     = 0,
+  ISM330DHCX_COUNT_OVERFLOW = 1,
+} ism330dhcx_carry_count_en_t;
+int32_t ism330dhcx_pedo_int_mode_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_carry_count_en_t val);
+int32_t ism330dhcx_pedo_int_mode_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_carry_count_en_t *val);
+
+int32_t ism330dhcx_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_motion_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t ism330dhcx_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_tilt_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val);
+
+int32_t ism330dhcx_mag_sensitivity_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_mag_sensitivity_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t ism330dhcx_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  ISM330DHCX_Z_EQ_Y     = 0,
+  ISM330DHCX_Z_EQ_MIN_Y = 1,
+  ISM330DHCX_Z_EQ_X     = 2,
+  ISM330DHCX_Z_EQ_MIN_X = 3,
+  ISM330DHCX_Z_EQ_MIN_Z = 4,
+  ISM330DHCX_Z_EQ_Z     = 5,
+} ism330dhcx_mag_z_axis_t;
+int32_t ism330dhcx_mag_z_orient_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_z_axis_t val);
+int32_t ism330dhcx_mag_z_orient_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_z_axis_t *val);
+
+typedef enum {
+  ISM330DHCX_Y_EQ_Y     = 0,
+  ISM330DHCX_Y_EQ_MIN_Y = 1,
+  ISM330DHCX_Y_EQ_X     = 2,
+  ISM330DHCX_Y_EQ_MIN_X = 3,
+  ISM330DHCX_Y_EQ_MIN_Z = 4,
+  ISM330DHCX_Y_EQ_Z     = 5,
+} ism330dhcx_mag_y_axis_t;
+int32_t ism330dhcx_mag_y_orient_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_y_axis_t val);
+int32_t ism330dhcx_mag_y_orient_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_y_axis_t *val);
+
+typedef enum {
+  ISM330DHCX_X_EQ_Y     = 0,
+  ISM330DHCX_X_EQ_MIN_Y = 1,
+  ISM330DHCX_X_EQ_X     = 2,
+  ISM330DHCX_X_EQ_MIN_X = 3,
+  ISM330DHCX_X_EQ_MIN_Z = 4,
+  ISM330DHCX_X_EQ_Z     = 5,
+} ism330dhcx_mag_x_axis_t;
+int32_t ism330dhcx_mag_x_orient_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_x_axis_t val);
+int32_t ism330dhcx_mag_x_orient_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_mag_x_axis_t *val);
+
+int32_t ism330dhcx_long_cnt_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                               uint8_t *val);
+
+int32_t ism330dhcx_emb_fsm_en_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_emb_fsm_en_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+    ism330dhcx_fsm_enable_a_t          fsm_enable_a;
+    ism330dhcx_fsm_enable_b_t          fsm_enable_b;
+} ism330dhcx_emb_fsm_enable_t;
+int32_t ism330dhcx_fsm_enable_set(stmdev_ctx_t *ctx,
+                                 ism330dhcx_emb_fsm_enable_t *val);
+int32_t ism330dhcx_fsm_enable_get(stmdev_ctx_t *ctx,
+                                 ism330dhcx_emb_fsm_enable_t *val);
+
+int32_t ism330dhcx_long_cnt_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dhcx_long_cnt_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  ISM330DHCX_LC_NORMAL     = 0,
+  ISM330DHCX_LC_CLEAR      = 1,
+  ISM330DHCX_LC_CLEAR_DONE = 2,
+} ism330dhcx_fsm_lc_clr_t;
+int32_t ism330dhcx_long_clr_set(stmdev_ctx_t *ctx,
+                               ism330dhcx_fsm_lc_clr_t val);
+int32_t ism330dhcx_long_clr_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_fsm_lc_clr_t *val);
+
+typedef struct {
+    ism330dhcx_fsm_outs1_t    fsm_outs1;
+    ism330dhcx_fsm_outs2_t    fsm_outs2;
+    ism330dhcx_fsm_outs3_t    fsm_outs3;
+    ism330dhcx_fsm_outs4_t    fsm_outs4;
+    ism330dhcx_fsm_outs5_t    fsm_outs5;
+    ism330dhcx_fsm_outs6_t    fsm_outs6;
+    ism330dhcx_fsm_outs7_t    fsm_outs7;
+    ism330dhcx_fsm_outs8_t    fsm_outs8;
+    ism330dhcx_fsm_outs9_t    fsm_outs9;
+    ism330dhcx_fsm_outs10_t    fsm_outs10;
+    ism330dhcx_fsm_outs11_t    fsm_outs11;
+    ism330dhcx_fsm_outs12_t    fsm_outs12;
+    ism330dhcx_fsm_outs13_t    fsm_outs13;
+    ism330dhcx_fsm_outs14_t    fsm_outs14;
+    ism330dhcx_fsm_outs15_t    fsm_outs15;
+    ism330dhcx_fsm_outs16_t    fsm_outs16;
+} ism330dhcx_fsm_out_t;
+int32_t ism330dhcx_fsm_out_get(stmdev_ctx_t *ctx,
+                               ism330dhcx_fsm_out_t *val);
+
+typedef enum {
+  ISM330DHCX_ODR_FSM_12Hz5 = 0,
+  ISM330DHCX_ODR_FSM_26Hz  = 1,
+  ISM330DHCX_ODR_FSM_52Hz  = 2,
+  ISM330DHCX_ODR_FSM_104Hz = 3,
+} ism330dhcx_fsm_odr_t;
+int32_t ism330dhcx_fsm_data_rate_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_fsm_odr_t val);
+int32_t ism330dhcx_fsm_data_rate_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_fsm_odr_t *val);
+
+int32_t ism330dhcx_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_long_cnt_int_value_set(stmdev_ctx_t *ctx,
+                                          uint8_t *buff);
+int32_t ism330dhcx_long_cnt_int_value_get(stmdev_ctx_t *ctx,
+                                          uint8_t *buff);
+
+int32_t ism330dhcx_fsm_number_of_programs_set(stmdev_ctx_t *ctx,
+                                             uint8_t *buff);
+int32_t ism330dhcx_fsm_number_of_programs_get(stmdev_ctx_t *ctx,
+                                             uint8_t *buff);
+
+int32_t ism330dhcx_fsm_start_address_set(stmdev_ctx_t *ctx,
+                                         uint8_t *buff);
+int32_t ism330dhcx_fsm_start_address_get(stmdev_ctx_t *ctx,
+                                         uint8_t *buff);
+
+int32_t ism330dhcx_mlc_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_mlc_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t ism330dhcx_mlc_status_get(stmdev_ctx_t *ctx,
+                                  ism330dhcx_mlc_status_mainpage_t *val);
+
+typedef enum {
+  ISM330DHCX_ODR_PRGS_12Hz5 = 0,
+  ISM330DHCX_ODR_PRGS_26Hz  = 1,
+  ISM330DHCX_ODR_PRGS_52Hz  = 2,
+  ISM330DHCX_ODR_PRGS_104Hz = 3,
+} ism330dhcx_mlc_odr_t;
+int32_t ism330dhcx_mlc_data_rate_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_mlc_odr_t val);
+int32_t ism330dhcx_mlc_data_rate_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_mlc_odr_t *val);
+
+typedef struct {
+    ism330dhcx_sensor_hub_1_t   sh_byte_1;
+    ism330dhcx_sensor_hub_2_t   sh_byte_2;
+    ism330dhcx_sensor_hub_3_t   sh_byte_3;
+    ism330dhcx_sensor_hub_4_t   sh_byte_4;
+    ism330dhcx_sensor_hub_5_t   sh_byte_5;
+    ism330dhcx_sensor_hub_6_t   sh_byte_6;
+    ism330dhcx_sensor_hub_7_t   sh_byte_7;
+    ism330dhcx_sensor_hub_8_t   sh_byte_8;
+    ism330dhcx_sensor_hub_9_t   sh_byte_9;
+    ism330dhcx_sensor_hub_10_t  sh_byte_10;
+    ism330dhcx_sensor_hub_11_t  sh_byte_11;
+    ism330dhcx_sensor_hub_12_t  sh_byte_12;
+    ism330dhcx_sensor_hub_13_t  sh_byte_13;
+    ism330dhcx_sensor_hub_14_t  sh_byte_14;
+    ism330dhcx_sensor_hub_15_t  sh_byte_15;
+    ism330dhcx_sensor_hub_16_t  sh_byte_16;
+    ism330dhcx_sensor_hub_17_t  sh_byte_17;
+    ism330dhcx_sensor_hub_18_t  sh_byte_18;
+} ism330dhcx_emb_sh_read_t;
+int32_t ism330dhcx_sh_read_data_raw_get(stmdev_ctx_t *ctx,
+                                       ism330dhcx_emb_sh_read_t *val);
+
+typedef enum {
+  ISM330DHCX_SLV_0       = 0,
+  ISM330DHCX_SLV_0_1     = 1,
+  ISM330DHCX_SLV_0_1_2   = 2,
+  ISM330DHCX_SLV_0_1_2_3 = 3,
+} ism330dhcx_aux_sens_on_t;
+int32_t ism330dhcx_sh_slave_connected_set(stmdev_ctx_t *ctx,
+                                         ism330dhcx_aux_sens_on_t val);
+int32_t ism330dhcx_sh_slave_connected_get(stmdev_ctx_t *ctx,
+                                         ism330dhcx_aux_sens_on_t *val);
+
+int32_t ism330dhcx_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_EXT_PULL_UP      = 0,
+  ISM330DHCX_INTERNAL_PULL_UP = 1,
+} ism330dhcx_shub_pu_en_t;
+int32_t ism330dhcx_sh_pin_mode_set(stmdev_ctx_t *ctx,
+                                  ism330dhcx_shub_pu_en_t val);
+int32_t ism330dhcx_sh_pin_mode_get(stmdev_ctx_t *ctx,
+                                  ism330dhcx_shub_pu_en_t *val);
+
+int32_t ism330dhcx_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dhcx_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_EXT_ON_INT2_PIN = 0,
+  ISM330DHCX_XL_GY_DRDY      = 1,
+} ism330dhcx_start_config_t;
+int32_t ism330dhcx_sh_syncro_mode_set(stmdev_ctx_t *ctx,
+                                     ism330dhcx_start_config_t val);
+int32_t ism330dhcx_sh_syncro_mode_get(stmdev_ctx_t *ctx,
+                                     ism330dhcx_start_config_t *val);
+
+typedef enum {
+  ISM330DHCX_EACH_SH_CYCLE    = 0,
+  ISM330DHCX_ONLY_FIRST_CYCLE = 1,
+} ism330dhcx_write_once_t;
+int32_t ism330dhcx_sh_write_mode_set(stmdev_ctx_t *ctx,
+                                    ism330dhcx_write_once_t val);
+int32_t ism330dhcx_sh_write_mode_get(stmdev_ctx_t *ctx,
+                                    ism330dhcx_write_once_t *val);
+
+int32_t ism330dhcx_sh_reset_set(stmdev_ctx_t *ctx);
+int32_t ism330dhcx_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  ISM330DHCX_SH_ODR_104Hz = 0,
+  ISM330DHCX_SH_ODR_52Hz  = 1,
+  ISM330DHCX_SH_ODR_26Hz  = 2,
+  ISM330DHCX_SH_ODR_13Hz  = 3,
+} ism330dhcx_shub_odr_t;
+int32_t ism330dhcx_sh_data_rate_set(stmdev_ctx_t *ctx,
+                                   ism330dhcx_shub_odr_t val);
+int32_t ism330dhcx_sh_data_rate_get(stmdev_ctx_t *ctx,
+                                   ism330dhcx_shub_odr_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} ism330dhcx_sh_cfg_write_t;
+int32_t ism330dhcx_sh_cfg_write(stmdev_ctx_t *ctx,
+                               ism330dhcx_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} ism330dhcx_sh_cfg_read_t;
+int32_t ism330dhcx_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sh_cfg_read_t *val);
+int32_t ism330dhcx_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sh_cfg_read_t *val);
+int32_t ism330dhcx_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sh_cfg_read_t *val);
+int32_t ism330dhcx_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
+                                   ism330dhcx_sh_cfg_read_t *val);
+
+int32_t ism330dhcx_sh_status_get(stmdev_ctx_t *ctx,
+                                ism330dhcx_status_master_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ISM330DHCX_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.c
+++ b/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.c
@@ -6,33 +6,16 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 #include "ism330dlc_reg.h"
 
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t ism330dlc_read_reg(ism330dlc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t ism330dlc_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t ism330dlc_read_reg(ism330dlc_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t ism330dlc_write_reg(ism330dlc_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t ism330dlc_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -172,7 +155,7 @@ float_t ism330dlc_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_full_scale_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_full_scale_set(stmdev_ctx_t *ctx,
                                     ism330dlc_fs_xl_t val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -196,7 +179,7 @@ int32_t ism330dlc_xl_full_scale_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_full_scale_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_full_scale_get(stmdev_ctx_t *ctx,
                                     ism330dlc_fs_xl_t *val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -233,7 +216,7 @@ int32_t ism330dlc_xl_full_scale_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_data_rate_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_data_rate_set(stmdev_ctx_t *ctx,
                                    ism330dlc_odr_xl_t val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -256,7 +239,7 @@ int32_t ism330dlc_xl_data_rate_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_data_rate_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_data_rate_get(stmdev_ctx_t *ctx,
                                    ism330dlc_odr_xl_t *val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -316,7 +299,7 @@ int32_t ism330dlc_xl_data_rate_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_full_scale_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_full_scale_set(stmdev_ctx_t *ctx,
                                     ism330dlc_fs_g_t val)
 {
   ism330dlc_ctrl2_g_t ctrl2_g;
@@ -338,7 +321,7 @@ int32_t ism330dlc_gy_full_scale_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_full_scale_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_full_scale_get(stmdev_ctx_t *ctx,
                                     ism330dlc_fs_g_t *val)
 {
   ism330dlc_ctrl2_g_t ctrl2_g;
@@ -377,7 +360,7 @@ int32_t ism330dlc_gy_full_scale_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_data_rate_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_data_rate_set(stmdev_ctx_t *ctx,
                                    ism330dlc_odr_g_t val)
 {
   ism330dlc_ctrl2_g_t ctrl2_g;
@@ -399,7 +382,7 @@ int32_t ism330dlc_gy_data_rate_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_data_rate_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_data_rate_get(stmdev_ctx_t *ctx,
                                    ism330dlc_odr_g_t *val)
 {
   ism330dlc_ctrl2_g_t ctrl2_g;
@@ -456,7 +439,7 @@ int32_t ism330dlc_gy_data_rate_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_block_data_update_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -477,7 +460,7 @@ int32_t ism330dlc_block_data_update_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_block_data_update_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -497,7 +480,7 @@ int32_t ism330dlc_block_data_update_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_offset_weight_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                        ism330dlc_usr_off_w_t val)
 {
   ism330dlc_ctrl6_c_t ctrl6_c;
@@ -520,7 +503,7 @@ int32_t ism330dlc_xl_offset_weight_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_offset_weight_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                        ism330dlc_usr_off_w_t *val)
 {
   ism330dlc_ctrl6_c_t ctrl6_c;
@@ -550,7 +533,7 @@ int32_t ism330dlc_xl_offset_weight_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_power_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_power_mode_set(stmdev_ctx_t *ctx,
                                     ism330dlc_xl_hm_mode_t val)
 {
   ism330dlc_ctrl6_c_t ctrl6_c;
@@ -572,7 +555,7 @@ int32_t ism330dlc_xl_power_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_power_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_power_mode_get(stmdev_ctx_t *ctx,
                                     ism330dlc_xl_hm_mode_t *val)
 {
   ism330dlc_ctrl6_c_t ctrl6_c;
@@ -604,7 +587,7 @@ int32_t ism330dlc_xl_power_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_rounding_on_status_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_rounding_on_status_set(stmdev_ctx_t *ctx,
                                          ism330dlc_rounding_status_t val)
 {
   ism330dlc_ctrl7_g_t ctrl7_g;
@@ -628,7 +611,7 @@ int32_t ism330dlc_rounding_on_status_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_rounding_on_status_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_rounding_on_status_get(stmdev_ctx_t *ctx,
                                          ism330dlc_rounding_status_t *val)
 {
   ism330dlc_ctrl7_g_t ctrl7_g;
@@ -658,7 +641,7 @@ int32_t ism330dlc_rounding_on_status_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_power_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_power_mode_set(stmdev_ctx_t *ctx,
                                     ism330dlc_g_hm_mode_t val)
 {
   ism330dlc_ctrl7_g_t ctrl7_g;
@@ -680,7 +663,7 @@ int32_t ism330dlc_gy_power_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_power_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_power_mode_get(stmdev_ctx_t *ctx,
                                     ism330dlc_g_hm_mode_t *val)
 {
   ism330dlc_ctrl7_g_t ctrl7_g;
@@ -711,7 +694,7 @@ int32_t ism330dlc_gy_power_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_all_sources_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_all_sources_get(stmdev_ctx_t *ctx,
                                   ism330dlc_all_sources_t *val)
 {
   int32_t ret;
@@ -752,7 +735,7 @@ int32_t ism330dlc_all_sources_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_status_reg_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_status_reg_get(stmdev_ctx_t *ctx,
                                  ism330dlc_status_reg_t *val)
 {
   int32_t ret;
@@ -768,7 +751,7 @@ int32_t ism330dlc_status_reg_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_status_reg_t status_reg;
   int32_t ret;
@@ -788,7 +771,7 @@ int32_t ism330dlc_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_status_reg_t status_reg;
   int32_t ret;
@@ -808,7 +791,7 @@ int32_t ism330dlc_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_temp_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_status_reg_t status_reg;
   int32_t ret;
@@ -830,7 +813,7 @@ int32_t ism330dlc_temp_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_usr_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ism330dlc_write_reg(ctx, ISM330DLC_X_OFS_USR, buff, 3);
@@ -847,7 +830,7 @@ int32_t ism330dlc_xl_usr_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_usr_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ism330dlc_read_reg(ctx, ISM330DLC_X_OFS_USR, buff, 3);
@@ -876,7 +859,7 @@ int32_t ism330dlc_xl_usr_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_timestamp_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -902,7 +885,7 @@ int32_t ism330dlc_timestamp_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_timestamp_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -926,7 +909,7 @@ int32_t ism330dlc_timestamp_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_timestamp_res_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_timestamp_res_set(stmdev_ctx_t *ctx,
                                     ism330dlc_timer_hr_t val)
 {
   ism330dlc_wake_up_dur_t wake_up_dur;
@@ -955,7 +938,7 @@ int32_t ism330dlc_timestamp_res_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_timestamp_res_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_timestamp_res_get(stmdev_ctx_t *ctx,
                                     ism330dlc_timer_hr_t *val)
 {
   ism330dlc_wake_up_dur_t wake_up_dur;
@@ -999,7 +982,7 @@ int32_t ism330dlc_timestamp_res_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_rounding_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_rounding_mode_set(stmdev_ctx_t *ctx,
                                     ism330dlc_rounding_t val)
 {
   ism330dlc_ctrl5_c_t ctrl5_c;
@@ -1022,7 +1005,7 @@ int32_t ism330dlc_rounding_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_rounding_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_rounding_mode_get(stmdev_ctx_t *ctx,
                                     ism330dlc_rounding_t *val)
 {
   ism330dlc_ctrl5_c_t ctrl5_c;
@@ -1071,7 +1054,7 @@ int32_t ism330dlc_rounding_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_temperature_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ism330dlc_read_reg(ctx, ISM330DLC_OUT_TEMP_L, buff, 2);
@@ -1087,7 +1070,7 @@ int32_t ism330dlc_temperature_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_angular_rate_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ism330dlc_read_reg(ctx, ISM330DLC_OUTX_L_G, buff, 6);
@@ -1103,7 +1086,7 @@ int32_t ism330dlc_angular_rate_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_acceleration_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ism330dlc_read_reg(ctx, ISM330DLC_OUTX_L_XL, buff, 6);
@@ -1118,7 +1101,7 @@ int32_t ism330dlc_acceleration_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_calibrated_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ism330dlc_read_reg(ctx, ISM330DLC_OUT_MAG_RAW_X_L, buff, 6);
@@ -1134,7 +1117,7 @@ int32_t ism330dlc_mag_calibrated_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_raw_data_get(ism330dlc_ctx_t *ctx, uint8_t *buffer,
+int32_t ism330dlc_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer,
                                   uint8_t len)
 {
   int32_t ret;
@@ -1163,7 +1146,7 @@ int32_t ism330dlc_fifo_raw_data_get(ism330dlc_ctx_t *ctx, uint8_t *buffer,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mem_bank_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_mem_bank_set(stmdev_ctx_t *ctx,
                                ism330dlc_func_cfg_en_t val)
 {
   ism330dlc_func_cfg_access_t func_cfg_access;
@@ -1189,7 +1172,7 @@ int32_t ism330dlc_mem_bank_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mem_bank_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_mem_bank_get(stmdev_ctx_t *ctx,
                                ism330dlc_func_cfg_en_t *val)
 {
   ism330dlc_func_cfg_access_t func_cfg_access;
@@ -1217,7 +1200,7 @@ int32_t ism330dlc_mem_bank_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_data_ready_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_data_ready_mode_set(stmdev_ctx_t *ctx,
                                       ism330dlc_drdy_pulsed_t val)
 {
   ism330dlc_drdy_pulse_cfg_t drdy_pulse_cfg_g;
@@ -1241,7 +1224,7 @@ int32_t ism330dlc_data_ready_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_data_ready_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_data_ready_mode_get(stmdev_ctx_t *ctx,
                                       ism330dlc_drdy_pulsed_t *val)
 {
   ism330dlc_drdy_pulse_cfg_t drdy_pulse_cfg_g;
@@ -1272,7 +1255,7 @@ int32_t ism330dlc_data_ready_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_device_id_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = ism330dlc_read_reg(ctx, ISM330DLC_WHO_AM_I, buff, 1);
@@ -1287,7 +1270,7 @@ int32_t ism330dlc_device_id_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_reset_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1308,7 +1291,7 @@ int32_t ism330dlc_reset_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_reset_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1327,7 +1310,7 @@ int32_t ism330dlc_reset_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_data_format_set(ism330dlc_ctx_t *ctx, ism330dlc_ble_t val)
+int32_t ism330dlc_data_format_set(stmdev_ctx_t *ctx, ism330dlc_ble_t val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1348,7 +1331,7 @@ int32_t ism330dlc_data_format_set(ism330dlc_ctx_t *ctx, ism330dlc_ble_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_data_format_get(ism330dlc_ctx_t *ctx, ism330dlc_ble_t *val)
+int32_t ism330dlc_data_format_get(stmdev_ctx_t *ctx, ism330dlc_ble_t *val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1378,7 +1361,7 @@ int32_t ism330dlc_data_format_get(ism330dlc_ctx_t *ctx, ism330dlc_ble_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_auto_increment_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1400,7 +1383,7 @@ int32_t ism330dlc_auto_increment_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_auto_increment_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1419,7 +1402,7 @@ int32_t ism330dlc_auto_increment_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_boot_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1440,7 +1423,7 @@ int32_t ism330dlc_boot_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_boot_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1459,7 +1442,7 @@ int32_t ism330dlc_boot_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_self_test_set(ism330dlc_ctx_t *ctx, ism330dlc_st_xl_t val)
+int32_t ism330dlc_xl_self_test_set(stmdev_ctx_t *ctx, ism330dlc_st_xl_t val)
 {
   ism330dlc_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1480,7 +1463,7 @@ int32_t ism330dlc_xl_self_test_set(ism330dlc_ctx_t *ctx, ism330dlc_st_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_self_test_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_self_test_get(stmdev_ctx_t *ctx,
                                    ism330dlc_st_xl_t *val)
 {
   ism330dlc_ctrl5_c_t ctrl5_c;
@@ -1512,7 +1495,7 @@ int32_t ism330dlc_xl_self_test_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_self_test_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_self_test_set(stmdev_ctx_t *ctx,
                                    ism330dlc_st_g_t val)
 {
   ism330dlc_ctrl5_c_t ctrl5_c;
@@ -1534,7 +1517,7 @@ int32_t ism330dlc_gy_self_test_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_self_test_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_self_test_get(stmdev_ctx_t *ctx,
                                    ism330dlc_st_g_t *val)
 {
   ism330dlc_ctrl5_c_t ctrl5_c;
@@ -1581,7 +1564,7 @@ int32_t ism330dlc_gy_self_test_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_filter_settling_mask_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1603,7 +1586,7 @@ int32_t ism330dlc_filter_settling_mask_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_filter_settling_mask_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1623,7 +1606,7 @@ int32_t ism330dlc_filter_settling_mask_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_hp_path_internal_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         ism330dlc_slope_fds_t val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
@@ -1646,7 +1629,7 @@ int32_t ism330dlc_xl_hp_path_internal_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_hp_path_internal_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                           ism330dlc_slope_fds_t *val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
@@ -1690,7 +1673,7 @@ int32_t ism330dlc_xl_hp_path_internal_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_filter_analog_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_filter_analog_set(stmdev_ctx_t *ctx,
                                        ism330dlc_bw0_xl_t val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -1713,7 +1696,7 @@ int32_t ism330dlc_xl_filter_analog_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_filter_analog_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_filter_analog_get(stmdev_ctx_t *ctx,
                                        ism330dlc_bw0_xl_t *val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -1758,7 +1741,7 @@ int32_t ism330dlc_xl_filter_analog_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                        ism330dlc_lpf1_bw_sel_t val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -1793,7 +1776,7 @@ int32_t ism330dlc_xl_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                        ism330dlc_lpf1_bw_sel_t *val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -1833,7 +1816,7 @@ int32_t ism330dlc_xl_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_lp2_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
                                        ism330dlc_input_composite_t val)
 {
   ism330dlc_ctrl8_xl_t ctrl8_xl;
@@ -1859,7 +1842,7 @@ int32_t ism330dlc_xl_lp2_bandwidth_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_lp2_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
                                        ism330dlc_input_composite_t *val)
 {
   ism330dlc_ctrl8_xl_t ctrl8_xl;
@@ -1915,7 +1898,7 @@ int32_t ism330dlc_xl_lp2_bandwidth_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_reference_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_xl_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1936,7 +1919,7 @@ int32_t ism330dlc_xl_reference_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_reference_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_xl_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1955,7 +1938,7 @@ int32_t ism330dlc_xl_reference_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_hp_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                       ism330dlc_hpcf_xl_t val)
 {
   ism330dlc_ctrl8_xl_t ctrl8_xl;
@@ -1980,7 +1963,7 @@ int32_t ism330dlc_xl_hp_bandwidth_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_hp_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                       ism330dlc_hpcf_xl_t *val)
 {
   ism330dlc_ctrl8_xl_t ctrl8_xl;
@@ -2034,7 +2017,7 @@ int32_t ism330dlc_xl_hp_bandwidth_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_ui_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_ui_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                           ism330dlc_ui_lpf1_bw_sel_t val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -2070,7 +2053,7 @@ int32_t ism330dlc_xl_ui_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_ui_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_ui_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                           ism330dlc_ui_lpf1_bw_sel_t *val)
 {
   ism330dlc_ctrl1_xl_t ctrl1_xl;
@@ -2110,7 +2093,7 @@ int32_t ism330dlc_xl_ui_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_ui_slope_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_xl_ui_slope_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl8_xl_t reg;
   int32_t ret;
@@ -2131,7 +2114,7 @@ int32_t ism330dlc_xl_ui_slope_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_ui_slope_get(ism330dlc_ctx_t *ctx,  uint8_t *val)
+int32_t ism330dlc_xl_ui_slope_get(stmdev_ctx_t *ctx,  uint8_t *val)
 {
   ism330dlc_ctrl8_xl_t reg;
   int32_t ret;
@@ -2163,7 +2146,7 @@ int32_t ism330dlc_xl_ui_slope_get(ism330dlc_ctx_t *ctx,  uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_aux_lp_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_aux_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                           ism330dlc_filter_xl_conf_ois_t val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -2198,7 +2181,7 @@ int32_t ism330dlc_xl_aux_lp_bandwidth_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_xl_aux_lp_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_aux_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                           ism330dlc_filter_xl_conf_ois_t *val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -2247,7 +2230,7 @@ int32_t ism330dlc_xl_aux_lp_bandwidth_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_band_pass_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_band_pass_set(stmdev_ctx_t *ctx,
                                    ism330dlc_lpf1_sel_g_t val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
@@ -2289,7 +2272,7 @@ int32_t ism330dlc_gy_band_pass_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_band_pass_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_band_pass_get(stmdev_ctx_t *ctx,
                                    ism330dlc_lpf1_sel_g_t *val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
@@ -2373,7 +2356,7 @@ int32_t ism330dlc_gy_band_pass_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_ui_high_pass_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_gy_ui_high_pass_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl7_g_t reg;
   int32_t ret;
@@ -2395,7 +2378,7 @@ int32_t ism330dlc_gy_ui_high_pass_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_ui_high_pass_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_gy_ui_high_pass_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl7_g_t reg;
   int32_t ret;
@@ -2418,7 +2401,7 @@ int32_t ism330dlc_gy_ui_high_pass_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_aux_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_aux_bandwidth_set(stmdev_ctx_t *ctx,
                                        ism330dlc_hp_en_ois_t val)
 {
   ism330dlc_ctrl7_g_t ctrl7_g;
@@ -2455,7 +2438,7 @@ int32_t ism330dlc_gy_aux_bandwidth_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_aux_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_aux_bandwidth_get(stmdev_ctx_t *ctx,
                                        ism330dlc_hp_en_ois_t *val)
 {
   ism330dlc_ctrl2_ois_t reg;
@@ -2517,7 +2500,7 @@ int32_t ism330dlc_gy_aux_bandwidth_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_status_reg_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_status_reg_get(stmdev_ctx_t *ctx,
                                      ism330dlc_status_spiaux_t *val)
 {
   int32_t ret;
@@ -2533,7 +2516,7 @@ int32_t ism330dlc_aux_status_reg_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx,
                                              uint8_t *val)
 {
   ism330dlc_status_spiaux_t reg;
@@ -2553,7 +2536,7 @@ int32_t ism330dlc_aux_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx,
                                              uint8_t *val)
 {
   ism330dlc_status_spiaux_t reg;
@@ -2573,7 +2556,7 @@ int32_t ism330dlc_aux_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_gy_flag_settling_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_aux_gy_flag_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_status_spiaux_t reg;
   int32_t ret;
@@ -2592,7 +2575,7 @@ int32_t ism330dlc_aux_gy_flag_settling_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_den_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_den_mode_set(stmdev_ctx_t *ctx,
                                    ism330dlc_lvl_ois_t val)
 {
   ism330dlc_ctrl1_ois_t ctrl1_ois;
@@ -2627,14 +2610,19 @@ int32_t ism330dlc_aux_den_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_den_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_den_mode_get(stmdev_ctx_t *ctx,
                                    ism330dlc_lvl_ois_t *val)
 {
-  ism330dlc_int_ois_t reg;
+  ism330dlc_ctrl1_ois_t ctrl1_ois;
+  ism330dlc_int_ois_t int_ois;
   int32_t ret;
 
-  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_OIS, (uint8_t*)&reg, 1);
-  switch ( reg.lvl2_ois ) {
+  ret = ism330dlc_read_reg(ctx, ISM330DLC_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    ret = ism330dlc_read_reg(ctx, ISM330DLC_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+  switch ( (ctrl1_ois.lvl1_ois << 1) | int_ois.lvl2_ois) {
     case ISM330DLC_AUX_DEN_DISABLE:
       *val = ISM330DLC_AUX_DEN_DISABLE;
       break;
@@ -2660,7 +2648,7 @@ int32_t ism330dlc_aux_den_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_drdy_on_int2_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_int_ois_t reg;
   int32_t ret;
@@ -2682,7 +2670,7 @@ int32_t ism330dlc_aux_drdy_on_int2_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_drdy_on_int2_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_int_ois_t reg;
   int32_t ret;
@@ -2708,7 +2696,7 @@ int32_t ism330dlc_aux_drdy_on_int2_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_mode_set(stmdev_ctx_t *ctx,
                                ism330dlc_ois_en_spi2_t val)
 {
   ism330dlc_ctrl1_ois_t reg;
@@ -2738,7 +2726,7 @@ int32_t ism330dlc_aux_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_mode_get(stmdev_ctx_t *ctx,
                                ism330dlc_ois_en_spi2_t *val)
 {
   ism330dlc_ctrl1_ois_t reg;
@@ -2770,7 +2758,7 @@ int32_t ism330dlc_aux_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_gy_full_scale_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
                                         ism330dlc_fs_g_ois_t val)
 {
   ism330dlc_ctrl1_ois_t reg;
@@ -2792,7 +2780,7 @@ int32_t ism330dlc_aux_gy_full_scale_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_gy_full_scale_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
                                         ism330dlc_fs_g_ois_t *val)
 {
   ism330dlc_ctrl1_ois_t reg;
@@ -2830,7 +2818,7 @@ int32_t ism330dlc_aux_gy_full_scale_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_spi_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_spi_mode_set(stmdev_ctx_t *ctx,
                                    ism330dlc_sim_ois_t val)
 {
   ism330dlc_ctrl1_ois_t reg;
@@ -2852,7 +2840,7 @@ int32_t ism330dlc_aux_spi_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_spi_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_spi_mode_get(stmdev_ctx_t *ctx,
                                    ism330dlc_sim_ois_t *val)
 {
   ism330dlc_ctrl1_ois_t reg;
@@ -2881,7 +2869,7 @@ int32_t ism330dlc_aux_spi_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_data_format_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_data_format_set(stmdev_ctx_t *ctx,
                                       ism330dlc_ble_ois_t val)
 {
   ism330dlc_ctrl1_ois_t reg;
@@ -2903,7 +2891,7 @@ int32_t ism330dlc_aux_data_format_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_data_format_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_data_format_get(stmdev_ctx_t *ctx,
                                       ism330dlc_ble_ois_t *val)
 {
   ism330dlc_ctrl1_ois_t reg;
@@ -2935,7 +2923,7 @@ int32_t ism330dlc_aux_data_format_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_gy_clamp_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_clamp_set(stmdev_ctx_t *ctx,
                                    ism330dlc_st_ois_clampdis_t val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -2960,7 +2948,7 @@ int32_t ism330dlc_aux_gy_clamp_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_gy_clamp_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_clamp_get(stmdev_ctx_t *ctx,
                                    ism330dlc_st_ois_clampdis_t *val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -2989,7 +2977,7 @@ int32_t ism330dlc_aux_gy_clamp_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_gy_self_test_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_self_test_set(stmdev_ctx_t *ctx,
                                        ism330dlc_st_ois_t val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -3011,7 +2999,7 @@ int32_t ism330dlc_aux_gy_self_test_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_gy_self_test_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_self_test_get(stmdev_ctx_t *ctx,
                                        ism330dlc_st_ois_t *val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -3043,7 +3031,7 @@ int32_t ism330dlc_aux_gy_self_test_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_xl_full_scale_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
                                         ism330dlc_fs_xl_ois_t val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -3065,7 +3053,7 @@ int32_t ism330dlc_aux_xl_full_scale_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_xl_full_scale_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
                                         ism330dlc_fs_xl_ois_t *val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -3100,7 +3088,7 @@ int32_t ism330dlc_aux_xl_full_scale_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_den_polarity_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_den_polarity_set(stmdev_ctx_t *ctx,
                                        ism330dlc_den_lh_ois_t val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -3122,7 +3110,7 @@ int32_t ism330dlc_aux_den_polarity_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_aux_den_polarity_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_den_polarity_get(stmdev_ctx_t *ctx,
                                        ism330dlc_den_lh_ois_t *val)
 {
   ism330dlc_ctrl3_ois_t reg;
@@ -3164,7 +3152,7 @@ int32_t ism330dlc_aux_den_polarity_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_spi_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_sim_t val)
+int32_t ism330dlc_spi_mode_set(stmdev_ctx_t *ctx, ism330dlc_sim_t val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3185,7 +3173,7 @@ int32_t ism330dlc_spi_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_spi_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_sim_t *val)
+int32_t ism330dlc_spi_mode_get(stmdev_ctx_t *ctx, ism330dlc_sim_t *val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3213,7 +3201,7 @@ int32_t ism330dlc_spi_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_i2c_interface_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_i2c_interface_set(stmdev_ctx_t *ctx,
                                     ism330dlc_i2c_disable_t val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
@@ -3235,7 +3223,7 @@ int32_t ism330dlc_i2c_interface_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_i2c_interface_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_i2c_interface_get(stmdev_ctx_t *ctx,
                                     ism330dlc_i2c_disable_t *val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
@@ -3279,7 +3267,7 @@ int32_t ism330dlc_i2c_interface_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_pin_int1_route_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      ism330dlc_int1_route_t val)
 {
   ism330dlc_master_config_t master_config;
@@ -3370,7 +3358,7 @@ int32_t ism330dlc_pin_int1_route_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_pin_int1_route_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      ism330dlc_int1_route_t *val)
 {
   ism330dlc_master_config_t master_config;
@@ -3419,7 +3407,7 @@ int32_t ism330dlc_pin_int1_route_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_pin_int2_route_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      ism330dlc_int2_route_t val)
 {
   ism330dlc_int2_ctrl_t int2_ctrl;
@@ -3503,7 +3491,7 @@ int32_t ism330dlc_pin_int2_route_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_pin_int2_route_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      ism330dlc_int2_route_t *val)
 {
   ism330dlc_int2_ctrl_t int2_ctrl;
@@ -3543,7 +3531,7 @@ int32_t ism330dlc_pin_int2_route_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_pin_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t val)
+int32_t ism330dlc_pin_mode_set(stmdev_ctx_t *ctx, ism330dlc_pp_od_t val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3564,7 +3552,7 @@ int32_t ism330dlc_pin_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_pin_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t *val)
+int32_t ism330dlc_pin_mode_get(stmdev_ctx_t *ctx, ism330dlc_pp_od_t *val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3593,7 +3581,7 @@ int32_t ism330dlc_pin_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_pin_polarity_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_polarity_set(stmdev_ctx_t *ctx,
                                    ism330dlc_h_lactive_t val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
@@ -3615,7 +3603,7 @@ int32_t ism330dlc_pin_polarity_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_pin_polarity_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_polarity_get(stmdev_ctx_t *ctx,
                                    ism330dlc_h_lactive_t *val)
 {
   ism330dlc_ctrl3_c_t ctrl3_c;
@@ -3645,7 +3633,7 @@ int32_t ism330dlc_pin_polarity_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_all_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3666,7 +3654,7 @@ int32_t ism330dlc_all_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_all_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3685,7 +3673,7 @@ int32_t ism330dlc_all_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_int_notification_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_int_notification_set(stmdev_ctx_t *ctx,
                                        ism330dlc_lir_t val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
@@ -3707,7 +3695,7 @@ int32_t ism330dlc_int_notification_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_int_notification_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_int_notification_get(stmdev_ctx_t *ctx,
                                        ism330dlc_lir_t *val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
@@ -3750,7 +3738,7 @@ int32_t ism330dlc_int_notification_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_wkup_threshold_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -3773,7 +3761,7 @@ int32_t ism330dlc_wkup_threshold_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_wkup_threshold_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -3793,7 +3781,7 @@ int32_t ism330dlc_wkup_threshold_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_wkup_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -3816,7 +3804,7 @@ int32_t ism330dlc_wkup_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_wkup_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -3849,7 +3837,7 @@ int32_t ism330dlc_wkup_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_sleep_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3870,7 +3858,7 @@ int32_t ism330dlc_gy_sleep_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_gy_sleep_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3889,7 +3877,7 @@ int32_t ism330dlc_gy_sleep_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_act_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_inact_en_t val)
+int32_t ism330dlc_act_mode_set(stmdev_ctx_t *ctx, ism330dlc_inact_en_t val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3910,7 +3898,7 @@ int32_t ism330dlc_act_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_inact_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_act_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_act_mode_get(stmdev_ctx_t *ctx,
                                ism330dlc_inact_en_t *val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
@@ -3946,7 +3934,7 @@ int32_t ism330dlc_act_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_act_sleep_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -3969,7 +3957,7 @@ int32_t ism330dlc_act_sleep_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_act_sleep_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -4002,7 +3990,7 @@ int32_t ism330dlc_act_sleep_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_src_get(ism330dlc_ctx_t *ctx, ism330dlc_tap_src_t *val)
+int32_t ism330dlc_tap_src_get(stmdev_ctx_t *ctx, ism330dlc_tap_src_t *val)
 {
   int32_t ret;
   ret = ism330dlc_read_reg(ctx, ISM330DLC_TAP_SRC, (uint8_t*) val, 1);
@@ -4016,7 +4004,7 @@ int32_t ism330dlc_tap_src_get(ism330dlc_ctx_t *ctx, ism330dlc_tap_src_t *val)
   * @param  val    Change the values of tap_z_en in reg TAP_CFG
   *
   */
-int32_t ism330dlc_tap_detection_on_z_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4037,7 +4025,7 @@ int32_t ism330dlc_tap_detection_on_z_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_detection_on_z_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4056,7 +4044,7 @@ int32_t ism330dlc_tap_detection_on_z_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_detection_on_y_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4077,7 +4065,7 @@ int32_t ism330dlc_tap_detection_on_y_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_detection_on_y_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4096,7 +4084,7 @@ int32_t ism330dlc_tap_detection_on_y_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_detection_on_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4117,7 +4105,7 @@ int32_t ism330dlc_tap_detection_on_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_detection_on_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4136,7 +4124,7 @@ int32_t ism330dlc_tap_detection_on_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_threshold_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4159,7 +4147,7 @@ int32_t ism330dlc_tap_threshold_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_threshold_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4184,7 +4172,7 @@ int32_t ism330dlc_tap_threshold_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_shock_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_int_dur2_t int_dur2;
   int32_t ret;
@@ -4211,7 +4199,7 @@ int32_t ism330dlc_tap_shock_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_shock_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_int_dur2_t int_dur2;
   int32_t ret;
@@ -4235,7 +4223,7 @@ int32_t ism330dlc_tap_shock_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_quiet_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_int_dur2_t int_dur2;
   int32_t ret;
@@ -4261,7 +4249,7 @@ int32_t ism330dlc_tap_quiet_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_quiet_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_int_dur2_t int_dur2;
   int32_t ret;
@@ -4286,7 +4274,7 @@ int32_t ism330dlc_tap_quiet_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_int_dur2_t int_dur2;
   int32_t ret;
@@ -4313,7 +4301,7 @@ int32_t ism330dlc_tap_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_int_dur2_t int_dur2;
   int32_t ret;
@@ -4332,7 +4320,7 @@ int32_t ism330dlc_tap_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_tap_mode_set(stmdev_ctx_t *ctx,
                              ism330dlc_single_double_tap_t val)
 {
   ism330dlc_wake_up_ths_t wake_up_ths;
@@ -4356,7 +4344,7 @@ int32_t ism330dlc_tap_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_tap_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_tap_mode_get(stmdev_ctx_t *ctx,
                                ism330dlc_single_double_tap_t *val)
 {
   ism330dlc_wake_up_ths_t wake_up_ths;
@@ -4400,7 +4388,7 @@ int32_t ism330dlc_tap_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_6d_feed_data_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_6d_feed_data_set(stmdev_ctx_t *ctx,
                                    ism330dlc_low_pass_on_6d_t val)
 {
   ism330dlc_ctrl8_xl_t ctrl8_xl;
@@ -4423,7 +4411,7 @@ int32_t ism330dlc_6d_feed_data_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_6d_feed_data_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_6d_feed_data_get(stmdev_ctx_t *ctx,
                                    ism330dlc_low_pass_on_6d_t *val)
 {
   ism330dlc_ctrl8_xl_t ctrl8_xl;
@@ -4453,7 +4441,7 @@ int32_t ism330dlc_6d_feed_data_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_6d_threshold_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_6d_threshold_set(stmdev_ctx_t *ctx,
                                    ism330dlc_sixd_ths_t val)
 {
   ism330dlc_tap_ths_6d_t tap_ths_6d;
@@ -4477,7 +4465,7 @@ int32_t ism330dlc_6d_threshold_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_6d_threshold_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_6d_threshold_get(stmdev_ctx_t *ctx,
                                    ism330dlc_sixd_ths_t *val)
 {
   ism330dlc_tap_ths_6d_t tap_ths_6d;
@@ -4514,7 +4502,7 @@ int32_t ism330dlc_6d_threshold_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_4d_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4537,7 +4525,7 @@ int32_t ism330dlc_4d_mode_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_4d_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4570,7 +4558,7 @@ int32_t ism330dlc_4d_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_ff_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_wake_up_dur_t wake_up_dur;
   ism330dlc_free_fall_t free_fall;
@@ -4602,7 +4590,7 @@ int32_t ism330dlc_ff_dur_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_ff_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_wake_up_dur_t wake_up_dur;
   ism330dlc_free_fall_t free_fall;
@@ -4627,7 +4615,7 @@ int32_t ism330dlc_ff_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_ff_threshold_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_ff_threshold_set(stmdev_ctx_t *ctx,
                                    ism330dlc_ff_ths_t val)
 {
   ism330dlc_free_fall_t free_fall;
@@ -4650,7 +4638,7 @@ int32_t ism330dlc_ff_threshold_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_ff_threshold_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_ff_threshold_get(stmdev_ctx_t *ctx,
                                    ism330dlc_ff_ths_t *val)
 {
   ism330dlc_free_fall_t free_fall;
@@ -4711,7 +4699,7 @@ int32_t ism330dlc_ff_threshold_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_watermark_set(ism330dlc_ctx_t *ctx, uint16_t val)
+int32_t ism330dlc_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   ism330dlc_fifo_ctrl1_t fifo_ctrl1;
   ism330dlc_fifo_ctrl2_t fifo_ctrl2;
@@ -4740,7 +4728,7 @@ int32_t ism330dlc_fifo_watermark_set(ism330dlc_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_watermark_get(ism330dlc_ctx_t *ctx, uint16_t *val)
+int32_t ism330dlc_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   ism330dlc_fifo_ctrl1_t fifo_ctrl1;
   ism330dlc_fifo_ctrl2_t fifo_ctrl2;
@@ -4767,7 +4755,7 @@ int32_t ism330dlc_fifo_watermark_get(ism330dlc_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_data_level_get(ism330dlc_ctx_t *ctx, uint16_t *val)
+int32_t ism330dlc_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   ism330dlc_fifo_status1_t fifo_status1;
   ism330dlc_fifo_status2_t fifo_status2;
@@ -4793,7 +4781,7 @@ int32_t ism330dlc_fifo_data_level_get(ism330dlc_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_wtm_flag_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_fifo_status2_t fifo_status2;
   int32_t ret;
@@ -4814,7 +4802,7 @@ int32_t ism330dlc_fifo_wtm_flag_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_pattern_get(ism330dlc_ctx_t *ctx, uint16_t *val)
+int32_t ism330dlc_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   ism330dlc_fifo_status3_t fifo_status3;
   ism330dlc_fifo_status4_t fifo_status4;
@@ -4839,7 +4827,7 @@ int32_t ism330dlc_fifo_pattern_get(ism330dlc_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_temp_batch_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -4863,7 +4851,7 @@ int32_t ism330dlc_fifo_temp_batch_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_temp_batch_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -4884,7 +4872,7 @@ int32_t ism330dlc_fifo_temp_batch_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_write_trigger_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_write_trigger_set(stmdev_ctx_t *ctx,
                                          ism330dlc_trigger_fifo_t val)
 {
   ism330dlc_master_config_t master_config;
@@ -4909,7 +4897,7 @@ int32_t ism330dlc_fifo_write_trigger_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_xl_batch_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                     ism330dlc_dec_fifo_xl_t val)
 {
   ism330dlc_fifo_ctrl3_t fifo_ctrl3;
@@ -4934,7 +4922,7 @@ int32_t ism330dlc_fifo_xl_batch_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_xl_batch_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                     ism330dlc_dec_fifo_xl_t *val)
 {
   ism330dlc_fifo_ctrl3_t fifo_ctrl3;
@@ -4984,7 +4972,7 @@ int32_t ism330dlc_fifo_xl_batch_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_gy_batch_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                     ism330dlc_dec_fifo_gyro_t val)
 {
   ism330dlc_fifo_ctrl3_t fifo_ctrl3;
@@ -5009,7 +4997,7 @@ int32_t ism330dlc_fifo_gy_batch_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_gy_batch_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                     ism330dlc_dec_fifo_gyro_t *val)
 {
   ism330dlc_fifo_ctrl3_t fifo_ctrl3;
@@ -5059,7 +5047,7 @@ int32_t ism330dlc_fifo_gy_batch_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_dataset_3_batch_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
                                            ism330dlc_dec_ds3_fifo_t val)
 {
   ism330dlc_fifo_ctrl4_t fifo_ctrl4;
@@ -5084,7 +5072,7 @@ int32_t ism330dlc_fifo_dataset_3_batch_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_dataset_3_batch_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
                                            ism330dlc_dec_ds3_fifo_t *val)
 {
   ism330dlc_fifo_ctrl4_t fifo_ctrl4;
@@ -5134,7 +5122,7 @@ int32_t ism330dlc_fifo_dataset_3_batch_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_dataset_4_batch_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
                                            ism330dlc_dec_ds4_fifo_t val)
 {
   ism330dlc_fifo_ctrl4_t fifo_ctrl4;
@@ -5159,7 +5147,7 @@ int32_t ism330dlc_fifo_dataset_4_batch_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_dataset_4_batch_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
                                            ism330dlc_dec_ds4_fifo_t *val)
 {
   ism330dlc_fifo_ctrl4_t fifo_ctrl4;
@@ -5208,7 +5196,7 @@ int32_t ism330dlc_fifo_dataset_4_batch_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_xl_gy_8bit_format_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx,
                                              uint8_t val)
 {
   ism330dlc_fifo_ctrl4_t fifo_ctrl4;
@@ -5232,7 +5220,7 @@ int32_t ism330dlc_fifo_xl_gy_8bit_format_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_xl_gy_8bit_format_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx,
                                              uint8_t *val)
 {
   ism330dlc_fifo_ctrl4_t fifo_ctrl4;
@@ -5254,7 +5242,7 @@ int32_t ism330dlc_fifo_xl_gy_8bit_format_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_stop_on_wtm_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -5278,7 +5266,7 @@ int32_t ism330dlc_fifo_stop_on_wtm_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_stop_on_wtm_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -5298,7 +5286,7 @@ int32_t ism330dlc_fifo_stop_on_wtm_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_mode_set(stmdev_ctx_t *ctx,
                                 ism330dlc_fifo_mode_t val)
 {
   ism330dlc_fifo_ctrl5_t fifo_ctrl5;
@@ -5322,7 +5310,7 @@ int32_t ism330dlc_fifo_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_mode_get(stmdev_ctx_t *ctx,
                                 ism330dlc_fifo_mode_t *val)
 {
   ism330dlc_fifo_ctrl5_t fifo_ctrl5;
@@ -5362,7 +5350,7 @@ int32_t ism330dlc_fifo_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_data_rate_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_data_rate_set(stmdev_ctx_t *ctx,
                                      ism330dlc_odr_fifo_t val)
 {
   ism330dlc_fifo_ctrl5_t fifo_ctrl5;
@@ -5386,7 +5374,7 @@ int32_t ism330dlc_fifo_data_rate_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_fifo_data_rate_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_data_rate_get(stmdev_ctx_t *ctx,
                                      ism330dlc_odr_fifo_t *val)
 {
   ism330dlc_fifo_ctrl5_t fifo_ctrl5;
@@ -5457,7 +5445,7 @@ int32_t ism330dlc_fifo_data_rate_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
- int32_t ism330dlc_den_polarity_set(ism330dlc_ctx_t *ctx,
+ int32_t ism330dlc_den_polarity_set(stmdev_ctx_t *ctx,
                                     ism330dlc_den_lh_t val)
 {
   ism330dlc_ctrl5_c_t ctrl5_c;
@@ -5479,7 +5467,7 @@ int32_t ism330dlc_fifo_data_rate_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_polarity_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_den_polarity_get(stmdev_ctx_t *ctx,
                                    ism330dlc_den_lh_t *val)
 {
   ism330dlc_ctrl5_c_t ctrl5_c;
@@ -5509,7 +5497,7 @@ int32_t ism330dlc_den_polarity_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t val)
+int32_t ism330dlc_den_mode_set(stmdev_ctx_t *ctx, ism330dlc_den_mode_t val)
 {
   ism330dlc_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -5530,7 +5518,7 @@ int32_t ism330dlc_den_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t *val)
+int32_t ism330dlc_den_mode_get(stmdev_ctx_t *ctx, ism330dlc_den_mode_t *val)
 {
   ism330dlc_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -5566,7 +5554,7 @@ int32_t ism330dlc_den_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_enable_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_den_enable_set(stmdev_ctx_t *ctx,
                                  ism330dlc_den_xl_en_t val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
@@ -5600,7 +5588,7 @@ int32_t ism330dlc_den_enable_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_enable_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_den_enable_get(stmdev_ctx_t *ctx,
                                  ism330dlc_den_xl_en_t *val)
 {
   ism330dlc_ctrl4_c_t ctrl4_c;
@@ -5636,7 +5624,7 @@ int32_t ism330dlc_den_enable_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_mark_axis_z_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5658,7 +5646,7 @@ int32_t ism330dlc_den_mark_axis_z_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_mark_axis_z_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5677,7 +5665,7 @@ int32_t ism330dlc_den_mark_axis_z_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_mark_axis_y_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5699,7 +5687,7 @@ int32_t ism330dlc_den_mark_axis_y_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_mark_axis_y_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5718,7 +5706,7 @@ int32_t ism330dlc_den_mark_axis_y_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_mark_axis_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5739,7 +5727,7 @@ int32_t ism330dlc_den_mark_axis_x_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_den_mark_axis_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5771,7 +5759,7 @@ int32_t ism330dlc_den_mark_axis_x_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_soft_iron_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5792,7 +5780,7 @@ int32_t ism330dlc_mag_soft_iron_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_soft_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5811,7 +5799,7 @@ int32_t ism330dlc_mag_soft_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_hard_iron_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_master_config_t master_config;
   ism330dlc_ctrl10_c_t ctrl10_c;
@@ -5846,7 +5834,7 @@ int32_t ism330dlc_mag_hard_iron_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_hard_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_master_config_t master_config;
   int32_t ret;
@@ -5867,7 +5855,7 @@ int32_t ism330dlc_mag_hard_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_soft_iron_mat_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_mag_soft_iron_mat_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5890,7 +5878,7 @@ int32_t ism330dlc_mag_soft_iron_mat_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_soft_iron_mat_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_mag_soft_iron_mat_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5913,7 +5901,7 @@ int32_t ism330dlc_mag_soft_iron_mat_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5936,7 +5924,7 @@ int32_t ism330dlc_mag_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_mag_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
+int32_t ism330dlc_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5972,7 +5960,7 @@ int32_t ism330dlc_mag_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_sync_sens_frame_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_sensor_sync_time_frame_t sensor_sync_time_frame;
   int32_t ret;
@@ -5996,7 +5984,7 @@ int32_t ism330dlc_sh_sync_sens_frame_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_sync_sens_frame_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_sensor_sync_time_frame_t sensor_sync_time_frame;
   int32_t ret;
@@ -6016,7 +6004,7 @@ int32_t ism330dlc_sh_sync_sens_frame_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_sync_sens_ratio_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_sync_sens_ratio_set(stmdev_ctx_t *ctx,
                                          ism330dlc_rr_t val)
 {
   ism330dlc_sensor_sync_res_ratio_t sensor_sync_res_ratio;
@@ -6040,7 +6028,7 @@ int32_t ism330dlc_sh_sync_sens_ratio_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_sync_sens_ratio_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_sync_sens_ratio_get(stmdev_ctx_t *ctx,
                                          ism330dlc_rr_t *val)
 {
   ism330dlc_sensor_sync_res_ratio_t sensor_sync_res_ratio;
@@ -6078,7 +6066,7 @@ int32_t ism330dlc_sh_sync_sens_ratio_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_master_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_master_config_t master_config;
   int32_t ret;
@@ -6101,7 +6089,7 @@ int32_t ism330dlc_sh_master_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_master_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_master_config_t master_config;
   int32_t ret;
@@ -6121,7 +6109,7 @@ int32_t ism330dlc_sh_master_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_pass_through_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_master_config_t master_config;
   int32_t ret;
@@ -6144,7 +6132,7 @@ int32_t ism330dlc_sh_pass_through_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_pass_through_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_master_config_t master_config;
   int32_t ret;
@@ -6164,7 +6152,7 @@ int32_t ism330dlc_sh_pass_through_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_pin_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_pin_mode_set(stmdev_ctx_t *ctx,
                                   ism330dlc_pull_up_en_t val)
 {
   ism330dlc_master_config_t master_config;
@@ -6189,7 +6177,7 @@ int32_t ism330dlc_sh_pin_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_pin_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_pin_mode_get(stmdev_ctx_t *ctx,
                                   ism330dlc_pull_up_en_t *val)
 {
   ism330dlc_master_config_t master_config;
@@ -6219,7 +6207,7 @@ int32_t ism330dlc_sh_pin_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_syncro_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                      ism330dlc_start_config_t val)
 {
   ism330dlc_master_config_t master_config;
@@ -6243,7 +6231,7 @@ int32_t ism330dlc_sh_syncro_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_syncro_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                      ism330dlc_start_config_t *val)
 {
   ism330dlc_master_config_t master_config;
@@ -6274,7 +6262,7 @@ int32_t ism330dlc_sh_syncro_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_drdy_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_sh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_master_config_t master_config;
   int32_t ret;
@@ -6297,7 +6285,7 @@ int32_t ism330dlc_sh_drdy_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_drdy_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_sh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_master_config_t master_config;
   int32_t ret;
@@ -6317,7 +6305,7 @@ int32_t ism330dlc_sh_drdy_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_read_data_raw_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                        ism330dlc_emb_sh_read_t *val)
 {
   int32_t ret;
@@ -6339,7 +6327,7 @@ int32_t ism330dlc_sh_read_data_raw_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_cmd_sens_sync_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_sh_cmd_sens_sync_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_master_cmd_code_t master_cmd_code;
   int32_t ret;
@@ -6363,7 +6351,7 @@ int32_t ism330dlc_sh_cmd_sens_sync_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_cmd_sens_sync_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_sh_cmd_sens_sync_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_master_cmd_code_t master_cmd_code;
   int32_t ret;
@@ -6384,7 +6372,7 @@ int32_t ism330dlc_sh_cmd_sens_sync_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_spi_sync_error_set(ism330dlc_ctx_t *ctx, uint8_t val)
+int32_t ism330dlc_sh_spi_sync_error_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   ism330dlc_sens_sync_spi_error_code_t sens_sync_spi_error_code;
   int32_t ret;
@@ -6408,7 +6396,7 @@ int32_t ism330dlc_sh_spi_sync_error_set(ism330dlc_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_spi_sync_error_get(ism330dlc_ctx_t *ctx, uint8_t *val)
+int32_t ism330dlc_sh_spi_sync_error_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   ism330dlc_sens_sync_spi_error_code_t sens_sync_spi_error_code;
   int32_t ret;
@@ -6428,7 +6416,7 @@ int32_t ism330dlc_sh_spi_sync_error_get(ism330dlc_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_num_of_dev_connected_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
                                             ism330dlc_aux_sens_on_t val)
 {
   ism330dlc_slave0_config_t slave0_config;
@@ -6458,7 +6446,7 @@ int32_t ism330dlc_sh_num_of_dev_connected_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_num_of_dev_connected_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
                                               ism330dlc_aux_sens_on_t *val)
 {
   ism330dlc_slave0_config_t slave0_config;
@@ -6504,7 +6492,7 @@ int32_t ism330dlc_sh_num_of_dev_connected_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_cfg_write(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_cfg_write(stmdev_ctx_t *ctx,
                                ism330dlc_sh_cfg_write_t *val)
 {
   ism330dlc_slv0_add_t slv0_add;
@@ -6542,7 +6530,7 @@ int32_t ism330dlc_sh_cfg_write(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slv0_cfg_read(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                    ism330dlc_sh_cfg_read_t *val)
 {
   ism330dlc_slave0_config_t slave0_config;
@@ -6586,7 +6574,7 @@ int32_t ism330dlc_sh_slv0_cfg_read(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slv1_cfg_read(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                    ism330dlc_sh_cfg_read_t *val)
 {
   ism330dlc_slave1_config_t slave1_config;
@@ -6630,7 +6618,7 @@ int32_t ism330dlc_sh_slv1_cfg_read(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slv2_cfg_read(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                    ism330dlc_sh_cfg_read_t *val)
 {
   ism330dlc_slv2_add_t slv2_add;
@@ -6675,7 +6663,7 @@ int32_t ism330dlc_sh_slv2_cfg_read(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slv3_cfg_read(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                    ism330dlc_sh_cfg_read_t *val)
 {
   ism330dlc_slave3_config_t slave3_config;
@@ -6717,7 +6705,7 @@ int32_t ism330dlc_sh_slv3_cfg_read(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slave_0_dec_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_0_dec_set(stmdev_ctx_t *ctx,
                                      ism330dlc_slave0_rate_t val)
 {
   ism330dlc_slave0_config_t slave0_config;
@@ -6748,7 +6736,7 @@ int32_t ism330dlc_sh_slave_0_dec_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slave_0_dec_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_0_dec_get(stmdev_ctx_t *ctx,
                                      ism330dlc_slave0_rate_t *val)
 {
   ism330dlc_slave0_config_t slave0_config;
@@ -6794,7 +6782,7 @@ int32_t ism330dlc_sh_slave_0_dec_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_write_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_write_mode_set(stmdev_ctx_t *ctx,
                                     ism330dlc_write_once_t val)
 {
   ism330dlc_slave1_config_t slave1_config;
@@ -6827,7 +6815,7 @@ int32_t ism330dlc_sh_write_mode_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_write_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_write_mode_get(stmdev_ctx_t *ctx,
                                     ism330dlc_write_once_t *val)
 {
   ism330dlc_slave1_config_t slave1_config;
@@ -6865,7 +6853,7 @@ int32_t ism330dlc_sh_write_mode_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slave_1_dec_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_1_dec_set(stmdev_ctx_t *ctx,
                                      ism330dlc_slave1_rate_t val)
 {
   ism330dlc_slave1_config_t slave1_config;
@@ -6895,7 +6883,7 @@ int32_t ism330dlc_sh_slave_1_dec_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slave_1_dec_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_1_dec_get(stmdev_ctx_t *ctx,
                                      ism330dlc_slave1_rate_t *val)
 {
   ism330dlc_slave1_config_t slave1_config;
@@ -6939,7 +6927,7 @@ int32_t ism330dlc_sh_slave_1_dec_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slave_2_dec_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_2_dec_set(stmdev_ctx_t *ctx,
                                      ism330dlc_slave2_rate_t val)
 {
   ism330dlc_slave2_config_t slave2_config;
@@ -6970,7 +6958,7 @@ int32_t ism330dlc_sh_slave_2_dec_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slave_2_dec_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_2_dec_get(stmdev_ctx_t *ctx,
                                      ism330dlc_slave2_rate_t *val)
 {
   ism330dlc_slave2_config_t slave2_config;
@@ -7014,7 +7002,7 @@ int32_t ism330dlc_sh_slave_2_dec_get(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slave_3_dec_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_3_dec_set(stmdev_ctx_t *ctx,
                                      ism330dlc_slave3_rate_t val)
 {
   ism330dlc_slave3_config_t slave3_config;
@@ -7045,7 +7033,7 @@ int32_t ism330dlc_sh_slave_3_dec_set(ism330dlc_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t ism330dlc_sh_slave_3_dec_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_3_dec_get(stmdev_ctx_t *ctx,
                                      ism330dlc_slave3_rate_t *val)
 {
   ism330dlc_slave3_config_t slave3_config;

--- a/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.h
+++ b/sensor/stmemsc/ism330dlc_STdC/driver/ism330dlc_reg.h
@@ -7,37 +7,20 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef ISM330DLC_DRIVER_H
-#define ISM330DLC_DRIVER_H
+#ifndef ISM330DLC_REGS_H
+#define ISM330DLC_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup ISM330DLC_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LSM9DS1_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*ism330dlc_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*ism330dlc_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  ism330dlc_write_ptr  write_reg;
-  ism330dlc_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} ism330dlc_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -1003,9 +975,9 @@ typedef union{
   *
   */
 
-int32_t ism330dlc_read_reg(ism330dlc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t ism330dlc_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t ism330dlc_write_reg(ism330dlc_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t ism330dlc_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float_t ism330dlc_from_fs2g_to_mg(int16_t lsb);
@@ -1028,8 +1000,8 @@ typedef enum {
   ISM330DLC_8g       = 3,
   ISM330DLC_XL_FS_ND = 4,  /* ERROR CODE */
 } ism330dlc_fs_xl_t;
-int32_t ism330dlc_xl_full_scale_set(ism330dlc_ctx_t *ctx, ism330dlc_fs_xl_t val);
-int32_t ism330dlc_xl_full_scale_get(ism330dlc_ctx_t *ctx, ism330dlc_fs_xl_t *val);
+int32_t ism330dlc_xl_full_scale_set(stmdev_ctx_t *ctx, ism330dlc_fs_xl_t val);
+int32_t ism330dlc_xl_full_scale_get(stmdev_ctx_t *ctx, ism330dlc_fs_xl_t *val);
 
 typedef enum {
   ISM330DLC_XL_ODR_OFF      =  0,
@@ -1045,8 +1017,8 @@ typedef enum {
   ISM330DLC_XL_ODR_6k66Hz   = 10,
   ISM330DLC_XL_ODR_1Hz6     = 11,
 } ism330dlc_odr_xl_t;
-int32_t ism330dlc_xl_data_rate_set(ism330dlc_ctx_t *ctx, ism330dlc_odr_xl_t val);
-int32_t ism330dlc_xl_data_rate_get(ism330dlc_ctx_t *ctx, ism330dlc_odr_xl_t *val);
+int32_t ism330dlc_xl_data_rate_set(stmdev_ctx_t *ctx, ism330dlc_odr_xl_t val);
+int32_t ism330dlc_xl_data_rate_get(stmdev_ctx_t *ctx, ism330dlc_odr_xl_t *val);
 
 typedef enum {
   ISM330DLC_250dps   = 0,
@@ -1055,8 +1027,8 @@ typedef enum {
   ISM330DLC_1000dps  = 4,
   ISM330DLC_2000dps  = 6,
 } ism330dlc_fs_g_t;
-int32_t ism330dlc_gy_full_scale_set(ism330dlc_ctx_t *ctx, ism330dlc_fs_g_t val);
-int32_t ism330dlc_gy_full_scale_get(ism330dlc_ctx_t *ctx, ism330dlc_fs_g_t *val);
+int32_t ism330dlc_gy_full_scale_set(stmdev_ctx_t *ctx, ism330dlc_fs_g_t val);
+int32_t ism330dlc_gy_full_scale_get(stmdev_ctx_t *ctx, ism330dlc_fs_g_t *val);
 
 typedef enum {
   ISM330DLC_GY_ODR_OFF    =  0,
@@ -1071,46 +1043,46 @@ typedef enum {
   ISM330DLC_GY_ODR_3k33Hz =  9,
   ISM330DLC_GY_ODR_6k66Hz = 10,
 } ism330dlc_odr_g_t;
-int32_t ism330dlc_gy_data_rate_set(ism330dlc_ctx_t *ctx, ism330dlc_odr_g_t val);
-int32_t ism330dlc_gy_data_rate_get(ism330dlc_ctx_t *ctx, ism330dlc_odr_g_t *val);
+int32_t ism330dlc_gy_data_rate_set(stmdev_ctx_t *ctx, ism330dlc_odr_g_t val);
+int32_t ism330dlc_gy_data_rate_get(stmdev_ctx_t *ctx, ism330dlc_odr_g_t *val);
 
-int32_t ism330dlc_block_data_update_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_block_data_update_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_LSb_1mg  = 0,
   ISM330DLC_LSb_16mg = 1,
 } ism330dlc_usr_off_w_t;
-int32_t ism330dlc_xl_offset_weight_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                      ism330dlc_usr_off_w_t val);
-int32_t ism330dlc_xl_offset_weight_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                      ism330dlc_usr_off_w_t *val);
 
 typedef enum {
   ISM330DLC_XL_HIGH_PERFORMANCE  = 0,
   ISM330DLC_XL_NORMAL            = 1,
 } ism330dlc_xl_hm_mode_t;
-int32_t ism330dlc_xl_power_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_power_mode_set(stmdev_ctx_t *ctx,
                                   ism330dlc_xl_hm_mode_t val);
-int32_t ism330dlc_xl_power_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_power_mode_get(stmdev_ctx_t *ctx,
                                   ism330dlc_xl_hm_mode_t *val);
 
 typedef enum {
   ISM330DLC_STAT_RND_DISABLE  = 0,
   ISM330DLC_STAT_RND_ENABLE   = 1,
 } ism330dlc_rounding_status_t;
-int32_t ism330dlc_rounding_on_status_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_rounding_on_status_set(stmdev_ctx_t *ctx,
                                        ism330dlc_rounding_status_t val);
-int32_t ism330dlc_rounding_on_status_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_rounding_on_status_get(stmdev_ctx_t *ctx,
                                        ism330dlc_rounding_status_t *val);
 
 typedef enum {
   ISM330DLC_GY_HIGH_PERFORMANCE  = 0,
   ISM330DLC_GY_NORMAL            = 1,
 } ism330dlc_g_hm_mode_t;
-int32_t ism330dlc_gy_power_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_power_mode_set(stmdev_ctx_t *ctx,
                                   ism330dlc_g_hm_mode_t val);
-int32_t ism330dlc_gy_power_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_power_mode_get(stmdev_ctx_t *ctx,
                                   ism330dlc_g_hm_mode_t *val);
 
 typedef struct {
@@ -1121,28 +1093,28 @@ typedef struct {
   ism330dlc_func_src1_t          func_src1;
   ism330dlc_func_src2_t          func_src2;
 } ism330dlc_all_sources_t;
-int32_t ism330dlc_all_sources_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_all_sources_get(stmdev_ctx_t *ctx,
                                 ism330dlc_all_sources_t *val);
 
-int32_t ism330dlc_status_reg_get(ism330dlc_ctx_t *ctx, ism330dlc_status_reg_t *val);
+int32_t ism330dlc_status_reg_get(stmdev_ctx_t *ctx, ism330dlc_status_reg_t *val);
 
-int32_t ism330dlc_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_temp_flag_data_ready_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_xl_usr_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
-int32_t ism330dlc_xl_usr_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
-int32_t ism330dlc_timestamp_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_timestamp_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_LSB_6ms4 = 0,
   ISM330DLC_LSB_25us = 1,
 } ism330dlc_timer_hr_t;
-int32_t ism330dlc_timestamp_res_set(ism330dlc_ctx_t *ctx, ism330dlc_timer_hr_t val);
-int32_t ism330dlc_timestamp_res_get(ism330dlc_ctx_t *ctx, ism330dlc_timer_hr_t *val);
+int32_t ism330dlc_timestamp_res_set(stmdev_ctx_t *ctx, ism330dlc_timer_hr_t val);
+int32_t ism330dlc_timestamp_res_get(stmdev_ctx_t *ctx, ism330dlc_timer_hr_t *val);
 
 typedef enum {
   ISM330DLC_ROUND_DISABLE            = 0,
@@ -1154,88 +1126,88 @@ typedef enum {
   ISM330DLC_ROUND_GY_XL_SH1_TO_SH12  = 6,
   ISM330DLC_ROUND_GY_XL_SH1_TO_SH6   = 7,
 } ism330dlc_rounding_t;
-int32_t ism330dlc_rounding_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_rounding_t val);
-int32_t ism330dlc_rounding_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_rounding_t *val);
+int32_t ism330dlc_rounding_mode_set(stmdev_ctx_t *ctx, ism330dlc_rounding_t val);
+int32_t ism330dlc_rounding_mode_get(stmdev_ctx_t *ctx, ism330dlc_rounding_t *val);
 
-int32_t ism330dlc_temperature_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism330dlc_angular_rate_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism330dlc_acceleration_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism330dlc_mag_calibrated_raw_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism330dlc_fifo_raw_data_get(ism330dlc_ctx_t *ctx, uint8_t *buffer,
+int32_t ism330dlc_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer,
                                   uint8_t len);
 
 typedef enum {
   ISM330DLC_USER_BANK   = 0,
   ISM330DLC_BANK_A      = 1,
 } ism330dlc_func_cfg_en_t;
-int32_t ism330dlc_mem_bank_set(ism330dlc_ctx_t *ctx, ism330dlc_func_cfg_en_t val);
-int32_t ism330dlc_mem_bank_get(ism330dlc_ctx_t *ctx, ism330dlc_func_cfg_en_t *val);
+int32_t ism330dlc_mem_bank_set(stmdev_ctx_t *ctx, ism330dlc_func_cfg_en_t val);
+int32_t ism330dlc_mem_bank_get(stmdev_ctx_t *ctx, ism330dlc_func_cfg_en_t *val);
 
 typedef enum {
   ISM330DLC_DRDY_LATCHED    = 0,
   ISM330DLC_DRDY_PULSED     = 1,
 } ism330dlc_drdy_pulsed_t;
-int32_t ism330dlc_data_ready_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_data_ready_mode_set(stmdev_ctx_t *ctx,
                                     ism330dlc_drdy_pulsed_t val);
-int32_t ism330dlc_data_ready_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_data_ready_mode_get(stmdev_ctx_t *ctx,
                                     ism330dlc_drdy_pulsed_t *val);
 
-int32_t ism330dlc_device_id_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
-int32_t ism330dlc_reset_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_reset_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_LSB_AT_LOW_ADD  = 0,
   ISM330DLC_MSB_AT_LOW_ADD  = 1,
 } ism330dlc_ble_t;
-int32_t ism330dlc_data_format_set(ism330dlc_ctx_t *ctx, ism330dlc_ble_t val);
-int32_t ism330dlc_data_format_get(ism330dlc_ctx_t *ctx, ism330dlc_ble_t *val);
+int32_t ism330dlc_data_format_set(stmdev_ctx_t *ctx, ism330dlc_ble_t val);
+int32_t ism330dlc_data_format_get(stmdev_ctx_t *ctx, ism330dlc_ble_t *val);
 
-int32_t ism330dlc_auto_increment_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_auto_increment_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_boot_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_boot_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_XL_ST_DISABLE    = 0,
   ISM330DLC_XL_ST_POSITIVE   = 1,
   ISM330DLC_XL_ST_NEGATIVE   = 2,
 } ism330dlc_st_xl_t;
-int32_t ism330dlc_xl_self_test_set(ism330dlc_ctx_t *ctx, ism330dlc_st_xl_t val);
-int32_t ism330dlc_xl_self_test_get(ism330dlc_ctx_t *ctx, ism330dlc_st_xl_t *val);
+int32_t ism330dlc_xl_self_test_set(stmdev_ctx_t *ctx, ism330dlc_st_xl_t val);
+int32_t ism330dlc_xl_self_test_get(stmdev_ctx_t *ctx, ism330dlc_st_xl_t *val);
 
 typedef enum {
   ISM330DLC_GY_ST_DISABLE    = 0,
   ISM330DLC_GY_ST_POSITIVE   = 1,
   ISM330DLC_GY_ST_NEGATIVE   = 3,
 } ism330dlc_st_g_t;
-int32_t ism330dlc_gy_self_test_set(ism330dlc_ctx_t *ctx, ism330dlc_st_g_t val);
-int32_t ism330dlc_gy_self_test_get(ism330dlc_ctx_t *ctx, ism330dlc_st_g_t *val);
+int32_t ism330dlc_gy_self_test_set(stmdev_ctx_t *ctx, ism330dlc_st_g_t val);
+int32_t ism330dlc_gy_self_test_get(stmdev_ctx_t *ctx, ism330dlc_st_g_t *val);
 
-int32_t ism330dlc_filter_settling_mask_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_filter_settling_mask_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_USE_SLOPE = 0,
   ISM330DLC_USE_HPF   = 1,
 } ism330dlc_slope_fds_t;
-int32_t ism330dlc_xl_hp_path_internal_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         ism330dlc_slope_fds_t val);
-int32_t ism330dlc_xl_hp_path_internal_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         ism330dlc_slope_fds_t *val);
 
 typedef enum {
   ISM330DLC_XL_ANA_BW_1k5Hz = 0,
   ISM330DLC_XL_ANA_BW_400Hz = 1,
 } ism330dlc_bw0_xl_t;
-int32_t ism330dlc_xl_filter_analog_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_filter_analog_set(stmdev_ctx_t *ctx,
                                      ism330dlc_bw0_xl_t val);
-int32_t ism330dlc_xl_filter_analog_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_filter_analog_get(stmdev_ctx_t *ctx,
                                      ism330dlc_bw0_xl_t *val);
 
 typedef enum {
@@ -1243,9 +1215,9 @@ typedef enum {
   ISM330DLC_XL_LP1_ODR_DIV_4 = 1,
   ISM330DLC_XL_LP1_NA        = 2,
 } ism330dlc_lpf1_bw_sel_t;
-int32_t ism330dlc_xl_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                      ism330dlc_lpf1_bw_sel_t val);
-int32_t ism330dlc_xl_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                      ism330dlc_lpf1_bw_sel_t *val);
 
 typedef enum {
@@ -1259,13 +1231,13 @@ typedef enum {
   ISM330DLC_XL_LOW_NOISE_LP_ODR_DIV_400  = 0x13,
   ISM330DLC_XL_LP_NA                     = 0x14
 } ism330dlc_input_composite_t;
-int32_t ism330dlc_xl_lp2_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
                                      ism330dlc_input_composite_t val);
-int32_t ism330dlc_xl_lp2_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
                                      ism330dlc_input_composite_t *val);
 
-int32_t ism330dlc_xl_reference_mode_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_xl_reference_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_xl_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_xl_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_XL_HP_ODR_DIV_4      = 0x00, /* Slope filter */
@@ -1274,9 +1246,9 @@ typedef enum {
   ISM330DLC_XL_HP_ODR_DIV_400    = 0x03,
   ISM330DLC_XL_HP_NA             = 0x04,
 } ism330dlc_hpcf_xl_t;
-int32_t ism330dlc_xl_hp_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                     ism330dlc_hpcf_xl_t val);
-int32_t ism330dlc_xl_hp_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                     ism330dlc_hpcf_xl_t *val);
 
 typedef enum {
@@ -1284,13 +1256,13 @@ typedef enum {
   ISM330DLC_XL_UI_LP1_ODR_DIV_4 = 1,
   ISM330DLC_XL_UI_LP1_NA        = 2,  /* ERROR CODE */
 } ism330dlc_ui_lpf1_bw_sel_t;
-int32_t ism330dlc_xl_ui_lp1_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_ui_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                         ism330dlc_ui_lpf1_bw_sel_t val);
-int32_t ism330dlc_xl_ui_lp1_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_ui_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                         ism330dlc_ui_lpf1_bw_sel_t *val);
 
-int32_t ism330dlc_xl_ui_slope_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_xl_ui_slope_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_xl_ui_slope_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_xl_ui_slope_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_AUX_LP_LIGHT          = 2,
@@ -1298,9 +1270,9 @@ typedef enum {
   ISM330DLC_AUX_LP_STRONG         = 0,
   ISM330DLC_AUX_LP_AGGRESSIVE     = 1,
 } ism330dlc_filter_xl_conf_ois_t;
-int32_t ism330dlc_xl_aux_lp_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_aux_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                         ism330dlc_filter_xl_conf_ois_t val);
-int32_t ism330dlc_xl_aux_lp_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_xl_aux_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                         ism330dlc_filter_xl_conf_ois_t *val);
 
 typedef enum {
@@ -1321,13 +1293,13 @@ typedef enum {
   ISM330DLC_HP_260mHz_LP1_STRONG        = 0xA8,
   ISM330DLC_HP_1Hz04_LP1_AGGRESSIVE     = 0xBB,
 } ism330dlc_lpf1_sel_g_t;
-int32_t ism330dlc_gy_band_pass_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_band_pass_set(stmdev_ctx_t *ctx,
                                     ism330dlc_lpf1_sel_g_t val);
-int32_t ism330dlc_gy_band_pass_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_band_pass_get(stmdev_ctx_t *ctx,
                                     ism330dlc_lpf1_sel_g_t *val);
 
-int32_t ism330dlc_gy_ui_high_pass_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_gy_ui_high_pass_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_gy_ui_high_pass_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_gy_ui_high_pass_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_HP_DISABLE_LP_173Hz        = 0x02,
@@ -1340,21 +1312,21 @@ typedef enum {
   ISM330DLC_HP_260mHz_LP_351Hz         = 0xA0,
   ISM330DLC_HP_1Hz04_LP_937Hz          = 0xB3,
 } ism330dlc_hp_en_ois_t;
-int32_t ism330dlc_gy_aux_bandwidth_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_aux_bandwidth_set(stmdev_ctx_t *ctx,
                                      ism330dlc_hp_en_ois_t val);
-int32_t ism330dlc_gy_aux_bandwidth_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_gy_aux_bandwidth_get(stmdev_ctx_t *ctx,
                                      ism330dlc_hp_en_ois_t *val);
 
-int32_t ism330dlc_aux_status_reg_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_status_reg_get(stmdev_ctx_t *ctx,
                                    ism330dlc_status_spiaux_t *val);
 
-int32_t ism330dlc_aux_xl_flag_data_ready_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx,
                                              uint8_t *val);
 
-int32_t ism330dlc_aux_gy_flag_data_ready_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx,
                                              uint8_t *val);
 
-int32_t ism330dlc_aux_gy_flag_settling_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_flag_settling_get(stmdev_ctx_t *ctx,
                                            uint8_t *val);
 
 typedef enum {
@@ -1362,22 +1334,22 @@ typedef enum {
   ISM330DLC_AUX_DEN_LEVEL_LATCH     = 3,
   ISM330DLC_AUX_DEN_LEVEL_TRIG      = 2,
 } ism330dlc_lvl_ois_t;
-int32_t ism330dlc_aux_den_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_den_mode_set(stmdev_ctx_t *ctx,
                                  ism330dlc_lvl_ois_t val);
-int32_t ism330dlc_aux_den_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_den_mode_get(stmdev_ctx_t *ctx,
                                  ism330dlc_lvl_ois_t *val);
 
-int32_t ism330dlc_aux_drdy_on_int2_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_aux_drdy_on_int2_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_AUX_DISABLE   = 0,
   ISM330DLC_MODE_3_GY     = 1,
   ISM330DLC_MODE_4_GY_XL  = 3,
 } ism330dlc_ois_en_spi2_t;
-int32_t ism330dlc_aux_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_mode_set(stmdev_ctx_t *ctx,
                                ism330dlc_ois_en_spi2_t val);
-int32_t ism330dlc_aux_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_mode_get(stmdev_ctx_t *ctx,
                                ism330dlc_ois_en_spi2_t *val);
 
 typedef enum {
@@ -1387,36 +1359,36 @@ typedef enum {
   ISM330DLC_1000dps_AUX  = 4,
   ISM330DLC_2000dps_AUX  = 6,
 } ism330dlc_fs_g_ois_t;
-int32_t ism330dlc_aux_gy_full_scale_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
                                       ism330dlc_fs_g_ois_t val);
-int32_t ism330dlc_aux_gy_full_scale_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
                                       ism330dlc_fs_g_ois_t *val);
 
 typedef enum {
   ISM330DLC_AUX_SPI_4_WIRE = 0,
   ISM330DLC_AUX_SPI_3_WIRE = 1,
 } ism330dlc_sim_ois_t;
-int32_t ism330dlc_aux_spi_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_spi_mode_set(stmdev_ctx_t *ctx,
                                    ism330dlc_sim_ois_t val);
-int32_t ism330dlc_aux_spi_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_spi_mode_get(stmdev_ctx_t *ctx,
                                    ism330dlc_sim_ois_t *val);
 
 typedef enum {
   ISM330DLC_AUX_LSB_AT_LOW_ADD = 0,
   ISM330DLC_AUX_MSB_AT_LOW_ADD = 1,
 } ism330dlc_ble_ois_t;
-int32_t ism330dlc_aux_data_format_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_data_format_set(stmdev_ctx_t *ctx,
                                     ism330dlc_ble_ois_t val);
-int32_t ism330dlc_aux_data_format_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_data_format_get(stmdev_ctx_t *ctx,
                                     ism330dlc_ble_ois_t *val);
 
 typedef enum {
   ISM330DLC_ENABLE_CLAMP    = 0,
   ISM330DLC_DISABLE_CLAMP   = 1,
 } ism330dlc_st_ois_clampdis_t;
-int32_t ism330dlc_aux_gy_clamp_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_clamp_set(stmdev_ctx_t *ctx,
                                  ism330dlc_st_ois_clampdis_t val);
-int32_t ism330dlc_aux_gy_clamp_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_clamp_get(stmdev_ctx_t *ctx,
                                  ism330dlc_st_ois_clampdis_t *val);
 
 typedef enum {
@@ -1424,9 +1396,9 @@ typedef enum {
   ISM330DLC_AUX_GY_POS      = 1,
   ISM330DLC_AUX_GY_NEG      = 3,
 } ism330dlc_st_ois_t;
-int32_t ism330dlc_aux_gy_self_test_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_self_test_set(stmdev_ctx_t *ctx,
                                      ism330dlc_st_ois_t val);
-int32_t ism330dlc_aux_gy_self_test_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_gy_self_test_get(stmdev_ctx_t *ctx,
                                      ism330dlc_st_ois_t *val);
 
 typedef enum {
@@ -1435,34 +1407,34 @@ typedef enum {
   ISM330DLC_AUX_4g   = 2,
   ISM330DLC_AUX_8g   = 3,
 } ism330dlc_fs_xl_ois_t;
-int32_t ism330dlc_aux_xl_full_scale_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
                                       ism330dlc_fs_xl_ois_t val);
-int32_t ism330dlc_aux_xl_full_scale_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
                                       ism330dlc_fs_xl_ois_t *val);
 
 typedef enum {
   ISM330DLC_AUX_DEN_ACTIVE_LOW   = 0,
   ISM330DLC_AUX_DEN_ACTIVE_HIGH  = 1,
 } ism330dlc_den_lh_ois_t;
-int32_t ism330dlc_aux_den_polarity_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_den_polarity_set(stmdev_ctx_t *ctx,
                                      ism330dlc_den_lh_ois_t val);
-int32_t ism330dlc_aux_den_polarity_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_aux_den_polarity_get(stmdev_ctx_t *ctx,
                                      ism330dlc_den_lh_ois_t *val);
 
 typedef enum {
   ISM330DLC_SPI_4_WIRE  = 0,
   ISM330DLC_SPI_3_WIRE  = 1,
 } ism330dlc_sim_t;
-int32_t ism330dlc_spi_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_sim_t val);
-int32_t ism330dlc_spi_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_sim_t *val);
+int32_t ism330dlc_spi_mode_set(stmdev_ctx_t *ctx, ism330dlc_sim_t val);
+int32_t ism330dlc_spi_mode_get(stmdev_ctx_t *ctx, ism330dlc_sim_t *val);
 
 typedef enum {
   ISM330DLC_I2C_ENABLE   = 0,
   ISM330DLC_I2C_DISABLE  = 1,
 } ism330dlc_i2c_disable_t;
-int32_t ism330dlc_i2c_interface_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_i2c_interface_set(stmdev_ctx_t *ctx,
                                   ism330dlc_i2c_disable_t val);
-int32_t ism330dlc_i2c_interface_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_i2c_interface_get(stmdev_ctx_t *ctx,
                                   ism330dlc_i2c_disable_t *val);
 
 typedef struct {
@@ -1482,9 +1454,9 @@ typedef struct {
   uint8_t den_drdy_int1            : 1;
   uint8_t drdy_on_int1             : 1;
 } ism330dlc_int1_route_t;
-int32_t ism330dlc_pin_int1_route_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    ism330dlc_int1_route_t val);
-int32_t ism330dlc_pin_int1_route_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    ism330dlc_int1_route_t *val);
 
 typedef struct{
@@ -1503,43 +1475,43 @@ typedef struct{
   uint8_t int2_single_tap          : 1;
   uint8_t int2_inact_state         : 1;
 } ism330dlc_int2_route_t;
-int32_t ism330dlc_pin_int2_route_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    ism330dlc_int2_route_t val);
-int32_t ism330dlc_pin_int2_route_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_pin_int2_route_get(stmdev_ctx_t *ctx,
                                    ism330dlc_int2_route_t *val);
 
 typedef enum {
   ISM330DLC_PUSH_PULL   = 0,
   ISM330DLC_OPEN_DRAIN  = 1,
 } ism330dlc_pp_od_t;
-int32_t ism330dlc_pin_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t val);
-int32_t ism330dlc_pin_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_pp_od_t *val);
+int32_t ism330dlc_pin_mode_set(stmdev_ctx_t *ctx, ism330dlc_pp_od_t val);
+int32_t ism330dlc_pin_mode_get(stmdev_ctx_t *ctx, ism330dlc_pp_od_t *val);
 
 typedef enum {
   ISM330DLC_ACTIVE_HIGH   = 0,
   ISM330DLC_ACTIVE_LOW    = 1,
 } ism330dlc_h_lactive_t;
-int32_t ism330dlc_pin_polarity_set(ism330dlc_ctx_t *ctx, ism330dlc_h_lactive_t val);
-int32_t ism330dlc_pin_polarity_get(ism330dlc_ctx_t *ctx, ism330dlc_h_lactive_t *val);
+int32_t ism330dlc_pin_polarity_set(stmdev_ctx_t *ctx, ism330dlc_h_lactive_t val);
+int32_t ism330dlc_pin_polarity_get(stmdev_ctx_t *ctx, ism330dlc_h_lactive_t *val);
 
-int32_t ism330dlc_all_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_all_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_INT_PULSED   = 0,
   ISM330DLC_INT_LATCHED  = 1,
 } ism330dlc_lir_t;
-int32_t ism330dlc_int_notification_set(ism330dlc_ctx_t *ctx, ism330dlc_lir_t val);
-int32_t ism330dlc_int_notification_get(ism330dlc_ctx_t *ctx, ism330dlc_lir_t *val);
+int32_t ism330dlc_int_notification_set(stmdev_ctx_t *ctx, ism330dlc_lir_t val);
+int32_t ism330dlc_int_notification_get(stmdev_ctx_t *ctx, ism330dlc_lir_t *val);
 
-int32_t ism330dlc_wkup_threshold_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_wkup_threshold_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_wkup_dur_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_wkup_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_gy_sleep_mode_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_gy_sleep_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_PROPERTY_DISABLE          = 0,
@@ -1547,51 +1519,51 @@ typedef enum {
   ISM330DLC_XL_12Hz5_GY_SLEEP         = 2,
   ISM330DLC_XL_12Hz5_GY_PD            = 3,
 } ism330dlc_inact_en_t;
-int32_t ism330dlc_act_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_inact_en_t val);
-int32_t ism330dlc_act_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_inact_en_t *val);
+int32_t ism330dlc_act_mode_set(stmdev_ctx_t *ctx, ism330dlc_inact_en_t val);
+int32_t ism330dlc_act_mode_get(stmdev_ctx_t *ctx, ism330dlc_inact_en_t *val);
 
-int32_t ism330dlc_act_sleep_dur_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_act_sleep_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tap_src_get(ism330dlc_ctx_t *ctx, ism330dlc_tap_src_t *val);
+int32_t ism330dlc_tap_src_get(stmdev_ctx_t *ctx, ism330dlc_tap_src_t *val);
 
-int32_t ism330dlc_tap_detection_on_z_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_tap_detection_on_z_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tap_detection_on_y_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_tap_detection_on_y_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tap_detection_on_x_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_tap_detection_on_x_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tap_threshold_x_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_tap_threshold_x_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tap_shock_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_tap_shock_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tap_quiet_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_tap_quiet_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tap_dur_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_tap_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_ONLY_SINGLE          = 0,
   ISM330DLC_BOTH_SINGLE_DOUBLE   = 1,
 } ism330dlc_single_double_tap_t;
-int32_t ism330dlc_tap_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_tap_mode_set(stmdev_ctx_t *ctx,
                              ism330dlc_single_double_tap_t val);
-int32_t ism330dlc_tap_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_tap_mode_get(stmdev_ctx_t *ctx,
                              ism330dlc_single_double_tap_t *val);
 
 typedef enum {
   ISM330DLC_ODR_DIV_2_FEED      = 0,
   ISM330DLC_LPF2_FEED           = 1,
 } ism330dlc_low_pass_on_6d_t;
-int32_t ism330dlc_6d_feed_data_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_6d_feed_data_set(stmdev_ctx_t *ctx,
                                  ism330dlc_low_pass_on_6d_t val);
-int32_t ism330dlc_6d_feed_data_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_6d_feed_data_get(stmdev_ctx_t *ctx,
                                  ism330dlc_low_pass_on_6d_t *val);
 
 typedef enum {
@@ -1600,14 +1572,14 @@ typedef enum {
   ISM330DLC_DEG_60      = 2,
   ISM330DLC_DEG_50      = 3,
 } ism330dlc_sixd_ths_t;
-int32_t ism330dlc_6d_threshold_set(ism330dlc_ctx_t *ctx, ism330dlc_sixd_ths_t val);
-int32_t ism330dlc_6d_threshold_get(ism330dlc_ctx_t *ctx, ism330dlc_sixd_ths_t *val);
+int32_t ism330dlc_6d_threshold_set(stmdev_ctx_t *ctx, ism330dlc_sixd_ths_t val);
+int32_t ism330dlc_6d_threshold_get(stmdev_ctx_t *ctx, ism330dlc_sixd_ths_t *val);
 
-int32_t ism330dlc_4d_mode_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_4d_mode_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_ff_dur_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_ff_dur_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_FF_TSH_156mg = 0,
@@ -1619,28 +1591,28 @@ typedef enum {
   ISM330DLC_FF_TSH_469mg = 6,
   ISM330DLC_FF_TSH_500mg = 7,
 } ism330dlc_ff_ths_t;
-int32_t ism330dlc_ff_threshold_set(ism330dlc_ctx_t *ctx, ism330dlc_ff_ths_t val);
-int32_t ism330dlc_ff_threshold_get(ism330dlc_ctx_t *ctx, ism330dlc_ff_ths_t *val);
+int32_t ism330dlc_ff_threshold_set(stmdev_ctx_t *ctx, ism330dlc_ff_ths_t val);
+int32_t ism330dlc_ff_threshold_get(stmdev_ctx_t *ctx, ism330dlc_ff_ths_t *val);
 
-int32_t ism330dlc_fifo_watermark_set(ism330dlc_ctx_t *ctx, uint16_t val);
-int32_t ism330dlc_fifo_watermark_get(ism330dlc_ctx_t *ctx, uint16_t *val);
+int32_t ism330dlc_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t ism330dlc_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t ism330dlc_fifo_data_level_get(ism330dlc_ctx_t *ctx, uint16_t *val);
+int32_t ism330dlc_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t ism330dlc_fifo_wtm_flag_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_fifo_pattern_get(ism330dlc_ctx_t *ctx, uint16_t *val);
+int32_t ism330dlc_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t ism330dlc_fifo_temp_batch_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_fifo_temp_batch_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_TRG_XL_GY_DRDY     = 0,
   ISM330DLC_TRG_SH_DRDY        = 1,
 } ism330dlc_trigger_fifo_t;
-int32_t ism330dlc_fifo_write_trigger_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_write_trigger_set(stmdev_ctx_t *ctx,
                                        ism330dlc_trigger_fifo_t val);
-int32_t ism330dlc_fifo_write_trigger_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_write_trigger_get(stmdev_ctx_t *ctx,
                                        ism330dlc_trigger_fifo_t *val);
 
 typedef enum {
@@ -1653,9 +1625,9 @@ typedef enum {
   ISM330DLC_FIFO_XL_DEC_16   = 6,
   ISM330DLC_FIFO_XL_DEC_32   = 7,
 } ism330dlc_dec_fifo_xl_t;
-int32_t ism330dlc_fifo_xl_batch_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                   ism330dlc_dec_fifo_xl_t val);
-int32_t ism330dlc_fifo_xl_batch_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                   ism330dlc_dec_fifo_xl_t *val);
 
 typedef enum {
@@ -1668,9 +1640,9 @@ typedef enum {
   ISM330DLC_FIFO_GY_DEC_16  = 6,
   ISM330DLC_FIFO_GY_DEC_32  = 7,
 } ism330dlc_dec_fifo_gyro_t;
-int32_t ism330dlc_fifo_gy_batch_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                   ism330dlc_dec_fifo_gyro_t val);
-int32_t ism330dlc_fifo_gy_batch_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                   ism330dlc_dec_fifo_gyro_t *val);
 
 typedef enum {
@@ -1683,9 +1655,9 @@ typedef enum {
   ISM330DLC_FIFO_DS3_DEC_16    = 6,
   ISM330DLC_FIFO_DS3_DEC_32    = 7,
 } ism330dlc_dec_ds3_fifo_t;
-int32_t ism330dlc_fifo_dataset_3_batch_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
                                          ism330dlc_dec_ds3_fifo_t val);
-int32_t ism330dlc_fifo_dataset_3_batch_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
                                          ism330dlc_dec_ds3_fifo_t *val);
 
 typedef enum {
@@ -1698,16 +1670,16 @@ typedef enum {
   ISM330DLC_FIFO_DS4_DEC_16   = 6,
   ISM330DLC_FIFO_DS4_DEC_32   = 7,
 } ism330dlc_dec_ds4_fifo_t;
-int32_t ism330dlc_fifo_dataset_4_batch_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
                                          ism330dlc_dec_ds4_fifo_t val);
-int32_t ism330dlc_fifo_dataset_4_batch_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
                                          ism330dlc_dec_ds4_fifo_t *val);
 
-int32_t ism330dlc_fifo_xl_gy_8bit_format_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_fifo_xl_gy_8bit_format_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_fifo_stop_on_wtm_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_fifo_stop_on_wtm_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_BYPASS_MODE           = 0,
@@ -1716,8 +1688,8 @@ typedef enum {
   ISM330DLC_BYPASS_TO_STREAM_MODE = 4,
   ISM330DLC_STREAM_MODE           = 6,
 } ism330dlc_fifo_mode_t;
-int32_t ism330dlc_fifo_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_fifo_mode_t val);
-int32_t ism330dlc_fifo_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_fifo_mode_t *val);
+int32_t ism330dlc_fifo_mode_set(stmdev_ctx_t *ctx, ism330dlc_fifo_mode_t val);
+int32_t ism330dlc_fifo_mode_get(stmdev_ctx_t *ctx, ism330dlc_fifo_mode_t *val);
 
 typedef enum {
   ISM330DLC_FIFO_DISABLE   =  0,
@@ -1732,17 +1704,17 @@ typedef enum {
   ISM330DLC_FIFO_3k33Hz    =  9,
   ISM330DLC_FIFO_6k66Hz    = 10,
 } ism330dlc_odr_fifo_t;
-int32_t ism330dlc_fifo_data_rate_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_data_rate_set(stmdev_ctx_t *ctx,
                                    ism330dlc_odr_fifo_t val);
-int32_t ism330dlc_fifo_data_rate_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_fifo_data_rate_get(stmdev_ctx_t *ctx,
                                    ism330dlc_odr_fifo_t *val);
 
 typedef enum {
   ISM330DLC_DEN_ACT_LOW    = 0,
   ISM330DLC_DEN_ACT_HIGH   = 1,
 } ism330dlc_den_lh_t;
-int32_t ism330dlc_den_polarity_set(ism330dlc_ctx_t *ctx, ism330dlc_den_lh_t val);
-int32_t ism330dlc_den_polarity_get(ism330dlc_ctx_t *ctx, ism330dlc_den_lh_t *val);
+int32_t ism330dlc_den_polarity_set(stmdev_ctx_t *ctx, ism330dlc_den_lh_t val);
+int32_t ism330dlc_den_polarity_get(stmdev_ctx_t *ctx, ism330dlc_den_lh_t *val);
 
 typedef enum {
   ISM330DLC_DEN_DISABLE    = 0,
@@ -1751,52 +1723,52 @@ typedef enum {
   ISM330DLC_LEVEL_TRIGGER  = 2,
   ISM330DLC_EDGE_TRIGGER   = 4,
 } ism330dlc_den_mode_t;
-int32_t ism330dlc_den_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t val);
-int32_t ism330dlc_den_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_den_mode_t *val);
+int32_t ism330dlc_den_mode_set(stmdev_ctx_t *ctx, ism330dlc_den_mode_t val);
+int32_t ism330dlc_den_mode_get(stmdev_ctx_t *ctx, ism330dlc_den_mode_t *val);
 
 typedef enum {
   ISM330DLC_STAMP_IN_GY_DATA     = 0,
   ISM330DLC_STAMP_IN_XL_DATA     = 1,
   ISM330DLC_STAMP_IN_GY_XL_DATA  = 2,
 } ism330dlc_den_xl_en_t;
-int32_t ism330dlc_den_enable_set(ism330dlc_ctx_t *ctx, ism330dlc_den_xl_en_t val);
-int32_t ism330dlc_den_enable_get(ism330dlc_ctx_t *ctx, ism330dlc_den_xl_en_t *val);
+int32_t ism330dlc_den_enable_set(stmdev_ctx_t *ctx, ism330dlc_den_xl_en_t val);
+int32_t ism330dlc_den_enable_get(stmdev_ctx_t *ctx, ism330dlc_den_xl_en_t *val);
 
-int32_t ism330dlc_den_mark_axis_z_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_den_mark_axis_z_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_den_mark_axis_y_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_den_mark_axis_y_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_den_mark_axis_x_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_den_mark_axis_x_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tilt_sens_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_tilt_sens_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_wrist_tilt_sens_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_wrist_tilt_sens_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_wrist_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_wrist_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_tilt_latency_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
-int32_t ism330dlc_tilt_latency_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_tilt_latency_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_tilt_latency_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism330dlc_tilt_threshold_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
-int32_t ism330dlc_tilt_threshold_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_tilt_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_tilt_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism330dlc_mag_soft_iron_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_mag_soft_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_mag_hard_iron_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_mag_hard_iron_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_mag_soft_iron_mat_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
-int32_t ism330dlc_mag_soft_iron_mat_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_mag_soft_iron_mat_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_mag_soft_iron_mat_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism330dlc_mag_offset_set(ism330dlc_ctx_t *ctx, uint8_t *buff);
-int32_t ism330dlc_mag_offset_get(ism330dlc_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t ism330dlc_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t ism330dlc_sh_sync_sens_frame_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_sh_sync_sens_frame_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_RES_RATIO_2_11  = 0,
@@ -1804,33 +1776,33 @@ typedef enum {
   ISM330DLC_RES_RATIO_2_13  = 2,
   ISM330DLC_RES_RATIO_2_14  = 3,
 } ism330dlc_rr_t;
-int32_t ism330dlc_sh_sync_sens_ratio_set(ism330dlc_ctx_t *ctx, ism330dlc_rr_t val);
-int32_t ism330dlc_sh_sync_sens_ratio_get(ism330dlc_ctx_t *ctx, ism330dlc_rr_t *val);
+int32_t ism330dlc_sh_sync_sens_ratio_set(stmdev_ctx_t *ctx, ism330dlc_rr_t val);
+int32_t ism330dlc_sh_sync_sens_ratio_get(stmdev_ctx_t *ctx, ism330dlc_rr_t *val);
 
-int32_t ism330dlc_sh_master_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_sh_master_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_sh_pass_through_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_sh_pass_through_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_EXT_PULL_UP       = 0,
   ISM330DLC_INTERNAL_PULL_UP  = 1,
 } ism330dlc_pull_up_en_t;
-int32_t ism330dlc_sh_pin_mode_set(ism330dlc_ctx_t *ctx, ism330dlc_pull_up_en_t val);
-int32_t ism330dlc_sh_pin_mode_get(ism330dlc_ctx_t *ctx, ism330dlc_pull_up_en_t *val);
+int32_t ism330dlc_sh_pin_mode_set(stmdev_ctx_t *ctx, ism330dlc_pull_up_en_t val);
+int32_t ism330dlc_sh_pin_mode_get(stmdev_ctx_t *ctx, ism330dlc_pull_up_en_t *val);
 
 typedef enum {
   ISM330DLC_XL_GY_DRDY        = 0,
   ISM330DLC_EXT_ON_INT2_PIN   = 1,
 } ism330dlc_start_config_t;
-int32_t ism330dlc_sh_syncro_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                    ism330dlc_start_config_t val);
-int32_t ism330dlc_sh_syncro_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    ism330dlc_start_config_t *val);
 
-int32_t ism330dlc_sh_drdy_on_int1_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_sh_drdy_on_int1_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_sh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
     ism330dlc_sensorhub1_reg_t   sh_byte_1;
@@ -1852,22 +1824,22 @@ typedef struct {
     ism330dlc_sensorhub17_reg_t  sh_byte_17;
     ism330dlc_sensorhub18_reg_t  sh_byte_18;
 } ism330dlc_emb_sh_read_t;
-int32_t ism330dlc_sh_read_data_raw_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                      ism330dlc_emb_sh_read_t *val);
 
-int32_t ism330dlc_sh_cmd_sens_sync_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_sh_cmd_sens_sync_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_sh_cmd_sens_sync_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_cmd_sens_sync_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t ism330dlc_sh_spi_sync_error_set(ism330dlc_ctx_t *ctx, uint8_t val);
-int32_t ism330dlc_sh_spi_sync_error_get(ism330dlc_ctx_t *ctx, uint8_t *val);
+int32_t ism330dlc_sh_spi_sync_error_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t ism330dlc_sh_spi_sync_error_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   ISM330DLC_NORMAL_MODE_READ  = 0,
   ISM330DLC_SRC_MODE_READ     = 1,
 } ism330dlc_src_mode_t;
-int32_t ism330dlc_sh_cfg_slave_0_rd_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_cfg_slave_0_rd_mode_set(stmdev_ctx_t *ctx,
                                            ism330dlc_src_mode_t val);
-int32_t ism330dlc_sh_cfg_slave_0_rd_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_cfg_slave_0_rd_mode_get(stmdev_ctx_t *ctx,
                                            ism330dlc_src_mode_t *val);
 
 typedef enum {
@@ -1876,9 +1848,9 @@ typedef enum {
   ISM330DLC_SLV_0_1_2    = 2,
   ISM330DLC_SLV_0_1_2_3  = 3,
 } ism330dlc_aux_sens_on_t;
-int32_t ism330dlc_sh_num_of_dev_connected_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
                                             ism330dlc_aux_sens_on_t val);
-int32_t ism330dlc_sh_num_of_dev_connected_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
                                             ism330dlc_aux_sens_on_t *val);
 
 typedef struct{
@@ -1886,20 +1858,20 @@ typedef struct{
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } ism330dlc_sh_cfg_write_t;
-int32_t ism330dlc_sh_cfg_write(ism330dlc_ctx_t *ctx, ism330dlc_sh_cfg_write_t *val);
+int32_t ism330dlc_sh_cfg_write(stmdev_ctx_t *ctx, ism330dlc_sh_cfg_write_t *val);
 
 typedef struct{
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } ism330dlc_sh_cfg_read_t;
-int32_t ism330dlc_sh_slv0_cfg_read(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  ism330dlc_sh_cfg_read_t *val);
-int32_t ism330dlc_sh_slv1_cfg_read(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  ism330dlc_sh_cfg_read_t *val);
-int32_t ism330dlc_sh_slv2_cfg_read(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  ism330dlc_sh_cfg_read_t *val);
-int32_t ism330dlc_sh_slv3_cfg_read(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  ism330dlc_sh_cfg_read_t *val);
 
 typedef enum {
@@ -1908,18 +1880,18 @@ typedef enum {
   ISM330DLC_SL0_DEC_4    = 2,
   ISM330DLC_SL0_DEC_8    = 3,
 } ism330dlc_slave0_rate_t;
-int32_t ism330dlc_sh_slave_0_dec_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_0_dec_set(stmdev_ctx_t *ctx,
                                    ism330dlc_slave0_rate_t val);
-int32_t ism330dlc_sh_slave_0_dec_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_0_dec_get(stmdev_ctx_t *ctx,
                                    ism330dlc_slave0_rate_t *val);
 
 typedef enum {
   ISM330DLC_EACH_SH_CYCLE     = 0,
   ISM330DLC_ONLY_FIRST_CYCLE  = 1,
 } ism330dlc_write_once_t;
-int32_t ism330dlc_sh_write_mode_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_write_mode_set(stmdev_ctx_t *ctx,
                                   ism330dlc_write_once_t val);
-int32_t ism330dlc_sh_write_mode_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_write_mode_get(stmdev_ctx_t *ctx,
                                   ism330dlc_write_once_t *val);
 
 typedef enum {
@@ -1928,9 +1900,9 @@ typedef enum {
   ISM330DLC_SL1_DEC_4    = 2,
   ISM330DLC_SL1_DEC_8    = 3,
 } ism330dlc_slave1_rate_t;
-int32_t ism330dlc_sh_slave_1_dec_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_1_dec_set(stmdev_ctx_t *ctx,
                                    ism330dlc_slave1_rate_t val);
-int32_t ism330dlc_sh_slave_1_dec_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_1_dec_get(stmdev_ctx_t *ctx,
                                    ism330dlc_slave1_rate_t *val);
 
 typedef enum {
@@ -1939,9 +1911,9 @@ typedef enum {
   ISM330DLC_SL2_DEC_4   = 2,
   ISM330DLC_SL2_DEC_8   = 3,
 } ism330dlc_slave2_rate_t;
-int32_t ism330dlc_sh_slave_2_dec_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_2_dec_set(stmdev_ctx_t *ctx,
                                    ism330dlc_slave2_rate_t val);
-int32_t ism330dlc_sh_slave_2_dec_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_2_dec_get(stmdev_ctx_t *ctx,
                                    ism330dlc_slave2_rate_t *val);
 
 typedef enum {
@@ -1950,9 +1922,9 @@ typedef enum {
   ISM330DLC_SL3_DEC_4   = 2,
   ISM330DLC_SL3_DEC_8   = 3,
 } ism330dlc_slave3_rate_t;
-int32_t ism330dlc_sh_slave_3_dec_set(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_3_dec_set(stmdev_ctx_t *ctx,
                                    ism330dlc_slave3_rate_t val);
-int32_t ism330dlc_sh_slave_3_dec_get(ism330dlc_ctx_t *ctx,
+int32_t ism330dlc_sh_slave_3_dec_get(stmdev_ctx_t *ctx,
                                    ism330dlc_slave3_rate_t *val);
 
 /**

--- a/sensor/stmemsc/l20g20is_STdC/driver/l20g20is_reg.c
+++ b/sensor/stmemsc/l20g20is_STdC/driver/l20g20is_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 #include "l20g20is_reg.h"
 
@@ -62,7 +45,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t l20g20is_read_reg(l20g20is_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t l20g20is_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -80,7 +63,7 @@ int32_t l20g20is_read_reg(l20g20is_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t l20g20is_write_reg(l20g20is_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t l20g20is_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -136,7 +119,7 @@ float_t l20g20is_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_flag_data_ready_get(l20g20is_ctx_t *ctx, uint8_t *val)
+int32_t l20g20is_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   l20g20is_data_status_ois_t data_status_ois;
   int32_t ret;
@@ -156,7 +139,7 @@ int32_t l20g20is_gy_flag_data_ready_get(l20g20is_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_data_rate_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_data_rate_set(stmdev_ctx_t *ctx,
                                   l20g20is_gy_data_rate_t val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
@@ -179,7 +162,7 @@ int32_t l20g20is_gy_data_rate_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_data_rate_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_data_rate_get(stmdev_ctx_t *ctx,
                                   l20g20is_gy_data_rate_t *val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
@@ -213,7 +196,7 @@ int32_t l20g20is_gy_data_rate_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_orient_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_orient_set(stmdev_ctx_t *ctx,
                                l20g20is_gy_orient_t val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
@@ -247,7 +230,7 @@ int32_t l20g20is_gy_orient_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_orient_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_orient_get(stmdev_ctx_t *ctx,
                                          l20g20is_gy_orient_t *val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
@@ -272,7 +255,7 @@ int32_t l20g20is_gy_orient_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_block_data_update_set(l20g20is_ctx_t *ctx, uint8_t val)
+int32_t l20g20is_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -294,7 +277,7 @@ int32_t l20g20is_block_data_update_set(l20g20is_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_block_data_update_get(l20g20is_ctx_t *ctx, uint8_t *val)
+int32_t l20g20is_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -314,7 +297,7 @@ int32_t l20g20is_block_data_update_get(l20g20is_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_angular_rate_offset_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_angular_rate_offset_set(stmdev_ctx_t *ctx,
                                          l20g20is_off_t val)
 {
   l20g20is_off_x_t off_x;
@@ -346,7 +329,7 @@ int32_t l20g20is_angular_rate_offset_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_angular_rate_offset_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_angular_rate_offset_get(stmdev_ctx_t *ctx,
                                           l20g20is_off_t *val)
 {
   l20g20is_off_x_t off_x;
@@ -372,7 +355,7 @@ int32_t l20g20is_angular_rate_offset_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_full_scale_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_full_scale_set(stmdev_ctx_t *ctx,
                                    l20g20is_gy_fs_t val)
 {
   l20g20is_ois_cfg_reg_t ois_cfg_reg;
@@ -396,7 +379,7 @@ int32_t l20g20is_gy_full_scale_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_full_scale_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_full_scale_get(stmdev_ctx_t *ctx,
                                    l20g20is_gy_fs_t *val)
 {
   l20g20is_ois_cfg_reg_t ois_cfg_reg;
@@ -439,7 +422,7 @@ int32_t l20g20is_gy_full_scale_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_temperature_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff)
+int32_t l20g20is_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = l20g20is_read_reg(ctx, L20G20IS_TEMP_OUT_L, buff, 2);
@@ -455,7 +438,7 @@ int32_t l20g20is_temperature_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_angular_rate_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff)
+int32_t l20g20is_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = l20g20is_read_reg(ctx, L20G20IS_OUT_X_L, buff, 4);
@@ -482,7 +465,7 @@ int32_t l20g20is_angular_rate_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_dev_id_get(l20g20is_ctx_t *ctx, uint8_t *buff)
+int32_t l20g20is_dev_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = l20g20is_read_reg(ctx, L20G20IS_WHO_AM_I, buff, 1);
@@ -497,7 +480,7 @@ int32_t l20g20is_dev_id_get(l20g20is_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_dev_status_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_dev_status_get(stmdev_ctx_t *ctx,
                                 l20g20is_dev_status_t *val)
 {
   l20g20is_data_status_ois_t data_status_ois;
@@ -518,7 +501,7 @@ int32_t l20g20is_dev_status_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_dev_data_format_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_dev_data_format_set(stmdev_ctx_t *ctx,
                                      l20g20is_ble_t val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
@@ -541,7 +524,7 @@ int32_t l20g20is_dev_data_format_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_dev_data_format_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_dev_data_format_get(stmdev_ctx_t *ctx,
                                      l20g20is_ble_t *val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
@@ -570,7 +553,7 @@ int32_t l20g20is_dev_data_format_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_dev_boot_set(l20g20is_ctx_t *ctx, uint8_t val)
+int32_t l20g20is_dev_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -591,7 +574,7 @@ int32_t l20g20is_dev_boot_set(l20g20is_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_dev_boot_get(l20g20is_ctx_t *ctx, uint8_t *val)
+int32_t l20g20is_dev_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -610,7 +593,7 @@ int32_t l20g20is_dev_boot_get(l20g20is_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_dev_reset_set(l20g20is_ctx_t *ctx, uint8_t val)
+int32_t l20g20is_dev_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   l20g20is_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
@@ -632,7 +615,7 @@ int32_t l20g20is_dev_reset_set(l20g20is_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_dev_reset_get(l20g20is_ctx_t *ctx, uint8_t *val)
+int32_t l20g20is_dev_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   l20g20is_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
@@ -664,7 +647,7 @@ int32_t l20g20is_dev_reset_get(l20g20is_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_filter_hp_bandwidth_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                             l20g20is_gy_hp_bw_t val)
 {
   l20g20is_ctrl2_ois_t ctrl2_ois;
@@ -698,32 +681,38 @@ int32_t l20g20is_gy_filter_hp_bandwidth_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_filter_hp_bandwidth_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                             l20g20is_gy_hp_bw_t *val)
 {
   l20g20is_ctrl2_ois_t ctrl2_ois;
+  l20g20is_ois_cfg_reg_t ois_cfg_reg;
   int32_t ret;
 
   ret = l20g20is_read_reg(ctx, L20G20IS_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
-  switch (ctrl2_ois.hpf){
-    case L20G20IS_HPF_BYPASS:
-      *val = L20G20IS_HPF_BYPASS;
-      break;
-    case L20G20IS_HPF_BW_23mHz:
-      *val = L20G20IS_HPF_BW_23mHz;
-      break;
-    case L20G20IS_HPF_BW_91mHz:
-      *val = L20G20IS_HPF_BW_91mHz;
-      break;
-    case L20G20IS_HPF_BW_324mHz:
-      *val = L20G20IS_HPF_BW_324mHz;
-      break;
-    case L20G20IS_HPF_BW_1Hz457:
-      *val = L20G20IS_HPF_BW_1Hz457;
-      break;
-    default:
-      *val = L20G20IS_HPF_BYPASS;
-      break;
+  if(ret == 0){
+    ret = l20g20is_read_reg(ctx, L20G20IS_OIS_CFG_REG,
+                            (uint8_t*)&ois_cfg_reg, 1);
+
+    switch ( ( ctrl2_ois.hpf << 4 ) + ois_cfg_reg.hpf_bw){
+      case L20G20IS_HPF_BYPASS:
+        *val = L20G20IS_HPF_BYPASS;
+        break;
+      case L20G20IS_HPF_BW_23mHz:
+        *val = L20G20IS_HPF_BW_23mHz;
+        break;
+      case L20G20IS_HPF_BW_91mHz:
+        *val = L20G20IS_HPF_BW_91mHz;
+        break;
+      case L20G20IS_HPF_BW_324mHz:
+        *val = L20G20IS_HPF_BW_324mHz;
+        break;
+      case L20G20IS_HPF_BW_1Hz457:
+        *val = L20G20IS_HPF_BW_1Hz457;
+        break;
+      default:
+        *val = L20G20IS_HPF_BYPASS;
+        break;
+    }
   }
   return ret;
 }
@@ -736,7 +725,7 @@ int32_t l20g20is_gy_filter_hp_bandwidth_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_filter_hp_reset_set(l20g20is_ctx_t *ctx, uint8_t val)
+int32_t l20g20is_gy_filter_hp_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   l20g20is_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
@@ -757,7 +746,7 @@ int32_t l20g20is_gy_filter_hp_reset_set(l20g20is_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_filter_hp_reset_get(l20g20is_ctx_t *ctx, uint8_t *val)
+int32_t l20g20is_gy_filter_hp_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   l20g20is_ctrl2_ois_t ctrl2_ois;
   int32_t ret;
@@ -776,7 +765,7 @@ int32_t l20g20is_gy_filter_hp_reset_get(l20g20is_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_filter_lp_bandwidth_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_filter_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                             l20g20is_gy_lp_bw_t val)
 {
   l20g20is_ctrl2_ois_t ctrl2_ois;
@@ -808,7 +797,7 @@ int32_t l20g20is_gy_filter_lp_bandwidth_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_filter_lp_bandwidth_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_filter_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                             l20g20is_gy_lp_bw_t *val)
 {
   l20g20is_ctrl2_ois_t ctrl2_ois;
@@ -863,7 +852,7 @@ int32_t l20g20is_gy_filter_lp_bandwidth_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_spi_mode_set(l20g20is_ctx_t *ctx, l20g20is_sim_t val)
+int32_t l20g20is_spi_mode_set(stmdev_ctx_t *ctx, l20g20is_sim_t val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -884,7 +873,7 @@ int32_t l20g20is_spi_mode_set(l20g20is_ctx_t *ctx, l20g20is_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_spi_mode_get(l20g20is_ctx_t *ctx, l20g20is_sim_t *val)
+int32_t l20g20is_spi_mode_get(stmdev_ctx_t *ctx, l20g20is_sim_t *val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -925,7 +914,7 @@ int32_t l20g20is_spi_mode_get(l20g20is_ctx_t *ctx, l20g20is_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_pin_notification_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_notification_set(stmdev_ctx_t *ctx,
                                       l20g20is_lir_t val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
@@ -948,7 +937,7 @@ int32_t l20g20is_pin_notification_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_pin_notification_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_notification_get(stmdev_ctx_t *ctx,
                                       l20g20is_lir_t *val)
 {
   l20g20is_ctrl1_ois_t ctrl1_ois;
@@ -977,7 +966,7 @@ int32_t l20g20is_pin_notification_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_pin_polarity_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_polarity_set(stmdev_ctx_t *ctx,
                                   l20g20is_pin_pol_t val)
 {
   l20g20is_ctrl3_ois_t ctrl3_ois;
@@ -1000,7 +989,7 @@ int32_t l20g20is_pin_polarity_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_pin_polarity_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_polarity_get(stmdev_ctx_t *ctx,
                                   l20g20is_pin_pol_t *val)
 {
   l20g20is_ctrl3_ois_t ctrl3_ois;
@@ -1029,7 +1018,7 @@ int32_t l20g20is_pin_polarity_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_pin_mode_set(l20g20is_ctx_t *ctx, l20g20is_pp_od_t val)
+int32_t l20g20is_pin_mode_set(stmdev_ctx_t *ctx, l20g20is_pp_od_t val)
 {
   l20g20is_ctrl4_ois_t ctrl4_ois;
   int32_t ret;
@@ -1050,7 +1039,7 @@ int32_t l20g20is_pin_mode_set(l20g20is_ctx_t *ctx, l20g20is_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_pin_mode_get(l20g20is_ctx_t *ctx, l20g20is_pp_od_t *val)
+int32_t l20g20is_pin_mode_get(stmdev_ctx_t *ctx, l20g20is_pp_od_t *val)
 {
   l20g20is_ctrl4_ois_t ctrl4_ois;
   int32_t ret;
@@ -1079,7 +1068,7 @@ int32_t l20g20is_pin_mode_get(l20g20is_ctx_t *ctx, l20g20is_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_pin_drdy_route_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_drdy_route_set(stmdev_ctx_t *ctx,
                                     l20g20is_pin_drdy_route_t val)
 {
   l20g20is_ctrl4_ois_t ctrl4_ois;
@@ -1103,7 +1092,7 @@ int32_t l20g20is_pin_drdy_route_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_pin_drdy_route_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_drdy_route_get(stmdev_ctx_t *ctx,
                                     l20g20is_pin_drdy_route_t *val)
 {
   l20g20is_ctrl4_ois_t ctrl4_ois;
@@ -1137,7 +1126,7 @@ int32_t l20g20is_pin_drdy_route_get(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_self_test_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_self_test_set(stmdev_ctx_t *ctx,
                                   l20g20is_gy_self_test_t val)
 {
   l20g20is_ctrl3_ois_t ctrl3_ois;
@@ -1161,7 +1150,7 @@ int32_t l20g20is_gy_self_test_set(l20g20is_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t l20g20is_gy_self_test_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_self_test_get(stmdev_ctx_t *ctx,
                                   l20g20is_gy_self_test_t *val)
 {
   l20g20is_ctrl3_ois_t ctrl3_ois;

--- a/sensor/stmemsc/l20g20is_STdC/driver/l20g20is_reg.h
+++ b/sensor/stmemsc/l20g20is_STdC/driver/l20g20is_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef L20G20IS_REGS_H
 #define L20G20IS_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup L20G20IS_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  L20G20IS_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -125,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*l20g20is_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*l20g20is_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  l20g20is_write_ptr  write_reg;
-  l20g20is_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} l20g20is_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -266,9 +239,9 @@ typedef union{
   *
   */
 
-int32_t l20g20is_read_reg(l20g20is_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t l20g20is_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t l20g20is_write_reg(l20g20is_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t l20g20is_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t l20g20is_from_fs100dps_to_mdps(int16_t lsb);
@@ -276,16 +249,16 @@ extern float_t l20g20is_from_fs200dps_to_mdps(int16_t lsb);
 
 extern float_t l20g20is_from_lsb_to_celsius(int16_t lsb);
 
-int32_t l20g20is_gy_flag_data_ready_get(l20g20is_ctx_t *ctx, uint8_t *val);
+int32_t l20g20is_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   L20G20IS_GY_OFF    = 0,
   L20G20IS_GY_SLEEP  = 2,
   L20G20IS_GY_9k33Hz = 3,
 } l20g20is_gy_data_rate_t;
-int32_t l20g20is_gy_data_rate_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_data_rate_set(stmdev_ctx_t *ctx,
                                   l20g20is_gy_data_rate_t val);
-int32_t l20g20is_gy_data_rate_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_data_rate_get(stmdev_ctx_t *ctx,
                                   l20g20is_gy_data_rate_t *val);
 
 typedef struct {
@@ -293,58 +266,58 @@ typedef struct {
   uint8_t signy     : 1;
   uint8_t signx     : 1;
 } l20g20is_gy_orient_t;
-int32_t l20g20is_gy_orient_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_orient_set(stmdev_ctx_t *ctx,
                                l20g20is_gy_orient_t val);
-int32_t l20g20is_gy_orient_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_orient_get(stmdev_ctx_t *ctx,
                                l20g20is_gy_orient_t *val);
 
-int32_t l20g20is_block_data_update_set(l20g20is_ctx_t *ctx, uint8_t val);
-int32_t l20g20is_block_data_update_get(l20g20is_ctx_t *ctx, uint8_t *val);
+int32_t l20g20is_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l20g20is_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t offx             : 7;
   uint8_t offy             : 7;
 } l20g20is_off_t;
-int32_t l20g20is_angular_rate_offset_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_angular_rate_offset_set(stmdev_ctx_t *ctx,
                                          l20g20is_off_t val);
-int32_t l20g20is_angular_rate_offset_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_angular_rate_offset_get(stmdev_ctx_t *ctx,
                                          l20g20is_off_t *val);
 
 typedef enum {
   L20G20IS_100dps   = 0,
   L20G20IS_200dps   = 1,
 } l20g20is_gy_fs_t;
-int32_t l20g20is_gy_full_scale_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_full_scale_set(stmdev_ctx_t *ctx,
                                    l20g20is_gy_fs_t val);
-int32_t l20g20is_gy_full_scale_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_full_scale_get(stmdev_ctx_t *ctx,
                                    l20g20is_gy_fs_t *val);
 
-int32_t l20g20is_temperature_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff);
+int32_t l20g20is_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t l20g20is_angular_rate_raw_get(l20g20is_ctx_t *ctx, uint8_t *buff);
+int32_t l20g20is_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t l20g20is_dev_id_get(l20g20is_ctx_t *ctx, uint8_t *buff);
+int32_t l20g20is_dev_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef struct {
   uint8_t xyda_ois             : 1;
 } l20g20is_dev_status_t;
-int32_t l20g20is_dev_status_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_dev_status_get(stmdev_ctx_t *ctx,
                                 l20g20is_dev_status_t *val);
 
 typedef enum {
   L20G20IS_LSB_LOW_ADDRESS = 0,
   L20G20IS_MSB_LOW_ADDRESS = 1,
 } l20g20is_ble_t;
-int32_t l20g20is_dev_data_format_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_dev_data_format_set(stmdev_ctx_t *ctx,
                                      l20g20is_ble_t val);
-int32_t l20g20is_dev_data_format_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_dev_data_format_get(stmdev_ctx_t *ctx,
                                      l20g20is_ble_t *val);
 
-int32_t l20g20is_dev_boot_set(l20g20is_ctx_t *ctx, uint8_t val);
-int32_t l20g20is_dev_boot_get(l20g20is_ctx_t *ctx, uint8_t *val);
+int32_t l20g20is_dev_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l20g20is_dev_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t l20g20is_dev_reset_set(l20g20is_ctx_t *ctx, uint8_t val);
-int32_t l20g20is_dev_reset_get(l20g20is_ctx_t *ctx, uint8_t *val);
+int32_t l20g20is_dev_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l20g20is_dev_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   L20G20IS_HPF_BYPASS    = 0x00,
@@ -353,13 +326,13 @@ typedef enum {
   L20G20IS_HPF_BW_324mHz = 0x82,
   L20G20IS_HPF_BW_1Hz457 = 0x83,
 } l20g20is_gy_hp_bw_t;
-int32_t l20g20is_gy_filter_hp_bandwidth_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                             l20g20is_gy_hp_bw_t val);
-int32_t l20g20is_gy_filter_hp_bandwidth_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                             l20g20is_gy_hp_bw_t *val);
 
-int32_t l20g20is_gy_filter_hp_reset_set(l20g20is_ctx_t *ctx, uint8_t val);
-int32_t l20g20is_gy_filter_hp_reset_get(l20g20is_ctx_t *ctx, uint8_t *val);
+int32_t l20g20is_gy_filter_hp_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l20g20is_gy_filter_hp_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   L20G20IS_LPF_BW_290Hz  = 0x00,
@@ -368,50 +341,50 @@ typedef enum {
   L20G20IS_LPF_BW_450Hz  = 0x03,
   L20G20IS_LPF_BW_1150Hz = 0x04,
 } l20g20is_gy_lp_bw_t;
-int32_t l20g20is_gy_filter_lp_bandwidth_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_filter_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                             l20g20is_gy_lp_bw_t val);
-int32_t l20g20is_gy_filter_lp_bandwidth_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_filter_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                             l20g20is_gy_lp_bw_t *val);
 
 typedef enum {
   L20G20IS_SPI_4_WIRE = 0,
   L20G20IS_SPI_3_WIRE = 1,
 } l20g20is_sim_t;
-int32_t l20g20is_spi_mode_set(l20g20is_ctx_t *ctx, l20g20is_sim_t val);
-int32_t l20g20is_spi_mode_get(l20g20is_ctx_t *ctx, l20g20is_sim_t *val);
+int32_t l20g20is_spi_mode_set(stmdev_ctx_t *ctx, l20g20is_sim_t val);
+int32_t l20g20is_spi_mode_get(stmdev_ctx_t *ctx, l20g20is_sim_t *val);
 
 typedef enum {
   L20G20IS_INT_PULSED = 1,
   L20G20IS_INT_LATCHED = 0,
 } l20g20is_lir_t;
-int32_t l20g20is_pin_notification_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_notification_set(stmdev_ctx_t *ctx,
                                       l20g20is_lir_t val);
-int32_t l20g20is_pin_notification_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_notification_get(stmdev_ctx_t *ctx,
                                       l20g20is_lir_t *val);
 
 typedef enum {
   L20G20IS_ACTIVE_HIGH = 0,
   L20G20IS_ACTIVE_LOW = 1,
 } l20g20is_pin_pol_t;
-int32_t l20g20is_pin_polarity_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_polarity_set(stmdev_ctx_t *ctx,
                                   l20g20is_pin_pol_t val);
-int32_t l20g20is_pin_polarity_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_polarity_get(stmdev_ctx_t *ctx,
                                   l20g20is_pin_pol_t *val);
 
 typedef enum {
   L20G20IS_PUSH_PULL = 0,
   L20G20IS_OPEN_DRAIN = 1,
 } l20g20is_pp_od_t;
-int32_t l20g20is_pin_mode_set(l20g20is_ctx_t *ctx, l20g20is_pp_od_t val);
-int32_t l20g20is_pin_mode_get(l20g20is_ctx_t *ctx, l20g20is_pp_od_t *val);
+int32_t l20g20is_pin_mode_set(stmdev_ctx_t *ctx, l20g20is_pp_od_t val);
+int32_t l20g20is_pin_mode_get(stmdev_ctx_t *ctx, l20g20is_pp_od_t *val);
 
 typedef struct {
   uint8_t temp_data_on_drdy             : 1;
   uint8_t drdy_en                       : 1;
 } l20g20is_pin_drdy_route_t;
-int32_t l20g20is_pin_drdy_route_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_drdy_route_set(stmdev_ctx_t *ctx,
                                     l20g20is_pin_drdy_route_t val);
-int32_t l20g20is_pin_drdy_route_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_pin_drdy_route_get(stmdev_ctx_t *ctx,
                                     l20g20is_pin_drdy_route_t *val);
 
 typedef enum {
@@ -419,9 +392,9 @@ typedef enum {
   L20G20IS_ST_POSITIVE = 0x02,
   L20G20IS_ST_NEGATIVE = 0x03,
 } l20g20is_gy_self_test_t;
-int32_t l20g20is_gy_self_test_set(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_self_test_set(stmdev_ctx_t *ctx,
                                   l20g20is_gy_self_test_t val);
-int32_t l20g20is_gy_self_test_get(l20g20is_ctx_t *ctx,
+int32_t l20g20is_gy_self_test_get(stmdev_ctx_t *ctx,
                                   l20g20is_gy_self_test_t *val);
 
 /**

--- a/sensor/stmemsc/l3gd20h_STdC/driver/l3gd20h_reg.c
+++ b/sensor/stmemsc/l3gd20h_STdC/driver/l3gd20h_reg.c
@@ -1,0 +1,2070 @@
+/*
+ ******************************************************************************
+ * @file    l3gd20h_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   L3GD20H driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+#include "l3gd20h_reg.h"
+
+/**
+  * @defgroup    L3GD20H
+  * @brief      This file provides a set of functions needed to drive the
+  *              l3gd20h enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Interfaces_Functions
+  * @brief      This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t l3gd20h_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t l3gd20h_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Sensitivity
+  * @brief      These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t l3gd20h_from_fs245_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 8.75f);
+}
+
+float_t l3gd20h_from_fs500_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 17.50f);
+}
+
+float_t l3gd20h_from_fs2000_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t l3gd20h_from_lsb_to_celsius(int16_t lsb)
+{
+  return ((float_t)lsb +25.0f);
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Datageneration
+  * @brief      This section groups all the functions concerning data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable gyroscope axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Gyroscope’s pitch axis (X) output enable..
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_axis_set(stmdev_ctx_t *ctx, l3gd20h_gy_axis_t val)
+{
+  l3gd20h_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0) {
+    ctrl1.xen  = val.xen;
+    ctrl1.yen  = val.yen;
+    ctrl1.zen  = val.zen;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable gyroscope axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Gyroscope’s pitch axis (X) output enable..(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_axis_get(stmdev_ctx_t *ctx, l3gd20h_gy_axis_t *val)
+{
+  l3gd20h_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  val->xen = ctrl1.xen;
+  val->yen = ctrl1.yen;
+  val->zen = ctrl1.zen;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "pd" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_data_rate_set(stmdev_ctx_t *ctx,
+                                 l3gd20h_gy_data_rate_t val)
+{
+  l3gd20h_low_odr_t low_odr;
+  l3gd20h_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ctrl1.pd = ( (uint8_t)val & 0x80U ) >> 7;
+    ctrl1.dr = (uint8_t)val & 0x07U;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  }
+  if(ret == 0){
+    low_odr.low_odr = ( (uint8_t)val & 0x10U ) >> 4;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pd in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_data_rate_get(stmdev_ctx_t *ctx,
+                                 l3gd20h_gy_data_rate_t *val)
+{
+  l3gd20h_low_odr_t low_odr;
+  l3gd20h_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  }
+  switch ((ctrl1.pd << 7) + (low_odr.low_odr << 4) + ctrl1.dr){
+    case L3GD20H_POWER_DOWN:
+      *val = L3GD20H_POWER_DOWN;
+      break;
+    case L3GD20H_12Hz5:
+      *val = L3GD20H_12Hz5;
+      break;
+    case L3GD20H_25Hz:
+      *val = L3GD20H_25Hz;
+      break;
+    case L3GD20H_50Hz:
+      *val = L3GD20H_50Hz;
+      break;
+    case L3GD20H_100Hz:
+      *val = L3GD20H_100Hz;
+      break;
+    case L3GD20H_200Hz:
+      *val = L3GD20H_200Hz;
+      break;
+    case L3GD20H_400Hz:
+      *val = L3GD20H_400Hz;
+      break;
+    case L3GD20H_800Hz:
+      *val = L3GD20H_800Hz;
+      break;
+    default:
+      *val = L3GD20H_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope full-scale selection..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fs" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_full_scale_set(stmdev_ctx_t *ctx, l3gd20h_gy_fs_t val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.fs = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Gyroscope full-scale selection..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_full_scale_get(stmdev_ctx_t *ctx, l3gd20h_gy_fs_t *val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch (ctrl4.fs){
+    case L3GD20H_245dps:
+      *val = L3GD20H_245dps;
+      break;
+    case L3GD20H_500dps:
+      *val = L3GD20H_500dps;
+      break;
+    default:
+      *val = L3GD20H_245dps;
+      break;
+  }
+  return ret;
+}
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL4.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.bdu = val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  *val = ctrl4.bdu;
+
+  return ret;
+}
+/**
+  * @brief  Gyroscope new data available..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "zyxda" in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_status_t status;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_STATUS, (uint8_t*)&status, 1);
+  *val = status.zyxda;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Dataoutput
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data output register (r). L and H registers together
+  *          express a 16-bit word in two’s complement..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = l3gd20h_read_reg(ctx, L3GD20H_OUT_TEMP, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit
+  *          word in two’s complement..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = l3gd20h_read_reg(ctx, L3GD20H_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores the data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_dev_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = l3gd20h_read_reg(ctx, L3GD20H_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "ble" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_dev_data_format_set(stmdev_ctx_t *ctx, l3gd20h_ble_t val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.ble = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian data selection..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ble in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_dev_data_format_get(stmdev_ctx_t *ctx, l3gd20h_ble_t *val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch (ctrl4.ble){
+    case L3GD20H_LSB_LOW_ADDRESS:
+      *val = L3GD20H_LSB_LOW_ADDRESS;
+      break;
+    case L3GD20H_MSB_LOW_ADDRESS:
+      *val = L3GD20H_MSB_LOW_ADDRESS;
+      break;
+    default:
+      *val = L3GD20H_LSB_LOW_ADDRESS;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL5.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_dev_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.boot = val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_dev_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  *val = ctrl5.boot;
+
+  return ret;
+}
+/**
+  * @brief  Device status register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     X axis new data available..(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_dev_status_get(stmdev_ctx_t *ctx, l3gd20h_status_reg_t *val)
+{
+  l3gd20h_status_t status;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_STATUS, (uint8_t*)&status, 1);
+  val->xda   = status.xda;
+  val->yda   = status.yda;
+  val->zda   = status.zda;
+  val->zyxda = status.zyxda;
+  val->_xor  = status._xor;
+  val->yor   = status.yor;
+  val->zor   = status.zor;
+  val->zyxor = status.zyxor;
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_res in reg LOW_ODR.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_dev_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  l3gd20h_low_odr_t low_odr;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  if(ret == 0){
+    low_odr.sw_res = val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sw_res in reg LOW_ODR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_dev_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_low_odr_t low_odr;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  *val = low_odr.sw_res;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Filters
+  * @brief       This section group all the functions concerning the
+  *              filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Low pass filter cutoff frequency.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "bw" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_lp_bandwidth_set(stmdev_ctx_t *ctx,
+                                           l3gd20h_lpbw_t val)
+{
+  l3gd20h_ctrl1_t ctrl1;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ctrl1.bw = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter cutoff frequency.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bw in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_lp_bandwidth_get(stmdev_ctx_t *ctx,
+                                           l3gd20h_lpbw_t *val)
+{
+  l3gd20h_low_odr_t low_odr;
+  l3gd20h_ctrl1_t ctrl1;
+  int32_t ret;
+  
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  }
+  switch ((low_odr.low_odr << 7) + (ctrl1.dr << 4) + ctrl1.bw){
+    case L3GD20H_16Hz6_USE_ODR_50Hz:
+      *val = L3GD20H_16Hz6_USE_ODR_50Hz;
+      break;
+    case L3GD20H_12Hz5_USE_ODR_100Hz:
+      *val = L3GD20H_12Hz5_USE_ODR_100Hz;
+      break;
+    case L3GD20H_25Hz_USE_ODR_100Hz:
+      *val = L3GD20H_25Hz_USE_ODR_100Hz;
+      break;
+    case L3GD20H_12Hz5_USE_ODR_200Hz:
+      *val = L3GD20H_12Hz5_USE_ODR_200Hz;
+      break;
+    case L3GD20H_70Hz_USE_ODR_200Hz:
+      *val = L3GD20H_70Hz_USE_ODR_200Hz;
+      break;
+    case L3GD20H_20Hz_USE_ODR_400Hz:
+      *val = L3GD20H_20Hz_USE_ODR_400Hz;
+      break;
+    case L3GD20H_25Hz_USE_ODR_400Hz:
+      *val = L3GD20H_25Hz_USE_ODR_400Hz;
+      break;
+    case L3GD20H_50Hz_USE_ODR_400Hz:
+      *val = L3GD20H_50Hz_USE_ODR_400Hz;
+      break;
+    case L3GD20H_110Hz_USE_ODR_400Hz:
+      *val = L3GD20H_110Hz_USE_ODR_400Hz;
+      break;
+    case L3GD20H_30Hz_USE_ODR_800Hz:
+      *val = L3GD20H_30Hz_USE_ODR_800Hz;
+      break;
+    case L3GD20H_35Hz_USE_ODR_800Hz:
+      *val = L3GD20H_35Hz_USE_ODR_800Hz;
+      break;
+    case L3GD20H_100Hz_USE_ODR_800Hz:
+      *val = L3GD20H_100Hz_USE_ODR_800Hz;
+      break;
+    default:
+      *val = L3GD20H_16Hz6_USE_ODR_50Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope high-pass filter bandwidth selection..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "hpcf" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
+                                            l3gd20h_gy_hp_bw_t val)
+{
+  l3gd20h_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.hpcf = (uint8_t)val & 0x03U;
+    ctrl2.hpm = ((uint8_t)val & 0x30U) >> 4;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope high-pass filter bandwidth selection..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpcf in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
+                                            l3gd20h_gy_hp_bw_t *val)
+{
+  l3gd20h_ctrl2_t ctrl2;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  switch ( (ctrl2.hpm << 4) + ctrl2.hpcf){
+    case L3GD20H_NORMAL_MODE_LIGHT:
+      *val = L3GD20H_NORMAL_MODE_LIGHT;
+      break;
+    case L3GD20H_NORMAL_MODE_NORMAL:
+      *val = L3GD20H_NORMAL_MODE_NORMAL;
+      break;
+    case L3GD20H_NORMAL_MODE_STRONG:
+      *val = L3GD20H_NORMAL_MODE_STRONG;
+      break;
+    case L3GD20H_NORMAL_MODE_EXTREME:
+      *val = L3GD20H_NORMAL_MODE_EXTREME;
+      break;
+    case L3GD20H_USE_REFERENCE_LIGHT:
+      *val = L3GD20H_USE_REFERENCE_LIGHT;
+      break;
+    case L3GD20H_USE_REFERENCE_NORMAL:
+      *val = L3GD20H_USE_REFERENCE_NORMAL;
+      break;
+    case L3GD20H_USE_REFERENCE_STRONG:
+      *val = L3GD20H_USE_REFERENCE_STRONG;
+      break;
+    case L3GD20H_USE_REFERENCE_EXTREME:
+      *val = L3GD20H_USE_REFERENCE_EXTREME;
+      break;
+    case L3GD20H_AUTORESET_LIGHT:
+      *val = L3GD20H_AUTORESET_LIGHT;
+      break;
+    case L3GD20H_AUTORESET_NORMAL:
+      *val = L3GD20H_AUTORESET_NORMAL;
+      break;
+    case L3GD20H_AUTORESET_STRONG:
+      *val = L3GD20H_AUTORESET_STRONG;
+      break;
+    case L3GD20H_AUTORESET_EXTREME:
+      *val = L3GD20H_AUTORESET_EXTREME;
+      break;
+    default:
+      *val = L3GD20H_NORMAL_MODE_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyro output filter path configuration..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "out_sel" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_out_path_set(stmdev_ctx_t *ctx,
+                                       l3gd20h_gy_out_path_t val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.out_sel = (uint8_t)val & 0x03U;
+    ctrl5.hpen = ( (uint8_t)val & 0x10U ) >> 4;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyro output filter path configuration..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of out_sel in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_out_path_get(stmdev_ctx_t *ctx,
+                                       l3gd20h_gy_out_path_t *val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  int32_t ret;
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  switch (( ctrl5.hpen << 4 ) + ctrl5.out_sel ){
+    case L3GD20H_LPF1_OUT:
+      *val = L3GD20H_LPF1_OUT;
+      break;
+    case L3GD20H_LPF1_HPF_OUT:
+      *val = L3GD20H_LPF1_HPF_OUT;
+      break;
+    case L3GD20H_LPF1_LPF2_OUT:
+      *val = L3GD20H_LPF1_LPF2_OUT;
+      break;
+    case L3GD20H_LPF1_HPF_LPF2_OUT:
+      *val = L3GD20H_LPF1_HPF_LPF2_OUT;
+      break;
+    default:
+      *val = L3GD20H_LPF1_OUT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyro interrupt filter path configuration..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "ig_sel" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_int_path_set(stmdev_ctx_t *ctx,
+                                       l3gd20h_gy_int_path_t val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.ig_sel = (uint8_t)val & 0x03U;
+    ctrl5.hpen = ( (uint8_t)val & 0x10U ) >> 4;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyro interrupt filter path configuration..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ig_sel in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_int_path_get(stmdev_ctx_t *ctx,
+                                       l3gd20h_gy_int_path_t *val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5,
+                            (uint8_t*)&ctrl5, 1);
+  switch (( ctrl5.hpen << 4 ) + ctrl5.ig_sel ){
+    case L3GD20H_LPF1_INT:
+      *val = L3GD20H_LPF1_INT;
+      break;
+    case L3GD20H_LPF1_HPF_INT:
+      *val = L3GD20H_LPF1_HPF_INT;
+      break;
+    case L3GD20H_LPF1_LPF2_INT:
+      *val = L3GD20H_LPF1_LPF2_INT;
+      break;
+    case L3GD20H_LPF1_HPF_LPF2_INT:
+      *val = L3GD20H_LPF1_HPF_LPF2_INT;
+      break;
+    default:
+      *val = L3GD20H_LPF1_INT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reference value for gyroscope’s digital high-pass filter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data to be write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = l3gd20h_write_reg(ctx, L3GD20H_REFERENCE, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Reference value for gyroscope’s digital high-pass filter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = l3gd20h_read_reg(ctx, L3GD20H_REFERENCE,
+                             buff, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Serialinterface
+  * @brief       This section groups all the functions concerning main
+  *              serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "sim" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_spi_mode_set(stmdev_ctx_t *ctx, l3gd20h_sim_t val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.sim = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_spi_mode_get(stmdev_ctx_t *ctx, l3gd20h_sim_t *val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch (ctrl4.sim){
+    case L3GD20H_SPI_4_WIRE:
+      *val = L3GD20H_SPI_4_WIRE;
+      break;
+    case L3GD20H_SPI_3_WIRE:
+      *val = L3GD20H_SPI_3_WIRE;
+      break;
+    default:
+      *val = L3GD20H_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disable I2C interface..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "i2c_dis" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_i2c_interface_set(stmdev_ctx_t *ctx, l3gd20h_i2c_dis_t val)
+{
+  l3gd20h_low_odr_t low_odr;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  if(ret == 0){
+    low_odr.i2c_dis = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disable I2C interface..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_dis in reg LOW_ODR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_i2c_interface_get(stmdev_ctx_t *ctx, l3gd20h_i2c_dis_t *val)
+{
+  l3gd20h_low_odr_t low_odr;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  switch (low_odr.i2c_dis){
+    case L3GD20H_I2C_ENABLE:
+      *val = L3GD20H_I2C_ENABLE;
+      break;
+    case L3GD20H_I2C_DISABLE:
+      *val = L3GD20H_I2C_DISABLE;
+      break;
+    default:
+      *val = L3GD20H_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Interruptpins
+  * @brief       This section groups all the functions that manage interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Route a signal on INT 2_A/G pin..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     FIFO Empty interrupt on DRDY/INT2 pin..
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                   l3gd20h_pin_int2_rt_t val)
+{
+  l3gd20h_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0) {
+    ctrl3.int2_empty = val.int2_empty;
+    ctrl3.int2_fth = val.int2_fth;
+    ctrl3.int2_orun = val.int2_orun;
+    ctrl3.int2_drdy = val.int2_drdy;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT 2_A/G pin..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     FIFO Empty interrupt on DRDY/INT2 pin..(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                   l3gd20h_pin_int2_rt_t *val)
+{
+  l3gd20h_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  val->int2_empty = ctrl3.int2_empty;
+  val->int2_orun = ctrl3.int2_orun;
+  val->int2_fth = ctrl3.int2_fth;
+  val->int2_drdy = ctrl3.int2_drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "pp_od" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_mode_set(stmdev_ctx_t *ctx, l3gd20h_pp_od_t val)
+{
+  l3gd20h_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.pp_od = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_mode_get(stmdev_ctx_t *ctx, l3gd20h_pp_od_t *val)
+{
+  l3gd20h_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  switch (ctrl3.pp_od){
+    case L3GD20H_PUSH_PULL:
+      *val = L3GD20H_PUSH_PULL;
+      break;
+    case L3GD20H_OPEN_DRAIN:
+      *val = L3GD20H_OPEN_DRAIN;
+      break;
+    default:
+      *val = L3GD20H_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.Interrupt active-high/low..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "h_lactive" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_polarity_set(stmdev_ctx_t *ctx, l3gd20h_pin_pol_t val)
+{
+  l3gd20h_low_odr_t low_odr;
+  l3gd20h_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  if(ret == 0){
+    low_odr.drdy_hl = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_LOW_ODR, (uint8_t*)&low_odr, 1);
+  }
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  if(ret == 0){
+    ctrl3.h_lactive = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.Interrupt active-high/low..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_polarity_get(stmdev_ctx_t *ctx, l3gd20h_pin_pol_t *val)
+{
+  l3gd20h_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  switch (ctrl3.h_lactive){
+    case L3GD20H_ACTIVE_HIGH:
+      *val = L3GD20H_ACTIVE_HIGH;
+      break;
+    case L3GD20H_ACTIVE_LOW:
+      *val = L3GD20H_ACTIVE_LOW;
+      break;
+    default:
+      *val = L3GD20H_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Boot status available on INT1 pin..
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                   l3gd20h_pin_int1_rt_t val)
+{
+  l3gd20h_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0) {
+    ctrl3.int1_boot  = val.int1_boot;
+    ctrl3.int1_ig  = val.int1_ig;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Route a signal on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     Boot status available on INT1 pin..(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                   l3gd20h_pin_int1_rt_t *val)
+{
+  l3gd20h_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL3, (uint8_t*)&ctrl3, 1);
+  val->int1_boot = ctrl3.int1_boot;
+  val->int1_ig = ctrl3.int1_ig;
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "lir" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_notification_set(stmdev_ctx_t *ctx, l3gd20h_lir_t val)
+{
+  l3gd20h_ig_cfg_t ig_cfg;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_CFG, (uint8_t*)&ig_cfg, 1);
+  if(ret == 0){
+    ig_cfg.lir = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_CFG, (uint8_t*)&ig_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg IG_CFG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_notification_get(stmdev_ctx_t *ctx, l3gd20h_lir_t *val)
+{
+  l3gd20h_ig_cfg_t ig_cfg;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_CFG,
+                            (uint8_t*)&ig_cfg, 1);
+  switch (ig_cfg.lir){
+    case L3GD20H_INT_PULSED:
+      *val = L3GD20H_INT_PULSED;
+      break;
+    case L3GD20H_INT_LATCHED:
+      *val = L3GD20H_INT_LATCHED;
+      break;
+    default:
+      *val = L3GD20H_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of accelerometer’s interrupt events..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "and_or" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_logic_set(stmdev_ctx_t *ctx, l3gd20h_pin_logic_t val)
+{
+  l3gd20h_ig_cfg_t ig_cfg;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_CFG, (uint8_t*)&ig_cfg, 1);
+  if(ret == 0){
+    ig_cfg.and_or = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_CFG, (uint8_t*)&ig_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  AND/OR combination of accelerometer’s interrupt events..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of and_or in reg IG_CFG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_pin_logic_get(stmdev_ctx_t *ctx, l3gd20h_pin_logic_t *val)
+{
+  l3gd20h_ig_cfg_t ig_cfg;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_CFG, (uint8_t*)&ig_cfg, 1);
+  switch (ig_cfg.and_or){
+    case L3GD20H_LOGIC_OR:
+      *val = L3GD20H_LOGIC_OR;
+      break;
+    case L3GD20H_LOGIC_AND:
+      *val = L3GD20H_LOGIC_AND;
+      break;
+    default:
+      *val = L3GD20H_LOGIC_OR;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Interrupt on threshold
+  * @brief       This section group all the functions concerning the
+  *              interrupt on threshold configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable interrupt generation on threshold event..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Enable interrupt generation on gyroscope’s pitch (X)
+  *                axis low event..
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_axis_set(stmdev_ctx_t *ctx,
+                                   l3gd20h_gy_trshld_en_t val)
+{
+  l3gd20h_ig_cfg_t ig_cfg;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_CFG, (uint8_t*)&ig_cfg, 1);
+  if(ret == 0) {
+    ig_cfg.xlie  = val.xlie;
+    ig_cfg.xhie  = val.xhie;
+    ig_cfg.ylie  = val.ylie;
+    ig_cfg.yhie  = val.yhie;
+    ig_cfg.zlie  = val.zlie;
+    ig_cfg.zhie  = val.zhie;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_CFG, (uint8_t*)&ig_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on threshold event..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Enable interrupt generation on gyroscope’s pitch (X)
+  *                axis low event..(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_axis_get(stmdev_ctx_t *ctx,
+                                   l3gd20h_gy_trshld_en_t *val)
+{
+  l3gd20h_ig_cfg_t ig_cfg;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_CFG,
+                            (uint8_t*)&ig_cfg, 1);
+  val->xlie = ig_cfg.xlie;
+  val->xhie = ig_cfg.xhie;
+  val->ylie = ig_cfg.ylie;
+  val->yhie = ig_cfg.yhie;
+  val->zlie = ig_cfg.zlie;
+  val->zhie = ig_cfg.zhie;
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt on threshold source..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Pitch(X)low..(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_src_get(stmdev_ctx_t *ctx,
+                                  l3gd20h_gy_trshld_src_t *val)
+{
+  l3gd20h_ig_src_t ig_src;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_SRC, (uint8_t*)&ig_src, 1);
+  val->xl = ig_src.xl;
+  val->xh = ig_src.xh;
+  val->yl = ig_src.yl;
+  val->yh = ig_src.yh;
+  val->zl = ig_src.zl;
+  val->zh = ig_src.zh;
+  val->ia = ig_src.ia;
+
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on pitch (X) axis..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsx in reg IG_THS_XH.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_x_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  l3gd20h_ig_ths_xl_t ig_ths_xl;
+  l3gd20h_ig_ths_xh_t ig_ths_xh;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_XL, (uint8_t*)&ig_ths_xl, 1);
+  if(ret == 0){
+    ig_ths_xl.thsx = (uint8_t)( val & 0xFFU );
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_THS_XL, (uint8_t*)&ig_ths_xl, 1);
+  }
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_XH, (uint8_t*)&ig_ths_xh, 1);
+  }
+  if(ret == 0){
+    ig_ths_xh.thsx = (uint8_t)( (val & 0x7F00U ) >> 8 );
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_THS_XH, (uint8_t*)&ig_ths_xh, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on pitch (X) axis..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsx in reg IG_THS_XH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_x_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  l3gd20h_ig_ths_xl_t ig_ths_xl;
+  l3gd20h_ig_ths_xh_t ig_ths_xh;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_XL, (uint8_t*)&ig_ths_xl, 1);
+  if(ret == 0){
+      ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_XH, (uint8_t*)&ig_ths_xh, 1);
+      *val = ig_ths_xh.thsx;
+      *val = *val << 8;
+      *val += ig_ths_xl.thsx;
+  }
+
+
+  return ret;
+}
+/**
+  * @brief  Decrement or reset counter mode selection..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "dcrm" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_mode_set(stmdev_ctx_t *ctx, l3gd20h_dcrm_g_t val)
+{
+  l3gd20h_ig_ths_xh_t ig_ths_xh;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_XH, (uint8_t*)&ig_ths_xh, 1);
+  if(ret == 0){
+    ig_ths_xh.dcrm = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_THS_XH, (uint8_t*)&ig_ths_xh, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decrement or reset counter mode selection..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dcrm in reg IG_THS_XH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_mode_get(stmdev_ctx_t *ctx, l3gd20h_dcrm_g_t *val)
+{
+  l3gd20h_ig_ths_xh_t ig_ths_xh;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_XH, (uint8_t*)&ig_ths_xh, 1);
+  switch (ig_ths_xh.dcrm){
+    case L3GD20H_RESET_MODE:
+      *val = L3GD20H_RESET_MODE;
+      break;
+    case L3GD20H_DECREMENT_MODE:
+      *val = L3GD20H_DECREMENT_MODE;
+      break;
+    default:
+      *val = L3GD20H_RESET_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on roll (Y) axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsy in reg IG_THS_YH.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_y_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  l3gd20h_ig_ths_yh_t ig_ths_yh;
+  l3gd20h_ig_ths_yl_t ig_ths_yl;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_YL, (uint8_t*)&ig_ths_yl, 1);
+  if(ret == 0){
+    ig_ths_yl.thsy = (uint8_t)(val & 0xFFU);
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_THS_YL, (uint8_t*)&ig_ths_yl, 1);
+  }
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_YH, (uint8_t*)&ig_ths_yh, 1);
+  }
+  if(ret == 0){
+    ig_ths_yh.thsy = (uint8_t)( (val & 0x7F00U) >> 8);
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_THS_YH, (uint8_t*)&ig_ths_yh, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on roll (Y) axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsy in reg IG_THS_YH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_y_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  l3gd20h_ig_ths_yh_t ig_ths_yh;
+  l3gd20h_ig_ths_yl_t ig_ths_yl;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_YL, (uint8_t*)&ig_ths_yl, 1);
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_YH, (uint8_t*)&ig_ths_yh, 1);
+    *val = ig_ths_yh.thsy;
+    *val = *val << 8;
+    *val += ig_ths_yl.thsy;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on roll (Z) axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of thsz in reg IG_THS_ZH.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_z_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  l3gd20h_ig_ths_zh_t ig_ths_zh;
+  l3gd20h_ig_ths_zl_t ig_ths_zl;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_ZL, (uint8_t*)&ig_ths_zl, 1);
+  if(ret == 0){
+    ig_ths_zl.thsz = (uint8_t)(val & 0xFFU);
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_THS_ZL, (uint8_t*)&ig_ths_zl, 1);
+  }
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_ZH, (uint8_t*)&ig_ths_zh, 1);
+  }
+  if(ret == 0){
+    ig_ths_zh.thsz = (uint8_t)( (val & 0x7F00U) >> 8);
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_THS_ZH, (uint8_t*)&ig_ths_zh, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor interrupt threshold on roll (Z) axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of thsz in reg IG_THS_ZH.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_z_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  l3gd20h_ig_ths_zh_t ig_ths_zh;
+  l3gd20h_ig_ths_zl_t ig_ths_zl;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_ZL, (uint8_t*)&ig_ths_zl, 1);
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_IG_THS_ZH, (uint8_t*)&ig_ths_zh, 1);
+    *val = ig_ths_zh.thsz;
+    *val = *val << 8;
+    *val += ig_ths_zh.thsz;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enter/exit interrupt duration value..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d in reg IG_DURATION.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_min_sample_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  l3gd20h_ig_duration_t ig_duration;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_DURATION, (uint8_t*)&ig_duration, 1);
+  if(ret == 0){
+    ig_duration.d = val;
+    if (val != 0x00U){
+      ig_duration.wait = PROPERTY_ENABLE;
+    }
+    else{
+      ig_duration.wait = PROPERTY_DISABLE;
+    }
+    ret = l3gd20h_write_reg(ctx, L3GD20H_IG_DURATION,
+                            (uint8_t*)&ig_duration, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enter/exit interrupt duration value..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of d in reg IG_DURATION.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_trshld_min_sample_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_ig_duration_t ig_duration;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_IG_DURATION, (uint8_t*)&ig_duration, 1);
+  *val = ig_duration.d;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Fifo
+  * @brief       This section group all the functions concerning the fifo usage.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold level.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stoponfth in reg CTRL5.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.stoponfth = val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold level.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of stoponfth in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  *val = ctrl5.stoponfth;
+
+  return ret;
+}
+/**
+  * @brief  FIFO mode selection..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "fifo_en" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_mode_set(stmdev_ctx_t *ctx, l3gd20h_fifo_m_t val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  l3gd20h_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.fm = ( (uint8_t)val & 0x07U );
+    ret = l3gd20h_write_reg(ctx, L3GD20H_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  if(ret == 0){
+    ctrl5.fifo_en = ( ( (uint8_t)val & 0x10U ) >> 4);
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_mode_get(stmdev_ctx_t *ctx, l3gd20h_fifo_m_t *val)
+{
+  l3gd20h_ctrl5_t ctrl5;
+  l3gd20h_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  switch ((ctrl5.fifo_en << 4) + fifo_ctrl.fm) {
+    case L3GD20H_BYPASS_MODE:
+      *val = L3GD20H_BYPASS_MODE;
+      break;
+    case L3GD20H_FIFO_MODE:
+      *val = L3GD20H_FIFO_MODE;
+      break;
+    case L3GD20H_STREAM_MODE:
+      *val = L3GD20H_STREAM_MODE;
+      break;
+    case L3GD20H_STREAM_TO_FIFO_MODE:
+      *val = L3GD20H_STREAM_TO_FIFO_MODE;
+      break;
+    case L3GD20H_BYPASS_TO_STREAM_MODE:
+      *val = L3GD20H_BYPASS_TO_STREAM_MODE;
+      break;
+    case L3GD20H_BYPASS_TO_FIFO_MODE:
+      *val = L3GD20H_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = L3GD20H_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+/**
+  * @brief  FIFO watermark level selection..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fth in reg FIFO_CTRL.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  l3gd20h_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.fth = val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = fifo_ctrl.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO source register..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val     FIFO stored data level of the unread samples..(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_src_get(stmdev_ctx_t *ctx, l3gd20h_fifo_srs_t *val)
+{
+  l3gd20h_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  val->fss = fifo_src.fss;
+  val->empty = fifo_src.empty;
+  val->ovrn = fifo_src.ovrn;
+  val->fth = fifo_src.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level of the unread samples..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "fss" in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFOfullstatus.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "fss" in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Iet the values of "fth" in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  l3gd20h_fifo_src_t fifo_src;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fth;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_DENPin
+  * @brief       This section group all the functions concerning DEN pin usage.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DEN pin mode..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "lvlen" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_den_mode_set(stmdev_ctx_t *ctx, l3gd20h_den_md_t val)
+{
+  l3gd20h_ctrl2_t ctrl2;
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.impen = (uint8_t)val & 0x01U;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  if(ret == 0){
+    ctrl2.lvlen = ((uint8_t)val & 0x04U) >> 2;
+    ctrl2.extren = ((uint8_t)val & 0x02U) >> 1;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN pin mode..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lvlen in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_den_mode_get(stmdev_ctx_t *ctx, l3gd20h_den_md_t *val)
+{
+  l3gd20h_ctrl2_t ctrl2;
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  switch ( (ctrl2.lvlen << 2) + (ctrl2.extren << 1) + ctrl4.impen ){
+    case L3GD20H_DEN_DISABLE:
+      *val = L3GD20H_DEN_DISABLE;
+      break;
+    case L3GD20H_DEN_ON_LEVEL_TRIGGER:
+      *val = L3GD20H_DEN_ON_LEVEL_TRIGGER;
+      break;
+    case L3GD20H_DEN_ON_EDGE_TRIGGER:
+      *val = L3GD20H_DEN_ON_EDGE_TRIGGER;
+      break;
+    case L3GD20H_DEN_IMPULSE_TRIGGER:
+      *val = L3GD20H_DEN_IMPULSE_TRIGGER;
+      break;
+    default:
+      *val = L3GD20H_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    L3GD20H_Selftest
+  * @brief       This section groups all the functions that manage self
+  *              test configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable/disable self-test mode for gyroscope..[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of "st" in reg L3GD20H.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_self_test_set(stmdev_ctx_t *ctx, l3gd20h_st_t val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.st = (uint8_t)val;
+    ret = l3gd20h_write_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/disable self-test mode for gyroscope..[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t l3gd20h_gy_self_test_get(stmdev_ctx_t *ctx, l3gd20h_st_t *val)
+{
+  l3gd20h_ctrl4_t ctrl4;
+  int32_t ret;
+
+  ret = l3gd20h_read_reg(ctx, L3GD20H_CTRL4, (uint8_t*)&ctrl4, 1);
+  switch (ctrl4.st){
+    case L3GD20H_ST_DISABLE:
+      *val = L3GD20H_ST_DISABLE;
+      break;
+    case L3GD20H_ST_POSITIVE:
+      *val = L3GD20H_ST_POSITIVE;
+      break;
+    case L3GD20H_ST_NEGATIVE:
+      *val = L3GD20H_ST_NEGATIVE;
+      break;
+    default:
+      *val = L3GD20H_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/l3gd20h_STdC/driver/l3gd20h_reg.h
+++ b/sensor/stmemsc/l3gd20h_STdC/driver/l3gd20h_reg.h
@@ -1,0 +1,644 @@
+/*
+ ******************************************************************************
+ * @file    l3gd20h_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          l3gd20h_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef L3GD20H_REGS_H
+#define L3GD20H_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup L3GD20H
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup L3GD20H_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> 0xD5 if SA0=1 -> 0xD7 **/
+#define L3GD20H_I2C_ADD_L     0xD5U
+#define L3GD20H_I2C_ADD_H     0xD7U
+
+/** Device Identification (Who am I) **/
+#define L3GD20H_ID            0xD7U
+
+/**
+  * @}
+  *
+  */
+
+#define L3GD20H_WHO_AM_I                0x0FU
+#define L3GD20H_CTRL1                   0x20U
+typedef struct {
+  uint8_t xen                 : 1;
+  uint8_t yen                 : 1;
+  uint8_t zen                 : 1;
+  uint8_t pd                  : 1;
+  uint8_t bw                  : 2;
+  uint8_t dr                  : 2;
+} l3gd20h_ctrl1_t;
+
+#define L3GD20H_CTRL2                   0x21U
+typedef struct {
+  uint8_t hpcf                : 4;
+  uint8_t hpm                 : 2;
+  uint8_t lvlen               : 1;
+  uint8_t extren              : 1;
+} l3gd20h_ctrl2_t;
+
+#define L3GD20H_CTRL3                   0x22U
+typedef struct {
+  uint8_t int2_empty          : 1;
+  uint8_t int2_orun           : 1;
+  uint8_t int2_fth            : 1;
+  uint8_t int2_drdy           : 1;
+  uint8_t pp_od               : 1;
+  uint8_t h_lactive           : 1;
+  uint8_t int1_boot           : 1;
+  uint8_t int1_ig             : 1;
+} l3gd20h_ctrl3_t;
+
+#define L3GD20H_CTRL4                   0x23U
+typedef struct {
+  uint8_t sim                 : 1;
+  uint8_t st                  : 2;
+  uint8_t impen               : 1;
+  uint8_t fs                  : 2;
+  uint8_t ble                 : 1;
+  uint8_t bdu                 : 1;
+} l3gd20h_ctrl4_t;
+
+#define L3GD20H_CTRL5                   0x24U
+typedef struct {
+  uint8_t out_sel             : 2;
+  uint8_t ig_sel              : 2;
+  uint8_t hpen                : 1;
+  uint8_t stoponfth           : 1;
+  uint8_t fifo_en             : 1;
+  uint8_t boot                : 1;
+} l3gd20h_ctrl5_t;
+
+#define L3GD20H_REFERENCE               0x25U
+#define L3GD20H_OUT_TEMP                0x26U
+#define L3GD20H_STATUS                  0x27U
+typedef struct {
+  uint8_t xda                 : 1;
+  uint8_t yda                 : 1;
+  uint8_t zda                 : 1;
+  uint8_t zyxda               : 1;
+  uint8_t _xor                : 1;
+  uint8_t yor                 : 1;
+  uint8_t zor                 : 1;
+  uint8_t zyxor               : 1;
+} l3gd20h_status_t;
+
+#define L3GD20H_OUT_X_L                 0x28U
+#define L3GD20H_OUT_X_H                 0x29U
+#define L3GD20H_OUT_Y_L                 0x2AU
+#define L3GD20H_OUT_Y_H                 0x2BU
+#define L3GD20H_OUT_Z_L                 0x2CU
+#define L3GD20H_OUT_Z_H                 0x2DU
+#define L3GD20H_FIFO_CTRL               0x2EU
+typedef struct {
+  uint8_t fth                 : 5;
+  uint8_t fm                  : 3;
+} l3gd20h_fifo_ctrl_t;
+
+#define L3GD20H_FIFO_SRC                0x2FU
+typedef struct {
+  uint8_t fss                 : 5;
+  uint8_t empty               : 1;
+  uint8_t ovrn                : 1;
+  uint8_t fth                 : 1;
+} l3gd20h_fifo_src_t;
+
+#define L3GD20H_IG_CFG                  0x30U
+typedef struct {
+  uint8_t xlie                : 1;
+  uint8_t xhie                : 1;
+  uint8_t ylie                : 1;
+  uint8_t yhie                : 1;
+  uint8_t zlie                : 1;
+  uint8_t zhie                : 1;
+  uint8_t lir                 : 1;
+  uint8_t and_or              : 1;
+} l3gd20h_ig_cfg_t;
+
+#define L3GD20H_IG_SRC                  0x31U
+typedef struct {
+  uint8_t xl                  : 1;
+  uint8_t xh                  : 1;
+  uint8_t yl                  : 1;
+  uint8_t yh                  : 1;
+  uint8_t zl                  : 1;
+  uint8_t zh                  : 1;
+  uint8_t ia                  : 1;
+  uint8_t not_used_01         : 1;
+} l3gd20h_ig_src_t;
+
+#define L3GD20H_IG_THS_XH               0x32U
+typedef struct {
+  uint8_t thsx                : 7;
+  uint8_t dcrm                : 1;
+} l3gd20h_ig_ths_xh_t;
+
+#define L3GD20H_IG_THS_XL               0x33U
+typedef struct {
+  uint8_t thsx                : 8;
+} l3gd20h_ig_ths_xl_t;
+
+#define L3GD20H_IG_THS_YH               0x34U
+typedef struct {
+  uint8_t thsy                : 7;
+  uint8_t not_used_01         : 1;
+} l3gd20h_ig_ths_yh_t;
+
+#define L3GD20H_IG_THS_YL               0x35U
+typedef struct {
+  uint8_t thsy                : 8;
+} l3gd20h_ig_ths_yl_t;
+
+#define L3GD20H_IG_THS_ZH               0x36U
+typedef struct {
+  uint8_t thsz                : 7;
+  uint8_t not_used_01         : 1;
+} l3gd20h_ig_ths_zh_t;
+
+#define L3GD20H_IG_THS_ZL               0x37U
+typedef struct {
+  uint8_t thsz                : 8;
+} l3gd20h_ig_ths_zl_t;
+
+#define L3GD20H_IG_DURATION             0x38U
+typedef struct {
+  uint8_t d                   : 7;
+  uint8_t wait                : 1;
+} l3gd20h_ig_duration_t;
+
+#define L3GD20H_LOW_ODR                 0x39U
+typedef struct {
+  uint8_t low_odr             : 1;
+  uint8_t not_used_01         : 1;
+  uint8_t sw_res              : 1;
+  uint8_t i2c_dis             : 1;
+  uint8_t not_used_02         : 1;
+  uint8_t drdy_hl             : 1;
+  uint8_t not_used_03         : 2;
+} l3gd20h_low_odr_t;
+
+/**
+  * @defgroup L3GD20H_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  l3gd20h_ctrl1_t             ctrl1;
+  l3gd20h_ctrl2_t             ctrl2;
+  l3gd20h_ctrl3_t             ctrl3;
+  l3gd20h_ctrl4_t             ctrl4;
+  l3gd20h_ctrl5_t             ctrl5;
+  l3gd20h_status_t            status;
+  l3gd20h_fifo_ctrl_t         fifo_ctrl;
+  l3gd20h_fifo_src_t          fifo_src;
+  l3gd20h_ig_cfg_t            ig_cfg;
+  l3gd20h_ig_src_t            ig_src;
+  l3gd20h_ig_ths_xh_t         ig_ths_xh;
+  l3gd20h_ig_ths_xl_t         ig_ths_xl;
+  l3gd20h_ig_ths_yh_t         ig_ths_yh;
+  l3gd20h_ig_ths_yl_t         ig_ths_yl;
+  l3gd20h_ig_ths_zh_t         ig_ths_zh;
+  l3gd20h_ig_ths_zl_t         ig_ths_zl;
+  l3gd20h_ig_duration_t       ig_duration;
+  l3gd20h_low_odr_t           low_odr;
+  bitwise_t                   bitwise;
+  uint8_t                     byte;
+} l3gd20h_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t l3gd20h_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t l3gd20h_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t l3gd20h_from_fs245_to_mdps(int16_t lsb);
+extern float_t l3gd20h_from_fs500_to_mdps(int16_t lsb);
+extern float_t l3gd20h_from_fs2000_to_mdps(int16_t lsb);
+
+extern float_t l3gd20h_from_lsb_to_celsius(int16_t lsb);
+
+typedef struct {
+  uint8_t xen             : 1;
+  uint8_t yen             : 1;
+  uint8_t zen             : 1;
+} l3gd20h_gy_axis_t;
+int32_t l3gd20h_gy_axis_set(stmdev_ctx_t *ctx, l3gd20h_gy_axis_t val);
+int32_t l3gd20h_gy_axis_get(stmdev_ctx_t *ctx, l3gd20h_gy_axis_t *val);
+
+typedef enum {
+  L3GD20H_POWER_DOWN    = 0x00,
+  L3GD20H_12Hz5         = 0x90,
+  L3GD20H_25Hz          = 0x91,
+  L3GD20H_50Hz          = 0x92,
+  L3GD20H_100Hz         = 0x80,
+  L3GD20H_200Hz         = 0x81,
+  L3GD20H_400Hz         = 0x82,
+  L3GD20H_800Hz         = 0x83,
+} l3gd20h_gy_data_rate_t;
+int32_t l3gd20h_gy_data_rate_set(stmdev_ctx_t *ctx, 
+                                 l3gd20h_gy_data_rate_t val);
+int32_t l3gd20h_gy_data_rate_get(stmdev_ctx_t *ctx,
+                                 l3gd20h_gy_data_rate_t *val);
+
+
+typedef enum {
+  L3GD20H_245dps    = 0x00,
+  L3GD20H_500dps    = 0x01,
+  L3GD20H_2000dps   = 0x02,
+} l3gd20h_gy_fs_t;
+int32_t l3gd20h_gy_full_scale_set(stmdev_ctx_t *ctx, l3gd20h_gy_fs_t val);
+int32_t l3gd20h_gy_full_scale_get(stmdev_ctx_t *ctx, l3gd20h_gy_fs_t *val);
+
+int32_t l3gd20h_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l3gd20h_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t l3gd20h_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t l3gd20h_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t l3gd20h_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t l3gd20h_dev_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  L3GD20H_LSB_LOW_ADDRESS = 0,
+  L3GD20H_MSB_LOW_ADDRESS = 1,
+} l3gd20h_ble_t;
+int32_t l3gd20h_dev_data_format_set(stmdev_ctx_t *ctx, l3gd20h_ble_t val);
+int32_t l3gd20h_dev_data_format_get(stmdev_ctx_t *ctx, l3gd20h_ble_t *val);
+
+int32_t l3gd20h_dev_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l3gd20h_dev_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t xda               : 1;
+  uint8_t yda               : 1;
+  uint8_t zda               : 1;
+  uint8_t zyxda             : 1;
+  uint8_t _xor              : 1;
+  uint8_t yor               : 1;
+  uint8_t zor               : 1;
+  uint8_t zyxor             : 1;
+} l3gd20h_status_reg_t;
+int32_t l3gd20h_dev_status_get(stmdev_ctx_t *ctx,
+                               l3gd20h_status_reg_t *val);
+
+int32_t l3gd20h_dev_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l3gd20h_dev_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  L3GD20H_16Hz6_USE_ODR_50Hz      = 0xA0,
+  L3GD20H_12Hz5_USE_ODR_100Hz     = 0x00,
+  L3GD20H_25Hz_USE_ODR_100Hz      = 0x01,
+  L3GD20H_12Hz5_USE_ODR_200Hz     = 0x10,
+  L3GD20H_70Hz_USE_ODR_200Hz      = 0x13,
+  L3GD20H_20Hz_USE_ODR_400Hz      = 0x20,
+  L3GD20H_25Hz_USE_ODR_400Hz      = 0x21,
+  L3GD20H_50Hz_USE_ODR_400Hz      = 0x22,
+  L3GD20H_110Hz_USE_ODR_400Hz     = 0x23,
+  L3GD20H_30Hz_USE_ODR_800Hz      = 0x30,
+  L3GD20H_35Hz_USE_ODR_800Hz      = 0x31,
+  L3GD20H_100Hz_USE_ODR_800Hz     = 0x33,
+} l3gd20h_lpbw_t;
+int32_t l3gd20h_gy_filter_lp_bandwidth_set(stmdev_ctx_t *ctx,
+                                           l3gd20h_lpbw_t val);
+int32_t l3gd20h_gy_filter_lp_bandwidth_get(stmdev_ctx_t *ctx,
+                                           l3gd20h_lpbw_t *val);
+
+typedef enum {
+  L3GD20H_NORMAL_MODE_LIGHT      = 0x00,
+  L3GD20H_NORMAL_MODE_NORMAL     = 0x01,
+  L3GD20H_NORMAL_MODE_STRONG     = 0x02,
+  L3GD20H_NORMAL_MODE_EXTREME    = 0x03,
+  L3GD20H_USE_REFERENCE_LIGHT    = 0x10,
+  L3GD20H_USE_REFERENCE_NORMAL   = 0x11,
+  L3GD20H_USE_REFERENCE_STRONG   = 0x12,
+  L3GD20H_USE_REFERENCE_EXTREME  = 0x13,
+  L3GD20H_AUTORESET_LIGHT        = 0x30,
+  L3GD20H_AUTORESET_NORMAL       = 0x31,
+  L3GD20H_AUTORESET_STRONG       = 0x32,
+  L3GD20H_AUTORESET_EXTREME      = 0x33,
+} l3gd20h_gy_hp_bw_t;
+int32_t l3gd20h_gy_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
+                                           l3gd20h_gy_hp_bw_t val);
+int32_t l3gd20h_gy_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
+                                           l3gd20h_gy_hp_bw_t *val);
+
+typedef enum {
+  L3GD20H_LPF1_OUT           = 0x00,
+  L3GD20H_LPF1_HPF_OUT       = 0x11,
+  L3GD20H_LPF1_LPF2_OUT      = 0x02,
+  L3GD20H_LPF1_HPF_LPF2_OUT  = 0x12,
+} l3gd20h_gy_out_path_t;
+int32_t l3gd20h_gy_filter_out_path_set(stmdev_ctx_t *ctx,
+                                       l3gd20h_gy_out_path_t val);
+int32_t l3gd20h_gy_filter_out_path_get(stmdev_ctx_t *ctx,
+                                       l3gd20h_gy_out_path_t *val);
+typedef enum {
+  L3GD20H_LPF1_INT           = 0x00,
+  L3GD20H_LPF1_HPF_INT       = 0x11,
+  L3GD20H_LPF1_LPF2_INT      = 0x02,
+  L3GD20H_LPF1_HPF_LPF2_INT  = 0x12,
+} l3gd20h_gy_int_path_t;
+int32_t l3gd20h_gy_filter_int_path_set(stmdev_ctx_t *ctx,
+                                       l3gd20h_gy_int_path_t val);
+int32_t l3gd20h_gy_filter_int_path_get(stmdev_ctx_t *ctx,
+                                       l3gd20h_gy_int_path_t *val);
+
+int32_t l3gd20h_gy_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t l3gd20h_gy_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  L3GD20H_SPI_4_WIRE = 0,
+  L3GD20H_SPI_3_WIRE = 1,
+} l3gd20h_sim_t;
+int32_t l3gd20h_spi_mode_set(stmdev_ctx_t *ctx, l3gd20h_sim_t val);
+int32_t l3gd20h_spi_mode_get(stmdev_ctx_t *ctx, l3gd20h_sim_t *val);
+
+typedef enum {
+  L3GD20H_I2C_ENABLE  = 0,
+  L3GD20H_I2C_DISABLE = 1,
+} l3gd20h_i2c_dis_t;
+int32_t l3gd20h_i2c_interface_set(stmdev_ctx_t *ctx,
+                                  l3gd20h_i2c_dis_t val);
+int32_t l3gd20h_i2c_interface_get(stmdev_ctx_t *ctx,
+                                  l3gd20h_i2c_dis_t *val);
+
+typedef struct {
+  uint8_t int2_empty            : 1;
+  uint8_t int2_orun             : 1;
+  uint8_t int2_fth              : 1;
+  uint8_t int2_drdy             : 1;
+} l3gd20h_pin_int2_rt_t;
+int32_t l3gd20h_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                   l3gd20h_pin_int2_rt_t val);
+int32_t l3gd20h_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                   l3gd20h_pin_int2_rt_t *val);
+
+typedef enum {
+  L3GD20H_PUSH_PULL  = 0,
+  L3GD20H_OPEN_DRAIN = 1,
+} l3gd20h_pp_od_t;
+int32_t l3gd20h_pin_mode_set(stmdev_ctx_t *ctx, l3gd20h_pp_od_t val);
+int32_t l3gd20h_pin_mode_get(stmdev_ctx_t *ctx, l3gd20h_pp_od_t *val);
+
+typedef enum {
+  L3GD20H_ACTIVE_HIGH = 0,
+  L3GD20H_ACTIVE_LOW  = 1,
+} l3gd20h_pin_pol_t;
+int32_t l3gd20h_pin_polarity_set(stmdev_ctx_t *ctx, l3gd20h_pin_pol_t val);
+int32_t l3gd20h_pin_polarity_get(stmdev_ctx_t *ctx, l3gd20h_pin_pol_t *val);
+
+typedef struct {
+  uint8_t int1_boot           : 1;
+  uint8_t int1_ig             : 1;
+} l3gd20h_pin_int1_rt_t;
+int32_t l3gd20h_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                   l3gd20h_pin_int1_rt_t val);
+int32_t l3gd20h_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                   l3gd20h_pin_int1_rt_t *val);
+
+typedef enum {
+  L3GD20H_INT_PULSED  = 0,
+  L3GD20H_INT_LATCHED = 1,
+} l3gd20h_lir_t;
+int32_t l3gd20h_pin_notification_set(stmdev_ctx_t *ctx, l3gd20h_lir_t val);
+int32_t l3gd20h_pin_notification_get(stmdev_ctx_t *ctx, l3gd20h_lir_t *val);
+typedef enum {
+  L3GD20H_LOGIC_OR  = 0,
+  L3GD20H_LOGIC_AND = 1,
+} l3gd20h_pin_logic_t;
+int32_t l3gd20h_pin_logic_set(stmdev_ctx_t *ctx, l3gd20h_pin_logic_t val);
+int32_t l3gd20h_pin_logic_get(stmdev_ctx_t *ctx, l3gd20h_pin_logic_t *val);
+
+typedef struct {
+  uint8_t xlie             : 1;
+  uint8_t xhie             : 1;
+  uint8_t ylie             : 1;
+  uint8_t yhie             : 1;
+  uint8_t zlie             : 1;
+  uint8_t zhie             : 1;
+} l3gd20h_gy_trshld_en_t;
+int32_t l3gd20h_gy_trshld_axis_set(stmdev_ctx_t *ctx,
+                                   l3gd20h_gy_trshld_en_t val);
+int32_t l3gd20h_gy_trshld_axis_get(stmdev_ctx_t *ctx,
+                                   l3gd20h_gy_trshld_en_t *val);
+
+typedef struct {
+  uint8_t xl             : 1;
+  uint8_t xh             : 1;
+  uint8_t yl             : 1;
+  uint8_t yh             : 1;
+  uint8_t zl             : 1;
+  uint8_t zh             : 1;
+  uint8_t ia             : 1;
+} l3gd20h_gy_trshld_src_t;
+int32_t l3gd20h_gy_trshld_src_get(stmdev_ctx_t *ctx,
+                                  l3gd20h_gy_trshld_src_t *val);
+
+int32_t l3gd20h_gy_trshld_x_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t l3gd20h_gy_trshld_x_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+typedef enum {
+  L3GD20H_RESET_MODE       = 0x00,
+  L3GD20H_DECREMENT_MODE   = 0x01,
+} l3gd20h_dcrm_g_t;
+int32_t l3gd20h_gy_trshld_mode_set(stmdev_ctx_t *ctx,
+                                   l3gd20h_dcrm_g_t val);
+int32_t l3gd20h_gy_trshld_mode_get(stmdev_ctx_t *ctx,
+                                   l3gd20h_dcrm_g_t *val);
+
+int32_t l3gd20h_gy_trshld_y_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t l3gd20h_gy_trshld_y_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t l3gd20h_gy_trshld_z_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t l3gd20h_gy_trshld_z_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t l3gd20h_gy_trshld_min_sample_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l3gd20h_gy_trshld_min_sample_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t l3gd20h_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l3gd20h_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  L3GD20H_BYPASS_MODE              = 0x00,
+  L3GD20H_FIFO_MODE                = 0x11,
+  L3GD20H_STREAM_MODE              = 0x12,
+  L3GD20H_STREAM_TO_FIFO_MODE      = 0x13,
+  L3GD20H_BYPASS_TO_STREAM_MODE    = 0x14,
+  L3GD20H_DYNAMIC_STREAM_MODE      = 0x16,
+  L3GD20H_BYPASS_TO_FIFO_MODE      = 0x17,
+} l3gd20h_fifo_m_t;
+int32_t l3gd20h_fifo_mode_set(stmdev_ctx_t *ctx, l3gd20h_fifo_m_t val);
+int32_t l3gd20h_fifo_mode_get(stmdev_ctx_t *ctx, l3gd20h_fifo_m_t *val);
+
+int32_t l3gd20h_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t l3gd20h_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+  uint8_t fss             : 1;
+  uint8_t empty           : 1;
+  uint8_t ovrn            : 1;
+  uint8_t fth             : 1;
+} l3gd20h_fifo_srs_t;
+int32_t l3gd20h_fifo_src_get(stmdev_ctx_t *ctx, l3gd20h_fifo_srs_t *val);
+
+int32_t l3gd20h_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t l3gd20h_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t l3gd20h_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  L3GD20H_DEN_DISABLE           = 0x00,
+  L3GD20H_DEN_ON_LEVEL_TRIGGER  = 0x04,
+  L3GD20H_DEN_ON_EDGE_TRIGGER   = 0x02,
+  L3GD20H_DEN_IMPULSE_TRIGGER   = 0x05,
+} l3gd20h_den_md_t;
+int32_t l3gd20h_den_mode_set(stmdev_ctx_t *ctx, l3gd20h_den_md_t val);
+int32_t l3gd20h_den_mode_get(stmdev_ctx_t *ctx, l3gd20h_den_md_t *val);
+
+typedef enum {
+  L3GD20H_ST_DISABLE    = 0x00,
+  L3GD20H_ST_POSITIVE   = 0x01,
+  L3GD20H_ST_NEGATIVE   = 0x03,
+} l3gd20h_st_t;
+int32_t l3gd20h_gy_self_test_set(stmdev_ctx_t *ctx, l3gd20h_st_t val);
+int32_t l3gd20h_gy_self_test_get(stmdev_ctx_t *ctx, l3gd20h_st_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* L3GD20H_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2de12_STdC/driver/lis2de12_reg.c
+++ b/sensor/stmemsc/lis2de12_STdC/driver/lis2de12_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis2de12_reg.h"
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_read_reg(lis2de12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2de12_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lis2de12_read_reg(lis2de12_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_write_reg(lis2de12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2de12_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -146,7 +129,7 @@ float_t lis2de12_from_lsb_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_temp_status_reg_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2de12_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2de12_read_reg(ctx, LIS2DE12_STATUS_REG_AUX, buff, 1);
@@ -160,7 +143,7 @@ int32_t lis2de12_temp_status_reg_get(lis2de12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_temp_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -179,7 +162,7 @@ int32_t lis2de12_temp_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_temp_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -198,7 +181,7 @@ int32_t lis2de12_temp_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_temperature_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2de12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2de12_read_reg(ctx, LIS2DE12_OUT_TEMP_L, buff, 2);
@@ -212,7 +195,7 @@ int32_t lis2de12_temperature_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_temperature_meas_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_temperature_meas_set(stmdev_ctx_t *ctx,
                                       lis2de12_temp_en_t val)
 {
   lis2de12_temp_cfg_reg_t temp_cfg_reg;
@@ -234,7 +217,7 @@ int32_t lis2de12_temperature_meas_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_temperature_meas_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_temperature_meas_get(stmdev_ctx_t *ctx,
                                       lis2de12_temp_en_t *val)
 {
   lis2de12_temp_cfg_reg_t temp_cfg_reg;
@@ -263,7 +246,7 @@ int32_t lis2de12_temperature_meas_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_data_rate_set(lis2de12_ctx_t *ctx, lis2de12_odr_t val)
+int32_t lis2de12_data_rate_set(stmdev_ctx_t *ctx, lis2de12_odr_t val)
 {
   lis2de12_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -285,7 +268,7 @@ int32_t lis2de12_data_rate_set(lis2de12_ctx_t *ctx, lis2de12_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_data_rate_get(lis2de12_ctx_t *ctx, lis2de12_odr_t *val)
+int32_t lis2de12_data_rate_get(stmdev_ctx_t *ctx, lis2de12_odr_t *val)
 {
   lis2de12_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -338,7 +321,7 @@ int32_t lis2de12_data_rate_get(lis2de12_ctx_t *ctx, lis2de12_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_high_pass_on_outputs_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -360,7 +343,7 @@ int32_t lis2de12_high_pass_on_outputs_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_high_pass_on_outputs_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -385,7 +368,7 @@ int32_t lis2de12_high_pass_on_outputs_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_high_pass_bandwidth_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis2de12_hpcf_t val)
 {
   lis2de12_ctrl_reg2_t ctrl_reg2;
@@ -413,7 +396,7 @@ int32_t lis2de12_high_pass_bandwidth_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_high_pass_bandwidth_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis2de12_hpcf_t *val)
 {
   lis2de12_ctrl_reg2_t ctrl_reg2;
@@ -448,7 +431,7 @@ int32_t lis2de12_high_pass_bandwidth_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_high_pass_mode_set(lis2de12_ctx_t *ctx, lis2de12_hpm_t val)
+int32_t lis2de12_high_pass_mode_set(stmdev_ctx_t *ctx, lis2de12_hpm_t val)
 {
   lis2de12_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -469,7 +452,7 @@ int32_t lis2de12_high_pass_mode_set(lis2de12_ctx_t *ctx, lis2de12_hpm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_high_pass_mode_get(lis2de12_ctx_t *ctx, lis2de12_hpm_t *val)
+int32_t lis2de12_high_pass_mode_get(stmdev_ctx_t *ctx, lis2de12_hpm_t *val)
 {
   lis2de12_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -503,7 +486,7 @@ int32_t lis2de12_high_pass_mode_get(lis2de12_ctx_t *ctx, lis2de12_hpm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_full_scale_set(lis2de12_ctx_t *ctx, lis2de12_fs_t val)
+int32_t lis2de12_full_scale_set(stmdev_ctx_t *ctx, lis2de12_fs_t val)
 {
   lis2de12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -524,7 +507,7 @@ int32_t lis2de12_full_scale_set(lis2de12_ctx_t *ctx, lis2de12_fs_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_full_scale_get(lis2de12_ctx_t *ctx, lis2de12_fs_t *val)
+int32_t lis2de12_full_scale_get(stmdev_ctx_t *ctx, lis2de12_fs_t *val)
 {
   lis2de12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -558,7 +541,7 @@ int32_t lis2de12_full_scale_get(lis2de12_ctx_t *ctx, lis2de12_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_block_data_update_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -579,7 +562,7 @@ int32_t lis2de12_block_data_update_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_block_data_update_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -599,7 +582,7 @@ int32_t lis2de12_block_data_update_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_filter_reference_set(lis2de12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2de12_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2de12_write_reg(ctx, LIS2DE12_REFERENCE, buff, 1);
@@ -615,7 +598,7 @@ int32_t lis2de12_filter_reference_set(lis2de12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_filter_reference_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2de12_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2de12_read_reg(ctx, LIS2DE12_REFERENCE, buff, 1);
@@ -629,7 +612,7 @@ int32_t lis2de12_filter_reference_get(lis2de12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_xl_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_status_reg_t status_reg;
   int32_t ret;
@@ -647,7 +630,7 @@ int32_t lis2de12_xl_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_xl_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_status_reg_t status_reg;
   int32_t ret;
@@ -665,7 +648,7 @@ int32_t lis2de12_xl_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_acceleration_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2de12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2de12_read_reg(ctx, LIS2DE12_FIFO_READ_START, buff, 6);
@@ -691,7 +674,7 @@ int32_t lis2de12_acceleration_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_device_id_get(lis2de12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2de12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2de12_read_reg(ctx, LIS2DE12_WHO_AM_I, buff, 1);
@@ -705,7 +688,7 @@ int32_t lis2de12_device_id_get(lis2de12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_self_test_set(lis2de12_ctx_t *ctx, lis2de12_st_t val)
+int32_t lis2de12_self_test_set(stmdev_ctx_t *ctx, lis2de12_st_t val)
 {
   lis2de12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -726,7 +709,7 @@ int32_t lis2de12_self_test_set(lis2de12_ctx_t *ctx, lis2de12_st_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_self_test_get(lis2de12_ctx_t *ctx, lis2de12_st_t *val)
+int32_t lis2de12_self_test_get(stmdev_ctx_t *ctx, lis2de12_st_t *val)
 {
   lis2de12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -757,7 +740,7 @@ int32_t lis2de12_self_test_get(lis2de12_ctx_t *ctx, lis2de12_st_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_boot_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -778,7 +761,7 @@ int32_t lis2de12_boot_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_boot_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -797,7 +780,7 @@ int32_t lis2de12_boot_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_status_get(lis2de12_ctx_t *ctx, lis2de12_status_reg_t *val)
+int32_t lis2de12_status_get(stmdev_ctx_t *ctx, lis2de12_status_reg_t *val)
 {
   int32_t ret;
   ret = lis2de12_read_reg(ctx, LIS2DE12_STATUS_REG, (uint8_t*) val, 1);
@@ -824,7 +807,7 @@ int32_t lis2de12_status_get(lis2de12_ctx_t *ctx, lis2de12_status_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_gen_conf_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis2de12_int1_cfg_t *val)
 {
   int32_t ret;
@@ -840,7 +823,7 @@ int32_t lis2de12_int1_gen_conf_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_gen_conf_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis2de12_int1_cfg_t *val)
 {
   int32_t ret;
@@ -856,7 +839,7 @@ int32_t lis2de12_int1_gen_conf_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_gen_source_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_gen_source_get(stmdev_ctx_t *ctx,
                                      lis2de12_int1_src_t *val)
 {
   int32_t ret;
@@ -873,7 +856,7 @@ int32_t lis2de12_int1_gen_source_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_int1_ths_t int1_ths;
   int32_t ret;
@@ -896,7 +879,7 @@ int32_t lis2de12_int1_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_int1_ths_t int1_ths;
   int32_t ret;
@@ -916,7 +899,7 @@ int32_t lis2de12_int1_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_int1_duration_t int1_duration;
   int32_t ret;
@@ -938,7 +921,7 @@ int32_t lis2de12_int1_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_int1_duration_t int1_duration;
   int32_t ret;
@@ -970,7 +953,7 @@ int32_t lis2de12_int1_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_gen_conf_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis2de12_int2_cfg_t *val)
 {
   int32_t ret;
@@ -986,7 +969,7 @@ int32_t lis2de12_int2_gen_conf_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_gen_conf_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis2de12_int2_cfg_t *val)
 {
   int32_t ret;
@@ -1001,7 +984,7 @@ int32_t lis2de12_int2_gen_conf_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_gen_source_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_gen_source_get(stmdev_ctx_t *ctx,
                                      lis2de12_int2_src_t *val)
 {
   int32_t ret;
@@ -1018,7 +1001,7 @@ int32_t lis2de12_int2_gen_source_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_int2_ths_t int2_ths;
   int32_t ret;
@@ -1041,7 +1024,7 @@ int32_t lis2de12_int2_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_int2_ths_t int2_ths;
   int32_t ret;
@@ -1061,7 +1044,7 @@ int32_t lis2de12_int2_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_int2_duration_t int2_duration;
   int32_t ret;
@@ -1083,7 +1066,7 @@ int32_t lis2de12_int2_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_int2_duration_t int2_duration;
   int32_t ret;
@@ -1114,7 +1097,7 @@ int32_t lis2de12_int2_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_high_pass_int_conf_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                         lis2de12_hp_t val)
 {
   lis2de12_ctrl_reg2_t ctrl_reg2;
@@ -1136,7 +1119,7 @@ int32_t lis2de12_high_pass_int_conf_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_high_pass_int_conf_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                         lis2de12_hp_t *val)
 {
   lis2de12_ctrl_reg2_t ctrl_reg2;
@@ -1183,7 +1166,7 @@ int32_t lis2de12_high_pass_int_conf_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_pin_int1_config_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_int1_config_set(stmdev_ctx_t *ctx,
                                      lis2de12_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1199,7 +1182,7 @@ int32_t lis2de12_pin_int1_config_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_pin_int1_config_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_int1_config_get(stmdev_ctx_t *ctx,
                                      lis2de12_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1216,7 +1199,7 @@ int32_t lis2de12_pin_int1_config_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1238,7 +1221,7 @@ int32_t lis2de12_int2_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1259,7 +1242,7 @@ int32_t lis2de12_int2_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_pin_notification_mode_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis2de12_lir_int2_t val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
@@ -1283,7 +1266,7 @@ int32_t lis2de12_int2_pin_notification_mode_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int2_pin_notification_mode_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis2de12_lir_int2_t *val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
@@ -1313,7 +1296,7 @@ int32_t lis2de12_int2_pin_notification_mode_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1335,7 +1318,7 @@ int32_t lis2de12_int1_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1355,7 +1338,7 @@ int32_t lis2de12_int1_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_pin_notification_mode_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis2de12_lir_int1_t val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
@@ -1378,7 +1361,7 @@ int32_t lis2de12_int1_pin_notification_mode_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_int1_pin_notification_mode_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis2de12_lir_int1_t *val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
@@ -1407,7 +1390,7 @@ int32_t lis2de12_int1_pin_notification_mode_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_pin_int2_config_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_int2_config_set(stmdev_ctx_t *ctx,
                                      lis2de12_ctrl_reg6_t *val)
 {
   int32_t ret;
@@ -1423,7 +1406,7 @@ int32_t lis2de12_pin_int2_config_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_pin_int2_config_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_int2_config_get(stmdev_ctx_t *ctx,
                                      lis2de12_ctrl_reg6_t *val)
 {
   int32_t ret;
@@ -1450,7 +1433,7 @@ int32_t lis2de12_pin_int2_config_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1471,7 +1454,7 @@ int32_t lis2de12_fifo_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1490,7 +1473,7 @@ int32_t lis2de12_fifo_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_watermark_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1511,7 +1494,7 @@ int32_t lis2de12_fifo_watermark_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_watermark_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1530,7 +1513,7 @@ int32_t lis2de12_fifo_watermark_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_trigger_event_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lis2de12_tr_t val)
 {
   lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
@@ -1552,7 +1535,7 @@ int32_t lis2de12_fifo_trigger_event_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_trigger_event_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                         lis2de12_tr_t *val)
 {
   lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
@@ -1581,7 +1564,7 @@ int32_t lis2de12_fifo_trigger_event_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_mode_set(lis2de12_ctx_t *ctx, lis2de12_fm_t val)
+int32_t lis2de12_fifo_mode_set(stmdev_ctx_t *ctx, lis2de12_fm_t val)
 {
   lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1602,7 +1585,7 @@ int32_t lis2de12_fifo_mode_set(lis2de12_ctx_t *ctx, lis2de12_fm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_mode_get(lis2de12_ctx_t *ctx, lis2de12_fm_t *val)
+int32_t lis2de12_fifo_mode_get(stmdev_ctx_t *ctx, lis2de12_fm_t *val)
 {
   lis2de12_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1636,7 +1619,7 @@ int32_t lis2de12_fifo_mode_get(lis2de12_ctx_t *ctx, lis2de12_fm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_status_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis2de12_fifo_src_reg_t *val)
 {
   int32_t ret;
@@ -1651,7 +1634,7 @@ int32_t lis2de12_fifo_status_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_data_level_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1669,7 +1652,7 @@ int32_t lis2de12_fifo_data_level_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_empty_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1687,7 +1670,7 @@ int32_t lis2de12_fifo_empty_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_ovr_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1705,7 +1688,7 @@ int32_t lis2de12_fifo_ovr_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_fifo_fth_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1736,7 +1719,7 @@ int32_t lis2de12_fifo_fth_flag_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_tap_conf_set(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val)
+int32_t lis2de12_tap_conf_set(stmdev_ctx_t *ctx, lis2de12_click_cfg_t *val)
 {
   int32_t ret;
   ret = lis2de12_write_reg(ctx, LIS2DE12_CLICK_CFG, (uint8_t*) val, 1);
@@ -1751,7 +1734,7 @@ int32_t lis2de12_tap_conf_set(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_tap_conf_get(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val)
+int32_t lis2de12_tap_conf_get(stmdev_ctx_t *ctx, lis2de12_click_cfg_t *val)
 {
   int32_t ret;
   ret = lis2de12_read_reg(ctx, LIS2DE12_CLICK_CFG, (uint8_t*) val, 1);
@@ -1765,7 +1748,7 @@ int32_t lis2de12_tap_conf_get(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_tap_source_get(lis2de12_ctx_t *ctx, lis2de12_click_src_t *val)
+int32_t lis2de12_tap_source_get(stmdev_ctx_t *ctx, lis2de12_click_src_t *val)
 {
   int32_t ret;
   ret = lis2de12_read_reg(ctx, LIS2DE12_CLICK_SRC, (uint8_t*) val, 1);
@@ -1780,7 +1763,7 @@ int32_t lis2de12_tap_source_get(lis2de12_ctx_t *ctx, lis2de12_click_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_tap_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_click_ths_t click_ths;
   int32_t ret;
@@ -1802,7 +1785,7 @@ int32_t lis2de12_tap_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_tap_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_click_ths_t click_ths;
   int32_t ret;
@@ -1824,7 +1807,7 @@ int32_t lis2de12_tap_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_tap_notification_mode_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis2de12_lir_click_t val)
 {
   lis2de12_click_ths_t click_ths;
@@ -1849,7 +1832,7 @@ int32_t lis2de12_tap_notification_mode_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_tap_notification_mode_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis2de12_lir_click_t *val)
 {
   lis2de12_click_ths_t click_ths;
@@ -1880,7 +1863,7 @@ int32_t lis2de12_tap_notification_mode_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_shock_dur_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_time_limit_t time_limit;
   int32_t ret;
@@ -1903,7 +1886,7 @@ int32_t lis2de12_shock_dur_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_shock_dur_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_time_limit_t time_limit;
   int32_t ret;
@@ -1925,7 +1908,7 @@ int32_t lis2de12_shock_dur_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_quiet_dur_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_time_latency_t time_latency;
   int32_t ret;
@@ -1949,7 +1932,7 @@ int32_t lis2de12_quiet_dur_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_quiet_dur_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_time_latency_t time_latency;
   int32_t ret;
@@ -1971,7 +1954,7 @@ int32_t lis2de12_quiet_dur_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_double_tap_timeout_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_time_window_t time_window;
   int32_t ret;
@@ -1995,7 +1978,7 @@ int32_t lis2de12_double_tap_timeout_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_double_tap_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_time_window_t time_window;
   int32_t ret;
@@ -2029,7 +2012,7 @@ int32_t lis2de12_double_tap_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_act_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_act_ths_t act_ths;
   int32_t ret;
@@ -2052,7 +2035,7 @@ int32_t lis2de12_act_threshold_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_act_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_act_ths_t act_ths;
   int32_t ret;
@@ -2072,7 +2055,7 @@ int32_t lis2de12_act_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_act_timeout_set(lis2de12_ctx_t *ctx, uint8_t val)
+int32_t lis2de12_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2de12_act_dur_t act_dur;
   int32_t ret;
@@ -2094,7 +2077,7 @@ int32_t lis2de12_act_timeout_set(lis2de12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_act_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val)
+int32_t lis2de12_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2de12_act_dur_t act_dur;
   int32_t ret;
@@ -2126,7 +2109,7 @@ int32_t lis2de12_act_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_pin_sdo_sa0_mode_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                       lis2de12_sdo_pu_disc_t val)
 {
   lis2de12_ctrl_reg0_t ctrl_reg0;
@@ -2148,7 +2131,7 @@ int32_t lis2de12_pin_sdo_sa0_mode_set(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_pin_sdo_sa0_mode_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                       lis2de12_sdo_pu_disc_t *val)
 {
   lis2de12_ctrl_reg0_t ctrl_reg0;
@@ -2177,7 +2160,7 @@ int32_t lis2de12_pin_sdo_sa0_mode_get(lis2de12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_spi_mode_set(lis2de12_ctx_t *ctx, lis2de12_sim_t val)
+int32_t lis2de12_spi_mode_set(stmdev_ctx_t *ctx, lis2de12_sim_t val)
 {
   lis2de12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -2198,7 +2181,7 @@ int32_t lis2de12_spi_mode_set(lis2de12_ctx_t *ctx, lis2de12_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2de12_spi_mode_get(lis2de12_ctx_t *ctx, lis2de12_sim_t *val)
+int32_t lis2de12_spi_mode_get(stmdev_ctx_t *ctx, lis2de12_sim_t *val)
 {
   lis2de12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;

--- a/sensor/stmemsc/lis2de12_STdC/driver/lis2de12_reg.h
+++ b/sensor/stmemsc/lis2de12_STdC/driver/lis2de12_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS2DE12_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup LIS3MDL_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis2de12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis2de12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis2de12_write_ptr  write_reg;
-  lis2de12_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis2de12_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -456,9 +428,9 @@ typedef union{
   *
   */
 
-int32_t lis2de12_read_reg(lis2de12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2de12_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lis2de12_write_reg(lis2de12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2de12_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t lis2de12_from_fs2_to_mg(int16_t lsb);
@@ -467,20 +439,20 @@ extern float_t lis2de12_from_fs8_to_mg(int16_t lsb);
 extern float_t lis2de12_from_fs16_to_mg(int16_t lsb);
 extern float_t lis2de12_from_lsb_to_celsius(int16_t lsb);
 
-int32_t lis2de12_temp_status_reg_get(lis2de12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2de12_temp_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2de12_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_temp_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_temperature_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2de12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS2DE12_TEMP_DISABLE  = 0,
   LIS2DE12_TEMP_ENABLE   = 3,
 } lis2de12_temp_en_t;
-int32_t lis2de12_temperature_meas_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_temperature_meas_set(stmdev_ctx_t *ctx,
                                       lis2de12_temp_en_t val);
-int32_t lis2de12_temperature_meas_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_temperature_meas_get(stmdev_ctx_t *ctx,
                                       lis2de12_temp_en_t *val);
 
 typedef enum {
@@ -495,11 +467,11 @@ typedef enum {
   LIS2DE12_ODR_1kHz620_LP                  = 0x08,
   LIS2DE12_ODR_5kHz376_LP_1kHz344_NM_HP    = 0x09,
 } lis2de12_odr_t;
-int32_t lis2de12_data_rate_set(lis2de12_ctx_t *ctx, lis2de12_odr_t val);
-int32_t lis2de12_data_rate_get(lis2de12_ctx_t *ctx, lis2de12_odr_t *val);
+int32_t lis2de12_data_rate_set(stmdev_ctx_t *ctx, lis2de12_odr_t val);
+int32_t lis2de12_data_rate_get(stmdev_ctx_t *ctx, lis2de12_odr_t *val);
 
-int32_t lis2de12_high_pass_on_outputs_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_high_pass_on_outputs_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DE12_AGGRESSIVE  = 0,
@@ -507,9 +479,9 @@ typedef enum {
   LIS2DE12_MEDIUM      = 2,
   LIS2DE12_LIGHT       = 3,
 } lis2de12_hpcf_t;
-int32_t lis2de12_high_pass_bandwidth_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis2de12_hpcf_t val);
-int32_t lis2de12_high_pass_bandwidth_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis2de12_hpcf_t *val);
 
 typedef enum {
@@ -518,8 +490,8 @@ typedef enum {
   LIS2DE12_NORMAL           = 2,
   LIS2DE12_AUTORST_ON_INT   = 3,
 } lis2de12_hpm_t;
-int32_t lis2de12_high_pass_mode_set(lis2de12_ctx_t *ctx, lis2de12_hpm_t val);
-int32_t lis2de12_high_pass_mode_get(lis2de12_ctx_t *ctx, lis2de12_hpm_t *val);
+int32_t lis2de12_high_pass_mode_set(stmdev_ctx_t *ctx, lis2de12_hpm_t val);
+int32_t lis2de12_high_pass_mode_get(stmdev_ctx_t *ctx, lis2de12_hpm_t *val);
 
 typedef enum {
   LIS2DE12_2g   = 0,
@@ -527,63 +499,63 @@ typedef enum {
   LIS2DE12_8g   = 2,
   LIS2DE12_16g  = 3,
 } lis2de12_fs_t;
-int32_t lis2de12_full_scale_set(lis2de12_ctx_t *ctx, lis2de12_fs_t val);
-int32_t lis2de12_full_scale_get(lis2de12_ctx_t *ctx, lis2de12_fs_t *val);
+int32_t lis2de12_full_scale_set(stmdev_ctx_t *ctx, lis2de12_fs_t val);
+int32_t lis2de12_full_scale_get(stmdev_ctx_t *ctx, lis2de12_fs_t *val);
 
-int32_t lis2de12_block_data_update_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_block_data_update_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_filter_reference_set(lis2de12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2de12_filter_reference_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2de12_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2de12_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2de12_xl_data_ready_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_xl_data_ovr_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_acceleration_raw_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2de12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2de12_device_id_get(lis2de12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2de12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS2DE12_ST_DISABLE   = 0,
   LIS2DE12_ST_POSITIVE  = 1,
   LIS2DE12_ST_NEGATIVE  = 2,
 } lis2de12_st_t;
-int32_t lis2de12_self_test_set(lis2de12_ctx_t *ctx, lis2de12_st_t val);
-int32_t lis2de12_self_test_get(lis2de12_ctx_t *ctx, lis2de12_st_t *val);
+int32_t lis2de12_self_test_set(stmdev_ctx_t *ctx, lis2de12_st_t val);
+int32_t lis2de12_self_test_get(stmdev_ctx_t *ctx, lis2de12_st_t *val);
 
-int32_t lis2de12_boot_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_boot_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_status_get(lis2de12_ctx_t *ctx, lis2de12_status_reg_t *val);
+int32_t lis2de12_status_get(stmdev_ctx_t *ctx, lis2de12_status_reg_t *val);
 
-int32_t lis2de12_int1_gen_conf_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis2de12_int1_cfg_t *val);
-int32_t lis2de12_int1_gen_conf_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis2de12_int1_cfg_t *val);
 
-int32_t lis2de12_int1_gen_source_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_gen_source_get(stmdev_ctx_t *ctx,
                                      lis2de12_int1_src_t *val);
 
-int32_t lis2de12_int1_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_int1_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_int1_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_int1_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_int2_gen_conf_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis2de12_int2_cfg_t *val);
-int32_t lis2de12_int2_gen_conf_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis2de12_int2_cfg_t *val);
 
-int32_t lis2de12_int2_gen_source_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_gen_source_get(stmdev_ctx_t *ctx,
                                      lis2de12_int2_src_t *val);
 
-int32_t lis2de12_int2_gen_threshold_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_int2_gen_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_int2_gen_duration_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_int2_gen_duration_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DE12_DISC_FROM_INT_GENERATOR  = 0,
@@ -595,58 +567,58 @@ typedef enum {
   LIS2DE12_ON_INT2_TAP_GEN          = 6,
   LIS2DE12_ON_INT1_INT2_TAP_GEN     = 7,
 } lis2de12_hp_t;
-int32_t lis2de12_high_pass_int_conf_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                         lis2de12_hp_t val);
-int32_t lis2de12_high_pass_int_conf_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                         lis2de12_hp_t *val);
 
-int32_t lis2de12_pin_int1_config_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_int1_config_set(stmdev_ctx_t *ctx,
                                      lis2de12_ctrl_reg3_t *val);
-int32_t lis2de12_pin_int1_config_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_int1_config_get(stmdev_ctx_t *ctx,
                                      lis2de12_ctrl_reg3_t *val);
 
-int32_t lis2de12_int2_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_int2_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DE12_INT2_PULSED   = 0,
   LIS2DE12_INT2_LATCHED  = 1,
 } lis2de12_lir_int2_t;
-int32_t lis2de12_int2_pin_notification_mode_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis2de12_lir_int2_t val);
-int32_t lis2de12_int2_pin_notification_mode_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis2de12_lir_int2_t *val);
 
-int32_t lis2de12_int1_pin_detect_4d_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_int1_pin_detect_4d_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DE12_INT1_PULSED   = 0,
   LIS2DE12_INT1_LATCHED  = 1,
 } lis2de12_lir_int1_t;
-int32_t lis2de12_int1_pin_notification_mode_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis2de12_lir_int1_t val);
-int32_t lis2de12_int1_pin_notification_mode_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis2de12_lir_int1_t *val);
 
-int32_t lis2de12_pin_int2_config_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_int2_config_set(stmdev_ctx_t *ctx,
                                      lis2de12_ctrl_reg6_t *val);
-int32_t lis2de12_pin_int2_config_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_int2_config_get(stmdev_ctx_t *ctx,
                                      lis2de12_ctrl_reg6_t *val);
 
-int32_t lis2de12_fifo_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_fifo_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_fifo_watermark_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_fifo_watermark_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DE12_INT1_GEN = 0,
   LIS2DE12_INT2_GEN = 1,
 } lis2de12_tr_t;
-int32_t lis2de12_fifo_trigger_event_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lis2de12_tr_t val);
-int32_t lis2de12_fifo_trigger_event_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                         lis2de12_tr_t *val);
 
 typedef enum {
@@ -655,68 +627,68 @@ typedef enum {
   LIS2DE12_DYNAMIC_STREAM_MODE   = 2,
   LIS2DE12_STREAM_TO_FIFO_MODE   = 3,
 } lis2de12_fm_t;
-int32_t lis2de12_fifo_mode_set(lis2de12_ctx_t *ctx, lis2de12_fm_t val);
-int32_t lis2de12_fifo_mode_get(lis2de12_ctx_t *ctx, lis2de12_fm_t *val);
+int32_t lis2de12_fifo_mode_set(stmdev_ctx_t *ctx, lis2de12_fm_t val);
+int32_t lis2de12_fifo_mode_get(stmdev_ctx_t *ctx, lis2de12_fm_t *val);
 
-int32_t lis2de12_fifo_status_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis2de12_fifo_src_reg_t *val);
 
-int32_t lis2de12_fifo_data_level_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_fifo_empty_flag_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_fifo_ovr_flag_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_fifo_fth_flag_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_tap_conf_set(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val);
-int32_t lis2de12_tap_conf_get(lis2de12_ctx_t *ctx, lis2de12_click_cfg_t *val);
+int32_t lis2de12_tap_conf_set(stmdev_ctx_t *ctx, lis2de12_click_cfg_t *val);
+int32_t lis2de12_tap_conf_get(stmdev_ctx_t *ctx, lis2de12_click_cfg_t *val);
 
-int32_t lis2de12_tap_source_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_tap_source_get(stmdev_ctx_t *ctx,
                                 lis2de12_click_src_t *val);
 
-int32_t lis2de12_tap_threshold_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_tap_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DE12_TAP_PULSED   = 0,
   LIS2DE12_TAP_LATCHED  = 1,
 } lis2de12_lir_click_t;
-int32_t lis2de12_tap_notification_mode_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis2de12_lir_click_t val);
-int32_t lis2de12_tap_notification_mode_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis2de12_lir_click_t *val);
 
-int32_t lis2de12_shock_dur_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_shock_dur_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_quiet_dur_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_quiet_dur_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_double_tap_timeout_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_double_tap_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_act_threshold_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_act_threshold_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2de12_act_timeout_set(lis2de12_ctx_t *ctx, uint8_t val);
-int32_t lis2de12_act_timeout_get(lis2de12_ctx_t *ctx, uint8_t *val);
+int32_t lis2de12_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2de12_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DE12_PULL_UP_DISCONNECT  = 0,
   LIS2DE12_PULL_UP_CONNECT     = 1,
 } lis2de12_sdo_pu_disc_t;
-int32_t lis2de12_pin_sdo_sa0_mode_set(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                       lis2de12_sdo_pu_disc_t val);
-int32_t lis2de12_pin_sdo_sa0_mode_get(lis2de12_ctx_t *ctx,
+int32_t lis2de12_pin_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                       lis2de12_sdo_pu_disc_t *val);
 
 typedef enum {
   LIS2DE12_SPI_4_WIRE = 0,
   LIS2DE12_SPI_3_WIRE = 1,
 } lis2de12_sim_t;
-int32_t lis2de12_spi_mode_set(lis2de12_ctx_t *ctx, lis2de12_sim_t val);
-int32_t lis2de12_spi_mode_get(lis2de12_ctx_t *ctx, lis2de12_sim_t *val);
+int32_t lis2de12_spi_mode_set(stmdev_ctx_t *ctx, lis2de12_sim_t val);
+int32_t lis2de12_spi_mode_get(stmdev_ctx_t *ctx, lis2de12_sim_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/lis2dh12_STdC/driver/lis2dh12_reg.c
+++ b/sensor/stmemsc/lis2dh12_STdC/driver/lis2dh12_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis2dh12_reg.h"
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_read_reg(lis2dh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2dh12_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lis2dh12_read_reg(lis2dh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_write_reg(lis2dh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2dh12_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -196,7 +179,7 @@ float lis2dh12_from_lsb_lp_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_temp_status_reg_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dh12_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dh12_read_reg(ctx, LIS2DH12_STATUS_REG_AUX, buff, 1);
@@ -210,7 +193,7 @@ int32_t lis2dh12_temp_status_reg_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_temp_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -229,7 +212,7 @@ int32_t lis2dh12_temp_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_temp_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -248,7 +231,7 @@ int32_t lis2dh12_temp_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_temperature_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dh12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dh12_read_reg(ctx, LIS2DH12_OUT_TEMP_L, buff, 2);
@@ -262,7 +245,7 @@ int32_t lis2dh12_temperature_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_temperature_meas_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_temperature_meas_set(stmdev_ctx_t *ctx,
                                       lis2dh12_temp_en_t val)
 {
   lis2dh12_temp_cfg_reg_t temp_cfg_reg;
@@ -284,7 +267,7 @@ int32_t lis2dh12_temperature_meas_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_temperature_meas_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_temperature_meas_get(stmdev_ctx_t *ctx,
                                       lis2dh12_temp_en_t *val)
 {
   lis2dh12_temp_cfg_reg_t temp_cfg_reg;
@@ -314,7 +297,7 @@ int32_t lis2dh12_temperature_meas_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_operating_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_op_md_t val)
+int32_t lis2dh12_operating_mode_set(stmdev_ctx_t *ctx, lis2dh12_op_md_t val)
 {
   lis2dh12_ctrl_reg1_t ctrl_reg1;
   lis2dh12_ctrl_reg4_t ctrl_reg4;
@@ -355,7 +338,7 @@ int32_t lis2dh12_operating_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_op_md_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_operating_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_op_md_t *val)
+int32_t lis2dh12_operating_mode_get(stmdev_ctx_t *ctx, lis2dh12_op_md_t *val)
 {
   lis2dh12_ctrl_reg1_t ctrl_reg1;
   lis2dh12_ctrl_reg4_t ctrl_reg4;
@@ -383,7 +366,7 @@ int32_t lis2dh12_operating_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_op_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_data_rate_set(lis2dh12_ctx_t *ctx, lis2dh12_odr_t val)
+int32_t lis2dh12_data_rate_set(stmdev_ctx_t *ctx, lis2dh12_odr_t val)
 {
   lis2dh12_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -404,7 +387,7 @@ int32_t lis2dh12_data_rate_set(lis2dh12_ctx_t *ctx, lis2dh12_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_data_rate_get(lis2dh12_ctx_t *ctx, lis2dh12_odr_t *val)
+int32_t lis2dh12_data_rate_get(stmdev_ctx_t *ctx, lis2dh12_odr_t *val)
 {
   lis2dh12_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -457,7 +440,7 @@ int32_t lis2dh12_data_rate_get(lis2dh12_ctx_t *ctx, lis2dh12_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_high_pass_on_outputs_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -479,7 +462,7 @@ int32_t lis2dh12_high_pass_on_outputs_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_high_pass_on_outputs_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -504,7 +487,7 @@ int32_t lis2dh12_high_pass_on_outputs_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_high_pass_bandwidth_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis2dh12_hpcf_t val)
 {
   lis2dh12_ctrl_reg2_t ctrl_reg2;
@@ -532,7 +515,7 @@ int32_t lis2dh12_high_pass_bandwidth_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_high_pass_bandwidth_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis2dh12_hpcf_t *val)
 {
   lis2dh12_ctrl_reg2_t ctrl_reg2;
@@ -567,7 +550,7 @@ int32_t lis2dh12_high_pass_bandwidth_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_high_pass_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t val)
+int32_t lis2dh12_high_pass_mode_set(stmdev_ctx_t *ctx, lis2dh12_hpm_t val)
 {
   lis2dh12_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -588,7 +571,7 @@ int32_t lis2dh12_high_pass_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_high_pass_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t *val)
+int32_t lis2dh12_high_pass_mode_get(stmdev_ctx_t *ctx, lis2dh12_hpm_t *val)
 {
   lis2dh12_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -622,7 +605,7 @@ int32_t lis2dh12_high_pass_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_full_scale_set(lis2dh12_ctx_t *ctx, lis2dh12_fs_t val)
+int32_t lis2dh12_full_scale_set(stmdev_ctx_t *ctx, lis2dh12_fs_t val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -643,7 +626,7 @@ int32_t lis2dh12_full_scale_set(lis2dh12_ctx_t *ctx, lis2dh12_fs_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_full_scale_get(lis2dh12_ctx_t *ctx, lis2dh12_fs_t *val)
+int32_t lis2dh12_full_scale_get(stmdev_ctx_t *ctx, lis2dh12_fs_t *val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -677,7 +660,7 @@ int32_t lis2dh12_full_scale_get(lis2dh12_ctx_t *ctx, lis2dh12_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_block_data_update_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -698,7 +681,7 @@ int32_t lis2dh12_block_data_update_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_block_data_update_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -718,7 +701,7 @@ int32_t lis2dh12_block_data_update_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_filter_reference_set(lis2dh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dh12_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dh12_write_reg(ctx, LIS2DH12_REFERENCE, buff, 1);
@@ -734,7 +717,7 @@ int32_t lis2dh12_filter_reference_set(lis2dh12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_filter_reference_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dh12_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dh12_read_reg(ctx, LIS2DH12_REFERENCE, buff, 1);
@@ -748,7 +731,7 @@ int32_t lis2dh12_filter_reference_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_xl_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_status_reg_t status_reg;
   int32_t ret;
@@ -766,7 +749,7 @@ int32_t lis2dh12_xl_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_xl_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_status_reg_t status_reg;
   int32_t ret;
@@ -784,7 +767,7 @@ int32_t lis2dh12_xl_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_acceleration_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dh12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dh12_read_reg(ctx, LIS2DH12_OUT_X_L, buff, 6);
@@ -810,7 +793,7 @@ int32_t lis2dh12_acceleration_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_device_id_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dh12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dh12_read_reg(ctx, LIS2DH12_WHO_AM_I, buff, 1);
@@ -824,7 +807,7 @@ int32_t lis2dh12_device_id_get(lis2dh12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_self_test_set(lis2dh12_ctx_t *ctx, lis2dh12_st_t val)
+int32_t lis2dh12_self_test_set(stmdev_ctx_t *ctx, lis2dh12_st_t val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -845,7 +828,7 @@ int32_t lis2dh12_self_test_set(lis2dh12_ctx_t *ctx, lis2dh12_st_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_self_test_get(lis2dh12_ctx_t *ctx, lis2dh12_st_t *val)
+int32_t lis2dh12_self_test_get(stmdev_ctx_t *ctx, lis2dh12_st_t *val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -876,7 +859,7 @@ int32_t lis2dh12_self_test_get(lis2dh12_ctx_t *ctx, lis2dh12_st_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_data_format_set(lis2dh12_ctx_t *ctx, lis2dh12_ble_t val)
+int32_t lis2dh12_data_format_set(stmdev_ctx_t *ctx, lis2dh12_ble_t val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -897,7 +880,7 @@ int32_t lis2dh12_data_format_set(lis2dh12_ctx_t *ctx, lis2dh12_ble_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_data_format_get(lis2dh12_ctx_t *ctx, lis2dh12_ble_t *val)
+int32_t lis2dh12_data_format_get(stmdev_ctx_t *ctx, lis2dh12_ble_t *val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -925,7 +908,7 @@ int32_t lis2dh12_data_format_get(lis2dh12_ctx_t *ctx, lis2dh12_ble_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_boot_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -946,7 +929,7 @@ int32_t lis2dh12_boot_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_boot_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -965,7 +948,7 @@ int32_t lis2dh12_boot_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_status_get(lis2dh12_ctx_t *ctx, lis2dh12_status_reg_t *val)
+int32_t lis2dh12_status_get(stmdev_ctx_t *ctx, lis2dh12_status_reg_t *val)
 {
   int32_t ret;
   ret = lis2dh12_read_reg(ctx, LIS2DH12_STATUS_REG, (uint8_t*) val, 1);
@@ -992,7 +975,7 @@ int32_t lis2dh12_status_get(lis2dh12_ctx_t *ctx, lis2dh12_status_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_gen_conf_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis2dh12_int1_cfg_t *val)
 {
   int32_t ret;
@@ -1008,7 +991,7 @@ int32_t lis2dh12_int1_gen_conf_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_gen_conf_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis2dh12_int1_cfg_t *val)
 {
   int32_t ret;
@@ -1024,7 +1007,7 @@ int32_t lis2dh12_int1_gen_conf_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_gen_source_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_gen_source_get(stmdev_ctx_t *ctx,
                                      lis2dh12_int1_src_t *val)
 {
   int32_t ret;
@@ -1041,7 +1024,7 @@ int32_t lis2dh12_int1_gen_source_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_int1_ths_t int1_ths;
   int32_t ret;
@@ -1064,7 +1047,7 @@ int32_t lis2dh12_int1_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_int1_ths_t int1_ths;
   int32_t ret;
@@ -1084,7 +1067,7 @@ int32_t lis2dh12_int1_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_int1_duration_t int1_duration;
   int32_t ret;
@@ -1106,7 +1089,7 @@ int32_t lis2dh12_int1_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_int1_duration_t int1_duration;
   int32_t ret;
@@ -1138,7 +1121,7 @@ int32_t lis2dh12_int1_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_gen_conf_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis2dh12_int2_cfg_t *val)
 {
   int32_t ret;
@@ -1154,7 +1137,7 @@ int32_t lis2dh12_int2_gen_conf_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_gen_conf_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis2dh12_int2_cfg_t *val)
 {
   int32_t ret;
@@ -1169,7 +1152,7 @@ int32_t lis2dh12_int2_gen_conf_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_gen_source_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_gen_source_get(stmdev_ctx_t *ctx,
                                      lis2dh12_int2_src_t *val)
 {
   int32_t ret;
@@ -1186,7 +1169,7 @@ int32_t lis2dh12_int2_gen_source_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_int2_ths_t int2_ths;
   int32_t ret;
@@ -1209,7 +1192,7 @@ int32_t lis2dh12_int2_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_int2_ths_t int2_ths;
   int32_t ret;
@@ -1229,7 +1212,7 @@ int32_t lis2dh12_int2_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_int2_duration_t int2_duration;
   int32_t ret;
@@ -1251,7 +1234,7 @@ int32_t lis2dh12_int2_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_int2_duration_t int2_duration;
   int32_t ret;
@@ -1282,7 +1265,7 @@ int32_t lis2dh12_int2_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_high_pass_int_conf_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                         lis2dh12_hp_t val)
 {
   lis2dh12_ctrl_reg2_t ctrl_reg2;
@@ -1304,7 +1287,7 @@ int32_t lis2dh12_high_pass_int_conf_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_high_pass_int_conf_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                         lis2dh12_hp_t *val)
 {
   lis2dh12_ctrl_reg2_t ctrl_reg2;
@@ -1351,7 +1334,7 @@ int32_t lis2dh12_high_pass_int_conf_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_pin_int1_config_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_int1_config_set(stmdev_ctx_t *ctx,
                                      lis2dh12_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1367,7 +1350,7 @@ int32_t lis2dh12_pin_int1_config_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_pin_int1_config_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_int1_config_get(stmdev_ctx_t *ctx,
                                      lis2dh12_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1384,7 +1367,7 @@ int32_t lis2dh12_pin_int1_config_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1406,7 +1389,7 @@ int32_t lis2dh12_int2_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1427,7 +1410,7 @@ int32_t lis2dh12_int2_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis2dh12_lir_int2_t val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
@@ -1451,7 +1434,7 @@ int32_t lis2dh12_int2_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int2_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis2dh12_lir_int2_t *val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
@@ -1481,7 +1464,7 @@ int32_t lis2dh12_int2_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1503,7 +1486,7 @@ int32_t lis2dh12_int1_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1523,7 +1506,7 @@ int32_t lis2dh12_int1_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis2dh12_lir_int1_t val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
@@ -1546,7 +1529,7 @@ int32_t lis2dh12_int1_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_int1_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis2dh12_lir_int1_t *val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
@@ -1575,7 +1558,7 @@ int32_t lis2dh12_int1_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_pin_int2_config_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_int2_config_set(stmdev_ctx_t *ctx,
                                      lis2dh12_ctrl_reg6_t *val)
 {
   int32_t ret;
@@ -1591,7 +1574,7 @@ int32_t lis2dh12_pin_int2_config_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_pin_int2_config_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_int2_config_get(stmdev_ctx_t *ctx,
                                      lis2dh12_ctrl_reg6_t *val)
 {
   int32_t ret;
@@ -1618,7 +1601,7 @@ int32_t lis2dh12_pin_int2_config_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1639,7 +1622,7 @@ int32_t lis2dh12_fifo_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1658,7 +1641,7 @@ int32_t lis2dh12_fifo_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_watermark_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1679,7 +1662,7 @@ int32_t lis2dh12_fifo_watermark_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_watermark_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1698,7 +1681,7 @@ int32_t lis2dh12_fifo_watermark_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_trigger_event_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lis2dh12_tr_t val)
 {
   lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
@@ -1720,7 +1703,7 @@ int32_t lis2dh12_fifo_trigger_event_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_trigger_event_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                         lis2dh12_tr_t *val)
 {
   lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
@@ -1749,7 +1732,7 @@ int32_t lis2dh12_fifo_trigger_event_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_fm_t val)
+int32_t lis2dh12_fifo_mode_set(stmdev_ctx_t *ctx, lis2dh12_fm_t val)
 {
   lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1770,7 +1753,7 @@ int32_t lis2dh12_fifo_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_fm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_fm_t *val)
+int32_t lis2dh12_fifo_mode_get(stmdev_ctx_t *ctx, lis2dh12_fm_t *val)
 {
   lis2dh12_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1804,7 +1787,7 @@ int32_t lis2dh12_fifo_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_fm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_status_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis2dh12_fifo_src_reg_t *val)
 {
   int32_t ret;
@@ -1819,7 +1802,7 @@ int32_t lis2dh12_fifo_status_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_data_level_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1837,7 +1820,7 @@ int32_t lis2dh12_fifo_data_level_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_empty_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1855,7 +1838,7 @@ int32_t lis2dh12_fifo_empty_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_ovr_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1873,7 +1856,7 @@ int32_t lis2dh12_fifo_ovr_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_fifo_fth_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1904,7 +1887,7 @@ int32_t lis2dh12_fifo_fth_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_tap_conf_set(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val)
+int32_t lis2dh12_tap_conf_set(stmdev_ctx_t *ctx, lis2dh12_click_cfg_t *val)
 {
   int32_t ret;
   ret = lis2dh12_write_reg(ctx, LIS2DH12_CLICK_CFG, (uint8_t*) val, 1);
@@ -1919,7 +1902,7 @@ int32_t lis2dh12_tap_conf_set(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_tap_conf_get(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val)
+int32_t lis2dh12_tap_conf_get(stmdev_ctx_t *ctx, lis2dh12_click_cfg_t *val)
 {
   int32_t ret;
   ret = lis2dh12_read_reg(ctx, LIS2DH12_CLICK_CFG, (uint8_t*) val, 1);
@@ -1933,7 +1916,7 @@ int32_t lis2dh12_tap_conf_get(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_tap_source_get(lis2dh12_ctx_t *ctx, lis2dh12_click_src_t *val)
+int32_t lis2dh12_tap_source_get(stmdev_ctx_t *ctx, lis2dh12_click_src_t *val)
 {
   int32_t ret;
   ret = lis2dh12_read_reg(ctx, LIS2DH12_CLICK_SRC, (uint8_t*) val, 1);
@@ -1948,7 +1931,7 @@ int32_t lis2dh12_tap_source_get(lis2dh12_ctx_t *ctx, lis2dh12_click_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_tap_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_click_ths_t click_ths;
   int32_t ret;
@@ -1970,7 +1953,7 @@ int32_t lis2dh12_tap_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_tap_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_click_ths_t click_ths;
   int32_t ret;
@@ -1992,7 +1975,7 @@ int32_t lis2dh12_tap_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_tap_notification_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis2dh12_lir_click_t val)
 {
   lis2dh12_click_ths_t click_ths;
@@ -2017,7 +2000,7 @@ int32_t lis2dh12_tap_notification_mode_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_tap_notification_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis2dh12_lir_click_t *val)
 {
   lis2dh12_click_ths_t click_ths;
@@ -2048,7 +2031,7 @@ int32_t lis2dh12_tap_notification_mode_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_shock_dur_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_time_limit_t time_limit;
   int32_t ret;
@@ -2071,7 +2054,7 @@ int32_t lis2dh12_shock_dur_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_shock_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_time_limit_t time_limit;
   int32_t ret;
@@ -2093,7 +2076,7 @@ int32_t lis2dh12_shock_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_quiet_dur_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_time_latency_t time_latency;
   int32_t ret;
@@ -2117,7 +2100,7 @@ int32_t lis2dh12_quiet_dur_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_quiet_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_time_latency_t time_latency;
   int32_t ret;
@@ -2139,7 +2122,7 @@ int32_t lis2dh12_quiet_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_double_tap_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_time_window_t time_window;
   int32_t ret;
@@ -2163,7 +2146,7 @@ int32_t lis2dh12_double_tap_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_double_tap_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_time_window_t time_window;
   int32_t ret;
@@ -2197,7 +2180,7 @@ int32_t lis2dh12_double_tap_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_act_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_act_ths_t act_ths;
   int32_t ret;
@@ -2220,7 +2203,7 @@ int32_t lis2dh12_act_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_act_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_act_ths_t act_ths;
   int32_t ret;
@@ -2240,7 +2223,7 @@ int32_t lis2dh12_act_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_act_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val)
+int32_t lis2dh12_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dh12_act_dur_t act_dur;
   int32_t ret;
@@ -2262,7 +2245,7 @@ int32_t lis2dh12_act_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_act_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dh12_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dh12_act_dur_t act_dur;
   int32_t ret;
@@ -2294,7 +2277,7 @@ int32_t lis2dh12_act_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_pin_sdo_sa0_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                       lis2dh12_sdo_pu_disc_t val)
 {
   lis2dh12_ctrl_reg0_t ctrl_reg0;
@@ -2316,7 +2299,7 @@ int32_t lis2dh12_pin_sdo_sa0_mode_set(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_pin_sdo_sa0_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                       lis2dh12_sdo_pu_disc_t *val)
 {
   lis2dh12_ctrl_reg0_t ctrl_reg0;
@@ -2345,7 +2328,7 @@ int32_t lis2dh12_pin_sdo_sa0_mode_get(lis2dh12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_spi_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_sim_t val)
+int32_t lis2dh12_spi_mode_set(stmdev_ctx_t *ctx, lis2dh12_sim_t val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -2366,7 +2349,7 @@ int32_t lis2dh12_spi_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dh12_spi_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_sim_t *val)
+int32_t lis2dh12_spi_mode_get(stmdev_ctx_t *ctx, lis2dh12_sim_t *val)
 {
   lis2dh12_ctrl_reg4_t ctrl_reg4;
   int32_t ret;

--- a/sensor/stmemsc/lis2dh12_STdC/driver/lis2dh12_reg.h
+++ b/sensor/stmemsc/lis2dh12_STdC/driver/lis2dh12_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS2DH12_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup LIS3MDL_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis2dh12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis2dh12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis2dh12_write_ptr  write_reg;
-  lis2dh12_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis2dh12_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -458,9 +430,9 @@ typedef union{
   *
   */
 
-int32_t lis2dh12_read_reg(lis2dh12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2dh12_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lis2dh12_write_reg(lis2dh12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2dh12_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float lis2dh12_from_fs2_hr_to_mg(int16_t lsb);
@@ -481,20 +453,20 @@ extern float lis2dh12_from_fs8_lp_to_mg(int16_t lsb);
 extern float lis2dh12_from_fs16_lp_to_mg(int16_t lsb);
 extern float lis2dh12_from_lsb_lp_to_celsius(int16_t lsb);
 
-int32_t lis2dh12_temp_status_reg_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2dh12_temp_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dh12_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_temp_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_temperature_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dh12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS2DH12_TEMP_DISABLE  = 0,
   LIS2DH12_TEMP_ENABLE   = 3,
 } lis2dh12_temp_en_t;
-int32_t lis2dh12_temperature_meas_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_temperature_meas_set(stmdev_ctx_t *ctx,
                                       lis2dh12_temp_en_t val);
-int32_t lis2dh12_temperature_meas_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_temperature_meas_get(stmdev_ctx_t *ctx,
                                       lis2dh12_temp_en_t *val);
 
 typedef enum {
@@ -502,9 +474,9 @@ typedef enum {
   LIS2DH12_NM_10bit   = 1,
   LIS2DH12_LP_8bit    = 2,
 } lis2dh12_op_md_t;
-int32_t lis2dh12_operating_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_operating_mode_set(stmdev_ctx_t *ctx,
                                     lis2dh12_op_md_t val);
-int32_t lis2dh12_operating_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_operating_mode_get(stmdev_ctx_t *ctx,
                                     lis2dh12_op_md_t *val);
 
 typedef enum {
@@ -519,11 +491,11 @@ typedef enum {
   LIS2DH12_ODR_1kHz620_LP                  = 0x08,
   LIS2DH12_ODR_5kHz376_LP_1kHz344_NM_HP    = 0x09,
 } lis2dh12_odr_t;
-int32_t lis2dh12_data_rate_set(lis2dh12_ctx_t *ctx, lis2dh12_odr_t val);
-int32_t lis2dh12_data_rate_get(lis2dh12_ctx_t *ctx, lis2dh12_odr_t *val);
+int32_t lis2dh12_data_rate_set(stmdev_ctx_t *ctx, lis2dh12_odr_t val);
+int32_t lis2dh12_data_rate_get(stmdev_ctx_t *ctx, lis2dh12_odr_t *val);
 
-int32_t lis2dh12_high_pass_on_outputs_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_high_pass_on_outputs_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DH12_AGGRESSIVE  = 0,
@@ -531,9 +503,9 @@ typedef enum {
   LIS2DH12_MEDIUM      = 2,
   LIS2DH12_LIGHT       = 3,
 } lis2dh12_hpcf_t;
-int32_t lis2dh12_high_pass_bandwidth_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis2dh12_hpcf_t val);
-int32_t lis2dh12_high_pass_bandwidth_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis2dh12_hpcf_t *val);
 
 typedef enum {
@@ -542,8 +514,8 @@ typedef enum {
   LIS2DH12_NORMAL           = 2,
   LIS2DH12_AUTORST_ON_INT   = 3,
 } lis2dh12_hpm_t;
-int32_t lis2dh12_high_pass_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t val);
-int32_t lis2dh12_high_pass_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_hpm_t *val);
+int32_t lis2dh12_high_pass_mode_set(stmdev_ctx_t *ctx, lis2dh12_hpm_t val);
+int32_t lis2dh12_high_pass_mode_get(stmdev_ctx_t *ctx, lis2dh12_hpm_t *val);
 
 typedef enum {
   LIS2DH12_2g   = 0,
@@ -551,70 +523,70 @@ typedef enum {
   LIS2DH12_8g   = 2,
   LIS2DH12_16g  = 3,
 } lis2dh12_fs_t;
-int32_t lis2dh12_full_scale_set(lis2dh12_ctx_t *ctx, lis2dh12_fs_t val);
-int32_t lis2dh12_full_scale_get(lis2dh12_ctx_t *ctx, lis2dh12_fs_t *val);
+int32_t lis2dh12_full_scale_set(stmdev_ctx_t *ctx, lis2dh12_fs_t val);
+int32_t lis2dh12_full_scale_get(stmdev_ctx_t *ctx, lis2dh12_fs_t *val);
 
-int32_t lis2dh12_block_data_update_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_block_data_update_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_filter_reference_set(lis2dh12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2dh12_filter_reference_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dh12_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dh12_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2dh12_xl_data_ready_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_xl_data_ovr_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_acceleration_raw_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dh12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2dh12_device_id_get(lis2dh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dh12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS2DH12_ST_DISABLE   = 0,
   LIS2DH12_ST_POSITIVE  = 1,
   LIS2DH12_ST_NEGATIVE  = 2,
 } lis2dh12_st_t;
-int32_t lis2dh12_self_test_set(lis2dh12_ctx_t *ctx, lis2dh12_st_t val);
-int32_t lis2dh12_self_test_get(lis2dh12_ctx_t *ctx, lis2dh12_st_t *val);
+int32_t lis2dh12_self_test_set(stmdev_ctx_t *ctx, lis2dh12_st_t val);
+int32_t lis2dh12_self_test_get(stmdev_ctx_t *ctx, lis2dh12_st_t *val);
 
 typedef enum {
   LIS2DH12_LSB_AT_LOW_ADD = 0,
   LIS2DH12_MSB_AT_LOW_ADD = 1,
 } lis2dh12_ble_t;
-int32_t lis2dh12_data_format_set(lis2dh12_ctx_t *ctx, lis2dh12_ble_t val);
-int32_t lis2dh12_data_format_get(lis2dh12_ctx_t *ctx, lis2dh12_ble_t *val);
+int32_t lis2dh12_data_format_set(stmdev_ctx_t *ctx, lis2dh12_ble_t val);
+int32_t lis2dh12_data_format_get(stmdev_ctx_t *ctx, lis2dh12_ble_t *val);
 
-int32_t lis2dh12_boot_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_boot_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_status_get(lis2dh12_ctx_t *ctx, lis2dh12_status_reg_t *val);
+int32_t lis2dh12_status_get(stmdev_ctx_t *ctx, lis2dh12_status_reg_t *val);
 
-int32_t lis2dh12_int1_gen_conf_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis2dh12_int1_cfg_t *val);
-int32_t lis2dh12_int1_gen_conf_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis2dh12_int1_cfg_t *val);
 
-int32_t lis2dh12_int1_gen_source_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_gen_source_get(stmdev_ctx_t *ctx,
                                      lis2dh12_int1_src_t *val);
 
-int32_t lis2dh12_int1_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_int1_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_int1_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_int1_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_int2_gen_conf_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis2dh12_int2_cfg_t *val);
-int32_t lis2dh12_int2_gen_conf_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis2dh12_int2_cfg_t *val);
 
-int32_t lis2dh12_int2_gen_source_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_gen_source_get(stmdev_ctx_t *ctx,
                                      lis2dh12_int2_src_t *val);
 
-int32_t lis2dh12_int2_gen_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_int2_gen_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_int2_gen_duration_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_int2_gen_duration_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DH12_DISC_FROM_INT_GENERATOR  = 0,
@@ -626,58 +598,58 @@ typedef enum {
   LIS2DH12_ON_INT2_TAP_GEN          = 6,
   LIS2DH12_ON_INT1_INT2_TAP_GEN     = 7,
 } lis2dh12_hp_t;
-int32_t lis2dh12_high_pass_int_conf_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                         lis2dh12_hp_t val);
-int32_t lis2dh12_high_pass_int_conf_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                         lis2dh12_hp_t *val);
 
-int32_t lis2dh12_pin_int1_config_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_int1_config_set(stmdev_ctx_t *ctx,
                                      lis2dh12_ctrl_reg3_t *val);
-int32_t lis2dh12_pin_int1_config_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_int1_config_get(stmdev_ctx_t *ctx,
                                      lis2dh12_ctrl_reg3_t *val);
 
-int32_t lis2dh12_int2_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_int2_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DH12_INT2_PULSED   = 0,
   LIS2DH12_INT2_LATCHED  = 1,
 } lis2dh12_lir_int2_t;
-int32_t lis2dh12_int2_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis2dh12_lir_int2_t val);
-int32_t lis2dh12_int2_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis2dh12_lir_int2_t *val);
 
-int32_t lis2dh12_int1_pin_detect_4d_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_int1_pin_detect_4d_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DH12_INT1_PULSED   = 0,
   LIS2DH12_INT1_LATCHED  = 1,
 } lis2dh12_lir_int1_t;
-int32_t lis2dh12_int1_pin_notification_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis2dh12_lir_int1_t val);
-int32_t lis2dh12_int1_pin_notification_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis2dh12_lir_int1_t *val);
 
-int32_t lis2dh12_pin_int2_config_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_int2_config_set(stmdev_ctx_t *ctx,
                                      lis2dh12_ctrl_reg6_t *val);
-int32_t lis2dh12_pin_int2_config_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_int2_config_get(stmdev_ctx_t *ctx,
                                      lis2dh12_ctrl_reg6_t *val);
 
-int32_t lis2dh12_fifo_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_fifo_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_fifo_watermark_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_fifo_watermark_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DH12_INT1_GEN = 0,
   LIS2DH12_INT2_GEN = 1,
 } lis2dh12_tr_t;
-int32_t lis2dh12_fifo_trigger_event_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lis2dh12_tr_t val);
-int32_t lis2dh12_fifo_trigger_event_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                         lis2dh12_tr_t *val);
 
 typedef enum {
@@ -686,68 +658,68 @@ typedef enum {
   LIS2DH12_DYNAMIC_STREAM_MODE   = 2,
   LIS2DH12_STREAM_TO_FIFO_MODE   = 3,
 } lis2dh12_fm_t;
-int32_t lis2dh12_fifo_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_fm_t val);
-int32_t lis2dh12_fifo_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_fm_t *val);
+int32_t lis2dh12_fifo_mode_set(stmdev_ctx_t *ctx, lis2dh12_fm_t val);
+int32_t lis2dh12_fifo_mode_get(stmdev_ctx_t *ctx, lis2dh12_fm_t *val);
 
-int32_t lis2dh12_fifo_status_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis2dh12_fifo_src_reg_t *val);
 
-int32_t lis2dh12_fifo_data_level_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_fifo_empty_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_fifo_ovr_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_fifo_fth_flag_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_tap_conf_set(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val);
-int32_t lis2dh12_tap_conf_get(lis2dh12_ctx_t *ctx, lis2dh12_click_cfg_t *val);
+int32_t lis2dh12_tap_conf_set(stmdev_ctx_t *ctx, lis2dh12_click_cfg_t *val);
+int32_t lis2dh12_tap_conf_get(stmdev_ctx_t *ctx, lis2dh12_click_cfg_t *val);
 
-int32_t lis2dh12_tap_source_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_tap_source_get(stmdev_ctx_t *ctx,
                                 lis2dh12_click_src_t *val);
 
-int32_t lis2dh12_tap_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_tap_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DH12_TAP_PULSED   = 0,
   LIS2DH12_TAP_LATCHED  = 1,
 } lis2dh12_lir_click_t;
-int32_t lis2dh12_tap_notification_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis2dh12_lir_click_t val);
-int32_t lis2dh12_tap_notification_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis2dh12_lir_click_t *val);
 
-int32_t lis2dh12_shock_dur_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_shock_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_quiet_dur_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_quiet_dur_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_double_tap_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_double_tap_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_act_threshold_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_act_threshold_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dh12_act_timeout_set(lis2dh12_ctx_t *ctx, uint8_t val);
-int32_t lis2dh12_act_timeout_get(lis2dh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dh12_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dh12_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DH12_PULL_UP_DISCONNECT  = 0,
   LIS2DH12_PULL_UP_CONNECT     = 1,
 } lis2dh12_sdo_pu_disc_t;
-int32_t lis2dh12_pin_sdo_sa0_mode_set(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                       lis2dh12_sdo_pu_disc_t val);
-int32_t lis2dh12_pin_sdo_sa0_mode_get(lis2dh12_ctx_t *ctx,
+int32_t lis2dh12_pin_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                       lis2dh12_sdo_pu_disc_t *val);
 
 typedef enum {
   LIS2DH12_SPI_4_WIRE = 0,
   LIS2DH12_SPI_3_WIRE = 1,
 } lis2dh12_sim_t;
-int32_t lis2dh12_spi_mode_set(lis2dh12_ctx_t *ctx, lis2dh12_sim_t val);
-int32_t lis2dh12_spi_mode_get(lis2dh12_ctx_t *ctx, lis2dh12_sim_t *val);
+int32_t lis2dh12_spi_mode_set(stmdev_ctx_t *ctx, lis2dh12_sim_t val);
+int32_t lis2dh12_spi_mode_get(stmdev_ctx_t *ctx, lis2dh12_sim_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/lis2ds12_STdC/driver/lis2ds12_reg.c
+++ b/sensor/stmemsc/lis2ds12_STdC/driver/lis2ds12_reg.c
@@ -1,2693 +1,3205 @@
 /*
  ******************************************************************************
  * @file    lis2ds12_reg.c
- * @author  MEMS Software Solution Team
+ * @author  Sensors Software Solution Team
  * @brief   LIS2DS12 driver file
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis2ds12_reg.h"
 
 /**
-  * @addtogroup  lis2ds12
-  * @brief  This file provides a set of functions needed to drive the
-  *         lis2ds12 enanced inertial module.
+  * @defgroup  LIS2DS12
+  * @brief     This file provides a set of functions needed to drive the
+  *            lis2ds12 enhanced inertial module.
   * @{
+  *
   */
 
 /**
-  * @addtogroup  interfaces_functions
-  * @brief  This section provide a set of functions used to read and write
-  *         a generic register of the device.
+  * @defgroup  LIS2DS12_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
   * @{
+  *
   */
 
 /**
   * @brief  Read generic device register
   *
-  * @param  lis2ds12_ctx_t* ctx: read / write interface definitions
-  * @param  uint8_t reg: register to read
-  * @param  uint8_t* data: pointer to buffer that store the data read
-  * @param  uint16_t len: number of consecutive register to read
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2ds12_read_reg(lis2ds12_ctx_t* ctx, uint8_t reg, uint8_t* data,
-                          uint16_t len)
+int32_t lis2ds12_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
 {
-  return ctx->read_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @brief  Write generic device register
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t reg: register to write
-  * @param  uint8_t* data: pointer to data to write in register reg
-  * @param  uint16_t len: number of consecutive register to write
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
-*/
-int32_t lis2ds12_write_reg(lis2ds12_ctx_t* ctx, uint8_t reg, uint8_t* data,
-                           uint16_t len)
+  */
+int32_t lis2ds12_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
 {
-  return ctx->write_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
-/**
-  * @addtogroup  data_generation_c
-  * @brief   This section groups all the functions concerning data generation
+  /**
+  * @defgroup    LIS2DS12_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
   * @{
+  *
+  */
+
+float_t lis2ds12_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.061f);
+}
+
+float_t lis2ds12_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.122f);
+}
+
+float_t lis2ds12_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.244f);
+}
+
+float_t lis2ds12_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb *0.488f);
+}
+
+float_t lis2ds12_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
   */
 
 /**
-  * @brief  all_sources: [get] Read all the interrupt/status flag of
-  *                            the device.
-  *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_all_sources: FIFO_SRC, STATUS_DUP, WAKE_UP_SRC, TAP_SRC,
-  *                               6D_SRC, FUNC_CK_GATE, FUNC_SRC.
+  * @defgroup  Data generation
+  * @brief     This section groups all the functions concerning
+  *            data generation
+  * @{
   *
   */
-int32_t lis2ds12_all_sources_get(lis2ds12_ctx_t *ctx,
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get FIFO_SRC, STATUS_DUP, WAKE_UP_SRC, TAP_SRC,
+  *                6D_SRC, FUNC_CK_GATE, FUNC_SRC.(ptr)
+  *
+  */
+int32_t lis2ds12_all_sources_get(stmdev_ctx_t *ctx,
                                  lis2ds12_all_sources_t *val)
 {
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &(val->byte[0]), 1);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STATUS_DUP, &(val->byte[1]), 4);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE, &(val->byte[5]), 2);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC,
+                          (uint8_t*)&(val->fifo_src), 1);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_STATUS_DUP,
+                            (uint8_t*)&(val->status_dup), 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_SRC,
+                            (uint8_t*)&(val->wake_up_src), 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_TAP_SRC,
+                            (uint8_t*)&(val->tap_src), 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_6D_SRC,
+                            (uint8_t*)&(val->_6d_src), 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE,
+                            (uint8_t*)&(val->func_ck_gate), 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_SRC,
+                            (uint8_t*)&(val->func_src), 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [set] Blockdataupdate.
+  * @brief  Blockdataupdate.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of bdu in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of bdu in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_block_data_update_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl1_t ctrl1;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-  reg.ctrl1.bdu = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ctrl1.bdu = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [get] Blockdataupdate.
+  * @brief  Blockdataupdate.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of bdu in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    get the values of bdu in reg CTRL1(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_block_data_update_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl1_t ctrl1;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-  *val = reg.ctrl1.bdu;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  *val = ctrl1.bdu;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  xl_full_scale: [set]   Accelerometer full-scale selection.
+  * @brief  Accelerometer full-scale selection.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_fs_t: change the values of fs in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of fs in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_full_scale_set(lis2ds12_ctx_t *ctx, lis2ds12_fs_t val)
+int32_t lis2ds12_xl_full_scale_set(stmdev_ctx_t *ctx, lis2ds12_fs_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl1_t ctrl1;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-  reg.ctrl1.fs = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ctrl1.fs = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_full_scale: [get]   Accelerometer full-scale selection.
+  * @brief  Accelerometer full-scale selection.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_fs_t: Get the values of fs in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs in reg CTRL1(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_full_scale_get(lis2ds12_ctx_t *ctx, lis2ds12_fs_t *val)
+int32_t lis2ds12_xl_full_scale_get(stmdev_ctx_t *ctx, lis2ds12_fs_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl1_t ctrl1;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-  *val = (lis2ds12_fs_t) reg.ctrl1.fs;
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  switch (ctrl1.fs){
+    case LIS2DS12_2g:
+      *val = LIS2DS12_2g;
+      break;
+    case LIS2DS12_16g:
+      *val = LIS2DS12_16g;
+      break;
+    case LIS2DS12_4g:
+      *val = LIS2DS12_4g;
+      break;
+    case LIS2DS12_8g:
+      *val = LIS2DS12_8g;
+      break;
+    default:
+      *val = LIS2DS12_2g;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_data_rate: [set]  Accelerometer data rate selection.
+  * @brief  Accelerometer data rate selection.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_odr_t: change the values of odr in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of odr in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_data_rate_set(lis2ds12_ctx_t *ctx, lis2ds12_odr_t val)
+int32_t lis2ds12_xl_data_rate_set(stmdev_ctx_t *ctx, lis2ds12_odr_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl1_t ctrl1;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-  reg.ctrl1.odr = val & 0x0F;
-  reg.ctrl1.hf_odr = (val & 0x10) >> 4;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  if(ret == 0){
+    ctrl1.odr = (uint8_t)val & 0x0FU;
+    ctrl1.hf_odr = ((uint8_t)val & 0x10U) >> 4;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_data_rate: [get]  Accelerometer data rate selection.
+  * @brief  Accelerometer data rate selection.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_odr_t: Get the values of odr in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CTRL1(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_data_rate_get(lis2ds12_ctx_t *ctx, lis2ds12_odr_t *val)
+int32_t lis2ds12_xl_data_rate_get(stmdev_ctx_t *ctx, lis2ds12_odr_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl1_t ctrl1;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, &reg.byte, 1);
-  *val = (lis2ds12_odr_t) ((reg.ctrl1.hf_odr << 4) + reg.ctrl1.odr);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL1, (uint8_t*)&ctrl1, 1);
+  switch ((ctrl1.hf_odr << 4) + ctrl1.odr){
+    case LIS2DS12_XL_ODR_OFF:
+      *val = LIS2DS12_XL_ODR_OFF;
+      break;
+    case LIS2DS12_XL_ODR_1Hz_LP:
+      *val = LIS2DS12_XL_ODR_1Hz_LP;
+      break;
+    case LIS2DS12_XL_ODR_12Hz5_LP:
+      *val = LIS2DS12_XL_ODR_12Hz5_LP;
+      break;
+    case LIS2DS12_XL_ODR_25Hz_LP:
+      *val = LIS2DS12_XL_ODR_25Hz_LP;
+      break;
+    case LIS2DS12_XL_ODR_50Hz_LP:
+      *val = LIS2DS12_XL_ODR_50Hz_LP;
+      break;
+    case LIS2DS12_XL_ODR_100Hz_LP:
+      *val = LIS2DS12_XL_ODR_100Hz_LP;
+      break;
+    case LIS2DS12_XL_ODR_200Hz_LP:
+      *val = LIS2DS12_XL_ODR_200Hz_LP;
+      break;
+    case LIS2DS12_XL_ODR_400Hz_LP:
+      *val = LIS2DS12_XL_ODR_400Hz_LP;
+      break;
+    case LIS2DS12_XL_ODR_800Hz_LP:
+      *val = LIS2DS12_XL_ODR_800Hz_LP;
+      break;
+    case LIS2DS12_XL_ODR_12Hz5_HR:
+      *val = LIS2DS12_XL_ODR_12Hz5_HR;
+      break;
+    case LIS2DS12_XL_ODR_25Hz_HR:
+      *val = LIS2DS12_XL_ODR_25Hz_HR;
+      break;
+    case LIS2DS12_XL_ODR_50Hz_HR:
+      *val = LIS2DS12_XL_ODR_50Hz_HR;
+      break;
+    case LIS2DS12_XL_ODR_100Hz_HR:
+      *val = LIS2DS12_XL_ODR_100Hz_HR;
+      break;
+    case LIS2DS12_XL_ODR_200Hz_HR:
+      *val = LIS2DS12_XL_ODR_200Hz_HR;
+      break;
+    case LIS2DS12_XL_ODR_400Hz_HR:
+      *val = LIS2DS12_XL_ODR_400Hz_HR;
+      break;
+    case LIS2DS12_XL_ODR_800Hz_HR:
+      *val = LIS2DS12_XL_ODR_800Hz_HR;
+      break;
+    case LIS2DS12_XL_ODR_1k6Hz_HF:
+      *val = LIS2DS12_XL_ODR_1k6Hz_HF;
+      break;
+    case LIS2DS12_XL_ODR_3k2Hz_HF:
+      *val = LIS2DS12_XL_ODR_3k2Hz_HF;
+      break;
+    case LIS2DS12_XL_ODR_6k4Hz_HF:
+      *val = LIS2DS12_XL_ODR_6k4Hz_HF;
+      break;
+    default:
+      *val = LIS2DS12_XL_ODR_OFF;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  status_reg: [get]  The STATUS_REG register.
+  * @brief  The STATUS_REG register.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_status_reg_t: registers STATUS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_status_reg_get(lis2ds12_ctx_t *ctx, lis2ds12_status_t *val)
+int32_t lis2ds12_status_reg_get(stmdev_ctx_t *ctx, lis2ds12_status_t *val)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_STATUS, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STATUS, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  xl_flag_data_ready: [get]  Accelerometer new data available.
+  * @brief  Accelerometer new data available.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of drdy in reg STATUS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    get the values of drdy in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_flag_data_ready_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STATUS, &reg.byte, 1);
-  *val = reg.status.drdy;
-
-  return mm_error;
+  lis2ds12_status_t status;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STATUS, (uint8_t*)&status, 1);
+  *val = status.drdy;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Dataoutput
-  * @brief   This section groups all the data output functions.
+  * @defgroup  Data output
+  * @brief     This section groups all the data output functions.
   * @{
+  *
   */
 
 /**
-  * @brief   acceleration_module_raw: [get]   Module output value (8-bit).
+  * @brief  Module output value (8-bit).[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_acceleration_module_raw_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_acceleration_module_raw_get(stmdev_ctx_t *ctx,
                                              uint8_t *buff)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_MODULE_8BIT, buff, 1);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_MODULE_8BIT, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  temperature_raw: [get] Temperature data output register (r).
-  *                                L and H registers together express a 16-bit
-  *                                word in two’s complement.
+  * @brief  Temperature data output register (r). L and H registers together
+  *         express a 16-bit word in two’s complement.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_temperature_raw_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2ds12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_OUT_T, buff, 1);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_OUT_T, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  acceleration_raw: [get] Linear acceleration output register.
-  *                                 The value is expressed as a 16-bit word
-  *                                 in two’s complement.
+  * @brief  Linear acceleration output register. The value is expressed as a
+  *         16-bit word in two’s complement.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_acceleration_raw_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2ds12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_OUT_X_L, buff, 6);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_OUT_X_L, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  number_of_steps: [get] Number of steps detected by step
-  *                                counter routine.
+  * @brief  Number of steps detected by step counter routine.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_number_of_steps_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2ds12_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_L, buff, 2);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_L, buff, 2);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  common
-  * @brief   This section groups common usefull functions.
+  * @defgroup  Common
+  * @brief     This section groups common usefull functions.
   * @{
+  *
   */
 
 /**
-  * @brief  device_id: [get] DeviceWhoamI.
+  * @brief  DeviceWhoamI.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_device_id_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2ds12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_WHO_AM_I, buff, 1);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WHO_AM_I, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  auto_increment: [set] Register address automatically
-  *                               incremented during a multiple byte
-  *                               access with a serial interface.
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of if_add_inc in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of if_add_inc in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_auto_increment_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  reg.ctrl2.if_add_inc = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-
-  return mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.if_add_inc = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  auto_increment: [get] Register address automatically incremented
-  *                               during a multiple byte access with a
-  *                               serial interface.
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of if_add_inc in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_add_inc in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_auto_increment_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  *val = reg.ctrl2.if_add_inc;
-
-  return mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  *val = ctrl2.if_add_inc;
+  return ret;
 }
 
 /**
-  * @brief  mem_bank: [set] Enable access to the embedded functions/sensor
-  *                         hub configuration registers.
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_func_cfg_en_t: change the values of func_cfg_en in
-  *                                 reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of func_cfg_en in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_mem_bank_set(lis2ds12_ctx_t *ctx, lis2ds12_func_cfg_en_t val)
+int32_t lis2ds12_mem_bank_set(stmdev_ctx_t *ctx, lis2ds12_func_cfg_en_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  lis2ds12_ctrl2_adv_t ctrl2_adv;
+  int32_t ret;
 
   if (val == LIS2DS12_ADV_BANK){
-    mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-    reg.ctrl2.func_cfg_en = val;
-    mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+    if(ret == 0){
+      ctrl2.func_cfg_en = (uint8_t)val;
+      ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+    }
   }
   else {
-    mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2_ADV, &reg.byte, 1);
-    reg.ctrl2.func_cfg_en = val;
-    mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2_ADV, &reg.byte, 1);
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2_ADV,
+                            (uint8_t*)&ctrl2_adv, 1);
+    if(ret == 0){
+      ctrl2_adv.func_cfg_en = (uint8_t)val;
+      ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2_ADV,
+                               (uint8_t*)&ctrl2_adv, 1);
+    }
   }
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  reset: [set] Software reset. Restore the default values in
-  *                      user registers.
+  * @brief  Software reset. Restore the default values in
+  *         user registers.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of soft_reset in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of soft_reset in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_reset_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  reg.ctrl2.soft_reset = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.soft_reset = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  reset: [get] Software reset. Restore the default values in
-  *                      user registers.
+  * @brief  Software reset. Restore the default values
+  *         in user registers.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of soft_reset in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    get the values of soft_reset in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_reset_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  *val = reg.ctrl2.soft_reset;
-
-  return mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  *val = ctrl2.soft_reset;
+  return ret;
 }
 
 /**
-  * @brief  boot: [set] Reboot memory content. Reload the calibration
-  *                     parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of boot in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of boot in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_boot_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  reg.ctrl2.boot = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.boot = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  boot: [get] Reboot memory content. Reload the calibration
-  *                     parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of boot in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    get the values of boot in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_boot_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  *val = reg.ctrl2.boot;
-
-  return mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  *val = ctrl2.boot;
+  return ret;
 }
 
 /**
   * @brief  xl_self_test: [set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_st_t: change the values of st in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of st in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_self_test_set(lis2ds12_ctx_t *ctx, lis2ds12_st_t val)
+int32_t lis2ds12_xl_self_test_set(stmdev_ctx_t *ctx, lis2ds12_st_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  reg.ctrl3.st = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.st = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_self_test: [get]
+  * @brief  xl_self_test [get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_st_t: Get the values of st in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_self_test_get(lis2ds12_ctx_t *ctx, lis2ds12_st_t *val)
+int32_t lis2ds12_xl_self_test_get(stmdev_ctx_t *ctx, lis2ds12_st_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  *val = (lis2ds12_st_t) reg.ctrl3.st;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  switch (ctrl3.st){
+    case LIS2DS12_XL_ST_DISABLE:
+      *val = LIS2DS12_XL_ST_DISABLE;
+      break;
+    case LIS2DS12_XL_ST_POSITIVE:
+      *val = LIS2DS12_XL_ST_POSITIVE;
+      break;
+    case LIS2DS12_XL_ST_NEGATIVE:
+      *val = LIS2DS12_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS2DS12_XL_ST_DISABLE;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  data_ready_mode: [set]
+  * @brief  data_ready_mode [set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_drdy_pulsed_t: change the values of drdy_pulsed in
-  *                                 reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of drdy_pulsed in reg CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_data_ready_mode_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_data_ready_mode_set(stmdev_ctx_t *ctx,
                                      lis2ds12_drdy_pulsed_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl5_t ctrl5;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-  reg.ctrl5.drdy_pulsed = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.drdy_pulsed = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
 }
 
 /**
   * @brief  data_ready_mode: [get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_drdy_pulsed_t: Get the values of drdy_pulsed in reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_pulsed in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_data_ready_mode_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_data_ready_mode_get(stmdev_ctx_t *ctx,
                                      lis2ds12_drdy_pulsed_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl5_t ctrl5;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-  *val = (lis2ds12_drdy_pulsed_t) reg.ctrl5.drdy_pulsed;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  switch (ctrl5.drdy_pulsed){
+    case LIS2DS12_DRDY_LATCHED:
+      *val = LIS2DS12_DRDY_LATCHED;
+      break;
+    case LIS2DS12_DRDY_PULSED:
+      *val = LIS2DS12_DRDY_PULSED;
+      break;
+    default:
+      *val = LIS2DS12_DRDY_LATCHED;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Filters
-  * @brief   This section group all the functions concerning the filters
-  *          configuration.
+  * @defgroup  Filters
+  * @brief     This section group all the functions concerning the filters
+  *            configuration.
   * @{
+  *
   */
 
 /**
-  * @brief  xl_hp_path: [set] High-pass filter data selection on output
-  *                           register and FIFO.
+  * @brief  High-pass filter data selection on output register and FIFO.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_fds_slope_t: change the values of fds_slope in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of fds_slope in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_hp_path_set(lis2ds12_ctx_t *ctx, lis2ds12_fds_slope_t val)
+int32_t lis2ds12_xl_hp_path_set(stmdev_ctx_t *ctx, lis2ds12_fds_slope_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  reg.ctrl2.fds_slope = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.fds_slope = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_hp_path: [get] High-pass filter data selection on output
-  *                           register and FIFO.
+  * @brief  High-pass filter data selection on output register and FIFO.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_fds_slope_t: Get the values of fds_slope in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fds_slope in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_xl_hp_path_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_xl_hp_path_get(stmdev_ctx_t *ctx,
                                 lis2ds12_fds_slope_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  *val = (lis2ds12_fds_slope_t) reg.ctrl2.fds_slope;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  switch (ctrl2.fds_slope){
+    case LIS2DS12_HP_INTERNAL_ONLY:
+      *val = LIS2DS12_HP_INTERNAL_ONLY;
+      break;
+    case LIS2DS12_HP_ON_OUTPUTS:
+      *val = LIS2DS12_HP_ON_OUTPUTS;
+      break;
+    default:
+      *val = LIS2DS12_HP_INTERNAL_ONLY;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   Auxiliary_interface
-  * @brief   This section groups all the functions concerning auxiliary
-  *          interface.
+  * @defgroup   Auxiliary_interface
+  * @brief      This section groups all the functions concerning auxiliary
+  *             interface.
   * @{
+  *
   */
 
 /**
-  * @brief  spi_mode: [set]  SPI Serial Interface Mode selection.
+  * @brief  SPI Serial Interface Mode selection.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_sim_t: change the values of sim in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of sim in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_spi_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_sim_t val)
+int32_t lis2ds12_spi_mode_set(stmdev_ctx_t *ctx, lis2ds12_sim_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  reg.ctrl2.sim = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.sim = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  spi_mode: [get]  SPI Serial Interface Mode selection.
+  * @brief  SPI Serial Interface Mode selection.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_sim_t: Get the values of sim in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_spi_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_sim_t *val)
+int32_t lis2ds12_spi_mode_get(stmdev_ctx_t *ctx, lis2ds12_sim_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  *val = (lis2ds12_sim_t) reg.ctrl2.sim;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  switch (ctrl2.sim){
+    case LIS2DS12_SPI_4_WIRE:
+      *val = LIS2DS12_SPI_4_WIRE;
+      break;
+    case LIS2DS12_SPI_3_WIRE:
+      *val = LIS2DS12_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS2DS12_SPI_4_WIRE;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [set]  Disable / Enable I2C interface.
+  * @brief  Disable / Enable I2C interface.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_i2c_disable_t: change the values of i2c_disable
-  *                                 in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of i2c_disable in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_i2c_interface_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_i2c_interface_set(stmdev_ctx_t *ctx,
                                    lis2ds12_i2c_disable_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  reg.ctrl2.i2c_disable = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  if(ret == 0){
+    ctrl2.i2c_disable = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [get]  Disable / Enable I2C interface.
+  * @brief  Disable / Enable I2C interface.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_i2c_disable_t: Get the values of i2c_disable in
-  *                                 reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_disable in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_i2c_interface_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_i2c_interface_get(stmdev_ctx_t *ctx,
                                    lis2ds12_i2c_disable_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl2_t ctrl2;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, &reg.byte, 1);
-  *val = (lis2ds12_i2c_disable_t) reg.ctrl2.i2c_disable;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL2, (uint8_t*)&ctrl2, 1);
+  switch (ctrl2.i2c_disable){
+    case LIS2DS12_I2C_ENABLE:
+      *val = LIS2DS12_I2C_ENABLE;
+      break;
+    case LIS2DS12_I2C_DISABLE:
+      *val = LIS2DS12_I2C_DISABLE;
+      break;
+    default:
+      *val = LIS2DS12_I2C_ENABLE;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  cs_mode: [set]  Connect/Disconnects pull-up in if_cs pad.
+  * @brief  Connect/Disconnects pull-up in if_cs pad.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_if_cs_pu_dis_t: change the values of if_cs_pu_dis
-  *                                  in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of if_cs_pu_dis in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_cs_mode_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_cs_mode_set(stmdev_ctx_t *ctx,
                              lis2ds12_if_cs_pu_dis_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-  reg.fifo_ctrl.if_cs_pu_dis = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.if_cs_pu_dis = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL,
+                             (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  cs_mode: [get]  Connect/Disconnects pull-up in if_cs pad.
+  * @brief  Connect/Disconnects pull-up in if_cs pad.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_if_cs_pu_dis_t: Get the values of if_cs_pu_dis in
-  *                                  reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_cs_pu_dis in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_cs_mode_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_cs_mode_get(stmdev_ctx_t *ctx,
                              lis2ds12_if_cs_pu_dis_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-  *val = (lis2ds12_if_cs_pu_dis_t) reg.fifo_ctrl.if_cs_pu_dis;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL,
+                          (uint8_t*)&fifo_ctrl, 1);
+  switch (fifo_ctrl.if_cs_pu_dis){
+    case LIS2DS12_PULL_UP_CONNECTED:
+      *val = LIS2DS12_PULL_UP_CONNECTED;
+      break;
+    case LIS2DS12_PULL_UP_DISCONNECTED:
+      *val = LIS2DS12_PULL_UP_DISCONNECTED;
+      break;
+    default:
+      *val = LIS2DS12_PULL_UP_CONNECTED;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   main_serial_interface
-  * @brief   This section groups all the functions concerning main serial
-  *          interface management (not auxiliary)
+  * @defgroup   Serial Interface
+  * @brief      This section groups all the functions concerning main serial
+  *             interface management (not auxiliary)
   * @{
+  *
   */
 
 /**
-  * @brief  pin_mode: [set]  Push-pull/open-drain selection on interrupt pad.
+  * @brief  Push-pull/open-drain selection on interrupt pad.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_pp_od_t: change the values of pp_od in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of pp_od in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pin_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_pp_od_t val)
+int32_t lis2ds12_pin_mode_set(stmdev_ctx_t *ctx, lis2ds12_pp_od_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  reg.ctrl3.pp_od = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.pp_od = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_mode: [get]  Push-pull/open-drain selection on interrupt pad.
+  * @brief  Push-pull/open-drain selection on interrupt pad.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_pp_od_t: Get the values of pp_od in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pin_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_pp_od_t *val)
+int32_t lis2ds12_pin_mode_get(stmdev_ctx_t *ctx, lis2ds12_pp_od_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  *val = (lis2ds12_pp_od_t) reg.ctrl3.pp_od;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  switch (ctrl3.pp_od){
+    case LIS2DS12_PUSH_PULL:
+      *val = LIS2DS12_PUSH_PULL;
+      break;
+    case LIS2DS12_OPEN_DRAIN:
+      *val = LIS2DS12_OPEN_DRAIN;
+      break;
+    default:
+      *val = LIS2DS12_PUSH_PULL;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_polarity: [set]  Interrupt active-high/low.
+  * @brief  pin_polarity:   Interrupt active-high/low.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_h_lactive_t: change the values of h_lactive in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of h_lactive in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pin_polarity_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_polarity_set(stmdev_ctx_t *ctx,
                                   lis2ds12_h_lactive_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  reg.ctrl3.h_lactive = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.h_lactive = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_polarity: [get]  Interrupt active-high/low.
+  * @brief  Interrupt active-high/low.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_h_lactive_t: Get the values of h_lactive in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pin_polarity_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_polarity_get(stmdev_ctx_t *ctx,
                                   lis2ds12_h_lactive_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  *val = (lis2ds12_h_lactive_t) reg.ctrl3.h_lactive;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  switch (ctrl3.h_lactive){
+    case LIS2DS12_ACTIVE_HIGH:
+      *val = LIS2DS12_ACTIVE_HIGH;
+      break;
+    case LIS2DS12_ACTIVE_LOW:
+      *val = LIS2DS12_ACTIVE_LOW;
+      break;
+    default:
+      *val = LIS2DS12_ACTIVE_HIGH;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_notification: [set]  Latched/pulsed interrupt.
+  * @brief  Latched/pulsed interrupt.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_lir_t: change the values of lir in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of lir in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_int_notification_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_int_notification_set(stmdev_ctx_t *ctx,
                                       lis2ds12_lir_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  reg.ctrl3.lir = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.lir = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  int_notification: [get]  Latched/pulsed interrupt.
+  * @brief  Latched/pulsed interrupt.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_lir_t: Get the values of lir in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_int_notification_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_int_notification_get(stmdev_ctx_t *ctx,
                                       lis2ds12_lir_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  *val = (lis2ds12_lir_t) reg.ctrl3.lir;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  switch (ctrl3.lir){
+    case LIS2DS12_INT_PULSED:
+      *val = LIS2DS12_INT_PULSED;
+      break;
+    case LIS2DS12_INT_LATCHED:
+      *val = LIS2DS12_INT_LATCHED;
+      break;
+    default:
+      *val = LIS2DS12_INT_PULSED;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_int1_route: [set] Select the signal that need to route
-  *                               on int1 pad.
+  * @brief  Select the signal that need to route on int1 pad.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_pin_int1_route_t: union of registers from CTRL4 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change union of registers from CTRL4 to
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pin_int1_route_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     lis2ds12_pin_int1_route_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_dur_t wake_up_dur;
+  lis2ds12_ctrl4_t ctrl4;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL4, &reg.byte, 1);
-  reg.ctrl4.int1_drdy         = val.int1_drdy;
-  reg.ctrl4.int1_fth          = val.int1_fth;
-  reg.ctrl4.int1_6d           = val.int1_6d;
-  reg.ctrl4.int1_tap          = val.int1_tap;
-  reg.ctrl4.int1_ff           = val.int1_ff;
-  reg.ctrl4.int1_wu           = val.int1_wu;
-  reg.ctrl4.int1_s_tap        = val.int1_s_tap;
-  reg.ctrl4.int1_master_drdy  = val.int1_master_drdy;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL4, &reg.byte, 1);
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-  reg.wake_up_dur.int1_fss7   = val.int1_fss7;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    ctrl4.int1_drdy         = (uint8_t)val.int1_drdy;
+    ctrl4.int1_fth          = (uint8_t)val.int1_fth;
+    ctrl4.int1_6d           = (uint8_t)val.int1_6d;
+    ctrl4.int1_tap          = (uint8_t)val.int1_tap;
+    ctrl4.int1_ff           = (uint8_t)val.int1_ff;
+    ctrl4.int1_wu           = (uint8_t)val.int1_wu;
+    ctrl4.int1_s_tap        = (uint8_t)val.int1_s_tap;
+    ctrl4.int1_master_drdy  = (uint8_t)val.int1_master_drdy;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL4, (uint8_t*)&ctrl4, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  if(ret == 0){
+    wake_up_dur.int1_fss7   = (uint8_t)val.int1_fss7;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                             (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_int1_route: [get] Select the signal that need to route on
-  *                               int1 pad.
+  * @brief  Select the signal that need to route on int1 pad.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_pin_int1_route_t: union of registers from CTRL4 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from CTRL4 to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pin_int1_route_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     lis2ds12_pin_int1_route_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_dur_t wake_up_dur;
+  lis2ds12_ctrl4_t ctrl4;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL4, &reg.byte, 1);
-  val->int1_drdy          = reg.ctrl4.int1_drdy;
-  val->int1_fth           = reg.ctrl4.int1_fth;
-  val->int1_6d            = reg.ctrl4.int1_6d;
-  val->int1_tap           = reg.ctrl4.int1_tap;
-  val->int1_ff            = reg.ctrl4.int1_ff;
-  val->int1_wu            = reg.ctrl4.int1_wu;
-  val->int1_s_tap         = reg.ctrl4.int1_s_tap;
-  val->int1_master_drdy   = reg.ctrl4.int1_master_drdy;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-  val->int1_fss7 = reg.wake_up_dur.int1_fss7;
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL4, (uint8_t*)&ctrl4, 1);
+  if(ret == 0){
+    val->int1_drdy          = ctrl4.int1_drdy;
+    val->int1_fth           = ctrl4.int1_fth;
+    val->int1_6d            = ctrl4.int1_6d;
+    val->int1_tap           = ctrl4.int1_tap;
+    val->int1_ff            = ctrl4.int1_ff;
+    val->int1_wu            = ctrl4.int1_wu;
+    val->int1_s_tap         = ctrl4.int1_s_tap;
+    val->int1_master_drdy   = ctrl4.int1_master_drdy;
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+    val->int1_fss7 = wake_up_dur.int1_fss7;
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_int2_route: [set] Select the signal that need to route on
-  *                               int2 pad.
+  * @brief  Select the signal that need to route on int2 pad.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_pin_int2_route_t: union of registers from CTRL5 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change union of registers from CTRL5 to
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pin_int2_route_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     lis2ds12_pin_int2_route_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl5_t ctrl5;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-  reg.ctrl5.int2_boot       = val.int2_boot;
-  reg.ctrl5.int2_tilt       = val.int2_tilt;
-  reg.ctrl5.int2_sig_mot    = val.int2_sig_mot;
-  reg.ctrl5.int2_step_det   = val.int2_step_det;
-  reg.ctrl5.int2_fth        = val.int2_fth;
-  reg.ctrl5.int2_drdy       = val.int2_drdy;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.int2_boot       = val.int2_boot;
+    ctrl5.int2_tilt       = val.int2_tilt;
+    ctrl5.int2_sig_mot    = val.int2_sig_mot;
+    ctrl5.int2_step_det   = val.int2_step_det;
+    ctrl5.int2_fth        = val.int2_fth;
+    ctrl5.int2_drdy       = val.int2_drdy;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_int2_route: [get] Select the signal that need to route on
-  *                               int2 pad.
+  * @brief  Select the signal that need to route on int2 pad.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_pin_int2_route_t: union of registers from CTRL5 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from CTRL5 to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pin_int2_route_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     lis2ds12_pin_int2_route_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl5_t ctrl5;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-  val->int2_boot     = reg.ctrl5.int2_boot;
-  val->int2_tilt     = reg.ctrl5.int2_tilt;
-  val->int2_sig_mot  = reg.ctrl5.int2_sig_mot;
-  val->int2_step_det = reg.ctrl5.int2_step_det;
-  val->int2_fth      = reg.ctrl5.int2_fth;
-  val->int2_drdy     = reg.ctrl5.int2_drdy;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  val->int2_boot     = ctrl5.int2_boot;
+  val->int2_tilt     = ctrl5.int2_tilt;
+  val->int2_sig_mot  = ctrl5.int2_sig_mot;
+  val->int2_step_det = ctrl5.int2_step_det;
+  val->int2_fth      = ctrl5.int2_fth;
+  val->int2_drdy     = ctrl5.int2_drdy;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  all_on_int1: [set] All interrupt signals become available on
-  *                            INT1 pin.
+  * @brief  All interrupt signals become available on INT1 pin.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int2_on_int1 in reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of int2_on_int1 in reg CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_all_on_int1_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl5_t ctrl5;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-  reg.ctrl5.int2_on_int1 = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  if(ret == 0){
+    ctrl5.int2_on_int1 = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  all_on_int1: [get] All interrupt signals become available on
-  *                            INT1 pin.
+  * @brief  All interrupt signals become available on INT1 pin.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int2_on_int1 in reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_on_int1 in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_all_on_int1_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl5_t ctrl5;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, &reg.byte, 1);
-  *val = reg.ctrl5.int2_on_int1;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL5, (uint8_t*)&ctrl5, 1);
+  *val = ctrl5.int2_on_int1;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  interrupt_pins
-  * @brief   This section groups all the functions that manage interrup pins
+  * @defgroup  Interrupt Pins
+  * @brief     This section groups all the functions that manage interrup pins.
   * @{
+  *
   */
 
   /**
-  * @brief  sh_pin_mode: [set] Connect / Disconnect pull-up on auxiliary
-  *                            I2C line.
+  * @brief  Connect / Disconnect pull-up on auxiliary I2C line.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_tud_en_t: change the values of tud_en in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of tud_en in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_sh_pin_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_tud_en_t val)
+int32_t lis2ds12_sh_pin_mode_set(stmdev_ctx_t *ctx, lis2ds12_tud_en_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  reg.func_ctrl.tud_en = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  if(ret == 0){
+    func_ctrl.tud_en = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  sh_pin_mode: [get] Connect / Disconnect pull-up on auxiliary
-  *                            I2C line.
+  * @brief  Connect / Disconnect pull-up on auxiliary I2C line.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_tud_en_t: Get the values of tud_en in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tud_en in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_sh_pin_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_tud_en_t *val)
+int32_t lis2ds12_sh_pin_mode_get(stmdev_ctx_t *ctx, lis2ds12_tud_en_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  *val = (lis2ds12_tud_en_t) reg.func_ctrl.tud_en;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  switch (func_ctrl.tud_en){
+    case LIS2DS12_EXT_PULL_UP:
+      *val = LIS2DS12_EXT_PULL_UP;
+      break;
+    case LIS2DS12_INTERNAL_PULL_UP:
+      *val = LIS2DS12_INTERNAL_PULL_UP;
+      break;
+    default:
+      *val = LIS2DS12_EXT_PULL_UP;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Wake_Up_event
-  * @brief   This section groups all the functions that manage the Wake Up
-  *          event generation.
+  * @defgroup  Wake_Up_event
+  * @brief     This section groups all the functions that manage the Wake Up
+  *            event generation.
   * @{
+  *
   */
 
   /**
-  * @brief  wkup_threshold: [set]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  * @brief  Threshold for wakeup [1 LSb = FS_XL / 64].[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of wu_ths in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of wu_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_wkup_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_ths_t wake_up_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-  reg.wake_up_ths.wu_ths = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                          (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wu_ths = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                             (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  wkup_threshold: [get]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  * @brief  Threshold for wakeup [1 LSb = FS_XL / 64].[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of wu_ths in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of wu_ths in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_wkup_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_ths_t wake_up_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-  *val = reg.wake_up_ths.wu_ths;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                          (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wu_ths;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  wkup_dur: [set]  Wakeup duration [1 LSb = 1 / ODR].
+  * @brief  Wakeup duration [1 LSb = 1 / ODR].[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of wu_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of wu_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_wkup_dur_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-  reg.wake_up_dur.wu_dur = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                          (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wu_dur = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                             (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  wkup_dur: [get]  Wakeup duration [1 LSb = 1 / ODR].
+  * @brief  Wakeup duration [1 LSb = 1 / ODR].[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of wu_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of wu_dur in reg WAKE_UP_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_wkup_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-  *val = reg.wake_up_dur.wu_dur;
-
-  return mm_error;
-}
-
-/**
-  * @}
-  */
-
-/**
-  * @addtogroup   Activity/Inactivity_detection
-  * @brief   This section groups all the functions concerning
-  *          activity/inactivity detection.
-  * @{
-  */
-/**
-  * @brief  sleep_mode: [set]  Enables Sleep mode.
-  *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sleep_on in reg WAKE_UP_THS
-  *
-  */
-int32_t lis2ds12_sleep_mode_set(lis2ds12_ctx_t *ctx, uint8_t val)
-{
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-  reg.wake_up_ths.sleep_on = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  sleep_mode: [get]  Enables Sleep mode.
-  *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sleep_on in reg WAKE_UP_THS
-  *
-  */
-int32_t lis2ds12_sleep_mode_get(lis2ds12_ctx_t *ctx, uint8_t *val)
-{
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-  *val = reg.wake_up_ths.sleep_on;
-
-  return mm_error;
-}
-
-/**
-  * @brief  act_sleep_dur: [set] Duration to go in sleep mode
-  *                              [1 LSb = 512 / ODR].
-  *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sleep_dur in reg WAKE_UP_DUR
-  *
-  */
-int32_t lis2ds12_act_sleep_dur_set(lis2ds12_ctx_t *ctx, uint8_t val)
-{
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-  reg.wake_up_dur.sleep_dur = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  act_sleep_dur: [get] Duration to go in sleep mode
-  *                              [1 LSb = 512 / ODR].
-  *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sleep_dur in reg WAKE_UP_DUR
-  *
-  */
-int32_t lis2ds12_act_sleep_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val)
-{
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg.byte, 1);
-  *val = reg.wake_up_dur.sleep_dur;
-
-  return mm_error;
+  lis2ds12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                          (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wu_dur;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  tap_generator
-  * @brief   This section groups all the functions that manage the tap and
-  *          double tap event generation.
+  * @defgroup   Activity/Inactivity detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
   * @{
+  *
   */
 
 /**
-  * @brief  tap_detection_on_z: [set]  Enable Z direction in tap recognition.
+  * @brief  Enables Sleep mode.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_z_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of sleep_on in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_detection_on_z_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_ths_t wake_up_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  reg.ctrl3.tap_z_en = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                          (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.sleep_on = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                             (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_z: [get]  Enable Z direction in tap recognition.
+  * @brief  Enables Sleep mode.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_z_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_on in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_detection_on_z_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  *val = reg.ctrl3.tap_z_en;
-
-  return mm_error;
+  lis2ds12_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                          (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.sleep_on;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_y: [set]  Enable Y direction in tap recognition.
+  * @brief  Duration to go in sleep mode [1 LSb = 512 / ODR].[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_y_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_detection_on_y_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  reg.ctrl3.tap_y_en = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                          (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                             (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_y: [get]  Enable Y direction in tap recognition.
+  * @brief  Duration to go in sleep mode [1 LSb = 512 / ODR].[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_y_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_dur in reg WAKE_UP_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_detection_on_y_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  *val = reg.ctrl3.tap_y_en;
-
-  return mm_error;
+  lis2ds12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                          (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_x: [set]  Enable X direction in tap recognition.
-  *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_x_en in reg CTRL3
+  * @}
   *
   */
-int32_t lis2ds12_tap_detection_on_x_set(lis2ds12_ctx_t *ctx, uint8_t val)
+
+/**
+  * @defgroup  Tap Generator
+  * @brief     This section groups all the functions that manage the tap and
+  *            double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of tap_z_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2ds12_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  reg.ctrl3.tap_x_en = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.tap_z_en = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_x: [get]  Enable X direction in tap recognition.
+  * @brief  Enable Z direction in tap recognition.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_x_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_z_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_detection_on_x_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, &reg.byte, 1);
-  *val = reg.ctrl3.tap_x_en;
-
-  return mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  *val = ctrl3.tap_z_en;
+  return ret;
 }
 
 /**
-  * @brief  tap_threshold: [set] Threshold for tap recognition
-  *                              [1 LSb = FS/32].
+  * @brief  Enable Y direction in tap recognition.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of tap_y_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-  reg.tap_6d_ths.tap_ths = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.tap_y_en = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_threshold: [get] Threshold for tap recognition
-  *                              [1 LSb = FS/32].
+  * @brief  Enable Y direction in tap recognition.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_y_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-  *val = reg.tap_6d_ths.tap_ths;
-
-  return mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  *val = ctrl3.tap_y_en;
+  return ret;
 }
 
 /**
-  * @brief  tap_shock: [set] Maximum duration is the maximum time of
-  *                          an overthreshold signal detection to be
-  *                          recognized as a tap event. The default value
-  *                          of these bits is 00b which corresponds to
-  *                          4*ODR_XL time. If the SHOCK[1:0] bits are set
-  *                          to a different value, 1LSB corresponds to
-  *                          8*ODR_XL time.
+  * @brief  Enable X direction in tap recognition.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of shock in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of tap_x_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_shock_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-  reg.int_dur.shock = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  if(ret == 0){
+    ctrl3.tap_x_en = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_shock: [get] Maximum duration is the maximum time of an
-  *                          overthreshold signal detection to be recognized
-  *                          as a tap event. The default value of these bits
-  *                          is 00b which corresponds to 4*ODR_XL time.
-  *                          If the SHOCK[1:0] bits are set to a different
-                             value, 1LSB corresponds to 8*ODR_XL time.
+  * @brief  Enable X direction in tap recognition.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of shock in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_x_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_shock_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-  *val = reg.int_dur.shock;
-
-  return mm_error;
+  lis2ds12_ctrl3_t ctrl3;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_CTRL3, (uint8_t*)&ctrl3, 1);
+  *val = ctrl3.tap_x_en;
+  return ret;
 }
 
 /**
-  * @brief  tap_quiet: [set] Quiet time is the time after the first
-  *                          detected tap in which there must not be any
-  *                          overthreshold event. The default value of these
-  *                          bits is 00b which corresponds to 2*ODR_XL time.
-  *                          If the QUIET[1:0] bits are set to a different
-  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  * @brief  Threshold for tap recognition [1 LSb = FS/32].[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of quiet in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of tap_ths in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_quiet_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_tap_6d_ths_t tap_6d_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-  reg.int_dur.quiet = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS,
+                          (uint8_t*)&tap_6d_ths, 1);
+  if(ret == 0){
+    tap_6d_ths.tap_ths = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS,
+                             (uint8_t*)&tap_6d_ths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_quiet: [get] Quiet time is the time after the first detected
-  *                          tap in which there must not be any overthreshold
-  *                          event. The default value of these bits is 00b
-  *                          which corresponds to 2*ODR_XL time.
-  *                          If the QUIET[1:0] bits are set to a different
-  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  * @brief  Threshold for tap recognition [1 LSb = FS/32].[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of quiet in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_ths in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_quiet_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-  *val = reg.int_dur.quiet;
-
-  return mm_error;
+  lis2ds12_tap_6d_ths_t tap_6d_ths;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS,
+                          (uint8_t*)&tap_6d_ths, 1);
+  *val = tap_6d_ths.tap_ths;
+  return ret;
 }
 
 /**
-  * @brief  tap_dur: [set] When double tap recognition is enabled, this
-  *                        register expresses the maximum time between two
-  *                        consecutive detected taps to determine a double
-  *                        tap event. The default value of these bits is
-  *                        0000b which corresponds to 16*ODR_XL time.
-  *                        If the DUR[3:0] bits are set to a different value,
-  *                        1LSB corresponds to 32*ODR_XL time.
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value of
+  *         these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of lat in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of shock in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_dur_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_int_dur_t int_dur;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-  reg.int_dur.lat = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  if(ret == 0){
+    int_dur.shock = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_dur: [get] When double tap recognition is enabled,
-  *                        this register expresses the maximum time
-  *                        between two consecutive detected taps to
-  *                        determine a double tap event. The default
-  *                        value of these bits is 0000b which corresponds
-  *                        to 16*ODR_XL time. If the DUR[3:0] bits are set
-  *                        to a different value, 1LSB corresponds to
-  *                        32*ODR_XL time.
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value of
+  *         these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of lat in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of shock in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_int_dur_t int_dur;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, &reg.byte, 1);
-  *val = reg.int_dur.lat;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  *val = int_dur.shock;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_mode: [set]  Single/double-tap event enable/disable.
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event. The default value of these
+  *         bits is 00b which corresponds to 2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_single_double_tap_t: change the values of
-  *                                       single_double_tap in regWAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of quiet in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_mode_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_int_dur_t int_dur;
+  int32_t ret;
+
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  if(ret == 0){
+    int_dur.quiet = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event. The default value of these
+  *         bits is 00b which corresponds to 2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of quiet in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2ds12_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_int_dur_t int_dur;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  *val = int_dur.quiet;
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event. The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time. If the DUR[3:0] bits are set to a
+  *         different value, 1LSB corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of lat in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2ds12_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2ds12_int_dur_t int_dur;
+  int32_t ret;
+
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  if(ret == 0){
+    int_dur.lat = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event. The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time. If the DUR[3:0] bits are set to a
+  *         different value, 1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lat in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2ds12_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2ds12_int_dur_t int_dur;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_INT_DUR, (uint8_t*)&int_dur, 1);
+  *val = int_dur.lat;
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[set]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of single_double_tap in regWAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lis2ds12_tap_mode_set(stmdev_ctx_t *ctx,
                               lis2ds12_single_double_tap_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_ths_t wake_up_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-  reg.wake_up_ths.single_double_tap = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                          (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.single_double_tap = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                             (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_mode: [get]  Single/double-tap event enable/disable.
+  * @brief  Single/double-tap event enable/disable.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_single_double_tap_t: Get the values of single_double_tap
-  *                                       in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of single_double_tap in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_mode_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_tap_mode_get(stmdev_ctx_t *ctx,
                               lis2ds12_single_double_tap_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_wake_up_ths_t wake_up_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS, &reg.byte, 1);
-  *val = (lis2ds12_single_double_tap_t) reg.wake_up_ths.single_double_tap;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_THS,
+                          (uint8_t*)&wake_up_ths, 1);
+  switch (wake_up_ths.single_double_tap){
+    case LIS2DS12_ONLY_SINGLE:
+      *val = LIS2DS12_ONLY_SINGLE;
+      break;
+    case LIS2DS12_ONLY_DOUBLE:
+      *val = LIS2DS12_ONLY_DOUBLE;
+      break;
+    default:
+      *val = LIS2DS12_ONLY_SINGLE;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_src: [get]  TAP source register
+  * @brief  TAP source register[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_tap_src_t: registers TAP_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers TAP_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tap_src_get(lis2ds12_ctx_t *ctx, lis2ds12_tap_src_t *val)
+int32_t lis2ds12_tap_src_get(stmdev_ctx_t *ctx, lis2ds12_tap_src_t *val)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_TAP_SRC, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_TAP_SRC, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   Six_position_detection(6D/4D)
-  * @brief   This section groups all the functions concerning six
-  *          position detection (6D).
+  * @defgroup   Six_position_detection(6D/4D)
+  * @brief      This section groups all the functions concerning six
+  *             position detection (6D).
   * @{
+  *
   */
 
 /**
-  * @brief  6d_threshold: [set]  Threshold for 4D/6D function.
+  * @brief  Threshold for 4D/6D function.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_6d_ths_t: change the values of 6d_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of 6d_ths in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_6d_threshold_set(lis2ds12_ctx_t *ctx, lis2ds12_6d_ths_t val)
+int32_t lis2ds12_6d_threshold_set(stmdev_ctx_t *ctx, lis2ds12_6d_ths_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_tap_6d_ths_t tap_6d_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-  reg.tap_6d_ths._6d_ths = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, (uint8_t*)&tap_6d_ths, 1);
+  if(ret == 0){
+    tap_6d_ths._6d_ths = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS,
+                             (uint8_t*)&tap_6d_ths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  6d_threshold: [get]  Threshold for 4D/6D function.
+  * @brief  Threshold for 4D/6D function.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_6d_ths_t: Get the values of 6d_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of 6d_ths in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_6d_threshold_get(lis2ds12_ctx_t *ctx, lis2ds12_6d_ths_t *val)
+int32_t lis2ds12_6d_threshold_get(stmdev_ctx_t *ctx, lis2ds12_6d_ths_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_tap_6d_ths_t tap_6d_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-  *val = (lis2ds12_6d_ths_t) reg.tap_6d_ths._6d_ths;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, (uint8_t*)&tap_6d_ths, 1);
+  switch (tap_6d_ths._6d_ths){
+    case LIS2DS12_DEG_80:
+      *val = LIS2DS12_DEG_80;
+      break;
+    case LIS2DS12_DEG_70:
+      *val = LIS2DS12_DEG_70;
+      break;
+    case LIS2DS12_DEG_60:
+      *val = LIS2DS12_DEG_60;
+      break;
+    case LIS2DS12_DEG_50:
+      *val = LIS2DS12_DEG_50;
+      break;
+    default:
+      *val = LIS2DS12_DEG_80;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  4d_mode: [set]  4D orientation detection enable.
+  * @brief  4D orientation detection enable.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of 4d_en in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of 4d_en in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_4d_mode_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_tap_6d_ths_t tap_6d_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-  reg.tap_6d_ths._4d_en = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS,
+                          (uint8_t*)& tap_6d_ths, 1);
+  if(ret == 0){
+    tap_6d_ths._4d_en = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_TAP_6D_THS,
+                             (uint8_t*)& tap_6d_ths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  4d_mode: [get]  4D orientation detection enable.
+  * @brief  4D orientation detection enable.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of 4d_en in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of 4d_en in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_4d_mode_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS, &reg.byte, 1);
-  *val = reg.tap_6d_ths._4d_en;
-
-  return mm_error;
+  lis2ds12_tap_6d_ths_t tap_6d_ths;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_TAP_6D_THS,
+                          (uint8_t*)&tap_6d_ths, 1);
+  *val = tap_6d_ths._4d_en;
+  return ret;
 }
 
 /**
-  * @brief  6d_src: [get]  6D source register.
+  * @brief  6D source register.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_6d_src_t: union of registers from 6D_SRC to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from 6D_SRC to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_6d_src_get(lis2ds12_ctx_t *ctx, lis2ds12_6d_src_t *val)
+int32_t lis2ds12_6d_src_get(stmdev_ctx_t *ctx, lis2ds12_6d_src_t *val)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_6D_SRC, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_6D_SRC, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  free_fall
-  * @brief   This section group all the functions concerning the
-  *          free fall detection.
+  * @defgroup  free_fall
+  * @brief     This section group all the functions concerning the
+  *            free fall detection.
   * @{
+  *
   */
 
 /**
-  * @brief  ff_dur: [set]  Free-fall duration [1 LSb = 1 / ODR].
+  * @brief  Free-fall duration [1 LSb = 1 / ODR].[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of ff_dur in reg
-  *                      WAKE_UP_DUR/FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_ff_dur_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg[2];
-  int32_t mm_error;
+  lis2ds12_free_fall_t free_fall;
+  lis2ds12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg[0].byte, 2);
-  reg[1].free_fall.ff_dur = 0x1F & val;
-  reg[0].wake_up_dur.ff_dur = (val & 0x20) >> 5;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg[0].byte, 2);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_dur =  val & 0x1FU;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FREE_FALL,
+                             (uint8_t*)&free_fall, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  if(ret == 0){
+    wake_up_dur.ff_dur = (val & 0x20U) >> 5;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                             (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  ff_dur: [get]  Free-fall duration [1 LSb = 1 / ODR].
+  * @brief  Free-fall duration [1 LSb = 1 / ODR].[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_ff_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg[2];
-  int32_t mm_error;
+  lis2ds12_free_fall_t free_fall;
+  lis2ds12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR, &reg[0].byte, 2);
-  *val = (reg[0].wake_up_dur.ff_dur << 5) + reg[1].free_fall.ff_dur;
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+    *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  }
+  return ret;
 }
 
 /**
-  * @brief  ff_threshold: [set]  Free-fall threshold [1 LSB = 31.25 mg].
+  * @brief  Free-fall threshold [1 LSB = 31.25 mg].[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of ff_ths in reg FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_ff_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_ff_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_free_fall_t free_fall;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FREE_FALL, &reg.byte, 1);
-  reg.free_fall.ff_ths = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FREE_FALL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  ff_threshold: [get]  Free-fall threshold [1 LSB = 31.25 mg].
+  * @brief  Free-fall threshold [1 LSB = 31.25 mg].[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ff_ths in reg FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_ths in reg FREE_FALL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_ff_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_ff_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FREE_FALL, &reg.byte, 1);
-  *val = reg.free_fall.ff_ths;
-
-  return mm_error;
+  lis2ds12_free_fall_t free_fall;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FREE_FALL, (uint8_t*)&free_fall, 1);
+  *val = free_fall.ff_ths;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Fifo
-  * @brief   This section group all the functions concerning the fifo usage
+  * @defgroup  Fifo
+  * @brief     This section group all the functions concerning the fifo usage
   * @{
+  *
   */
 
 /**
-  * @brief   fifo_xl_module_batch: [set]  Module routine result is send to
-  *          FIFO instead of X,Y,Z acceleration data
+  * @brief  Module routine result is send to FIFO instead of X,Y,Z
+  *         acceleration data[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of module_to_fifo in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of module_to_fifo in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_xl_module_batch_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_fifo_xl_module_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-  reg.fifo_ctrl.module_to_fifo = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.module_to_fifo = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL,
+                             (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief   fifo_xl_module_batch: [get]  Module routine result is send to
-  *                                       FIFO instead of X,Y,Z acceleration
-  *                                       data
+  * @brief   Module routine result is send to FIFO instead of X,Y,Z
+  *          acceleration data[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of module_to_fifo in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of module_to_fifo in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_xl_module_batch_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_fifo_xl_module_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-  *val = reg.fifo_ctrl.module_to_fifo;
-
-  return mm_error;
+  lis2ds12_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = fifo_ctrl.module_to_fifo;
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [set]  FIFO mode selection.
+  * @brief  FIFO mode selection.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_fmode_t: change the values of fmode in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of fmode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_fmode_t val)
+int32_t lis2ds12_fifo_mode_set(stmdev_ctx_t *ctx, lis2ds12_fmode_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-  reg.fifo_ctrl.fmode = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.fmode = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_CTRL,
+                             (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [get]  FIFO mode selection.
+  * @brief  FIFO mode selection.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_fmode_t: Get the values of fmode in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fmode in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_fmode_t *val)
+int32_t lis2ds12_fifo_mode_get(stmdev_ctx_t *ctx, lis2ds12_fmode_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, &reg.byte, 1);
-  *val = (lis2ds12_fmode_t) reg.fifo_ctrl.fmode;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  switch (fifo_ctrl.fmode){
+    case LIS2DS12_BYPASS_MODE:
+      *val = LIS2DS12_BYPASS_MODE;
+      break;
+    case LIS2DS12_FIFO_MODE:
+      *val = LIS2DS12_FIFO_MODE;
+      break;
+    case LIS2DS12_STREAM_TO_FIFO_MODE:
+      *val = LIS2DS12_STREAM_TO_FIFO_MODE;
+      break;
+    case LIS2DS12_BYPASS_TO_STREAM_MODE:
+      *val = LIS2DS12_BYPASS_TO_STREAM_MODE;
+      break;
 
-  return mm_error;
+    case LIS2DS12_STREAM_MODE:
+      *val = LIS2DS12_STREAM_MODE;
+      break;
+    default:
+      *val = LIS2DS12_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of fifo_watermark in reg FIFO_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of fifo_watermark in reg FIFO_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_watermark_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  int32_t mm_error;
-
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_THS, &val, 1);
-
-  return mm_error;
+  int32_t ret;
+  ret = lis2ds12_write_reg(ctx, LIS2DS12_FIFO_THS, (uint8_t*)&val, 1);
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_watermark in reg FIFO_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_watermark in reg FIFO_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_watermark_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_THS, val, 1);
-
-  return mm_error;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_THS, val, 1);
+  return ret;
 }
 
 /**
-  * @brief  fifo_full_flag: [get]  FIFO full, 256 unread samples.
+  * @brief  FIFO full, 256 unread samples.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of diff in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of diff in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_full_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &reg.byte, 1);
-  *val = reg.fifo_src.diff;
-
-  return mm_error;
+  lis2ds12_fifo_src_t fifo_src;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.diff;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_flag: [get]  FIFO overrun status.
+  * @brief  FIFO overrun status.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_ovr in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_ovr in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_ovr_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &reg.byte, 1);
-  *val = reg.fifo_src.fifo_ovr;
-
-  return mm_error;
+  lis2ds12_fifo_src_t fifo_src;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fifo_ovr;
+  return ret;
 }
 
 /**
-  * @brief  fifo_wtm_flag: [get]  FIFO threshold status.
+  * @brief  FIFO threshold status.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fth in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_wtm_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &reg.byte, 1);
-  *val = reg.fifo_src.fth;
-
-  return mm_error;
+  lis2ds12_fifo_src_t fifo_src;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+  *val = fifo_src.fth;
+  return ret;
 }
 
 /**
-  * @brief  fifo_data_level: [get] The number of unread samples
-  *                                stored in FIFO.
+  * @brief  The number of unread samples stored in FIFO.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint16_t: change the values of diff in reg FIFO_SAMPLES
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of diff in reg FIFO_SAMPLES.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_data_level_get(lis2ds12_ctx_t *ctx, uint16_t *val)
+int32_t lis2ds12_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
-  lis2ds12_reg_t reg[2];
-  int32_t mm_error;
+  lis2ds12_fifo_ths_t fifo_ths;
+  lis2ds12_fifo_src_t fifo_src;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_THS, &reg[0].byte, 2);
-  *val = (reg[1].fifo_src.diff << 8) + reg[0].byte;
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_THS, (uint8_t*)&fifo_ths, 1);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, (uint8_t*)&fifo_src, 1);
+    *val = fifo_src.diff;
+    *val =  *val << 8;
+    *val += fifo_ths.fth;
+    
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_src: [get] FIFO_SRCregister.
+  * @brief  FIFO_SRCregister.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_fifo_src_t: registers FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_fifo_src_get(lis2ds12_ctx_t *ctx, lis2ds12_fifo_src_t *val)
+int32_t lis2ds12_fifo_src_get(stmdev_ctx_t *ctx, lis2ds12_fifo_src_t *val)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Pedometer
-  * @brief   This section groups all the functions that manage pedometer.
+  * @defgroup  Pedometer
+  * @brief     This section groups all the functions that manage pedometer.
   * @{
+  *
   */
 
 /**
-  * @brief  pedo_threshold: [set] Minimum threshold value for step
-  *                               counter routine.
+  * @brief  Minimum threshold value for step counter routine.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sc_mths in
-  *                      reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of sc_mths in reg STEP_COUNTER_MINTHS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_step_counter_minths_t step_counter_minths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                               &reg.byte, 1);
-  reg. step_counter_minths.sc_mths = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                                &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                          (uint8_t*)&step_counter_minths, 1);
+  if(ret == 0){
+    step_counter_minths.sc_mths = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                             (uint8_t*)&step_counter_minths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_threshold: [get] Minimum threshold value for step
-  *                               counter routine.
+  * @brief  Minimum threshold value for step counter routine.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sc_mths in reg  STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sc_mths in reg  STEP_COUNTER_MINTHS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                               &reg.byte, 1);
-  *val = reg. step_counter_minths.sc_mths;
-
-  return mm_error;
+  lis2ds12_step_counter_minths_t step_counter_minths;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                          (uint8_t*)&step_counter_minths, 1);
+  *val = step_counter_minths.sc_mths;
+  return ret;
 }
 
 /**
-  * @brief  pedo_full_scale: [set]  Pedometer data range.
+  * @brief  Pedometer data range.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_pedo4g_t: change the values of pedo4g in
-  *                            reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of pedo4g in reg STEP_COUNTER_MINTHS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_full_scale_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pedo_full_scale_set(stmdev_ctx_t *ctx,
                                      lis2ds12_pedo4g_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_step_counter_minths_t step_counter_minths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                               &reg.byte, 1);
-  reg. step_counter_minths.pedo4g = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                                &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                          (uint8_t*)&step_counter_minths, 1);
+  if(ret == 0){
+    step_counter_minths.pedo4g = (uint8_t)val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                             (uint8_t*)&step_counter_minths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_full_scale: [get]  Pedometer data range.
+  * @brief  Pedometer data range.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_pedo4g_t: Get the values of pedo4g in
-  *                            reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of pedo4g in reg STEP_COUNTER_MINTHS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_full_scale_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pedo_full_scale_get(stmdev_ctx_t *ctx,
                                      lis2ds12_pedo4g_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_step_counter_minths_t step_counter_minths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                               &reg.byte, 1);
-  *val = (lis2ds12_pedo4g_t) reg. step_counter_minths.pedo4g;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                          (uint8_t*)&step_counter_minths, 1);
+  switch (step_counter_minths.pedo4g){
+    case LIS2DS12_PEDO_AT_2g:
+      *val = LIS2DS12_PEDO_AT_2g;
+      break;
+    case LIS2DS12_PEDO_AT_4g:
+      *val = LIS2DS12_PEDO_AT_4g;
+      break;
+    default:
+      *val = LIS2DS12_PEDO_AT_2g;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_step_reset: [set]  Reset pedometer step counter.
+  * @brief  Reset pedometer step counter.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of rst_nstep in
-  *                      reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of rst_nstep in reg STEP_COUNTER_MINTHS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_step_reset_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_step_counter_minths_t step_counter_minths;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                               &reg.byte, 1);
-  reg. step_counter_minths.rst_nstep = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                                &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                          (uint8_t*)&step_counter_minths, 1);
+  if(ret == 0){
+    step_counter_minths.rst_nstep = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                             (uint8_t*)&step_counter_minths, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_step_reset: [get]  Reset pedometer step counter.
+  * @brief  Reset pedometer step counter.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of rst_nstep in
-  *                  reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of rst_nstep in reg STEP_COUNTER_MINTHS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_step_reset_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
-                               &reg.byte, 1);
-  *val = reg. step_counter_minths.rst_nstep;
-
-  return mm_error;
+  lis2ds12_step_counter_minths_t step_counter_minths;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNTER_MINTHS,
+                          (uint8_t*)&step_counter_minths, 1);
+  *val = step_counter_minths.rst_nstep;
+  return ret;
 }
 
 /**
-  * @brief   pedo_step_detect_flag: [get]  Step detection flag.
+  * @brief  Step detection flag.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of step_detect in reg FUNC_CK_GATE
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of step_detect in reg FUNC_CK_GATE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_step_detect_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_pedo_step_detect_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE, &reg.byte, 1);
-  *val = reg.func_ck_gate.step_detect;
-
-  return mm_error;
+  lis2ds12_func_ck_gate_t func_ck_gate;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE,
+                          (uint8_t*)&func_ck_gate, 1);
+  *val = func_ck_gate.step_detect;
+  return ret;
 }
 
 /**
-  * @brief  pedo_sens: [set]  Enable pedometer algorithm.
+  * @brief  Enable pedometer algorithm.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of step_cnt_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of step_cnt_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_sens_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  reg.func_ctrl.step_cnt_on = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  if(ret == 0){
+    func_ctrl.step_cnt_on = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL,
+                             (uint8_t*)&func_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_sens: [get]  Enable pedometer algorithm.
+  * @brief  Enable pedometer algorithm.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of step_cnt_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of step_cnt_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  *val = reg.func_ctrl.step_cnt_on;
-
-  return mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  *val = func_ctrl.step_cnt_on;
+  return ret;
 }
 
 /**
-  * @brief   pedo_debounce_steps: [set] Minimum number of steps to start
-  *                                     the increment step counter.
+  * @brief  Minimum number of steps to start the increment step counter.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of deb_step in reg PEDO_DEB_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of deb_step in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_debounce_steps_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
-  reg.pedo_deb_reg.deb_step = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG,
+                            (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    pedo_deb_reg.deb_step = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_PEDO_DEB_REG,
+                             (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
-  * @brief   pedo_debounce_steps: [get] Minimum number of steps to start
-  *                                     the increment step counter.
+  * @brief   Minimum number of steps to start the increment step counter.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of deb_step in reg PEDO_DEB_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of deb_step in reg PEDO_DEB_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_debounce_steps_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
-  *val = reg.pedo_deb_reg.deb_step;
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG,
+                            (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    *val = pedo_deb_reg.deb_step;
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_timeout: [set] Debounce time. If the time between two
-  *                             consecutive steps is greater than
-  *                             DEB_TIME*80ms, the debouncer is reactivated.
-  *                             Default value: 01101
+  * @brief  Debounce time. If the time between two consecutive steps is greater
+  *         than DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of deb_time in reg PEDO_DEB_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of deb_time in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_timeout_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
-  reg.pedo_deb_reg.deb_time = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG,
+                            (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    pedo_deb_reg.deb_time = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_PEDO_DEB_REG,
+                             (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_timeout: [get] Debounce time. If the time between two
-  *                             consecutive steps is greater than
-  *                             DEB_TIME*80ms, the debouncer is reactivated.
-  *                             Default value: 01101
+  * @brief  Debounce time. If the time between two consecutive steps is
+  *         greater than DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of deb_time in reg PEDO_DEB_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of deb_time in reg PEDO_DEB_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_timeout_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG, &reg.byte, 1);
-  *val = reg.pedo_deb_reg.deb_time;
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_PEDO_DEB_REG,
+                            (uint8_t*)&pedo_deb_reg, 1);
+  }
+  if(ret == 0){
+    *val = pedo_deb_reg.deb_time;
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_steps_period: [set] Period of time to detect at
-  *                                  least one step to generate step
-  *                                  recognition [1 LSb = 1.6384 s].
+  * @brief  Period of time to detect at least one step to generate step
+  *         recognition [1 LSb = 1.6384 s].[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that contains data to write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_steps_period_set(lis2ds12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2ds12_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNT_DELTA, buff, 1);
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_STEP_COUNT_DELTA, buff, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_steps_period: [get] Period of time to detect at least
-  *                                  one step to generate step recognition
-  *                                  [1 LSb = 1.6384 s].
+  * @brief  Period of time to detect at least one step to generate step
+  *         recognition [1 LSb = 1.6384 s].[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_pedo_steps_period_get(lis2ds12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2ds12_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNT_DELTA, buff, 1);
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_STEP_COUNT_DELTA, buff, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  significant_motion
+  * @defgroup  significant_motion
   * @brief   This section groups all the functions that manage the
   *          significant motion detection.
   * @{
+  *
   */
 
 /**
-  * @brief   motion_data_ready_flag: [get] Significant motion event
-  *                                        detection status.
+  * @brief  Significant motion event detection status.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sig_mot_detect in reg FUNC_CK_GATE
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sig_mot_detect in reg FUNC_CK_GATE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_motion_data_ready_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_motion_data_ready_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE, &reg.byte, 1);
-  *val = reg.func_ck_gate.sig_mot_detect;
-
-  return mm_error;
+  lis2ds12_func_ck_gate_t func_ck_gate;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE,
+                          (uint8_t*)&func_ck_gate, 1);
+  *val = func_ck_gate.sig_mot_detect;
+  return ret;
 }
 
 /**
-  * @brief  motion_sens: [set]  Enable significant motion detection function.
+  * @brief  Enable significant motion detection function.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sign_mot_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of sign_mot_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_motion_sens_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  reg.func_ctrl.sign_mot_on = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  if(ret == 0){
+    func_ctrl.sign_mot_on = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL,
+                             (uint8_t*)&func_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  motion_sens: [get]  Enable significant motion detection function.
+  * @brief  Enable significant motion detection function.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sign_mot_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sign_mot_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_motion_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  *val = reg.func_ctrl.sign_mot_on;
-
-  return mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  *val = func_ctrl.sign_mot_on;
+  return ret;
 }
 
 /**
-  * @brief  motion_threshold: [set] These bits define the threshold value
-  *                                 which corresponds to the number of steps
-  *                                 to be performed by the user upon a change
-  *                                 of location before the significant motion
-  *                                 interrupt is generated. It is expressed
-  *                                 as an 8-bit unsigned value.
-  *                                 The default value of this field is equal
-  *                                 to 6 (= 00000110b).
+  * @brief  These bits define the threshold value which corresponds to the
+  *         number of steps to be performed by the user upon a change of
+  *         location before the significant motion interrupt is generated.
+  *         It is expressed as an 8-bit unsigned value.
+  *         The default value of this field is equal to 6 (= 00000110b).[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sm_ths in reg SM_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of sm_ths in reg SM_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_motion_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_sm_ths_t sm_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_SM_THS, &reg.byte, 1);
-  reg.sm_ths.sm_ths = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SM_THS, &reg.byte, 1);
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_SM_THS, (uint8_t*)&sm_ths, 1);
+  }
+  if(ret == 0){
+    sm_ths.sm_ths = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_SM_THS, (uint8_t*)&sm_ths, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
-  * @brief  motion_threshold: [get] These bits define the threshold value
-  *                                 which corresponds to the number of steps
-  *                                 to be performed by the user upon a change
-  *                                 of location before the significant motion
-  *                                 interrupt is generated. It is expressed as
-  *                                 an 8-bit unsigned value. The default value
-  *                                 of this field is equal to 6 (= 00000110b).
+  * @brief  These bits define the threshold value which corresponds to the
+  *         number of steps to be performed by the user upon a change of
+  *         location before the significant motion interrupt is generated.
+  *         It is expressed as an 8-bit unsigned value.
+  *         The default value of this field is equal to 6 (= 00000110b).[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sm_ths in reg SM_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sm_ths in reg SM_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_motion_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_sm_ths_t sm_ths;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_SM_THS, &reg.byte, 1);
-  *val = reg.sm_ths.sm_ths;
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_SM_THS, (uint8_t*)&sm_ths, 1);
+  }
+  if(ret == 0){
+    *val = sm_ths.sm_ths;
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  tilt_detection
+  * @defgroup  tilt_detection
   * @brief   This section groups all the functions that manage the tilt
   *          event detection.
   * @{
+  *
   */
 
 /**
-  * @brief   tilt_data_ready_flag: [get]  Tilt event detection status.
+  * @brief  Tilt event detection status.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tilt_int in reg FUNC_CK_GATE
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tilt_int in reg FUNC_CK_GATE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tilt_data_ready_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_tilt_data_ready_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE, &reg.byte, 1);
-  *val = reg.func_ck_gate.tilt_int;
-
-  return mm_error;
+  lis2ds12_func_ck_gate_t func_ck_gate;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CK_GATE,
+                          (uint8_t*)&func_ck_gate, 1);
+  *val = func_ck_gate.tilt_int;
+  return ret;
 }
 
 /**
-  * @brief  tilt_sens: [set]  Enable tilt calculation.
+  * @brief  Enable tilt calculation.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tilt_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param val     change the values of tilt_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tilt_sens_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  reg.func_ctrl.tilt_on = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  if(ret == 0){
+    func_ctrl.tilt_on = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  tilt_sens: [get]  Enable tilt calculation.
+  * @brief  Enable tilt calculation.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tilt_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tilt_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_tilt_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  *val = reg.func_ctrl.tilt_on;
-
-  return mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  *val = func_ctrl.tilt_on;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  module
+  * @defgroup  module
   * @brief   This section groups all the functions that manage
   *          module calculation
   * @{
+  *
   */
 
 /**
-  * @brief  module_sens: [set]  Module processing enable.
+  * @brief  Module processing enable.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of module_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of module_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_module_sens_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_module_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  reg.func_ctrl.module_on = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  if(ret == 0){
+    func_ctrl.module_on = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  module_sens: [get]  Module processing enable.
+  * @brief  Module processing enable.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of module_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of module_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_module_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_module_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  *val = reg.func_ctrl.module_on;
-
-  return mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  *val = func_ctrl.module_on;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Sensor_hub
+  * @defgroup  Sensor_hub
   * @brief   This section groups all the functions that manage the sensor
   *          hub functionality.
   * @{
+  *
   */
 
 /**
-  * @brief  sh_read_data_raw: [get]  Sensor hub output registers.
+  * @brief  Sensor hub output registers.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_sh_read_data_raw_t: registers from SENSORHUB1_REG
-  *                                      to SENSORHUB6_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers from SENSORHUB1_REG to SENSORHUB6_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_sh_read_data_raw_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                       lis2ds12_sh_read_data_raw_t *val)
 {
-  return lis2ds12_read_reg(ctx, LIS2DS12_SENSORHUB1_REG, (uint8_t*) val, 6);
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_SENSORHUB1_REG, (uint8_t*) val, 6);
+  return ret;
 }
 
 /**
-  * @brief  sh_master: [set]  Sensor hub I2C master enable.
+  * @brief  Sensor hub I2C master enable.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of master_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change the values of master_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_sh_master_set(lis2ds12_ctx_t *ctx, uint8_t val)
+int32_t lis2ds12_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
 
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  reg.func_ctrl.master_on = val;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  if(ret == 0){
+    func_ctrl.master_on = val;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  sh_master: [get]  Sensor hub I2C master enable.
+  * @brief  Sensor hub I2C master enable.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of master_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of master_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_sh_master_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, &reg.byte, 1);
-  *val = reg.func_ctrl.master_on;
-
-  return mm_error;
+  lis2ds12_func_ctrl_t func_ctrl;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_CTRL, (uint8_t*)&func_ctrl, 1);
+  *val = func_ctrl.master_on;
+  return ret;
 }
 
 /**
-  * @brief  sh_cfg_write: Configure slave to perform a write.
+  * @brief  Configure slave to perform a write.[set]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_sh_cfg_write_t: a structure that contain
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    change a structure:
   *                      - uint8_t slv_add;    8 bit i2c device address
   *                      - uint8_t slv_subadd; 8 bit register device address
   *                      - uint8_t slv_data;   8 bit data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_sh_cfg_write(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_sh_cfg_write(stmdev_ctx_t *ctx,
                               lis2ds12_sh_cfg_write_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_slv0_add_t slv0_add;
+  int32_t ret;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  reg.byte = val->slv_add;
-  reg.slv0_add.rw_0 = 0;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_ADD, &reg.byte, 1);
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_SUBADD,
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    slv0_add.slave0_add = (val->slv_add & 0xFEU) >> 1; 
+    slv0_add.rw_0 = 0;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_ADD,
+                             (uint8_t*)&slv0_add, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_SUBADD,
                                &(val->slv_subadd), 1);
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_DATAWRITE_SLV0,
+  }
+  if(ret == 0){
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_DATAWRITE_SLV0,
                               &(val->slv_data), 1);
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
-
-  return mm_error;
+  }
+  if(ret == 0){
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
-  * @brief  sh_slv_cfg_read: [get] Configure slave 0 for perform a write/read.
+  * @brief  Configure slave 0 for perform a write/read.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  lis2ds12_sh_cfg_read_t: a structure that contain
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get a structure(ptr):
   *                      - uint8_t slv_add;    8 bit i2c device address
   *                      - uint8_t slv_subadd; 8 bit register device address
   *                      - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_sh_slv_cfg_read(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_sh_slv_cfg_read(stmdev_ctx_t *ctx,
                                  lis2ds12_sh_cfg_read_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
+  lis2ds12_slv0_add_t slv0_add;
+  lis2ds12_slv0_config_t slv0_config;
 
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
-  reg.byte = val->slv_add;
-  reg.slv0_add.rw_0 = 1;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_ADD, &reg.byte, 1);
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_SUBADD,
-                               &(val->slv_subadd), 1);
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_SLV0_CONFIG, &reg.byte, 1);
-  reg.slv0_config.slave0_numop = val->slv_len;
-  mm_error = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_CONFIG, &reg.byte, 1);
-  mm_error = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  int32_t ret;
 
-  return mm_error;
+  ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_ADV_BANK);
+  if(ret == 0){
+    slv0_add.slave0_add = (val->slv_add & 0xFEU) >> 1; 
+    slv0_add.rw_0 = 1;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_ADD, 
+                             (uint8_t*)&slv0_add, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_SUBADD,
+                             &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_read_reg(ctx, LIS2DS12_SLV0_CONFIG,
+                            (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    slv0_config.slave0_numop = val->slv_len;
+    ret = lis2ds12_write_reg(ctx, LIS2DS12_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = lis2ds12_mem_bank_set(ctx, LIS2DS12_USER_BANK);
+  }
+  return ret;
 }
 
 /**
-  * @brief  lis2ds12_sh_end_op_flag_get: [get] Sensor hub communication status.
+  * @brief  Sensor hub communication status.[get]
   *
-  * @param  lis2ds12_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sensorhub_end_op
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sensorhub_end_op.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2ds12_sh_end_op_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val)
+int32_t lis2ds12_sh_end_op_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lis2ds12_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_SRC, &reg.byte, 1);
-  *val = reg.func_src.sensorhub_end_op;
-
-  return mm_error;
+  lis2ds12_func_src_t func_src;
+  int32_t ret;
+  ret = lis2ds12_read_reg(ctx, LIS2DS12_FUNC_SRC, (uint8_t*)&func_src, 1);
+  *val = func_src.sensorhub_end_op;
+  return ret;
 }
 
 /**
   * @}
+  *
+  */
+
+/**
+  * @}
+  *
   */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2ds12_STdC/driver/lis2ds12_reg.h
+++ b/sensor/stmemsc/lis2ds12_STdC/driver/lis2ds12_reg.h
@@ -1,43 +1,26 @@
 /*
  ******************************************************************************
  * @file    lis2ds12_reg.h
- * @author  MEMS Software Solution Team
+ * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
  *          lis2ds12_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __LIS2DS12_DRIVER__H
-#define __LIS2DS12_DRIVER__H
+#ifndef LIS2DS12_REGS_H
+#define LIS2DS12_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -52,33 +35,13 @@
   *
   */
 
-/** @defgroup LIS2DS12_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -94,63 +57,81 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
-/** @defgroup lis2ds12_interface
-  * @{
-  */
+#endif /* MEMS_SHARED_TYPES */
 
-typedef int32_t (*lis2ds12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis2ds12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
 
 typedef struct {
-  /** Component mandatory fields **/
-  lis2ds12_write_ptr  write_reg;
-  lis2ds12_read_ptr   read_reg;
-  /** Customizable optional pointer **/
-  void *handle;
-} lis2ds12_ctx_t;
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
 
 /**
   * @}
+  *
   */
 
-/** @defgroup lis2ds12_Infos
-  * @{
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
   */
+
+/** @defgroup LIS2DS12_Infos
+  * @{
+  *
+  */
+
   /** I2C Device Address 8 bit format  if SA0=0 -> 0x3D if SA0=1 -> 0x3B **/
-#define LIS2DS12_I2C_ADD_L     0x3D
-#define LIS2DS12_I2C_ADD_H     0x3B
+#define LIS2DS12_I2C_ADD_L     0x3DU
+#define LIS2DS12_I2C_ADD_H     0x3BU
 
 /** Device Identification (Who am I) **/
-#define LIS2DS12_ID            0x43
+#define LIS2DS12_ID            0x43U
 
 /**
   * @}
+  *
   */
 
-/**
-  * @defgroup lis2ds12_Sensitivity
-  * @{
-  */
-
-#define LIS2DS12_FROM_FS_2g_TO_mg(lsb)    (float)(lsb *  61.0f) / 1000.0f
-#define LIS2DS12_FROM_FS_4g_TO_mg(lsb)    (float)(lsb * 122.0f) / 1000.0f
-#define LIS2DS12_FROM_FS_8g_TO_mg(lsb)    (float)(lsb * 244.0f) / 1000.0f
-#define LIS2DS12_FROM_FS_16g_TO_mg(lsb)   (float)(lsb * 488.0f) / 1000.0f
-
-#define LIS2DS12_FROM_LSB_TO_degC(lsb)  ((float)((int16_t)lsb>>8)*1.0f + 25.0f)
-
-/**
-  * @}
-  */
-
-#define LIS2DS12_SENSORHUB1_REG        0x06
+#define LIS2DS12_SENSORHUB1_REG        0x06U
 typedef struct {
   uint8_t bit0                : 1;
   uint8_t bit1                : 1;
@@ -162,7 +143,7 @@ typedef struct {
   uint8_t bit7                : 1;
 } lis2ds12_sensorhub1_reg_t;
 
-#define LIS2DS12_SENSORHUB2_REG        0x07
+#define LIS2DS12_SENSORHUB2_REG        0x07U
 typedef struct {
   uint8_t bit0                : 1;
   uint8_t bit1                : 1;
@@ -174,7 +155,7 @@ typedef struct {
   uint8_t bit7                : 1;
 } lis2ds12_sensorhub2_reg_t;
 
-#define LIS2DS12_SENSORHUB3_REG        0x08
+#define LIS2DS12_SENSORHUB3_REG        0x08U
 typedef struct {
   uint8_t bit0                : 1;
   uint8_t bit1                : 1;
@@ -186,7 +167,7 @@ typedef struct {
   uint8_t bit7                : 1;
 } lis2ds12_sensorhub3_reg_t;
 
-#define LIS2DS12_SENSORHUB4_REG        0x09
+#define LIS2DS12_SENSORHUB4_REG        0x09U
 typedef struct {
   uint8_t bit0                : 1;
   uint8_t bit1                : 1;
@@ -198,7 +179,7 @@ typedef struct {
   uint8_t bit7                : 1;
 } lis2ds12_sensorhub4_reg_t;
 
-#define LIS2DS12_SENSORHUB5_REG        0x0A
+#define LIS2DS12_SENSORHUB5_REG        0x0AU
 typedef struct {
   uint8_t bit0                : 1;
   uint8_t bit1                : 1;
@@ -210,7 +191,7 @@ typedef struct {
   uint8_t bit7                : 1;
 } lis2ds12_sensorhub5_reg_t;
 
-#define LIS2DS12_SENSORHUB6_REG        0x0B
+#define LIS2DS12_SENSORHUB6_REG        0x0BU
 typedef struct {
   uint8_t bit0                : 1;
   uint8_t bit1                : 1;
@@ -222,9 +203,9 @@ typedef struct {
   uint8_t bit7                : 1;
 } lis2ds12_sensorhub6_reg_t;
 
-#define LIS2DS12_MODULE_8BIT           0x0C
-#define LIS2DS12_WHO_AM_I              0x0F
-#define LIS2DS12_CTRL1                 0x20
+#define LIS2DS12_MODULE_8BIT           0x0CU
+#define LIS2DS12_WHO_AM_I              0x0FU
+#define LIS2DS12_CTRL1                 0x20U
 typedef struct {
   uint8_t bdu                 : 1;
   uint8_t hf_odr              : 1;
@@ -232,7 +213,7 @@ typedef struct {
   uint8_t odr                 : 4;
 } lis2ds12_ctrl1_t;
 
-#define LIS2DS12_CTRL2                 0x21
+#define LIS2DS12_CTRL2                 0x21U
 typedef struct {
   uint8_t sim                 : 1;
   uint8_t i2c_disable         : 1;
@@ -244,7 +225,7 @@ typedef struct {
   uint8_t boot                : 1;
 } lis2ds12_ctrl2_t;
 
-#define LIS2DS12_CTRL3                 0x22
+#define LIS2DS12_CTRL3                 0x22U
 typedef struct {
   uint8_t pp_od               : 1;
   uint8_t h_lactive           : 1;
@@ -255,7 +236,7 @@ typedef struct {
   uint8_t st                  : 2;
 } lis2ds12_ctrl3_t;
 
-#define LIS2DS12_CTRL4                 0x23
+#define LIS2DS12_CTRL4                 0x23U
 typedef struct {
   uint8_t int1_drdy           : 1;
   uint8_t int1_fth            : 1;
@@ -267,7 +248,7 @@ typedef struct {
   uint8_t int1_master_drdy    : 1;
 } lis2ds12_ctrl4_t;
 
-#define LIS2DS12_CTRL5                 0x24
+#define LIS2DS12_CTRL5                 0x24U
 typedef struct {
   uint8_t int2_drdy           : 1;
   uint8_t int2_fth            : 1;
@@ -279,7 +260,7 @@ typedef struct {
   uint8_t drdy_pulsed         : 1;
 } lis2ds12_ctrl5_t;
 
-#define LIS2DS12_FIFO_CTRL             0x25
+#define LIS2DS12_FIFO_CTRL             0x25U
 typedef struct {
   uint8_t if_cs_pu_dis        : 1;
   uint8_t not_used_01         : 2;
@@ -288,8 +269,8 @@ typedef struct {
   uint8_t fmode               : 3;
 } lis2ds12_fifo_ctrl_t;
 
-#define LIS2DS12_OUT_T                 0x26
-#define LIS2DS12_STATUS                0x27
+#define LIS2DS12_OUT_T                 0x26U
+#define LIS2DS12_STATUS                0x27U
 typedef struct {
   uint8_t drdy                : 1;
   uint8_t ff_ia               : 1;
@@ -301,14 +282,18 @@ typedef struct {
   uint8_t fifo_ths            : 1;
 } lis2ds12_status_t;
 
-#define LIS2DS12_OUT_X_L               0x28
-#define LIS2DS12_OUT_X_H               0x29
-#define LIS2DS12_OUT_Y_L               0x2A
-#define LIS2DS12_OUT_Y_H               0x2B
-#define LIS2DS12_OUT_Z_L               0x2C
-#define LIS2DS12_OUT_Z_H               0x2D
-#define LIS2DS12_FIFO_THS              0x2E
-#define LIS2DS12_FIFO_SRC              0x2F
+#define LIS2DS12_OUT_X_L               0x28U
+#define LIS2DS12_OUT_X_H               0x29U
+#define LIS2DS12_OUT_Y_L               0x2AU
+#define LIS2DS12_OUT_Y_H               0x2BU
+#define LIS2DS12_OUT_Z_L               0x2CU
+#define LIS2DS12_OUT_Z_H               0x2DU
+#define LIS2DS12_FIFO_THS              0x2EU
+typedef struct {
+  uint8_t fth                 : 8;
+} lis2ds12_fifo_ths_t;
+
+#define LIS2DS12_FIFO_SRC              0x2FU
 typedef struct {
   uint8_t not_used_01         : 5;
   uint8_t diff                : 1;
@@ -316,29 +301,29 @@ typedef struct {
   uint8_t fth                 : 1;
 } lis2ds12_fifo_src_t;
 
-#define LIS2DS12_FIFO_SAMPLES          0x30
-#define LIS2DS12_TAP_6D_THS            0x31
+#define LIS2DS12_FIFO_SAMPLES          0x30U
+#define LIS2DS12_TAP_6D_THS            0x31U
 typedef struct {
   uint8_t tap_ths             : 5;
   uint8_t _6d_ths             : 2;
   uint8_t _4d_en              : 1;
 } lis2ds12_tap_6d_ths_t;
 
-#define LIS2DS12_INT_DUR               0x32
+#define LIS2DS12_INT_DUR               0x32U
 typedef struct {
   uint8_t shock               : 2;
   uint8_t quiet               : 2;
   uint8_t lat                 : 4;
 } lis2ds12_int_dur_t;
 
-#define LIS2DS12_WAKE_UP_THS           0x33
+#define LIS2DS12_WAKE_UP_THS           0x33U
 typedef struct {
   uint8_t wu_ths              : 6;
   uint8_t sleep_on            : 1;
   uint8_t single_double_tap   : 1;
 } lis2ds12_wake_up_ths_t;
 
-#define LIS2DS12_WAKE_UP_DUR           0x34
+#define LIS2DS12_WAKE_UP_DUR           0x34U
 typedef struct {
   uint8_t sleep_dur           : 4;
   uint8_t int1_fss7           : 1;
@@ -346,13 +331,13 @@ typedef struct {
   uint8_t ff_dur              : 1;
 } lis2ds12_wake_up_dur_t;
 
-#define LIS2DS12_FREE_FALL             0x35
+#define LIS2DS12_FREE_FALL             0x35U
 typedef struct {
   uint8_t ff_ths              : 3;
   uint8_t ff_dur              : 5;
 } lis2ds12_free_fall_t;
 
-#define LIS2DS12_STATUS_DUP            0x36
+#define LIS2DS12_STATUS_DUP            0x36U
 typedef struct {
   uint8_t drdy                : 1;
   uint8_t ff_ia               : 1;
@@ -364,7 +349,7 @@ typedef struct {
   uint8_t ovr                 : 1;
 } lis2ds12_status_dup_t;
 
-#define LIS2DS12_WAKE_UP_SRC           0x37
+#define LIS2DS12_WAKE_UP_SRC           0x37U
 typedef struct {
   uint8_t z_wu                : 1;
   uint8_t y_wu                : 1;
@@ -375,7 +360,7 @@ typedef struct {
   uint8_t not_used_01         : 2;
 } lis2ds12_wake_up_src_t;
 
-#define LIS2DS12_TAP_SRC               0x38
+#define LIS2DS12_TAP_SRC               0x38U
 typedef struct {
   uint8_t z_tap               : 1;
   uint8_t y_tap               : 1;
@@ -387,7 +372,7 @@ typedef struct {
   uint8_t not_used_01         : 1;
 } lis2ds12_tap_src_t;
 
-#define LIS2DS12_6D_SRC                0x39
+#define LIS2DS12_6D_SRC                0x39U
 typedef struct {
   uint8_t xl                  : 1;
   uint8_t xh                  : 1;
@@ -399,16 +384,16 @@ typedef struct {
   uint8_t not_used_01         : 1;
 } lis2ds12_6d_src_t;
 
-#define LIS2DS12_STEP_COUNTER_MINTHS   0x3A
+#define LIS2DS12_STEP_COUNTER_MINTHS   0x3AU
 typedef struct {
   uint8_t sc_mths             : 6;
   uint8_t pedo4g              : 1;
   uint8_t rst_nstep           : 1;
 } lis2ds12_step_counter_minths_t;
 
-#define LIS2DS12_STEP_COUNTER_L        0x3B
-#define LIS2DS12_STEP_COUNTER_H        0x3C
-#define LIS2DS12_FUNC_CK_GATE          0x3D
+#define LIS2DS12_STEP_COUNTER_L        0x3BU
+#define LIS2DS12_STEP_COUNTER_H        0x3CU
+#define LIS2DS12_FUNC_CK_GATE          0x3DU
 typedef struct {
   uint8_t ck_gate_func        : 1;
   uint8_t step_detect         : 1;
@@ -419,7 +404,7 @@ typedef struct {
   uint8_t tilt_int            : 1;
 } lis2ds12_func_ck_gate_t;
 
-#define LIS2DS12_FUNC_SRC              0x3E
+#define LIS2DS12_FUNC_SRC              0x3EU
 typedef struct {
   uint8_t sensorhub_end_op    : 1;
   uint8_t module_ready        : 1;
@@ -427,7 +412,7 @@ typedef struct {
   uint8_t not_used_01         : 5;
 } lis2ds12_func_src_t;
 
-#define LIS2DS12_FUNC_CTRL             0x3F
+#define LIS2DS12_FUNC_CTRL             0x3FU
 typedef struct {
   uint8_t step_cnt_on         : 1;
   uint8_t sign_mot_on         : 1;
@@ -438,45 +423,45 @@ typedef struct {
   uint8_t not_used_01         : 2;
 } lis2ds12_func_ctrl_t;
 
-#define LIS2DS12_PEDO_DEB_REG          0x2B
+#define LIS2DS12_PEDO_DEB_REG          0x2BU
 typedef struct {
   uint8_t deb_step            : 3;
   uint8_t deb_time            : 5;
 } lis2ds12_pedo_deb_reg_t;
 
-#define LIS2DS12_SLV0_ADD              0x30
+#define LIS2DS12_SLV0_ADD              0x30U
 typedef struct {
   uint8_t rw_0                : 1;
   uint8_t slave0_add          : 7;
 } lis2ds12_slv0_add_t;
 
-#define LIS2DS12_SLV0_SUBADD           0x31
+#define LIS2DS12_SLV0_SUBADD           0x31U
 typedef struct {
   uint8_t slave0_reg          : 8;
 } lis2ds12_slv0_subadd_t;
 
-#define LIS2DS12_SLV0_CONFIG           0x32
+#define LIS2DS12_SLV0_CONFIG           0x32U
 typedef struct {
   uint8_t slave0_numop        : 3;
   uint8_t not_used_01         : 5;
 } lis2ds12_slv0_config_t;
 
-#define LIS2DS12_DATAWRITE_SLV0        0x33
+#define LIS2DS12_DATAWRITE_SLV0        0x33U
 typedef struct {
   uint8_t slave_dataw         : 8;
 } lis2ds12_datawrite_slv0_t;
 
-#define LIS2DS12_SM_THS                0x34
+#define LIS2DS12_SM_THS                0x34U
 typedef struct {
   uint8_t sm_ths              : 8;
 } lis2ds12_sm_ths_t;
 
-#define LIS2DS12_STEP_COUNT_DELTA      0x3A
+#define LIS2DS12_STEP_COUNT_DELTA      0x3AU
 typedef struct {
   uint8_t step_count_d        : 8;
 } lis2ds12_step_count_delta_t;
 
-#define LIS2DS12_CTRL2_ADV             0x3F
+#define LIS2DS12_CTRL2_ADV             0x3FU
 typedef struct {
   uint8_t sim                 : 1;
   uint8_t i2c_disable         : 1;
@@ -488,6 +473,18 @@ typedef struct {
   uint8_t boot                : 1;
 } lis2ds12_ctrl2_adv_t;
 
+/**
+  * @defgroup LIS2DS12_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
 typedef union{
   lis2ds12_sensorhub1_reg_t            sensorhub1_reg;
   lis2ds12_sensorhub2_reg_t            sensorhub2_reg;
@@ -527,13 +524,25 @@ typedef union{
   bitwise_t                            bitwise;
   uint8_t                              byte;
 } lis2ds12_reg_t;
-int32_t lis2ds12_read_reg(lis2ds12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis2ds12_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lis2ds12_write_reg(lis2ds12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2ds12_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
-typedef union {
-  struct {
+extern float_t lis2ds12_from_fs2g_to_mg(int16_t lsb);
+extern float_t lis2ds12_from_fs4g_to_mg(int16_t lsb);
+extern float_t lis2ds12_from_fs8g_to_mg(int16_t lsb);
+extern float_t lis2ds12_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t lis2ds12_from_lsb_to_celsius(int16_t lsb);
+
+typedef struct {
   lis2ds12_fifo_src_t       fifo_src;
   lis2ds12_status_dup_t     status_dup;
   lis2ds12_wake_up_src_t    wake_up_src;
@@ -541,15 +550,12 @@ typedef union {
   lis2ds12_6d_src_t         _6d_src;
   lis2ds12_func_ck_gate_t   func_ck_gate;
   lis2ds12_func_src_t       func_src;
-  } reg;
-  uint8_t byte[7];
-} lis2ds12_all_sources_t;
-int32_t lis2ds12_all_sources_get(lis2ds12_ctx_t *ctx,
+  } lis2ds12_all_sources_t;
+int32_t lis2ds12_all_sources_get(stmdev_ctx_t *ctx,
                                  lis2ds12_all_sources_t *val);
 
-
-int32_t lis2ds12_block_data_update_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_block_data_update_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DS12_2g = 0,
@@ -557,8 +563,8 @@ typedef enum {
   LIS2DS12_4g = 2,
   LIS2DS12_8g = 3,
 } lis2ds12_fs_t;
-int32_t lis2ds12_xl_full_scale_set(lis2ds12_ctx_t *ctx, lis2ds12_fs_t val);
-int32_t lis2ds12_xl_full_scale_get(lis2ds12_ctx_t *ctx, lis2ds12_fs_t *val);
+int32_t lis2ds12_xl_full_scale_set(stmdev_ctx_t *ctx, lis2ds12_fs_t val);
+int32_t lis2ds12_xl_full_scale_get(stmdev_ctx_t *ctx, lis2ds12_fs_t *val);
 
 typedef enum {
   LIS2DS12_XL_ODR_OFF         = 0x00,
@@ -581,114 +587,114 @@ typedef enum {
   LIS2DS12_XL_ODR_3k2Hz_HF    = 0x16,
   LIS2DS12_XL_ODR_6k4Hz_HF    = 0x17,
 } lis2ds12_odr_t;
-int32_t lis2ds12_xl_data_rate_set(lis2ds12_ctx_t *ctx, lis2ds12_odr_t val);
-int32_t lis2ds12_xl_data_rate_get(lis2ds12_ctx_t *ctx, lis2ds12_odr_t *val);
+int32_t lis2ds12_xl_data_rate_set(stmdev_ctx_t *ctx, lis2ds12_odr_t val);
+int32_t lis2ds12_xl_data_rate_get(stmdev_ctx_t *ctx, lis2ds12_odr_t *val);
 
-int32_t lis2ds12_status_reg_get(lis2ds12_ctx_t *ctx, lis2ds12_status_t *val);
+int32_t lis2ds12_status_reg_get(stmdev_ctx_t *ctx, lis2ds12_status_t *val);
 
-int32_t lis2ds12_xl_flag_data_ready_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_acceleration_module_raw_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_acceleration_module_raw_get(stmdev_ctx_t *ctx,
                                              uint8_t *buff);
 
-int32_t lis2ds12_temperature_raw_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2ds12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2ds12_acceleration_raw_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2ds12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2ds12_number_of_steps_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2ds12_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2ds12_device_id_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2ds12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2ds12_auto_increment_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_auto_increment_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DS12_USER_BANK   = 0,
   LIS2DS12_ADV_BANK    = 1,
 } lis2ds12_func_cfg_en_t;
-int32_t lis2ds12_mem_bank_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_mem_bank_set(stmdev_ctx_t *ctx,
                               lis2ds12_func_cfg_en_t val);
 
-int32_t lis2ds12_reset_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_reset_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_boot_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_boot_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DS12_XL_ST_DISABLE     = 0,
   LIS2DS12_XL_ST_POSITIVE    = 1,
   LIS2DS12_XL_ST_NEGATIVE    = 2,
 } lis2ds12_st_t;
-int32_t lis2ds12_xl_self_test_set(lis2ds12_ctx_t *ctx, lis2ds12_st_t val);
-int32_t lis2ds12_xl_self_test_get(lis2ds12_ctx_t *ctx, lis2ds12_st_t *val);
+int32_t lis2ds12_xl_self_test_set(stmdev_ctx_t *ctx, lis2ds12_st_t val);
+int32_t lis2ds12_xl_self_test_get(stmdev_ctx_t *ctx, lis2ds12_st_t *val);
 
 typedef enum {
   LIS2DS12_DRDY_LATCHED   = 0,
   LIS2DS12_DRDY_PULSED    = 1,
 } lis2ds12_drdy_pulsed_t;
-int32_t lis2ds12_data_ready_mode_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_data_ready_mode_set(stmdev_ctx_t *ctx,
                                      lis2ds12_drdy_pulsed_t val);
-int32_t lis2ds12_data_ready_mode_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_data_ready_mode_get(stmdev_ctx_t *ctx,
                                      lis2ds12_drdy_pulsed_t *val);
 
 typedef enum {
   LIS2DS12_HP_INTERNAL_ONLY  = 0,
   LIS2DS12_HP_ON_OUTPUTS     = 1,
 } lis2ds12_fds_slope_t;
-int32_t lis2ds12_xl_hp_path_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_xl_hp_path_set(stmdev_ctx_t *ctx,
                                 lis2ds12_fds_slope_t val);
-int32_t lis2ds12_xl_hp_path_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_xl_hp_path_get(stmdev_ctx_t *ctx,
                                 lis2ds12_fds_slope_t *val);
 
 typedef enum {
   LIS2DS12_SPI_4_WIRE   = 0,
   LIS2DS12_SPI_3_WIRE   = 1,
 } lis2ds12_sim_t;
-int32_t lis2ds12_spi_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_sim_t val);
-int32_t lis2ds12_spi_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_sim_t *val);
+int32_t lis2ds12_spi_mode_set(stmdev_ctx_t *ctx, lis2ds12_sim_t val);
+int32_t lis2ds12_spi_mode_get(stmdev_ctx_t *ctx, lis2ds12_sim_t *val);
 
 typedef enum {
   LIS2DS12_I2C_ENABLE   = 0,
   LIS2DS12_I2C_DISABLE  = 1,
 } lis2ds12_i2c_disable_t;
-int32_t lis2ds12_i2c_interface_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_i2c_interface_set(stmdev_ctx_t *ctx,
                                    lis2ds12_i2c_disable_t val);
-int32_t lis2ds12_i2c_interface_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_i2c_interface_get(stmdev_ctx_t *ctx,
                                    lis2ds12_i2c_disable_t *val);
 
 typedef enum {
   LIS2DS12_PULL_UP_CONNECTED     = 0,
   LIS2DS12_PULL_UP_DISCONNECTED  = 1,
 } lis2ds12_if_cs_pu_dis_t;
-int32_t lis2ds12_cs_mode_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_cs_mode_set(stmdev_ctx_t *ctx,
                              lis2ds12_if_cs_pu_dis_t val);
-int32_t lis2ds12_cs_mode_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_cs_mode_get(stmdev_ctx_t *ctx,
                              lis2ds12_if_cs_pu_dis_t *val);
 
 typedef enum {
   LIS2DS12_PUSH_PULL   = 0,
   LIS2DS12_OPEN_DRAIN  = 1,
 } lis2ds12_pp_od_t;
-int32_t lis2ds12_pin_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_pp_od_t val);
-int32_t lis2ds12_pin_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_pp_od_t *val);
+int32_t lis2ds12_pin_mode_set(stmdev_ctx_t *ctx, lis2ds12_pp_od_t val);
+int32_t lis2ds12_pin_mode_get(stmdev_ctx_t *ctx, lis2ds12_pp_od_t *val);
 
 typedef enum {
   LIS2DS12_ACTIVE_HIGH  = 0,
   LIS2DS12_ACTIVE_LOW   = 1,
 } lis2ds12_h_lactive_t;
-int32_t lis2ds12_pin_polarity_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_polarity_set(stmdev_ctx_t *ctx,
                                   lis2ds12_h_lactive_t val);
-int32_t lis2ds12_pin_polarity_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_polarity_get(stmdev_ctx_t *ctx,
                                   lis2ds12_h_lactive_t *val);
 
 typedef enum {
   LIS2DS12_INT_PULSED   = 0,
   LIS2DS12_INT_LATCHED  = 1,
 } lis2ds12_lir_t;
-int32_t lis2ds12_int_notification_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_int_notification_set(stmdev_ctx_t *ctx,
                                       lis2ds12_lir_t val);
-int32_t lis2ds12_int_notification_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_int_notification_get(stmdev_ctx_t *ctx,
                                       lis2ds12_lir_t *val);
 
 typedef struct{
@@ -702,9 +708,9 @@ typedef struct{
   uint8_t int1_master_drdy        : 1;
   uint8_t int1_fss7               : 1;
 } lis2ds12_pin_int1_route_t;
-int32_t lis2ds12_pin_int1_route_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     lis2ds12_pin_int1_route_t val);
-int32_t lis2ds12_pin_int1_route_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     lis2ds12_pin_int1_route_t *val);
 
 typedef struct{
@@ -715,57 +721,57 @@ typedef struct{
   uint8_t int2_fth                : 1;
   uint8_t int2_drdy               : 1;
 } lis2ds12_pin_int2_route_t;
-int32_t lis2ds12_pin_int2_route_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     lis2ds12_pin_int2_route_t val);
-int32_t lis2ds12_pin_int2_route_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     lis2ds12_pin_int2_route_t *val);
 
-int32_t lis2ds12_all_on_int1_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_all_on_int1_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_wkup_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_wkup_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_wkup_dur_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_wkup_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_sleep_mode_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_sleep_mode_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_act_sleep_dur_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_act_sleep_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tap_detection_on_z_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_tap_detection_on_z_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tap_detection_on_y_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_tap_detection_on_y_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tap_detection_on_x_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_tap_detection_on_x_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tap_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_tap_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tap_shock_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_tap_shock_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tap_quiet_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_tap_quiet_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tap_dur_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_tap_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DS12_ONLY_SINGLE  = 0,
   LIS2DS12_ONLY_DOUBLE  = 1,
 } lis2ds12_single_double_tap_t;
-int32_t lis2ds12_tap_mode_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_tap_mode_set(stmdev_ctx_t *ctx,
                               lis2ds12_single_double_tap_t val);
-int32_t lis2ds12_tap_mode_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_tap_mode_get(stmdev_ctx_t *ctx,
                               lis2ds12_single_double_tap_t *val);
 
-int32_t lis2ds12_tap_src_get(lis2ds12_ctx_t *ctx, lis2ds12_tap_src_t *val);
+int32_t lis2ds12_tap_src_get(stmdev_ctx_t *ctx, lis2ds12_tap_src_t *val);
 
 typedef enum {
   LIS2DS12_DEG_80   = 0,
@@ -773,22 +779,22 @@ typedef enum {
   LIS2DS12_DEG_60   = 2,
   LIS2DS12_DEG_50   = 3,
 } lis2ds12_6d_ths_t;
-int32_t lis2ds12_6d_threshold_set(lis2ds12_ctx_t *ctx, lis2ds12_6d_ths_t val);
-int32_t lis2ds12_6d_threshold_get(lis2ds12_ctx_t *ctx, lis2ds12_6d_ths_t *val);
+int32_t lis2ds12_6d_threshold_set(stmdev_ctx_t *ctx, lis2ds12_6d_ths_t val);
+int32_t lis2ds12_6d_threshold_get(stmdev_ctx_t *ctx, lis2ds12_6d_ths_t *val);
 
-int32_t lis2ds12_4d_mode_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_4d_mode_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_6d_src_get(lis2ds12_ctx_t *ctx, lis2ds12_6d_src_t *val);
+int32_t lis2ds12_6d_src_get(stmdev_ctx_t *ctx, lis2ds12_6d_src_t *val);
 
-int32_t lis2ds12_ff_dur_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_ff_dur_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_ff_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_ff_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_ff_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_ff_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_fifo_xl_module_batch_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_fifo_xl_module_batch_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_fifo_xl_module_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_fifo_xl_module_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DS12_BYPASS_MODE            = 0,
@@ -797,96 +803,93 @@ typedef enum {
   LIS2DS12_BYPASS_TO_STREAM_MODE  = 4,
   LIS2DS12_STREAM_MODE            = 6,
 } lis2ds12_fmode_t;
-int32_t lis2ds12_fifo_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_fmode_t val);
-int32_t lis2ds12_fifo_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_fmode_t *val);
+int32_t lis2ds12_fifo_mode_set(stmdev_ctx_t *ctx, lis2ds12_fmode_t val);
+int32_t lis2ds12_fifo_mode_get(stmdev_ctx_t *ctx, lis2ds12_fmode_t *val);
 
-int32_t lis2ds12_fifo_watermark_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_fifo_watermark_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_fifo_full_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_fifo_ovr_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_fifo_wtm_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_fifo_data_level_get(lis2ds12_ctx_t *ctx, uint16_t *val);
+int32_t lis2ds12_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lis2ds12_fifo_src_get(lis2ds12_ctx_t *ctx, lis2ds12_fifo_src_t *val);
+int32_t lis2ds12_fifo_src_get(stmdev_ctx_t *ctx, lis2ds12_fifo_src_t *val);
 
-int32_t lis2ds12_pedo_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_pedo_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DS12_PEDO_AT_2g  = 0,
   LIS2DS12_PEDO_AT_4g  = 1,
 } lis2ds12_pedo4g_t;
-int32_t lis2ds12_pedo_full_scale_set(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pedo_full_scale_set(stmdev_ctx_t *ctx,
                                      lis2ds12_pedo4g_t val);
-int32_t lis2ds12_pedo_full_scale_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_pedo_full_scale_get(stmdev_ctx_t *ctx,
                                      lis2ds12_pedo4g_t *val);
 
-int32_t lis2ds12_pedo_step_reset_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_pedo_step_reset_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_pedo_step_detect_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_pedo_step_detect_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_pedo_sens_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_pedo_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_pedo_debounce_steps_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_pedo_debounce_steps_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_pedo_timeout_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_pedo_timeout_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_pedo_steps_period_set(lis2ds12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2ds12_pedo_steps_period_get(lis2ds12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2ds12_motion_data_ready_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2ds12_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2ds12_motion_data_ready_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_motion_sens_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_motion_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_motion_threshold_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_motion_threshold_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tilt_data_ready_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tilt_data_ready_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_tilt_sens_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_tilt_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_module_sens_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_module_sens_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_module_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_module_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef union {
-  struct {
+typedef struct {
     lis2ds12_sensorhub1_reg_t  sensorhub1_reg;
     lis2ds12_sensorhub2_reg_t  sensorhub2_reg;
     lis2ds12_sensorhub3_reg_t  sensorhub3_reg;
     lis2ds12_sensorhub4_reg_t  sensorhub4_reg;
     lis2ds12_sensorhub5_reg_t  sensorhub5_reg;
     lis2ds12_sensorhub6_reg_t  sensorhub6_reg;
-  } reg;
-  uint8_t byte[6];
 } lis2ds12_sh_read_data_raw_t;
-int32_t lis2ds12_sh_read_data_raw_get(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                       lis2ds12_sh_read_data_raw_t *val);
 
-int32_t lis2ds12_sh_master_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_sh_master_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DS12_EXT_PULL_UP        = 0,
   LIS2DS12_INTERNAL_PULL_UP   = 1,
 } lis2ds12_tud_en_t;
-int32_t lis2ds12_sh_pin_mode_set(lis2ds12_ctx_t *ctx, lis2ds12_tud_en_t val);
-int32_t lis2ds12_sh_pin_mode_get(lis2ds12_ctx_t *ctx, lis2ds12_tud_en_t *val);
+int32_t lis2ds12_sh_pin_mode_set(stmdev_ctx_t *ctx, lis2ds12_tud_en_t val);
+int32_t lis2ds12_sh_pin_mode_get(stmdev_ctx_t *ctx, lis2ds12_tud_en_t *val);
 
 typedef struct{
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_data;
 } lis2ds12_sh_cfg_write_t;
-int32_t lis2ds12_sh_cfg_write(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_sh_cfg_write(stmdev_ctx_t *ctx,
                               lis2ds12_sh_cfg_write_t *val);
 
 typedef struct{
@@ -894,16 +897,17 @@ typedef struct{
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lis2ds12_sh_cfg_read_t;
-int32_t lis2ds12_sh_slv_cfg_read(lis2ds12_ctx_t *ctx,
+int32_t lis2ds12_sh_slv_cfg_read(stmdev_ctx_t *ctx,
                                  lis2ds12_sh_cfg_read_t *val);
 
-int32_t lis2ds12_sh_slv0_cfg_read_set(lis2ds12_ctx_t *ctx, uint8_t val);
-int32_t lis2ds12_sh_slv0_cfg_read_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_sh_slv0_cfg_read_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2ds12_sh_slv0_cfg_read_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2ds12_sh_end_op_flag_get(lis2ds12_ctx_t *ctx, uint8_t *val);
+int32_t lis2ds12_sh_end_op_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}
+  *
   */
 
 #ifdef __cplusplus

--- a/sensor/stmemsc/lis2dtw12_STdC/driver/lis2dtw12_reg.c
+++ b/sensor/stmemsc/lis2dtw12_STdC/driver/lis2dtw12_reg.c
@@ -1,0 +1,2872 @@
+/*
+ ******************************************************************************
+ * @file    lis2dtw12_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LIS2DTW12 driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "lis2dtw12_reg.h"
+
+/**
+  * @defgroup  LIS2DTW12
+  * @brief     This file provides a set of functions needed to drive the
+  *            lis2dtw12 enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+  
+/**
+  * @defgroup    LIS2DTW12_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lis2dtw12_from_fs2_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lis2dtw12_from_fs4_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t lis2dtw12_from_fs8_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t lis2dtw12_from_fs16_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) *0.488f;
+}
+
+float_t lis2dtw12_from_fs2_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.061f;
+}
+
+float_t lis2dtw12_from_fs4_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.122f;
+}
+
+float_t lis2dtw12_from_fs8_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.244f;
+}
+
+float_t lis2dtw12_from_fs16_lp1_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb) * 0.488f;
+}
+
+float_t lis2dtw12_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 16.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Data_Generation
+  * @brief     This section groups all the functions concerning 
+  *            data generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select accelerometer operating modes.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mode / lp_mode in reg CTRL1
+  *                  and low_noise in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_power_mode_set(stmdev_ctx_t *ctx, lis2dtw12_mode_t val)
+{
+  lis2dtw12_ctrl1_t ctrl1;
+  lis2dtw12_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ctrl1.mode = ( (uint8_t) val & 0x0CU ) >> 2;
+    ctrl1.lp_mode = (uint8_t) val & 0x03U ;  
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  } 
+  if (ret == 0) {
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  } 
+  if (ret == 0) {
+    ctrl6.low_noise = ( (uint8_t) val & 0x10U ) >> 4;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  } 
+  return ret;
+}
+
+/**
+  * @brief  Select accelerometer operating modes.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of mode / lp_mode in reg CTRL1
+  *                  and low_noise in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_power_mode_get(stmdev_ctx_t *ctx, lis2dtw12_mode_t *val)
+{
+  lis2dtw12_ctrl1_t ctrl1;
+  lis2dtw12_ctrl6_t ctrl6;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &ctrl6, 1);
+
+    switch (((ctrl6.low_noise << 4) + (ctrl1.mode << 2) + 
+            ctrl1.lp_mode)) {
+      case LIS2DTW12_HIGH_PERFORMANCE:
+        *val = LIS2DTW12_HIGH_PERFORMANCE;
+        break;
+      case LIS2DTW12_CONT_LOW_PWR_4:
+        *val = LIS2DTW12_CONT_LOW_PWR_4;
+        break;
+      case LIS2DTW12_CONT_LOW_PWR_3:
+        *val = LIS2DTW12_CONT_LOW_PWR_3;
+        break;
+      case LIS2DTW12_CONT_LOW_PWR_2:
+        *val = LIS2DTW12_CONT_LOW_PWR_2;
+        break;
+      case LIS2DTW12_CONT_LOW_PWR_12bit:
+        *val = LIS2DTW12_CONT_LOW_PWR_12bit;
+        break;
+      case LIS2DTW12_SINGLE_LOW_PWR_4:
+        *val = LIS2DTW12_SINGLE_LOW_PWR_4;
+        break;
+      case LIS2DTW12_SINGLE_LOW_PWR_3:
+        *val = LIS2DTW12_SINGLE_LOW_PWR_3;
+        break;
+      case LIS2DTW12_SINGLE_LOW_PWR_2:
+        *val = LIS2DTW12_SINGLE_LOW_PWR_2;
+        break;
+      case LIS2DTW12_SINGLE_LOW_PWR_12bit:
+        *val = LIS2DTW12_SINGLE_LOW_PWR_12bit;
+        break;
+      case LIS2DTW12_HIGH_PERFORMANCE_LOW_NOISE:
+        *val = LIS2DTW12_HIGH_PERFORMANCE_LOW_NOISE;
+        break;
+      case LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_4:
+        *val = LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_4;
+        break;
+      case LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_3:
+        *val = LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_3;
+        break;
+      case LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_2:
+        *val = LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_2;
+        break;
+      case LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_12bit:
+        *val = LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_12bit;
+        break;
+      case LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_4:
+        *val = LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_4;
+        break;
+      case LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_3:
+        *val = LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_3;
+        break;
+      case LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_2:
+        *val = LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_2;
+        break;
+      case LIS2DTW12_SINGLE_LOW_LOW_NOISE_PWR_12bit:
+        *val = LIS2DTW12_SINGLE_LOW_LOW_NOISE_PWR_12bit;
+        break;
+      default:
+        *val = LIS2DTW12_HIGH_PERFORMANCE;
+        break;
+    }
+  } 
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_data_rate_set(stmdev_ctx_t *ctx, lis2dtw12_odr_t val)
+{
+  lis2dtw12_ctrl1_t ctrl1;
+  lis2dtw12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ctrl1.odr = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  } 
+  if (ret == 0) { 
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &ctrl3, 1);
+  } 
+  if (ret == 0) { 
+    ctrl3.slp_mode = ( (uint8_t) val & 0x30U ) >> 4;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &ctrl3, 1);
+  } 
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr in reg CTRL1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_data_rate_get(stmdev_ctx_t *ctx, lis2dtw12_odr_t *val)
+{
+  lis2dtw12_ctrl1_t ctrl1;
+  lis2dtw12_ctrl3_t ctrl3;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL1,(uint8_t*) &ctrl1, 1);
+  if (ret == 0) {
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &ctrl3, 1);
+   
+    switch ((ctrl3.slp_mode << 4) + ctrl1.odr) {
+      case LIS2DTW12_XL_ODR_OFF:
+        *val = LIS2DTW12_XL_ODR_OFF;
+        break;
+      case LIS2DTW12_XL_ODR_1Hz6_LP_ONLY:
+        *val = LIS2DTW12_XL_ODR_1Hz6_LP_ONLY;
+        break;
+      case LIS2DTW12_XL_ODR_12Hz5:
+        *val = LIS2DTW12_XL_ODR_12Hz5;
+        break;
+      case LIS2DTW12_XL_ODR_25Hz:
+        *val = LIS2DTW12_XL_ODR_25Hz;
+        break;
+       case LIS2DTW12_XL_ODR_50Hz:
+        *val = LIS2DTW12_XL_ODR_50Hz;
+        break;
+      case LIS2DTW12_XL_ODR_100Hz:
+        *val = LIS2DTW12_XL_ODR_100Hz;
+        break;
+      case LIS2DTW12_XL_ODR_200Hz:
+        *val = LIS2DTW12_XL_ODR_200Hz;
+        break;
+      case LIS2DTW12_XL_ODR_400Hz:
+        *val = LIS2DTW12_XL_ODR_400Hz;
+        break;     
+       case LIS2DTW12_XL_ODR_800Hz:
+        *val = LIS2DTW12_XL_ODR_800Hz;
+        break;
+      case LIS2DTW12_XL_ODR_1k6Hz:
+        *val = LIS2DTW12_XL_ODR_1k6Hz;
+        break;
+      case LIS2DTW12_XL_SET_SW_TRIG:
+        *val = LIS2DTW12_XL_SET_SW_TRIG;
+        break;
+      case LIS2DTW12_XL_SET_PIN_TRIG:
+        *val = LIS2DTW12_XL_SET_PIN_TRIG;
+        break;     
+      default:
+        *val = LIS2DTW12_XL_ODR_OFF;
+        break;
+    }
+  } 
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fs in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_full_scale_set(stmdev_ctx_t *ctx, lis2dtw12_fs_t val)
+{
+  lis2dtw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fs = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &reg, 1); 
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fs in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_full_scale_get(stmdev_ctx_t *ctx, lis2dtw12_fs_t *val)
+{
+  lis2dtw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &reg, 1);
+
+  switch (reg.fs) {
+    case LIS2DTW12_2g:
+      *val = LIS2DTW12_2g;
+      break;
+    case LIS2DTW12_4g:
+      *val = LIS2DTW12_4g;
+      break;
+    case LIS2DTW12_8g:
+      *val = LIS2DTW12_8g;
+      break;
+    case LIS2DTW12_16g:
+      *val = LIS2DTW12_16g;
+      break;
+    default:
+      *val = LIS2DTW12_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from STATUS to 
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_status_reg_get(stmdev_ctx_t *ctx, lis2dtw12_status_t *val)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_STATUS, (uint8_t*) val, 1);
+  return ret;     
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_status_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_STATUS,(uint8_t*) &reg, 1);
+  *val = reg.drdy;
+
+  return ret;
+}
+/**
+  * @brief   Read all the interrupt/status flag of the device.[get]
+  *                            
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers STATUS_DUP, WAKE_UP_SRC,
+  *                  TAP_SRC, SIXD_SRC, ALL_INT_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_all_sources_get(stmdev_ctx_t *ctx,
+                                 lis2dtw12_all_sources_t *val)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_STATUS_DUP, (uint8_t*) val, 5);
+  return ret;     
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s 
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_write_reg(ctx, LIS2DTW12_X_OFS_USR, buff, 1);
+  return ret;     
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s 
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_X_OFS_USR, buff, 1);
+  return ret;     
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s 
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_write_reg(ctx, LIS2DTW12_Y_OFS_USR, buff, 1);
+  return ret;     
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s 
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_Y_OFS_USR, buff, 1);
+  return ret;     
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s 
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_write_reg(ctx, LIS2DTW12_Z_OFS_USR, buff, 1);
+  return ret;     
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s 
+  *         complement, weight depends on bit USR_OFF_W. The value must be
+  *         in the range [-127 127].[get] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_Z_OFS_USR, buff, 1);
+  return ret;     
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR, 
+  *         Y_OFS_USR, Z_OFS_USR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_w in
+  *                               reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_offset_weight_set(stmdev_ctx_t *ctx,
+                                   lis2dtw12_usr_off_w_t val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.usr_off_w = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR, 
+  *         Y_OFS_USR, Z_OFS_USR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of usr_off_w in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_offset_weight_get(stmdev_ctx_t *ctx,
+                                   lis2dtw12_usr_off_w_t *val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  switch (reg.usr_off_w) {
+    case LIS2DTW12_LSb_977ug:
+      *val = LIS2DTW12_LSb_977ug;
+      break;
+    case LIS2DTW12_LSb_15mg6:
+      *val = LIS2DTW12_LSb_15mg6;
+      break;
+    default:
+      *val = LIS2DTW12_LSb_977ug;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Data_Output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Temperature data output register (r). L and H registers 
+  *         together express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_OUT_T_L, buff, 2);
+  return ret;     
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as 
+  *         a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_OUT_X_L, buff, 6);
+  return ret;     
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Common
+  * @brief     This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WHO_AM_I, buff, 1);
+  return ret;     
+}
+
+/**
+  * @brief  Register address automatically incremented during multiple byte 
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.if_add_inc = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during multiple 
+  *         byte access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_reset in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.soft_reset = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of soft_reset in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.soft_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.boot = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor self-test enable.[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of st in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_self_test_set(stmdev_ctx_t *ctx, lis2dtw12_st_t val)
+{
+  lis2dtw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.st = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor self-test enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of st in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_self_test_get(stmdev_ctx_t *ctx, lis2dtw12_st_t *val)
+{
+  lis2dtw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.st) {
+    case LIS2DTW12_XL_ST_DISABLE:
+      *val = LIS2DTW12_XL_ST_DISABLE;
+      break;
+    case LIS2DTW12_XL_ST_POSITIVE:
+      *val = LIS2DTW12_XL_ST_POSITIVE;
+      break;
+    case LIS2DTW12_XL_ST_NEGATIVE:
+      *val = LIS2DTW12_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LIS2DTW12_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of drdy_pulsed in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                     lis2dtw12_drdy_pulsed_t val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.drdy_pulsed = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of drdy_pulsed in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                     lis2dtw12_drdy_pulsed_t *val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.drdy_pulsed) {
+    case LIS2DTW12_DRDY_LATCHED:
+      *val = LIS2DTW12_DRDY_LATCHED;
+      break;
+    case LIS2DTW12_DRDY_PULSED:
+      *val = LIS2DTW12_DRDY_PULSED;
+      break;
+    default:
+      *val = LIS2DTW12_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Filters
+  * @brief     This section group all the functions concerning the filters
+  *            configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer filtering path for outputs.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fds in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_filter_path_set(stmdev_ctx_t *ctx, lis2dtw12_fds_t val)
+{
+  lis2dtw12_ctrl6_t ctrl6;
+  lis2dtw12_ctrl_reg7_t ctrl_reg7;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  if (ret == 0) {
+    ctrl6.fds = ( (uint8_t) val & 0x10U ) >> 4;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  } 
+  if (ret == 0) {
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+  } 
+  if (ret == 0) {  
+    ctrl_reg7.usr_off_on_out = (uint8_t) val & 0x01U;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);  
+  } 
+  
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer filtering path for outputs.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fds in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_filter_path_get(stmdev_ctx_t *ctx, lis2dtw12_fds_t *val)
+{
+  lis2dtw12_ctrl6_t ctrl6;
+  lis2dtw12_ctrl_reg7_t ctrl_reg7;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &ctrl6, 1);
+  if (ret == 0) {
+   ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &ctrl_reg7, 1);
+  
+    switch ((ctrl6.fds << 4 ) + ctrl_reg7.usr_off_on_out) {
+      case LIS2DTW12_LPF_ON_OUT:
+        *val = LIS2DTW12_LPF_ON_OUT;
+        break;
+      case LIS2DTW12_USER_OFFSET_ON_OUT:
+        *val = LIS2DTW12_USER_OFFSET_ON_OUT;
+        break;
+      case LIS2DTW12_HIGH_PASS_ON_OUT:
+        *val = LIS2DTW12_HIGH_PASS_ON_OUT;
+        break;
+      default:
+        *val = LIS2DTW12_LPF_ON_OUT;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer cutoff filter frequency. Valid for low and high 
+  *          pass filter.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bw_filt in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_filter_bandwidth_set(stmdev_ctx_t *ctx,
+                                         lis2dtw12_bw_filt_t val)
+{
+  lis2dtw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bw_filt = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Accelerometer cutoff filter frequency. Valid for low and 
+  *          high pass filter.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of bw_filt in reg CTRL6
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_filter_bandwidth_get(stmdev_ctx_t *ctx,
+                                         lis2dtw12_bw_filt_t *val)
+{
+  lis2dtw12_ctrl6_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL6,(uint8_t*) &reg, 1);
+
+  switch (reg.bw_filt) {
+    case LIS2DTW12_ODR_DIV_2:
+      *val = LIS2DTW12_ODR_DIV_2;
+      break;
+    case LIS2DTW12_ODR_DIV_4:
+      *val = LIS2DTW12_ODR_DIV_4;
+      break;
+    case LIS2DTW12_ODR_DIV_10:
+      *val = LIS2DTW12_ODR_DIV_10;
+      break;
+    case LIS2DTW12_ODR_DIV_20:
+      *val = LIS2DTW12_ODR_DIV_20;
+      break;
+    default:
+      *val = LIS2DTW12_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_ref_mode in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.hp_ref_mode = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of hp_ref_mode in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  *val = reg.hp_ref_mode;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DTW12_Serial_Interface
+  * @brief      This section groups all the functions concerning main serial
+  *             interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_spi_mode_set(stmdev_ctx_t *ctx, lis2dtw12_sim_t val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {  
+    reg.sim = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_spi_mode_get(stmdev_ctx_t *ctx, lis2dtw12_sim_t *val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.sim) {
+    case LIS2DTW12_SPI_4_WIRE:
+      *val = LIS2DTW12_SPI_4_WIRE;
+      break;
+    case LIS2DTW12_SPI_3_WIRE:
+      *val = LIS2DTW12_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS2DTW12_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_disable in
+  *                                 reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_i2c_interface_set(stmdev_ctx_t *ctx,
+                                   lis2dtw12_i2c_disable_t val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i2c_disable = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_disable in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_i2c_interface_get(stmdev_ctx_t *ctx,
+                                   lis2dtw12_i2c_disable_t *val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.i2c_disable) {
+    case LIS2DTW12_I2C_ENABLE:
+      *val = LIS2DTW12_I2C_ENABLE;
+      break;
+    case LIS2DTW12_I2C_DISABLE:
+      *val = LIS2DTW12_I2C_DISABLE;
+      break;
+    default:
+      *val = LIS2DTW12_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disconnect CS pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of cs_pu_disc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_cs_mode_set(stmdev_ctx_t *ctx, lis2dtw12_cs_pu_disc_t val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.cs_pu_disc = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disconnect CS pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of cs_pu_disc in reg CTRL2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_cs_mode_get(stmdev_ctx_t *ctx, lis2dtw12_cs_pu_disc_t *val)
+{
+  lis2dtw12_ctrl2_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL2,(uint8_t*) &reg, 1);
+
+  switch (reg.cs_pu_disc) {
+    case LIS2DTW12_PULL_UP_CONNECT:
+      *val = LIS2DTW12_PULL_UP_CONNECT;
+      break;
+    case LIS2DTW12_PULL_UP_DISCONNECT:
+      *val = LIS2DTW12_PULL_UP_DISCONNECT;
+      break;
+    default:
+      *val = LIS2DTW12_PULL_UP_CONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Interrupt_Pins
+  * @brief     This section groups all the functions that manage interrupt pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of h_lactive in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_pin_polarity_set(stmdev_ctx_t *ctx,
+                                  lis2dtw12_h_lactive_t val)
+{
+  lis2dtw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.h_lactive = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of h_lactive in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_pin_polarity_get(stmdev_ctx_t *ctx,
+                                  lis2dtw12_h_lactive_t *val)
+{
+  lis2dtw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.h_lactive) {
+    case LIS2DTW12_ACTIVE_HIGH:
+      *val = LIS2DTW12_ACTIVE_HIGH;
+      break;
+    case LIS2DTW12_ACTIVE_LOW:
+      *val = LIS2DTW12_ACTIVE_LOW;
+      break;
+    default:
+      *val = LIS2DTW12_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_int_notification_set(stmdev_ctx_t *ctx,
+                                      lis2dtw12_lir_t val)
+{
+  lis2dtw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lir = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_int_notification_get(stmdev_ctx_t *ctx,
+                                      lis2dtw12_lir_t *val)
+{
+  lis2dtw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.lir) {
+    case LIS2DTW12_INT_PULSED:
+      *val = LIS2DTW12_INT_PULSED;
+      break;
+    case LIS2DTW12_INT_LATCHED:
+      *val = LIS2DTW12_INT_LATCHED;
+      break;
+    default:
+      *val = LIS2DTW12_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pp_od in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_pin_mode_set(stmdev_ctx_t *ctx, lis2dtw12_pp_od_t val)
+{
+  lis2dtw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.pp_od = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pp_od in reg CTRL3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_pin_mode_get(stmdev_ctx_t *ctx, lis2dtw12_pp_od_t *val)
+{
+  lis2dtw12_ctrl3_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL3,(uint8_t*) &reg, 1);
+
+  switch (reg.pp_od) {
+    case LIS2DTW12_PUSH_PULL:
+      *val = LIS2DTW12_PUSH_PULL;
+      break;
+    case LIS2DTW12_OPEN_DRAIN:
+      *val = LIS2DTW12_OPEN_DRAIN;
+      break;
+    default:
+      *val = LIS2DTW12_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL4_INT1_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                    lis2dtw12_ctrl4_int1_pad_ctrl_t *val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+  
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    if ((val->int1_tap | val->int1_ff | val->int1_wu | val->int1_single_tap |
+         val->int1_6d) != PROPERTY_DISABLE){     
+      reg.interrupts_enable = PROPERTY_ENABLE;   
+    } 
+    else{
+      reg.interrupts_enable = PROPERTY_DISABLE;
+    }
+    
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL4_INT1_PAD_CTRL,
+                                (uint8_t*) val, 1);  
+  } if (ret == 0) {
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1); 
+  }                       
+  return ret;                          
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL4_INT1_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                    lis2dtw12_ctrl4_int1_pad_ctrl_t *val)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL4_INT1_PAD_CTRL,
+                          (uint8_t*) val, 1);
+  return ret;     
+}
+
+/**
+  * @brief   Select the signal that need to route on int2 pad.[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL5_INT2_PAD_CTRL.
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                    lis2dtw12_ctrl5_int2_pad_ctrl_t *val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+  
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    if ((val->int2_sleep_state | val->int2_sleep_chg ) != PROPERTY_DISABLE) {  
+      reg.interrupts_enable = PROPERTY_ENABLE;   
+    } 
+    else{
+      reg.interrupts_enable = PROPERTY_DISABLE;
+    }
+    
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL5_INT2_PAD_CTRL,
+                             (uint8_t*) val, 1);  
+  } 
+  if (ret == 0) {
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1); 
+  } 
+                      
+  return ret;     
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      register CTRL5_INT2_PAD_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                    lis2dtw12_ctrl5_int2_pad_ctrl_t *val)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL5_INT2_PAD_CTRL,
+                          (uint8_t*) val, 1);
+  return ret;     
+}
+/**
+  * @brief All interrupt signals become available on INT1 pin.[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.int2_on_int1 = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int2_on_int1 in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  *val = reg.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Wake_Up_Event
+  * @brief     This section groups all the functions that manage the Wake
+  *            Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wk_ths = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wk_ths in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  *val = reg.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wake_dur = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  *val = reg.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Data sent to wake-up interrupt function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of usr_off_on_wu in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_wkup_feed_data_set(stmdev_ctx_t *ctx,
+                                    lis2dtw12_usr_off_on_wu_t val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.usr_off_on_wu = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data sent to wake-up interrupt function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of usr_off_on_wu in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_wkup_feed_data_get(stmdev_ctx_t *ctx,
+                                    lis2dtw12_usr_off_on_wu_t *val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.usr_off_on_wu) {
+    case LIS2DTW12_HP_FEED:
+      *val = LIS2DTW12_HP_FEED;
+      break;
+    case LIS2DTW12_USER_OFFSET_FEED:
+      *val = LIS2DTW12_USER_OFFSET_FEED;
+      break;
+    default:
+      *val = LIS2DTW12_HP_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DTW12_Activity/Inactivity_Detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Config activity / inactivity or 
+  *         stationary / motion detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_on / stationary in
+  *                  reg WAKE_UP_THS / WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_act_mode_set(stmdev_ctx_t *ctx, lis2dtw12_sleep_on_t val)
+{
+  lis2dtw12_wake_up_ths_t wake_up_ths;
+  lis2dtw12_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+  
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  if (ret == 0) {
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  } 
+  if (ret == 0) {
+    wake_up_ths.sleep_on = (uint8_t) val & 0x01U;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  } 
+  if (ret == 0) {
+    wake_up_dur.stationary = ((uint8_t)val & 0x02U) >> 1;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  } 
+    
+  return ret;
+}
+
+/**
+  * @brief  Config activity / inactivity or 
+  *         stationary / motion detection. [get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sleep_on in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_act_mode_get(stmdev_ctx_t *ctx, lis2dtw12_sleep_on_t *val)
+{
+  lis2dtw12_wake_up_ths_t wake_up_ths;
+  lis2dtw12_wake_up_dur_t wake_up_dur;;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &wake_up_ths, 1);
+  if (ret == 0) {
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+
+    switch ((wake_up_dur.stationary << 1) + wake_up_ths.sleep_on){
+      case LIS2DTW12_NO_DETECTION:
+        *val = LIS2DTW12_NO_DETECTION;
+        break;
+      case LIS2DTW12_DETECT_ACT_INACT:
+        *val = LIS2DTW12_DETECT_ACT_INACT;
+        break;
+      case LIS2DTW12_DETECT_STAT_MOTION:
+        *val = LIS2DTW12_DETECT_STAT_MOTION;
+        break;
+      default:
+        *val = LIS2DTW12_NO_DETECTION;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sleep_dur = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_wake_up_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &reg, 1);
+  *val = reg.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Tap_Generator
+  * @brief     This section groups all the functions that manage the tap
+  *            and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsx in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsx = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsx in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsx;
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsy in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsy = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsy in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsy;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_prior in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_axis_priority_set(stmdev_ctx_t *ctx,
+                                       lis2dtw12_tap_prior_t val)
+{
+  lis2dtw12_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_prior = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of tap_prior in reg TAP_THS_Y
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_axis_priority_get(stmdev_ctx_t *ctx,
+                                       lis2dtw12_tap_prior_t *val)
+{
+  lis2dtw12_tap_ths_y_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Y,(uint8_t*) &reg, 1);
+
+  switch (reg.tap_prior) {
+    case LIS2DTW12_XYZ:
+      *val = LIS2DTW12_XYZ;
+      break;
+    case LIS2DTW12_YXZ:
+      *val = LIS2DTW12_YXZ;
+      break;
+    case LIS2DTW12_XZY:
+      *val = LIS2DTW12_XZY;
+      break;
+    case LIS2DTW12_ZYX:
+      *val = LIS2DTW12_ZYX;
+      break;
+    case LIS2DTW12_YZX:
+      *val = LIS2DTW12_YZX;
+      break;
+    case LIS2DTW12_ZXY:
+      *val = LIS2DTW12_ZXY;
+      break;
+    default:
+      *val = LIS2DTW12_XYZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsz in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_thsz = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_thsz in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_thsz;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_z_en = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_z_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_y_en = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_y_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.tap_x_en = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of tap_x_en in reg TAP_THS_Z
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_tap_ths_z_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_Z,(uint8_t*) &reg, 1);
+  *val = reg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value
+  *         of these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.shock = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value
+  *         of these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of shock in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which 
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds 
+  *         to 2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.quiet = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which 
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds 
+  *         to 2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of quiet in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses  
+  *         the maximum time between two consecutive detected taps to 
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which corresponds 
+  *         to 16*ODR_XL time. If the DUR[3:0] bits are set to a different 
+  *         value, 1LSB corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of latency in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.latency = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses  
+  *         the maximum time between two consecutive detected taps to 
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which corresponds 
+  *         to 16*ODR_XL time. If the DUR[3:0] bits are set to a different 
+  *         value, 1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of latency in reg INT_DUR
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_int_dur_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_INT_DUR,(uint8_t*) &reg, 1);
+  *val = reg.latency;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of single_double_tap in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_mode_set(stmdev_ctx_t *ctx,
+                              lis2dtw12_single_double_tap_t val)
+{
+  lis2dtw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.single_double_tap = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of single_double_tap in reg WAKE_UP_THS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_mode_get(stmdev_ctx_t *ctx,
+                              lis2dtw12_single_double_tap_t *val)
+{
+  lis2dtw12_wake_up_ths_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_THS,(uint8_t*) &reg, 1);
+
+  switch (reg.single_double_tap) {
+    case LIS2DTW12_ONLY_SINGLE:
+      *val = LIS2DTW12_ONLY_SINGLE;
+      break;
+    case LIS2DTW12_BOTH_SINGLE_DOUBLE:
+      *val = LIS2DTW12_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LIS2DTW12_ONLY_SINGLE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Read the tap / double tap source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  lis2dtw12_tap_src: union of registers from TAP_SRC to 
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_tap_src_get(stmdev_ctx_t *ctx, lis2dtw12_tap_src_t *val)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_SRC, (uint8_t*) val, 1);
+  return ret;     
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LIS2DTW12_Six_Position_Detection(6D/4D)
+  * @brief      This section groups all the functions concerning six
+  *             position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 6d_ths in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg._6d_ths = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 6d_ths in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg._6d_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4d_en in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg._4d_en = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4d_en in reg TAP_THS_X
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_tap_ths_x_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_TAP_THS_X,(uint8_t*) &reg, 1);
+  *val = reg._4d_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Read the 6D tap source register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      union of registers from SIXD_SRC
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_6d_src_get(stmdev_ctx_t *ctx, lis2dtw12_sixd_src_t *val)
+{
+  int32_t ret;
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_SIXD_SRC, (uint8_t*) val, 1);
+  return ret;     
+}
+/**
+  * @brief  Data sent to 6D interrupt function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpass_on6d in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_6d_feed_data_set(stmdev_ctx_t *ctx,
+                                  lis2dtw12_lpass_on6d_t val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lpass_on6d = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data sent to 6D interrupt function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lpass_on6d in reg CTRL_REG7
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_6d_feed_data_get(stmdev_ctx_t *ctx,
+                                  lis2dtw12_lpass_on6d_t *val)
+{
+  lis2dtw12_ctrl_reg7_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_CTRL_REG7,(uint8_t*) &reg, 1);
+
+  switch (reg.lpass_on6d) {
+    case LIS2DTW12_ODR_DIV_2_FEED:
+      *val = LIS2DTW12_ODR_DIV_2_FEED;
+      break;
+    case LIS2DTW12_LPF2_FEED:
+      *val = LIS2DTW12_LPF2_FEED;
+      break;
+    default:
+      *val = LIS2DTW12_ODR_DIV_2_FEED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Free_Fall
+  * @brief     This section group all the functions concerning
+  *            the free fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in reg
+  *                  WAKE_UP_DUR /F REE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_wake_up_dur_t wake_up_dur;
+  lis2dtw12_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  if (ret == 0) {
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+  } 
+  if(ret == 0) { 
+    wake_up_dur.ff_dur = ( (uint8_t) val & 0x20U) >> 5;
+    free_fall.ff_dur = (uint8_t) val & 0x1FU;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  } 
+  if(ret == 0) {     
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+  } 
+  
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_dur in
+  *                  reg WAKE_UP_DUR /F REE_FALL  
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_wake_up_dur_t wake_up_dur;
+  lis2dtw12_free_fall_t free_fall;
+  int32_t ret;
+  
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_WAKE_UP_DUR,(uint8_t*) &wake_up_dur, 1);
+  if (ret == 0) {
+    ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FREE_FALL,(uint8_t*) &free_fall, 1);
+    *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of ff_ths in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_ff_threshold_set(stmdev_ctx_t *ctx, lis2dtw12_ff_ths_t val)
+{
+  lis2dtw12_free_fall_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FREE_FALL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.ff_ths = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_FREE_FALL,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of ff_ths in reg FREE_FALL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_ff_threshold_get(stmdev_ctx_t *ctx,
+                                  lis2dtw12_ff_ths_t *val)
+{
+  lis2dtw12_free_fall_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FREE_FALL,(uint8_t*) &reg, 1);
+
+  switch (reg.ff_ths) {
+    case LIS2DTW12_FF_TSH_5LSb_FS2g:
+      *val = LIS2DTW12_FF_TSH_5LSb_FS2g;
+      break;
+    case LIS2DTW12_FF_TSH_7LSb_FS2g:
+      *val = LIS2DTW12_FF_TSH_7LSb_FS2g;
+      break;
+    case LIS2DTW12_FF_TSH_8LSb_FS2g:
+      *val = LIS2DTW12_FF_TSH_8LSb_FS2g;
+      break;
+    case LIS2DTW12_FF_TSH_10LSb_FS2g:
+      *val = LIS2DTW12_FF_TSH_10LSb_FS2g;
+      break;
+    case LIS2DTW12_FF_TSH_11LSb_FS2g:
+      *val = LIS2DTW12_FF_TSH_11LSb_FS2g;
+      break;
+    case LIS2DTW12_FF_TSH_13LSb_FS2g:
+      *val = LIS2DTW12_FF_TSH_13LSb_FS2g;
+      break;
+    case LIS2DTW12_FF_TSH_15LSb_FS2g:
+      *val = LIS2DTW12_FF_TSH_15LSb_FS2g;
+      break;
+    case LIS2DTW12_FF_TSH_16LSb_FS2g:
+      *val = LIS2DTW12_FF_TSH_16LSb_FS2g;
+      break;
+    default:
+      *val = LIS2DTW12_FF_TSH_5LSb_FS2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LIS2DTW12_Fifo
+  * @brief     This section group all the functions concerning the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lis2dtw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fth = val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get] 
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fth in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  *val = reg.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fmode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_fifo_mode_set(stmdev_ctx_t *ctx, lis2dtw12_fmode_t val)
+{
+  lis2dtw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.fmode = (uint8_t) val;
+    ret = lis2dtw12_write_reg(ctx, LIS2DTW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of fmode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_fifo_mode_get(stmdev_ctx_t *ctx, lis2dtw12_fmode_t *val)
+{
+  lis2dtw12_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FIFO_CTRL,(uint8_t*) &reg, 1);
+
+  switch (reg.fmode) {
+    case LIS2DTW12_BYPASS_MODE:
+      *val = LIS2DTW12_BYPASS_MODE;
+      break;
+    case LIS2DTW12_FIFO_MODE:
+      *val = LIS2DTW12_FIFO_MODE;
+      break;
+    case LIS2DTW12_STREAM_TO_FIFO_MODE:
+      *val = LIS2DTW12_STREAM_TO_FIFO_MODE;
+      break;
+    case LIS2DTW12_BYPASS_TO_STREAM_MODE:
+      *val = LIS2DTW12_BYPASS_TO_STREAM_MODE;
+      break;
+    case LIS2DTW12_STREAM_MODE:
+      *val = LIS2DTW12_STREAM_MODE;
+      break;
+    default:
+      *val = LIS2DTW12_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of unread samples stored in FIFO.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of diff in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.diff;
+
+  return ret;
+}
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_ovr in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.fifo_ovr;
+
+  return ret;
+}
+/**
+  * @brief  FIFO threshold status flag.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_fth in reg FIFO_SAMPLES
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2dtw12_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lis2dtw12_fifo_samples_t reg;
+  int32_t ret;
+
+  ret = lis2dtw12_read_reg(ctx, LIS2DTW12_FIFO_SAMPLES,(uint8_t*) &reg, 1);
+  *val = reg.fifo_fth;
+
+  return ret;
+}
+/**
+  * @}
+  *  
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2dtw12_STdC/driver/lis2dtw12_reg.h
+++ b/sensor/stmemsc/lis2dtw12_STdC/driver/lis2dtw12_reg.h
@@ -1,0 +1,752 @@
+/*
+ ******************************************************************************
+ * @file    lis2dtw12_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lis2dtw12_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LIS2DTW12_REGS_H
+#define LIS2DTW12_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LIS2DTW12
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LIS2DTW12_Infos
+  * @{
+  *
+  */
+  
+/** I2C Device Address 8 bit format  if SA0=0 -> 31 if SA0=1 -> 33 **/
+#define LIS2DTW12_I2C_ADD_L   0x31U
+#define LIS2DTW12_I2C_ADD_H   0x33U
+
+/** Device Identification (Who am I) **/
+#define LIS2DTW12_ID            0x44U
+
+/**
+  * @}
+  *
+  */
+
+#define LIS2DTW12_OUT_T_L                     0x0DU
+#define LIS2DTW12_OUT_T_H                     0x0EU
+#define LIS2DTW12_WHO_AM_I                    0x0FU
+#define LIS2DTW12_CTRL1                       0x20U
+typedef struct {
+  uint8_t lp_mode                    : 2;
+  uint8_t mode                       : 2;
+  uint8_t odr                        : 4;
+} lis2dtw12_ctrl1_t;
+
+#define LIS2DTW12_CTRL2                       0x21U
+typedef struct {
+  uint8_t sim                        : 1;
+  uint8_t i2c_disable                : 1;
+  uint8_t if_add_inc                 : 1;
+  uint8_t bdu                        : 1;
+  uint8_t cs_pu_disc                 : 1;
+  uint8_t not_used_01                : 1;
+  uint8_t soft_reset                 : 1;
+  uint8_t boot                       : 1;
+} lis2dtw12_ctrl2_t;
+
+#define LIS2DTW12_CTRL3                       0x22U
+typedef struct {
+  uint8_t slp_mode                   : 2;  /* slp_mode_sel + slp_mode_1 */
+  uint8_t not_used_01                : 1;
+  uint8_t h_lactive                  : 1;
+  uint8_t lir                        : 1;
+  uint8_t pp_od                      : 1;
+  uint8_t st                         : 2;
+} lis2dtw12_ctrl3_t;
+
+#define LIS2DTW12_CTRL4_INT1_PAD_CTRL         0x23U
+typedef struct {
+  uint8_t int1_drdy                  : 1;
+  uint8_t int1_fth                   : 1;
+  uint8_t int1_diff5                 : 1;
+  uint8_t int1_tap                   : 1;
+  uint8_t int1_ff                    : 1;
+  uint8_t int1_wu                    : 1;
+  uint8_t int1_single_tap            : 1;
+  uint8_t int1_6d                    : 1;
+} lis2dtw12_ctrl4_int1_pad_ctrl_t;
+
+#define LIS2DTW12_CTRL5_INT2_PAD_CTRL         0x24U
+typedef struct {
+  uint8_t int2_drdy                  : 1;
+  uint8_t int2_fth                   : 1;
+  uint8_t int2_diff5                 : 1;
+  uint8_t int2_ovr                   : 1;
+  uint8_t int2_drdy_t                : 1;
+  uint8_t int2_boot                  : 1;
+  uint8_t int2_sleep_chg             : 1;
+  uint8_t int2_sleep_state           : 1;
+} lis2dtw12_ctrl5_int2_pad_ctrl_t;
+
+#define LIS2DTW12_CTRL6                       0x25U
+typedef struct {
+  uint8_t not_used_01                : 2;
+  uint8_t low_noise                  : 1;
+  uint8_t fds                        : 1;
+  uint8_t fs                         : 2;
+  uint8_t bw_filt                    : 2;
+} lis2dtw12_ctrl6_t;
+
+#define LIS2DTW12_STATUS                      0x27U
+typedef struct {
+  uint8_t drdy                       : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t sleep_state                : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t fifo_ths                   : 1;
+} lis2dtw12_status_t;
+
+#define LIS2DTW12_OUT_X_L                     0x28U
+#define LIS2DTW12_OUT_X_H                     0x29U
+#define LIS2DTW12_OUT_Y_L                     0x2AU
+#define LIS2DTW12_OUT_Y_H                     0x2BU
+#define LIS2DTW12_OUT_Z_L                     0x2CU
+#define LIS2DTW12_OUT_Z_H                     0x2DU
+#define LIS2DTW12_FIFO_CTRL                   0x2EU
+typedef struct {
+  uint8_t fth                        : 5;
+  uint8_t fmode                      : 3;
+} lis2dtw12_fifo_ctrl_t;
+
+#define LIS2DTW12_FIFO_SAMPLES                0x2FU
+typedef struct {
+  uint8_t diff                       : 6;
+  uint8_t fifo_ovr                   : 1;
+  uint8_t fifo_fth                   : 1;
+} lis2dtw12_fifo_samples_t;
+
+#define LIS2DTW12_TAP_THS_X                   0x30U
+typedef struct {
+  uint8_t tap_thsx                    : 5;
+  uint8_t _6d_ths                     : 2;
+  uint8_t _4d_en                      : 1;
+} lis2dtw12_tap_ths_x_t;
+
+#define LIS2DTW12_TAP_THS_Y                   0x31U
+typedef struct {
+  uint8_t tap_thsy                   : 5;
+  uint8_t tap_prior                  : 3;
+} lis2dtw12_tap_ths_y_t;
+
+#define LIS2DTW12_TAP_THS_Z                   0x32U
+typedef struct {
+  uint8_t tap_thsz                   : 5;
+  uint8_t tap_z_en                   : 1;
+  uint8_t tap_y_en                   : 1;
+  uint8_t tap_x_en                   : 1;
+} lis2dtw12_tap_ths_z_t;
+
+#define LIS2DTW12_INT_DUR                     0x33U
+typedef struct {
+  uint8_t shock                      : 2;
+  uint8_t quiet                      : 2;
+  uint8_t latency                    : 4;
+} lis2dtw12_int_dur_t;
+
+#define LIS2DTW12_WAKE_UP_THS                 0x34U
+typedef struct {
+  uint8_t wk_ths                     : 6;
+  uint8_t sleep_on                   : 1;
+  uint8_t single_double_tap          : 1;
+} lis2dtw12_wake_up_ths_t;
+
+#define LIS2DTW12_WAKE_UP_DUR                 0x35U
+typedef struct {
+  uint8_t sleep_dur                  : 4;
+  uint8_t stationary                 : 1;
+  uint8_t wake_dur                   : 2;
+  uint8_t ff_dur                     : 1;
+} lis2dtw12_wake_up_dur_t;
+
+#define LIS2DTW12_FREE_FALL                   0x36U
+typedef struct {
+  uint8_t ff_ths                     : 3;
+  uint8_t ff_dur                     : 5;
+} lis2dtw12_free_fall_t;
+
+#define LIS2DTW12_STATUS_DUP                  0x37U
+typedef struct {
+  uint8_t drdy                       : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t sleep_state_ia             : 1;
+  uint8_t drdy_t                     : 1;
+  uint8_t ovr                        : 1;
+} lis2dtw12_status_dup_t;
+
+#define LIS2DTW12_WAKE_UP_SRC                 0x38U
+typedef struct {
+  uint8_t z_wu                       : 1;
+  uint8_t y_wu                       : 1;
+  uint8_t x_wu                       : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t sleep_state_ia             : 1;
+  uint8_t ff_ia                      : 1;
+  uint8_t not_used_01                : 2;
+} lis2dtw12_wake_up_src_t;
+
+#define LIS2DTW12_TAP_SRC                     0x39U
+typedef struct {
+  uint8_t z_tap                      : 1;
+  uint8_t y_tap                      : 1;
+  uint8_t x_tap                      : 1;
+  uint8_t tap_sign                   : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t tap_ia                     : 1;
+  uint8_t not_used_01                : 1;
+} lis2dtw12_tap_src_t;
+
+#define LIS2DTW12_SIXD_SRC                    0x3AU
+typedef struct {
+  uint8_t xl                         : 1;
+  uint8_t xh                         : 1;
+  uint8_t yl                         : 1;
+  uint8_t yh                         : 1;
+  uint8_t zl                         : 1;
+  uint8_t zh                         : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t not_used_01                : 1;
+} lis2dtw12_sixd_src_t;
+
+#define LIS2DTW12_ALL_INT_SRC                 0x3BU
+typedef struct {
+  uint8_t ff_ia                      : 1;
+  uint8_t wu_ia                      : 1;
+  uint8_t single_tap                 : 1;
+  uint8_t double_tap                 : 1;
+  uint8_t _6d_ia                     : 1;
+  uint8_t sleep_change_ia            : 1;
+  uint8_t not_used_01                : 2;
+} lis2dtw12_all_int_src_t;
+
+#define LIS2DTW12_X_OFS_USR                   0x3CU
+#define LIS2DTW12_Y_OFS_USR                   0x3DU
+#define LIS2DTW12_Z_OFS_USR                   0x3EU
+#define LIS2DTW12_CTRL_REG7                   0x3FU
+typedef struct {
+  uint8_t lpass_on6d                 : 1;
+  uint8_t hp_ref_mode                : 1;
+  uint8_t usr_off_w                  : 1;
+  uint8_t usr_off_on_wu              : 1;
+  uint8_t usr_off_on_out             : 1;
+  uint8_t interrupts_enable          : 1;
+  uint8_t int2_on_int1               : 1;
+  uint8_t drdy_pulsed                : 1;
+} lis2dtw12_ctrl_reg7_t;
+
+/**
+  * @defgroup LIS2DTW12_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lis2dtw12_ctrl1_t                   ctrl1;
+  lis2dtw12_ctrl2_t                   ctrl2;
+  lis2dtw12_ctrl3_t                   ctrl3;
+  lis2dtw12_ctrl4_int1_pad_ctrl_t     ctrl4_int1_pad_ctrl;
+  lis2dtw12_ctrl5_int2_pad_ctrl_t     ctrl5_int2_pad_ctrl;
+  lis2dtw12_ctrl6_t                   ctrl6;
+  lis2dtw12_status_t                  status;
+  lis2dtw12_fifo_ctrl_t               fifo_ctrl;
+  lis2dtw12_fifo_samples_t            fifo_samples;
+  lis2dtw12_tap_ths_x_t               tap_ths_x;
+  lis2dtw12_tap_ths_y_t               tap_ths_y;
+  lis2dtw12_tap_ths_z_t               tap_ths_z;
+  lis2dtw12_int_dur_t                 int_dur;
+  lis2dtw12_wake_up_ths_t             wake_up_ths;
+  lis2dtw12_wake_up_dur_t             wake_up_dur;
+  lis2dtw12_free_fall_t               free_fall;
+  lis2dtw12_status_dup_t              status_dup;
+  lis2dtw12_wake_up_src_t             wake_up_src;
+  lis2dtw12_tap_src_t                 tap_src;
+  lis2dtw12_sixd_src_t                sixd_src;
+  lis2dtw12_all_int_src_t             all_int_src;
+  lis2dtw12_ctrl_reg7_t               ctrl_reg7;
+  bitwise_t                          bitwise;
+  uint8_t                            byte;
+} lis2dtw12_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lis2dtw12_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+int32_t lis2dtw12_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len);
+                           
+extern float_t lis2dtw12_from_fs2_to_mg(int16_t lsb);
+extern float_t lis2dtw12_from_fs4_to_mg(int16_t lsb);
+extern float_t lis2dtw12_from_fs8_to_mg(int16_t lsb);
+extern float_t lis2dtw12_from_fs16_to_mg(int16_t lsb);
+extern float_t lis2dtw12_from_fs2_lp1_to_mg(int16_t lsb);
+extern float_t lis2dtw12_from_fs4_lp1_to_mg(int16_t lsb);
+extern float_t lis2dtw12_from_fs8_lp1_to_mg(int16_t lsb);
+extern float_t lis2dtw12_from_fs16_lp1_to_mg(int16_t lsb);
+extern float_t lis2dtw12_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  LIS2DTW12_HIGH_PERFORMANCE                    = 0x04,
+  LIS2DTW12_CONT_LOW_PWR_4                      = 0x03,
+  LIS2DTW12_CONT_LOW_PWR_3                      = 0x02,
+  LIS2DTW12_CONT_LOW_PWR_2                      = 0x01,
+  LIS2DTW12_CONT_LOW_PWR_12bit                  = 0x00,
+  LIS2DTW12_SINGLE_LOW_PWR_4                    = 0x0B,
+  LIS2DTW12_SINGLE_LOW_PWR_3                    = 0x0A,
+  LIS2DTW12_SINGLE_LOW_PWR_2                    = 0x09,
+  LIS2DTW12_SINGLE_LOW_PWR_12bit                = 0x08,
+  LIS2DTW12_HIGH_PERFORMANCE_LOW_NOISE          = 0x14,
+  LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_4            = 0x13,
+  LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_3            = 0x12,
+  LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_2            = 0x11,
+  LIS2DTW12_CONT_LOW_PWR_LOW_NOISE_12bit        = 0x10,
+  LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_4          = 0x1B,
+  LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_3          = 0x1A,
+  LIS2DTW12_SINGLE_LOW_PWR_LOW_NOISE_2          = 0x19,
+  LIS2DTW12_SINGLE_LOW_LOW_NOISE_PWR_12bit      = 0x18,
+} lis2dtw12_mode_t;
+int32_t lis2dtw12_power_mode_set(stmdev_ctx_t *ctx, lis2dtw12_mode_t val);
+int32_t lis2dtw12_power_mode_get(stmdev_ctx_t *ctx, lis2dtw12_mode_t *val);
+
+typedef enum {
+  LIS2DTW12_XL_ODR_OFF            = 0x00,
+  LIS2DTW12_XL_ODR_1Hz6_LP_ONLY   = 0x01,
+  LIS2DTW12_XL_ODR_12Hz5          = 0x02,
+  LIS2DTW12_XL_ODR_25Hz           = 0x03,
+  LIS2DTW12_XL_ODR_50Hz           = 0x04,
+  LIS2DTW12_XL_ODR_100Hz          = 0x05,
+  LIS2DTW12_XL_ODR_200Hz          = 0x06,
+  LIS2DTW12_XL_ODR_400Hz          = 0x07,
+  LIS2DTW12_XL_ODR_800Hz          = 0x08,
+  LIS2DTW12_XL_ODR_1k6Hz          = 0x09,
+  LIS2DTW12_XL_SET_SW_TRIG        = 0x12,  /* Use this only in SINGLE mode */
+  LIS2DTW12_XL_SET_PIN_TRIG       = 0x22,  /* Use this only in SINGLE mode */
+} lis2dtw12_odr_t;
+int32_t lis2dtw12_data_rate_set(stmdev_ctx_t *ctx, lis2dtw12_odr_t val);
+int32_t lis2dtw12_data_rate_get(stmdev_ctx_t *ctx, lis2dtw12_odr_t *val);
+
+int32_t lis2dtw12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DTW12_2g     = 0,
+  LIS2DTW12_4g     = 1,
+  LIS2DTW12_8g     = 2,
+  LIS2DTW12_16g    = 3,
+} lis2dtw12_fs_t;
+int32_t lis2dtw12_full_scale_set(stmdev_ctx_t *ctx, lis2dtw12_fs_t val);
+int32_t lis2dtw12_full_scale_get(stmdev_ctx_t *ctx, lis2dtw12_fs_t *val);
+
+int32_t lis2dtw12_status_reg_get(stmdev_ctx_t *ctx, lis2dtw12_status_t *val);
+
+int32_t lis2dtw12_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct{
+  lis2dtw12_status_dup_t   status_dup;
+  lis2dtw12_wake_up_src_t  wake_up_src;
+  lis2dtw12_tap_src_t      tap_src;
+  lis2dtw12_sixd_src_t     sixd_src;
+  lis2dtw12_all_int_src_t  all_int_src;
+} lis2dtw12_all_sources_t;
+int32_t lis2dtw12_all_sources_get(stmdev_ctx_t *ctx,
+                                 lis2dtw12_all_sources_t *val);
+
+int32_t lis2dtw12_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dtw12_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dtw12_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dtw12_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dtw12_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dtw12_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2DTW12_LSb_977ug    = 0,
+  LIS2DTW12_LSb_15mg6    = 1,
+} lis2dtw12_usr_off_w_t;
+int32_t lis2dtw12_offset_weight_set(stmdev_ctx_t *ctx,
+                                      lis2dtw12_usr_off_w_t val);
+int32_t lis2dtw12_offset_weight_get(stmdev_ctx_t *ctx,
+                                      lis2dtw12_usr_off_w_t *val);
+
+int32_t lis2dtw12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dtw12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dtw12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lis2dtw12_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DTW12_XL_ST_DISABLE      = 0,
+  LIS2DTW12_XL_ST_POSITIVE     = 1,
+  LIS2DTW12_XL_ST_NEGATIVE     = 2,
+} lis2dtw12_st_t;
+int32_t lis2dtw12_self_test_set(stmdev_ctx_t *ctx, lis2dtw12_st_t val);
+int32_t lis2dtw12_self_test_get(stmdev_ctx_t *ctx, lis2dtw12_st_t *val);
+
+typedef enum {
+  LIS2DTW12_DRDY_LATCHED   = 0,
+  LIS2DTW12_DRDY_PULSED    = 1,
+} lis2dtw12_drdy_pulsed_t;
+int32_t lis2dtw12_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                     lis2dtw12_drdy_pulsed_t val);
+int32_t lis2dtw12_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                     lis2dtw12_drdy_pulsed_t *val);
+
+typedef enum {
+  LIS2DTW12_LPF_ON_OUT         = 0x00,
+  LIS2DTW12_USER_OFFSET_ON_OUT  = 0x01,    
+  LIS2DTW12_HIGH_PASS_ON_OUT    = 0x10,
+} lis2dtw12_fds_t;
+int32_t lis2dtw12_filter_path_set(stmdev_ctx_t *ctx, lis2dtw12_fds_t val);
+int32_t lis2dtw12_filter_path_get(stmdev_ctx_t *ctx, lis2dtw12_fds_t *val);
+
+typedef enum {
+  LIS2DTW12_ODR_DIV_2     = 0,
+  LIS2DTW12_ODR_DIV_4     = 1,
+  LIS2DTW12_ODR_DIV_10    = 2,
+  LIS2DTW12_ODR_DIV_20    = 3,
+} lis2dtw12_bw_filt_t;
+int32_t lis2dtw12_filter_bandwidth_set(stmdev_ctx_t *ctx,
+                                         lis2dtw12_bw_filt_t val);
+int32_t lis2dtw12_filter_bandwidth_get(stmdev_ctx_t *ctx,
+                                         lis2dtw12_bw_filt_t *val);
+
+int32_t lis2dtw12_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DTW12_SPI_4_WIRE   = 0,
+  LIS2DTW12_SPI_3_WIRE   = 1,
+} lis2dtw12_sim_t;
+int32_t lis2dtw12_spi_mode_set(stmdev_ctx_t *ctx, lis2dtw12_sim_t val);
+int32_t lis2dtw12_spi_mode_get(stmdev_ctx_t *ctx, lis2dtw12_sim_t *val);
+
+typedef enum {
+  LIS2DTW12_I2C_ENABLE    = 0,
+  LIS2DTW12_I2C_DISABLE   = 1,
+} lis2dtw12_i2c_disable_t;
+int32_t lis2dtw12_i2c_interface_set(stmdev_ctx_t *ctx,
+                                   lis2dtw12_i2c_disable_t val);
+int32_t lis2dtw12_i2c_interface_get(stmdev_ctx_t *ctx,
+                                   lis2dtw12_i2c_disable_t *val);
+
+typedef enum {
+  LIS2DTW12_PULL_UP_CONNECT     = 0,
+  LIS2DTW12_PULL_UP_DISCONNECT  = 1,
+} lis2dtw12_cs_pu_disc_t;
+int32_t lis2dtw12_cs_mode_set(stmdev_ctx_t *ctx, lis2dtw12_cs_pu_disc_t val);
+int32_t lis2dtw12_cs_mode_get(stmdev_ctx_t *ctx, lis2dtw12_cs_pu_disc_t *val);
+
+typedef enum {
+  LIS2DTW12_ACTIVE_HIGH  = 0,
+  LIS2DTW12_ACTIVE_LOW   = 1,
+} lis2dtw12_h_lactive_t;
+int32_t lis2dtw12_pin_polarity_set(stmdev_ctx_t *ctx,
+                                  lis2dtw12_h_lactive_t val);
+int32_t lis2dtw12_pin_polarity_get(stmdev_ctx_t *ctx,
+                                  lis2dtw12_h_lactive_t *val);
+
+typedef enum {
+  LIS2DTW12_INT_PULSED   = 0,
+  LIS2DTW12_INT_LATCHED  = 1,
+} lis2dtw12_lir_t;
+int32_t lis2dtw12_int_notification_set(stmdev_ctx_t *ctx,
+                                      lis2dtw12_lir_t val);
+int32_t lis2dtw12_int_notification_get(stmdev_ctx_t *ctx,
+                                      lis2dtw12_lir_t *val);
+
+typedef enum {
+  LIS2DTW12_PUSH_PULL   = 0,
+  LIS2DTW12_OPEN_DRAIN  = 1,
+} lis2dtw12_pp_od_t;
+int32_t lis2dtw12_pin_mode_set(stmdev_ctx_t *ctx, lis2dtw12_pp_od_t val);
+int32_t lis2dtw12_pin_mode_get(stmdev_ctx_t *ctx, lis2dtw12_pp_od_t *val);
+
+int32_t lis2dtw12_pin_int1_route_set(stmdev_ctx_t *ctx, 
+                                    lis2dtw12_ctrl4_int1_pad_ctrl_t *val);
+int32_t lis2dtw12_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                    lis2dtw12_ctrl4_int1_pad_ctrl_t *val);
+
+int32_t lis2dtw12_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                    lis2dtw12_ctrl5_int2_pad_ctrl_t *val);
+int32_t lis2dtw12_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                    lis2dtw12_ctrl5_int2_pad_ctrl_t *val);
+
+int32_t lis2dtw12_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DTW12_HP_FEED           = 0,
+  LIS2DTW12_USER_OFFSET_FEED  = 1,
+} lis2dtw12_usr_off_on_wu_t;
+int32_t lis2dtw12_wkup_feed_data_set(stmdev_ctx_t *ctx,
+                                    lis2dtw12_usr_off_on_wu_t val);
+int32_t lis2dtw12_wkup_feed_data_get(stmdev_ctx_t *ctx,
+                                    lis2dtw12_usr_off_on_wu_t *val);
+
+typedef enum {
+  LIS2DTW12_NO_DETECTION        = 0,
+  LIS2DTW12_DETECT_ACT_INACT    = 1,
+  LIS2DTW12_DETECT_STAT_MOTION  = 3,
+} lis2dtw12_sleep_on_t;
+int32_t lis2dtw12_act_mode_set(stmdev_ctx_t *ctx, lis2dtw12_sleep_on_t val);
+int32_t lis2dtw12_act_mode_get(stmdev_ctx_t *ctx, lis2dtw12_sleep_on_t *val);
+
+int32_t lis2dtw12_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DTW12_XYZ    = 0,
+  LIS2DTW12_YXZ    = 1,
+  LIS2DTW12_XZY    = 2,
+  LIS2DTW12_ZYX    = 3,
+  LIS2DTW12_YZX    = 5,
+  LIS2DTW12_ZXY    = 6,
+} lis2dtw12_tap_prior_t;
+int32_t lis2dtw12_tap_axis_priority_set(stmdev_ctx_t *ctx,
+                                       lis2dtw12_tap_prior_t val);
+int32_t lis2dtw12_tap_axis_priority_get(stmdev_ctx_t *ctx,
+                                       lis2dtw12_tap_prior_t *val);
+
+int32_t lis2dtw12_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DTW12_ONLY_SINGLE          = 0,
+  LIS2DTW12_BOTH_SINGLE_DOUBLE   = 1,
+} lis2dtw12_single_double_tap_t;
+int32_t lis2dtw12_tap_mode_set(stmdev_ctx_t *ctx,
+                              lis2dtw12_single_double_tap_t val);
+int32_t lis2dtw12_tap_mode_get(stmdev_ctx_t *ctx,
+                              lis2dtw12_single_double_tap_t *val);
+
+int32_t lis2dtw12_tap_src_get(stmdev_ctx_t *ctx, lis2dtw12_tap_src_t *val);
+
+int32_t lis2dtw12_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_6d_src_get(stmdev_ctx_t *ctx, lis2dtw12_sixd_src_t *val);
+
+typedef enum {
+  LIS2DTW12_ODR_DIV_2_FEED   = 0,
+  LIS2DTW12_LPF2_FEED        = 1,
+} lis2dtw12_lpass_on6d_t;
+int32_t lis2dtw12_6d_feed_data_set(stmdev_ctx_t *ctx,
+                                  lis2dtw12_lpass_on6d_t val);
+int32_t lis2dtw12_6d_feed_data_get(stmdev_ctx_t *ctx,
+                                  lis2dtw12_lpass_on6d_t *val);
+
+int32_t lis2dtw12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DTW12_FF_TSH_5LSb_FS2g  = 0,
+  LIS2DTW12_FF_TSH_7LSb_FS2g  = 1,
+  LIS2DTW12_FF_TSH_8LSb_FS2g  = 2,
+  LIS2DTW12_FF_TSH_10LSb_FS2g = 3,
+  LIS2DTW12_FF_TSH_11LSb_FS2g = 4,
+  LIS2DTW12_FF_TSH_13LSb_FS2g = 5,
+  LIS2DTW12_FF_TSH_15LSb_FS2g = 6,
+  LIS2DTW12_FF_TSH_16LSb_FS2g = 7,
+} lis2dtw12_ff_ths_t;
+int32_t lis2dtw12_ff_threshold_set(stmdev_ctx_t *ctx,
+                                  lis2dtw12_ff_ths_t val);
+int32_t lis2dtw12_ff_threshold_get(stmdev_ctx_t *ctx,
+                                  lis2dtw12_ff_ths_t *val);
+
+int32_t lis2dtw12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dtw12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LIS2DTW12_BYPASS_MODE             = 0,
+  LIS2DTW12_FIFO_MODE               = 1,
+  LIS2DTW12_STREAM_TO_FIFO_MODE     = 3,
+  LIS2DTW12_BYPASS_TO_STREAM_MODE   = 4,
+  LIS2DTW12_STREAM_MODE             = 6,
+} lis2dtw12_fmode_t;
+int32_t lis2dtw12_fifo_mode_set(stmdev_ctx_t *ctx, lis2dtw12_fmode_t val);
+int32_t lis2dtw12_fifo_mode_get(stmdev_ctx_t *ctx, lis2dtw12_fmode_t *val);
+
+int32_t lis2dtw12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lis2dtw12_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*LIS2DTW12_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.c
+++ b/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis2dw12_reg.h"
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_read_reg(lis2dw12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2dw12_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lis2dw12_read_reg(lis2dw12_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_write_reg(lis2dw12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2dw12_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -168,7 +151,7 @@ float_t lis2dw12_from_lsb_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_power_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_mode_t val)
+int32_t lis2dw12_power_mode_set(stmdev_ctx_t *ctx, lis2dw12_mode_t val)
 {
   lis2dw12_ctrl1_t ctrl1;
   lis2dw12_ctrl6_t ctrl6;
@@ -199,7 +182,7 @@ int32_t lis2dw12_power_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_power_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_mode_t *val)
+int32_t lis2dw12_power_mode_get(stmdev_ctx_t *ctx, lis2dw12_mode_t *val)
 {
   lis2dw12_ctrl1_t ctrl1;
   lis2dw12_ctrl6_t ctrl6;
@@ -281,7 +264,7 @@ int32_t lis2dw12_power_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_data_rate_set(lis2dw12_ctx_t *ctx, lis2dw12_odr_t val)
+int32_t lis2dw12_data_rate_set(stmdev_ctx_t *ctx, lis2dw12_odr_t val)
 {
   lis2dw12_ctrl1_t ctrl1;
   lis2dw12_ctrl3_t ctrl3;
@@ -310,7 +293,7 @@ int32_t lis2dw12_data_rate_set(lis2dw12_ctx_t *ctx, lis2dw12_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_data_rate_get(lis2dw12_ctx_t *ctx, lis2dw12_odr_t *val)
+int32_t lis2dw12_data_rate_get(stmdev_ctx_t *ctx, lis2dw12_odr_t *val)
 {
   lis2dw12_ctrl1_t ctrl1;
   lis2dw12_ctrl3_t ctrl3;
@@ -373,7 +356,7 @@ int32_t lis2dw12_data_rate_get(lis2dw12_ctx_t *ctx, lis2dw12_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_block_data_update_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -394,7 +377,7 @@ int32_t lis2dw12_block_data_update_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_block_data_update_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -413,7 +396,7 @@ int32_t lis2dw12_block_data_update_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_full_scale_set(lis2dw12_ctx_t *ctx, lis2dw12_fs_t val)
+int32_t lis2dw12_full_scale_set(stmdev_ctx_t *ctx, lis2dw12_fs_t val)
 {
   lis2dw12_ctrl6_t reg;
   int32_t ret;
@@ -434,7 +417,7 @@ int32_t lis2dw12_full_scale_set(lis2dw12_ctx_t *ctx, lis2dw12_fs_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_full_scale_get(lis2dw12_ctx_t *ctx, lis2dw12_fs_t *val)
+int32_t lis2dw12_full_scale_get(stmdev_ctx_t *ctx, lis2dw12_fs_t *val)
 {
   lis2dw12_ctrl6_t reg;
   int32_t ret;
@@ -469,7 +452,7 @@ int32_t lis2dw12_full_scale_get(lis2dw12_ctx_t *ctx, lis2dw12_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_status_reg_get(lis2dw12_ctx_t *ctx, lis2dw12_status_t *val)
+int32_t lis2dw12_status_reg_get(stmdev_ctx_t *ctx, lis2dw12_status_t *val)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_STATUS, (uint8_t*) val, 1);
@@ -484,7 +467,7 @@ int32_t lis2dw12_status_reg_get(lis2dw12_ctx_t *ctx, lis2dw12_status_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_flag_data_ready_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_status_t reg;
   int32_t ret;
@@ -503,7 +486,7 @@ int32_t lis2dw12_flag_data_ready_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_all_sources_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_all_sources_get(stmdev_ctx_t *ctx,
                                  lis2dw12_all_sources_t *val)
 {
   int32_t ret;
@@ -521,7 +504,7 @@ int32_t lis2dw12_all_sources_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_usr_offset_x_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_write_reg(ctx, LIS2DW12_X_OFS_USR, buff, 1);
@@ -538,7 +521,7 @@ int32_t lis2dw12_usr_offset_x_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_usr_offset_x_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_X_OFS_USR, buff, 1);
@@ -555,7 +538,7 @@ int32_t lis2dw12_usr_offset_x_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_usr_offset_y_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_write_reg(ctx, LIS2DW12_Y_OFS_USR, buff, 1);
@@ -572,7 +555,7 @@ int32_t lis2dw12_usr_offset_y_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_usr_offset_y_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_Y_OFS_USR, buff, 1);
@@ -589,7 +572,7 @@ int32_t lis2dw12_usr_offset_y_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_usr_offset_z_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_write_reg(ctx, LIS2DW12_Z_OFS_USR, buff, 1);
@@ -606,7 +589,7 @@ int32_t lis2dw12_usr_offset_z_set(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_usr_offset_z_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_Z_OFS_USR, buff, 1);
@@ -623,7 +606,7 @@ int32_t lis2dw12_usr_offset_z_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_offset_weight_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_offset_weight_set(stmdev_ctx_t *ctx,
                                    lis2dw12_usr_off_w_t val)
 {
   lis2dw12_ctrl_reg7_t reg;
@@ -646,7 +629,7 @@ int32_t lis2dw12_offset_weight_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_offset_weight_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_offset_weight_get(stmdev_ctx_t *ctx,
                                    lis2dw12_usr_off_w_t *val)
 {
   lis2dw12_ctrl_reg7_t reg;
@@ -688,7 +671,7 @@ int32_t lis2dw12_offset_weight_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_temperature_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_OUT_T_L, buff, 2);
@@ -704,7 +687,7 @@ int32_t lis2dw12_temperature_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_acceleration_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_OUT_X_L, buff, 6);
@@ -731,7 +714,7 @@ int32_t lis2dw12_acceleration_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_device_id_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2dw12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_WHO_AM_I, buff, 1);
@@ -747,7 +730,7 @@ int32_t lis2dw12_device_id_get(lis2dw12_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_auto_increment_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -769,7 +752,7 @@ int32_t lis2dw12_auto_increment_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_auto_increment_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -788,7 +771,7 @@ int32_t lis2dw12_auto_increment_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_reset_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -810,7 +793,7 @@ int32_t lis2dw12_reset_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_reset_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -829,7 +812,7 @@ int32_t lis2dw12_reset_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_boot_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -850,7 +833,7 @@ int32_t lis2dw12_boot_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_boot_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -869,7 +852,7 @@ int32_t lis2dw12_boot_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_self_test_set(lis2dw12_ctx_t *ctx, lis2dw12_st_t val)
+int32_t lis2dw12_self_test_set(stmdev_ctx_t *ctx, lis2dw12_st_t val)
 {
   lis2dw12_ctrl3_t reg;
   int32_t ret;
@@ -891,7 +874,7 @@ int32_t lis2dw12_self_test_set(lis2dw12_ctx_t *ctx, lis2dw12_st_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_self_test_get(lis2dw12_ctx_t *ctx, lis2dw12_st_t *val)
+int32_t lis2dw12_self_test_get(stmdev_ctx_t *ctx, lis2dw12_st_t *val)
 {
   lis2dw12_ctrl3_t reg;
   int32_t ret;
@@ -923,7 +906,7 @@ int32_t lis2dw12_self_test_get(lis2dw12_ctx_t *ctx, lis2dw12_st_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_data_ready_mode_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_data_ready_mode_set(stmdev_ctx_t *ctx,
                                      lis2dw12_drdy_pulsed_t val)
 {
   lis2dw12_ctrl_reg7_t reg;
@@ -946,7 +929,7 @@ int32_t lis2dw12_data_ready_mode_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_data_ready_mode_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_data_ready_mode_get(stmdev_ctx_t *ctx,
                                      lis2dw12_drdy_pulsed_t *val)
 {
   lis2dw12_ctrl_reg7_t reg;
@@ -989,7 +972,7 @@ int32_t lis2dw12_data_ready_mode_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_filter_path_set(lis2dw12_ctx_t *ctx, lis2dw12_fds_t val)
+int32_t lis2dw12_filter_path_set(stmdev_ctx_t *ctx, lis2dw12_fds_t val)
 {
   lis2dw12_ctrl6_t ctrl6;
   lis2dw12_ctrl_reg7_t ctrl_reg7;
@@ -1019,7 +1002,7 @@ int32_t lis2dw12_filter_path_set(lis2dw12_ctx_t *ctx, lis2dw12_fds_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_filter_path_get(lis2dw12_ctx_t *ctx, lis2dw12_fds_t *val)
+int32_t lis2dw12_filter_path_get(stmdev_ctx_t *ctx, lis2dw12_fds_t *val)
 {
   lis2dw12_ctrl6_t ctrl6;
   lis2dw12_ctrl_reg7_t ctrl_reg7;
@@ -1056,7 +1039,7 @@ int32_t lis2dw12_filter_path_get(lis2dw12_ctx_t *ctx, lis2dw12_fds_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_filter_bandwidth_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_filter_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis2dw12_bw_filt_t val)
 {
   lis2dw12_ctrl6_t reg;
@@ -1080,7 +1063,7 @@ int32_t lis2dw12_filter_bandwidth_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_filter_bandwidth_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_filter_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis2dw12_bw_filt_t *val)
 {
   lis2dw12_ctrl6_t reg;
@@ -1116,7 +1099,7 @@ int32_t lis2dw12_filter_bandwidth_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_reference_mode_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_ctrl_reg7_t reg;
   int32_t ret;
@@ -1137,7 +1120,7 @@ int32_t lis2dw12_reference_mode_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_reference_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_ctrl_reg7_t reg;
   int32_t ret;
@@ -1169,7 +1152,7 @@ int32_t lis2dw12_reference_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_spi_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sim_t val)
+int32_t lis2dw12_spi_mode_set(stmdev_ctx_t *ctx, lis2dw12_sim_t val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -1190,7 +1173,7 @@ int32_t lis2dw12_spi_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_spi_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sim_t *val)
+int32_t lis2dw12_spi_mode_get(stmdev_ctx_t *ctx, lis2dw12_sim_t *val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -1220,7 +1203,7 @@ int32_t lis2dw12_spi_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sim_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_i2c_interface_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_i2c_interface_set(stmdev_ctx_t *ctx,
                                    lis2dw12_i2c_disable_t val)
 {
   lis2dw12_ctrl2_t reg;
@@ -1242,7 +1225,7 @@ int32_t lis2dw12_i2c_interface_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_i2c_interface_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_i2c_interface_get(stmdev_ctx_t *ctx,
                                    lis2dw12_i2c_disable_t *val)
 {
   lis2dw12_ctrl2_t reg;
@@ -1272,7 +1255,7 @@ int32_t lis2dw12_i2c_interface_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_cs_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t val)
+int32_t lis2dw12_cs_mode_set(stmdev_ctx_t *ctx, lis2dw12_cs_pu_disc_t val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -1293,7 +1276,7 @@ int32_t lis2dw12_cs_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_cs_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t *val)
+int32_t lis2dw12_cs_mode_get(stmdev_ctx_t *ctx, lis2dw12_cs_pu_disc_t *val)
 {
   lis2dw12_ctrl2_t reg;
   int32_t ret;
@@ -1334,7 +1317,7 @@ int32_t lis2dw12_cs_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_pin_polarity_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_polarity_set(stmdev_ctx_t *ctx,
                                   lis2dw12_h_lactive_t val)
 {
   lis2dw12_ctrl3_t reg;
@@ -1356,7 +1339,7 @@ int32_t lis2dw12_pin_polarity_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_pin_polarity_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_polarity_get(stmdev_ctx_t *ctx,
                                   lis2dw12_h_lactive_t *val)
 {
   lis2dw12_ctrl3_t reg;
@@ -1386,7 +1369,7 @@ int32_t lis2dw12_pin_polarity_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_int_notification_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_int_notification_set(stmdev_ctx_t *ctx,
                                       lis2dw12_lir_t val)
 {
   lis2dw12_ctrl3_t reg;
@@ -1408,7 +1391,7 @@ int32_t lis2dw12_int_notification_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_int_notification_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_int_notification_get(stmdev_ctx_t *ctx,
                                       lis2dw12_lir_t *val)
 {
   lis2dw12_ctrl3_t reg;
@@ -1438,7 +1421,7 @@ int32_t lis2dw12_int_notification_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_pin_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t val)
+int32_t lis2dw12_pin_mode_set(stmdev_ctx_t *ctx, lis2dw12_pp_od_t val)
 {
   lis2dw12_ctrl3_t reg;
   int32_t ret;
@@ -1459,7 +1442,7 @@ int32_t lis2dw12_pin_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_pin_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t *val)
+int32_t lis2dw12_pin_mode_get(stmdev_ctx_t *ctx, lis2dw12_pp_od_t *val)
 {
   lis2dw12_ctrl3_t reg;
   int32_t ret;
@@ -1488,7 +1471,7 @@ int32_t lis2dw12_pin_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_pin_int1_route_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     lis2dw12_ctrl4_int1_pad_ctrl_t *val)
 {
   lis2dw12_ctrl5_int2_pad_ctrl_t ctrl5_int2_pad_ctrl;
@@ -1531,7 +1514,7 @@ int32_t lis2dw12_pin_int1_route_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_pin_int1_route_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     lis2dw12_ctrl4_int1_pad_ctrl_t *val)
 {
   int32_t ret;
@@ -1548,7 +1531,7 @@ int32_t lis2dw12_pin_int1_route_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_pin_int2_route_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     lis2dw12_ctrl5_int2_pad_ctrl_t *val)
 {
   lis2dw12_ctrl4_int1_pad_ctrl_t ctrl4_int1_pad_ctrl;
@@ -1592,7 +1575,7 @@ int32_t lis2dw12_pin_int2_route_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_pin_int2_route_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     lis2dw12_ctrl5_int2_pad_ctrl_t *val)
 {
   int32_t ret;
@@ -1608,7 +1591,7 @@ int32_t lis2dw12_pin_int2_route_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_all_on_int1_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_ctrl_reg7_t reg;
   int32_t ret;
@@ -1629,7 +1612,7 @@ int32_t lis2dw12_all_on_int1_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_all_on_int1_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_ctrl_reg7_t reg;
   int32_t ret;
@@ -1661,7 +1644,7 @@ int32_t lis2dw12_all_on_int1_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_wkup_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_wake_up_ths_t reg;
   int32_t ret;
@@ -1682,7 +1665,7 @@ int32_t lis2dw12_wkup_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_wkup_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_wake_up_ths_t reg;
   int32_t ret;
@@ -1701,7 +1684,7 @@ int32_t lis2dw12_wkup_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_wkup_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_wake_up_dur_t reg;
   int32_t ret;
@@ -1722,7 +1705,7 @@ int32_t lis2dw12_wkup_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_wkup_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_wake_up_dur_t reg;
   int32_t ret;
@@ -1741,7 +1724,7 @@ int32_t lis2dw12_wkup_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_wkup_feed_data_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_wkup_feed_data_set(stmdev_ctx_t *ctx,
                                     lis2dw12_usr_off_on_wu_t val)
 {
   lis2dw12_ctrl_reg7_t reg;
@@ -1763,7 +1746,7 @@ int32_t lis2dw12_wkup_feed_data_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_wkup_feed_data_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_wkup_feed_data_get(stmdev_ctx_t *ctx,
                                     lis2dw12_usr_off_on_wu_t *val)
 {
   lis2dw12_ctrl_reg7_t reg;
@@ -1808,7 +1791,7 @@ int32_t lis2dw12_wkup_feed_data_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_act_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t val)
+int32_t lis2dw12_act_mode_set(stmdev_ctx_t *ctx, lis2dw12_sleep_on_t val)
 {
   lis2dw12_wake_up_ths_t wake_up_ths;
   lis2dw12_wake_up_dur_t wake_up_dur;
@@ -1839,7 +1822,7 @@ int32_t lis2dw12_act_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_act_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t *val)
+int32_t lis2dw12_act_mode_get(stmdev_ctx_t *ctx, lis2dw12_sleep_on_t *val)
 {
   lis2dw12_wake_up_ths_t wake_up_ths;
   lis2dw12_wake_up_dur_t wake_up_dur;;
@@ -1875,7 +1858,7 @@ int32_t lis2dw12_act_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_act_sleep_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_wake_up_dur_t reg;
   int32_t ret;
@@ -1896,7 +1879,7 @@ int32_t lis2dw12_act_sleep_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_act_sleep_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_wake_up_dur_t reg;
   int32_t ret;
@@ -1928,7 +1911,7 @@ int32_t lis2dw12_act_sleep_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_threshold_x_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_tap_ths_x_t reg;
   int32_t ret;
@@ -1949,7 +1932,7 @@ int32_t lis2dw12_tap_threshold_x_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_threshold_x_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_tap_ths_x_t reg;
   int32_t ret;
@@ -1968,7 +1951,7 @@ int32_t lis2dw12_tap_threshold_x_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_threshold_y_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_tap_ths_y_t reg;
   int32_t ret;
@@ -1989,7 +1972,7 @@ int32_t lis2dw12_tap_threshold_y_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_threshold_y_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_tap_ths_y_t reg;
   int32_t ret;
@@ -2008,7 +1991,7 @@ int32_t lis2dw12_tap_threshold_y_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_axis_priority_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_tap_axis_priority_set(stmdev_ctx_t *ctx,
                                        lis2dw12_tap_prior_t val)
 {
   lis2dw12_tap_ths_y_t reg;
@@ -2030,7 +2013,7 @@ int32_t lis2dw12_tap_axis_priority_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_axis_priority_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                        lis2dw12_tap_prior_t *val)
 {
   lis2dw12_tap_ths_y_t reg;
@@ -2072,7 +2055,7 @@ int32_t lis2dw12_tap_axis_priority_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_threshold_z_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_tap_ths_z_t reg;
   int32_t ret;
@@ -2094,7 +2077,7 @@ int32_t lis2dw12_tap_threshold_z_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_threshold_z_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_tap_ths_z_t reg;
   int32_t ret;
@@ -2113,7 +2096,7 @@ int32_t lis2dw12_tap_threshold_z_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_detection_on_z_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_tap_ths_z_t reg;
   int32_t ret;
@@ -2134,7 +2117,7 @@ int32_t lis2dw12_tap_detection_on_z_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_detection_on_z_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_tap_ths_z_t reg;
   int32_t ret;
@@ -2153,7 +2136,7 @@ int32_t lis2dw12_tap_detection_on_z_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_detection_on_y_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_tap_ths_z_t reg;
   int32_t ret;
@@ -2174,7 +2157,7 @@ int32_t lis2dw12_tap_detection_on_y_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_detection_on_y_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_tap_ths_z_t reg;
   int32_t ret;
@@ -2193,7 +2176,7 @@ int32_t lis2dw12_tap_detection_on_y_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_detection_on_x_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_tap_ths_z_t reg;
   int32_t ret;
@@ -2214,7 +2197,7 @@ int32_t lis2dw12_tap_detection_on_x_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_detection_on_x_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_tap_ths_z_t reg;
   int32_t ret;
@@ -2237,7 +2220,7 @@ int32_t lis2dw12_tap_detection_on_x_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_shock_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_int_dur_t reg;
   int32_t ret;
@@ -2263,7 +2246,7 @@ int32_t lis2dw12_tap_shock_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_shock_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_int_dur_t reg;
   int32_t ret;
@@ -2286,7 +2269,7 @@ int32_t lis2dw12_tap_shock_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_quiet_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_int_dur_t reg;
   int32_t ret;
@@ -2311,7 +2294,7 @@ int32_t lis2dw12_tap_quiet_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_quiet_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_int_dur_t reg;
   int32_t ret;
@@ -2335,7 +2318,7 @@ int32_t lis2dw12_tap_quiet_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_int_dur_t reg;
   int32_t ret;
@@ -2361,7 +2344,7 @@ int32_t lis2dw12_tap_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_int_dur_t reg;
   int32_t ret;
@@ -2380,7 +2363,7 @@ int32_t lis2dw12_tap_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_mode_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_tap_mode_set(stmdev_ctx_t *ctx,
                               lis2dw12_single_double_tap_t val)
 {
   lis2dw12_wake_up_ths_t reg;
@@ -2402,7 +2385,7 @@ int32_t lis2dw12_tap_mode_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_mode_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_tap_mode_get(stmdev_ctx_t *ctx,
                               lis2dw12_single_double_tap_t *val)
 {
   lis2dw12_wake_up_ths_t reg;
@@ -2433,7 +2416,7 @@ int32_t lis2dw12_tap_mode_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_tap_src_get(lis2dw12_ctx_t *ctx, lis2dw12_tap_src_t *val)
+int32_t lis2dw12_tap_src_get(stmdev_ctx_t *ctx, lis2dw12_tap_src_t *val)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_TAP_SRC, (uint8_t*) val, 1);
@@ -2461,7 +2444,7 @@ int32_t lis2dw12_tap_src_get(lis2dw12_ctx_t *ctx, lis2dw12_tap_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_6d_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_tap_ths_x_t reg;
   int32_t ret;
@@ -2482,7 +2465,7 @@ int32_t lis2dw12_6d_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_6d_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_tap_ths_x_t reg;
   int32_t ret;
@@ -2501,7 +2484,7 @@ int32_t lis2dw12_6d_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_4d_mode_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_tap_ths_x_t reg;
   int32_t ret;
@@ -2523,7 +2506,7 @@ int32_t lis2dw12_4d_mode_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_4d_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_tap_ths_x_t reg;
   int32_t ret;
@@ -2542,7 +2525,7 @@ int32_t lis2dw12_4d_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_6d_src_get(lis2dw12_ctx_t *ctx, lis2dw12_sixd_src_t *val)
+int32_t lis2dw12_6d_src_get(stmdev_ctx_t *ctx, lis2dw12_sixd_src_t *val)
 {
   int32_t ret;
   ret = lis2dw12_read_reg(ctx, LIS2DW12_SIXD_SRC, (uint8_t*) val, 1);
@@ -2556,7 +2539,7 @@ int32_t lis2dw12_6d_src_get(lis2dw12_ctx_t *ctx, lis2dw12_sixd_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_6d_feed_data_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_6d_feed_data_set(stmdev_ctx_t *ctx,
                                   lis2dw12_lpass_on6d_t val)
 {
   lis2dw12_ctrl_reg7_t reg;
@@ -2578,7 +2561,7 @@ int32_t lis2dw12_6d_feed_data_set(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_6d_feed_data_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_6d_feed_data_get(stmdev_ctx_t *ctx,
                                   lis2dw12_lpass_on6d_t *val)
 {
   lis2dw12_ctrl_reg7_t reg;
@@ -2622,7 +2605,7 @@ int32_t lis2dw12_6d_feed_data_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_ff_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_wake_up_dur_t wake_up_dur;
   lis2dw12_free_fall_t free_fall;
@@ -2653,7 +2636,7 @@ int32_t lis2dw12_ff_dur_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_ff_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_wake_up_dur_t wake_up_dur;
   lis2dw12_free_fall_t free_fall;
@@ -2675,7 +2658,7 @@ int32_t lis2dw12_ff_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_ff_threshold_set(lis2dw12_ctx_t *ctx, lis2dw12_ff_ths_t val)
+int32_t lis2dw12_ff_threshold_set(stmdev_ctx_t *ctx, lis2dw12_ff_ths_t val)
 {
   lis2dw12_free_fall_t reg;
   int32_t ret;
@@ -2697,7 +2680,7 @@ int32_t lis2dw12_ff_threshold_set(lis2dw12_ctx_t *ctx, lis2dw12_ff_ths_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_ff_threshold_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_ff_threshold_get(stmdev_ctx_t *ctx,
                                   lis2dw12_ff_ths_t *val)
 {
   lis2dw12_free_fall_t reg;
@@ -2757,7 +2740,7 @@ int32_t lis2dw12_ff_threshold_get(lis2dw12_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_fifo_watermark_set(lis2dw12_ctx_t *ctx, uint8_t val)
+int32_t lis2dw12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2dw12_fifo_ctrl_t reg;
   int32_t ret;
@@ -2779,7 +2762,7 @@ int32_t lis2dw12_fifo_watermark_set(lis2dw12_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_fifo_watermark_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_fifo_ctrl_t reg;
   int32_t ret;
@@ -2798,7 +2781,7 @@ int32_t lis2dw12_fifo_watermark_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_fifo_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t val)
+int32_t lis2dw12_fifo_mode_set(stmdev_ctx_t *ctx, lis2dw12_fmode_t val)
 {
   lis2dw12_fifo_ctrl_t reg;
   int32_t ret;
@@ -2819,7 +2802,7 @@ int32_t lis2dw12_fifo_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_fifo_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t *val)
+int32_t lis2dw12_fifo_mode_get(stmdev_ctx_t *ctx, lis2dw12_fmode_t *val)
 {
   lis2dw12_fifo_ctrl_t reg;
   int32_t ret;
@@ -2857,7 +2840,7 @@ int32_t lis2dw12_fifo_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_fifo_data_level_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_fifo_samples_t reg;
   int32_t ret;
@@ -2875,7 +2858,7 @@ int32_t lis2dw12_fifo_data_level_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_fifo_ovr_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_fifo_samples_t reg;
   int32_t ret;
@@ -2893,7 +2876,7 @@ int32_t lis2dw12_fifo_ovr_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2dw12_fifo_wtm_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val)
+int32_t lis2dw12_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2dw12_fifo_samples_t reg;
   int32_t ret;

--- a/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.h
+++ b/sensor/stmemsc/lis2dw12_STdC/driver/lis2dw12_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS2DW12_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LIS2DW12_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis2dw12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis2dw12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis2dw12_write_ptr  write_reg;
-  lis2dw12_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis2dw12_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -422,9 +394,9 @@ typedef union{
   *
   */
 
-int32_t lis2dw12_read_reg(lis2dw12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2dw12_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lis2dw12_write_reg(lis2dw12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2dw12_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t lis2dw12_from_fs2_to_mg(int16_t lsb);
@@ -457,8 +429,8 @@ typedef enum {
   LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2          = 0x19,
   LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit      = 0x18,
 } lis2dw12_mode_t;
-int32_t lis2dw12_power_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_mode_t val);
-int32_t lis2dw12_power_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_mode_t *val);
+int32_t lis2dw12_power_mode_set(stmdev_ctx_t *ctx, lis2dw12_mode_t val);
+int32_t lis2dw12_power_mode_get(stmdev_ctx_t *ctx, lis2dw12_mode_t *val);
 
 typedef enum {
   LIS2DW12_XL_ODR_OFF            = 0x00,
@@ -471,14 +443,14 @@ typedef enum {
   LIS2DW12_XL_ODR_400Hz          = 0x07,
   LIS2DW12_XL_ODR_800Hz          = 0x08,
   LIS2DW12_XL_ODR_1k6Hz          = 0x09,
-  LIS2DW12_XL_SET_SW_TRIG        = 0x10,  /* Use this only in SINGLE mode */
-  LIS2DW12_XL_SET_PIN_TRIG       = 0x20,  /* Use this only in SINGLE mode */
+  LIS2DW12_XL_SET_SW_TRIG        = 0x32,  /* Use this only in SINGLE mode */
+  LIS2DW12_XL_SET_PIN_TRIG       = 0x22,  /* Use this only in SINGLE mode */
 } lis2dw12_odr_t;
-int32_t lis2dw12_data_rate_set(lis2dw12_ctx_t *ctx, lis2dw12_odr_t val);
-int32_t lis2dw12_data_rate_get(lis2dw12_ctx_t *ctx, lis2dw12_odr_t *val);
+int32_t lis2dw12_data_rate_set(stmdev_ctx_t *ctx, lis2dw12_odr_t val);
+int32_t lis2dw12_data_rate_get(stmdev_ctx_t *ctx, lis2dw12_odr_t *val);
 
-int32_t lis2dw12_block_data_update_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_block_data_update_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DW12_2g     = 0,
@@ -486,12 +458,12 @@ typedef enum {
   LIS2DW12_8g     = 2,
   LIS2DW12_16g    = 3,
 } lis2dw12_fs_t;
-int32_t lis2dw12_full_scale_set(lis2dw12_ctx_t *ctx, lis2dw12_fs_t val);
-int32_t lis2dw12_full_scale_get(lis2dw12_ctx_t *ctx, lis2dw12_fs_t *val);
+int32_t lis2dw12_full_scale_set(stmdev_ctx_t *ctx, lis2dw12_fs_t val);
+int32_t lis2dw12_full_scale_get(stmdev_ctx_t *ctx, lis2dw12_fs_t *val);
 
-int32_t lis2dw12_status_reg_get(lis2dw12_ctx_t *ctx, lis2dw12_status_t *val);
+int32_t lis2dw12_status_reg_get(stmdev_ctx_t *ctx, lis2dw12_status_t *val);
 
-int32_t lis2dw12_flag_data_ready_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct{
   lis2dw12_status_dup_t   status_dup;
@@ -500,57 +472,57 @@ typedef struct{
   lis2dw12_sixd_src_t     sixd_src;
   lis2dw12_all_int_src_t  all_int_src;
 } lis2dw12_all_sources_t;
-int32_t lis2dw12_all_sources_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_all_sources_get(stmdev_ctx_t *ctx,
                                  lis2dw12_all_sources_t *val);
 
-int32_t lis2dw12_usr_offset_x_set(lis2dw12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2dw12_usr_offset_x_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2dw12_usr_offset_y_set(lis2dw12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2dw12_usr_offset_y_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2dw12_usr_offset_z_set(lis2dw12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2dw12_usr_offset_z_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS2DW12_LSb_977ug    = 0,
   LIS2DW12_LSb_15mg6    = 1,
 } lis2dw12_usr_off_w_t;
-int32_t lis2dw12_offset_weight_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_offset_weight_set(stmdev_ctx_t *ctx,
                                       lis2dw12_usr_off_w_t val);
-int32_t lis2dw12_offset_weight_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_offset_weight_get(stmdev_ctx_t *ctx,
                                       lis2dw12_usr_off_w_t *val);
 
-int32_t lis2dw12_temperature_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2dw12_acceleration_raw_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2dw12_device_id_get(lis2dw12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2dw12_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2dw12_auto_increment_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_auto_increment_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_reset_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_reset_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_boot_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_boot_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DW12_XL_ST_DISABLE      = 0,
   LIS2DW12_XL_ST_POSITIVE     = 1,
   LIS2DW12_XL_ST_NEGATIVE     = 2,
 } lis2dw12_st_t;
-int32_t lis2dw12_self_test_set(lis2dw12_ctx_t *ctx, lis2dw12_st_t val);
-int32_t lis2dw12_self_test_get(lis2dw12_ctx_t *ctx, lis2dw12_st_t *val);
+int32_t lis2dw12_self_test_set(stmdev_ctx_t *ctx, lis2dw12_st_t val);
+int32_t lis2dw12_self_test_get(stmdev_ctx_t *ctx, lis2dw12_st_t *val);
 
 typedef enum {
   LIS2DW12_DRDY_LATCHED   = 0,
   LIS2DW12_DRDY_PULSED    = 1,
 } lis2dw12_drdy_pulsed_t;
-int32_t lis2dw12_data_ready_mode_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_data_ready_mode_set(stmdev_ctx_t *ctx,
                                      lis2dw12_drdy_pulsed_t val);
-int32_t lis2dw12_data_ready_mode_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_data_ready_mode_get(stmdev_ctx_t *ctx,
                                      lis2dw12_drdy_pulsed_t *val);
 
 typedef enum {
@@ -558,8 +530,8 @@ typedef enum {
   LIS2DW12_USER_OFFSET_ON_OUT  = 0x01,
   LIS2DW12_HIGH_PASS_ON_OUT    = 0x10,
 } lis2dw12_fds_t;
-int32_t lis2dw12_filter_path_set(lis2dw12_ctx_t *ctx, lis2dw12_fds_t val);
-int32_t lis2dw12_filter_path_get(lis2dw12_ctx_t *ctx, lis2dw12_fds_t *val);
+int32_t lis2dw12_filter_path_set(stmdev_ctx_t *ctx, lis2dw12_fds_t val);
+int32_t lis2dw12_filter_path_get(stmdev_ctx_t *ctx, lis2dw12_fds_t *val);
 
 typedef enum {
   LIS2DW12_ODR_DIV_2     = 0,
@@ -567,88 +539,88 @@ typedef enum {
   LIS2DW12_ODR_DIV_10    = 2,
   LIS2DW12_ODR_DIV_20    = 3,
 } lis2dw12_bw_filt_t;
-int32_t lis2dw12_filter_bandwidth_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_filter_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis2dw12_bw_filt_t val);
-int32_t lis2dw12_filter_bandwidth_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_filter_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis2dw12_bw_filt_t *val);
 
-int32_t lis2dw12_reference_mode_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_reference_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DW12_SPI_4_WIRE   = 0,
   LIS2DW12_SPI_3_WIRE   = 1,
 } lis2dw12_sim_t;
-int32_t lis2dw12_spi_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sim_t val);
-int32_t lis2dw12_spi_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sim_t *val);
+int32_t lis2dw12_spi_mode_set(stmdev_ctx_t *ctx, lis2dw12_sim_t val);
+int32_t lis2dw12_spi_mode_get(stmdev_ctx_t *ctx, lis2dw12_sim_t *val);
 
 typedef enum {
   LIS2DW12_I2C_ENABLE    = 0,
   LIS2DW12_I2C_DISABLE   = 1,
 } lis2dw12_i2c_disable_t;
-int32_t lis2dw12_i2c_interface_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_i2c_interface_set(stmdev_ctx_t *ctx,
                                    lis2dw12_i2c_disable_t val);
-int32_t lis2dw12_i2c_interface_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_i2c_interface_get(stmdev_ctx_t *ctx,
                                    lis2dw12_i2c_disable_t *val);
 
 typedef enum {
   LIS2DW12_PULL_UP_CONNECT     = 0,
   LIS2DW12_PULL_UP_DISCONNECT  = 1,
 } lis2dw12_cs_pu_disc_t;
-int32_t lis2dw12_cs_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t val);
-int32_t lis2dw12_cs_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_cs_pu_disc_t *val);
+int32_t lis2dw12_cs_mode_set(stmdev_ctx_t *ctx, lis2dw12_cs_pu_disc_t val);
+int32_t lis2dw12_cs_mode_get(stmdev_ctx_t *ctx, lis2dw12_cs_pu_disc_t *val);
 
 typedef enum {
   LIS2DW12_ACTIVE_HIGH  = 0,
   LIS2DW12_ACTIVE_LOW   = 1,
 } lis2dw12_h_lactive_t;
-int32_t lis2dw12_pin_polarity_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_polarity_set(stmdev_ctx_t *ctx,
                                   lis2dw12_h_lactive_t val);
-int32_t lis2dw12_pin_polarity_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_polarity_get(stmdev_ctx_t *ctx,
                                   lis2dw12_h_lactive_t *val);
 
 typedef enum {
   LIS2DW12_INT_PULSED   = 0,
   LIS2DW12_INT_LATCHED  = 1,
 } lis2dw12_lir_t;
-int32_t lis2dw12_int_notification_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_int_notification_set(stmdev_ctx_t *ctx,
                                       lis2dw12_lir_t val);
-int32_t lis2dw12_int_notification_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_int_notification_get(stmdev_ctx_t *ctx,
                                       lis2dw12_lir_t *val);
 
 typedef enum {
   LIS2DW12_PUSH_PULL   = 0,
   LIS2DW12_OPEN_DRAIN  = 1,
 } lis2dw12_pp_od_t;
-int32_t lis2dw12_pin_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t val);
-int32_t lis2dw12_pin_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_pp_od_t *val);
+int32_t lis2dw12_pin_mode_set(stmdev_ctx_t *ctx, lis2dw12_pp_od_t val);
+int32_t lis2dw12_pin_mode_get(stmdev_ctx_t *ctx, lis2dw12_pp_od_t *val);
 
-int32_t lis2dw12_pin_int1_route_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     lis2dw12_ctrl4_int1_pad_ctrl_t *val);
-int32_t lis2dw12_pin_int1_route_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     lis2dw12_ctrl4_int1_pad_ctrl_t *val);
 
-int32_t lis2dw12_pin_int2_route_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     lis2dw12_ctrl5_int2_pad_ctrl_t *val);
-int32_t lis2dw12_pin_int2_route_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     lis2dw12_ctrl5_int2_pad_ctrl_t *val);
 
-int32_t lis2dw12_all_on_int1_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_all_on_int1_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_wkup_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_wkup_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_wkup_dur_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_wkup_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DW12_HP_FEED           = 0,
   LIS2DW12_USER_OFFSET_FEED  = 1,
 } lis2dw12_usr_off_on_wu_t;
-int32_t lis2dw12_wkup_feed_data_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_wkup_feed_data_set(stmdev_ctx_t *ctx,
                                     lis2dw12_usr_off_on_wu_t val);
-int32_t lis2dw12_wkup_feed_data_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_wkup_feed_data_get(stmdev_ctx_t *ctx,
                                     lis2dw12_usr_off_on_wu_t *val);
 
 typedef enum {
@@ -656,17 +628,17 @@ typedef enum {
   LIS2DW12_DETECT_ACT_INACT    = 1,
   LIS2DW12_DETECT_STAT_MOTION  = 3,
 } lis2dw12_sleep_on_t;
-int32_t lis2dw12_act_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t val);
-int32_t lis2dw12_act_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_sleep_on_t *val);
+int32_t lis2dw12_act_mode_set(stmdev_ctx_t *ctx, lis2dw12_sleep_on_t val);
+int32_t lis2dw12_act_mode_get(stmdev_ctx_t *ctx, lis2dw12_sleep_on_t *val);
 
-int32_t lis2dw12_act_sleep_dur_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_act_sleep_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_tap_threshold_x_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_threshold_x_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_tap_threshold_y_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_threshold_y_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DW12_XYZ    = 0,
@@ -676,62 +648,62 @@ typedef enum {
   LIS2DW12_YZX    = 5,
   LIS2DW12_ZXY    = 6,
 } lis2dw12_tap_prior_t;
-int32_t lis2dw12_tap_axis_priority_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_tap_axis_priority_set(stmdev_ctx_t *ctx,
                                        lis2dw12_tap_prior_t val);
-int32_t lis2dw12_tap_axis_priority_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                        lis2dw12_tap_prior_t *val);
 
-int32_t lis2dw12_tap_threshold_z_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_threshold_z_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_tap_detection_on_z_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_detection_on_z_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_tap_detection_on_y_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_detection_on_y_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_tap_detection_on_x_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_detection_on_x_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_tap_shock_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_shock_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_tap_quiet_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_quiet_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_tap_dur_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_tap_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DW12_ONLY_SINGLE          = 0,
   LIS2DW12_BOTH_SINGLE_DOUBLE   = 1,
 } lis2dw12_single_double_tap_t;
-int32_t lis2dw12_tap_mode_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_tap_mode_set(stmdev_ctx_t *ctx,
                               lis2dw12_single_double_tap_t val);
-int32_t lis2dw12_tap_mode_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_tap_mode_get(stmdev_ctx_t *ctx,
                               lis2dw12_single_double_tap_t *val);
 
-int32_t lis2dw12_tap_src_get(lis2dw12_ctx_t *ctx, lis2dw12_tap_src_t *val);
+int32_t lis2dw12_tap_src_get(stmdev_ctx_t *ctx, lis2dw12_tap_src_t *val);
 
-int32_t lis2dw12_6d_threshold_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_6d_threshold_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_4d_mode_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_4d_mode_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_6d_src_get(lis2dw12_ctx_t *ctx, lis2dw12_sixd_src_t *val);
+int32_t lis2dw12_6d_src_get(stmdev_ctx_t *ctx, lis2dw12_sixd_src_t *val);
 
 typedef enum {
   LIS2DW12_ODR_DIV_2_FEED   = 0,
   LIS2DW12_LPF2_FEED        = 1,
 } lis2dw12_lpass_on6d_t;
-int32_t lis2dw12_6d_feed_data_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_6d_feed_data_set(stmdev_ctx_t *ctx,
                                   lis2dw12_lpass_on6d_t val);
-int32_t lis2dw12_6d_feed_data_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_6d_feed_data_get(stmdev_ctx_t *ctx,
                                   lis2dw12_lpass_on6d_t *val);
 
-int32_t lis2dw12_ff_dur_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_ff_dur_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DW12_FF_TSH_5LSb_FS2g  = 0,
@@ -743,13 +715,13 @@ typedef enum {
   LIS2DW12_FF_TSH_15LSb_FS2g = 6,
   LIS2DW12_FF_TSH_16LSb_FS2g = 7,
 } lis2dw12_ff_ths_t;
-int32_t lis2dw12_ff_threshold_set(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_ff_threshold_set(stmdev_ctx_t *ctx,
                                   lis2dw12_ff_ths_t val);
-int32_t lis2dw12_ff_threshold_get(lis2dw12_ctx_t *ctx,
+int32_t lis2dw12_ff_threshold_get(stmdev_ctx_t *ctx,
                                   lis2dw12_ff_ths_t *val);
 
-int32_t lis2dw12_fifo_watermark_set(lis2dw12_ctx_t *ctx, uint8_t val);
-int32_t lis2dw12_fifo_watermark_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2dw12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2DW12_BYPASS_MODE             = 0,
@@ -758,14 +730,14 @@ typedef enum {
   LIS2DW12_BYPASS_TO_STREAM_MODE   = 4,
   LIS2DW12_STREAM_MODE             = 6,
 } lis2dw12_fmode_t;
-int32_t lis2dw12_fifo_mode_set(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t val);
-int32_t lis2dw12_fifo_mode_get(lis2dw12_ctx_t *ctx, lis2dw12_fmode_t *val);
+int32_t lis2dw12_fifo_mode_set(stmdev_ctx_t *ctx, lis2dw12_fmode_t val);
+int32_t lis2dw12_fifo_mode_get(stmdev_ctx_t *ctx, lis2dw12_fmode_t *val);
 
-int32_t lis2dw12_fifo_data_level_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_fifo_ovr_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2dw12_fifo_wtm_flag_get(lis2dw12_ctx_t *ctx, uint8_t *val);
+int32_t lis2dw12_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/lis2hh12_STdC/driver/lis2hh12_reg.c
+++ b/sensor/stmemsc/lis2hh12_STdC/driver/lis2hh12_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 #include "lis2hh12_reg.h"
 
@@ -62,7 +45,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2hh12_read_reg(lis2hh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2hh12_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -80,7 +63,7 @@ int32_t lis2hh12_read_reg(lis2hh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2hh12_write_reg(lis2hh12_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2hh12_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -141,7 +124,7 @@ float_t lis2hh12_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_axis_set(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t val)
+int32_t lis2hh12_xl_axis_set(stmdev_ctx_t *ctx, lis2hh12_xl_axis_t val)
 {
   lis2hh12_ctrl1_t ctrl1;
   int32_t ret;
@@ -164,7 +147,7 @@ int32_t lis2hh12_xl_axis_set(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_axis_get(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t *val)
+int32_t lis2hh12_xl_axis_get(stmdev_ctx_t *ctx, lis2hh12_xl_axis_t *val)
 {
   lis2hh12_ctrl1_t ctrl1;
   int32_t ret;
@@ -185,7 +168,7 @@ int32_t lis2hh12_xl_axis_get(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_block_data_update_set(lis2hh12_ctx_t *ctx, uint8_t val)
+int32_t lis2hh12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2hh12_ctrl1_t ctrl1;
   int32_t ret;
@@ -206,7 +189,7 @@ int32_t lis2hh12_block_data_update_set(lis2hh12_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_block_data_update_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2hh12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2hh12_ctrl1_t ctrl1;
   int32_t ret;
@@ -225,7 +208,7 @@ int32_t lis2hh12_block_data_update_get(lis2hh12_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_data_rate_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_data_rate_set(stmdev_ctx_t *ctx,
                                   lis2hh12_xl_data_rate_t val)
 {
   lis2hh12_ctrl1_t ctrl1;
@@ -247,7 +230,7 @@ int32_t lis2hh12_xl_data_rate_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_data_rate_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_data_rate_get(stmdev_ctx_t *ctx,
                                   lis2hh12_xl_data_rate_t *val)
 {
   lis2hh12_ctrl1_t ctrl1;
@@ -291,7 +274,7 @@ int32_t lis2hh12_xl_data_rate_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_full_scale_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_full_scale_set(stmdev_ctx_t *ctx,
                                    lis2hh12_xl_fs_t val)
 {
   lis2hh12_ctrl4_t ctrl4;
@@ -313,7 +296,7 @@ int32_t lis2hh12_xl_full_scale_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_full_scale_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_full_scale_get(stmdev_ctx_t *ctx,
                                    lis2hh12_xl_fs_t *val)
 {
   lis2hh12_ctrl4_t ctrl4;
@@ -345,7 +328,7 @@ int32_t lis2hh12_xl_full_scale_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_decimation_set(lis2hh12_ctx_t *ctx, lis2hh12_dec_t val)
+int32_t lis2hh12_xl_decimation_set(stmdev_ctx_t *ctx, lis2hh12_dec_t val)
 {
   lis2hh12_ctrl5_t ctrl5;
   int32_t ret;
@@ -366,7 +349,7 @@ int32_t lis2hh12_xl_decimation_set(lis2hh12_ctx_t *ctx, lis2hh12_dec_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_decimation_get(lis2hh12_ctx_t *ctx, lis2hh12_dec_t *val)
+int32_t lis2hh12_xl_decimation_get(stmdev_ctx_t *ctx, lis2hh12_dec_t *val)
 {
   lis2hh12_ctrl5_t ctrl5;
   int32_t ret;
@@ -400,7 +383,7 @@ int32_t lis2hh12_xl_decimation_get(lis2hh12_ctx_t *ctx, lis2hh12_dec_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_flag_data_ready_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2hh12_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2hh12_status_t status;
   int32_t ret;
@@ -432,7 +415,7 @@ int32_t lis2hh12_xl_flag_data_ready_get(lis2hh12_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_temperature_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2hh12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2hh12_read_reg(ctx, LIS2HH12_TEMP_L, buff, 2);
@@ -448,7 +431,7 @@ int32_t lis2hh12_temperature_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_acceleration_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2hh12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2hh12_read_reg(ctx, LIS2HH12_OUT_X_L, buff,
@@ -476,7 +459,7 @@ int32_t lis2hh12_acceleration_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_dev_id_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2hh12_dev_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2hh12_read_reg(ctx, LIS2HH12_WHO_AM_I, buff,
@@ -493,7 +476,7 @@ int32_t lis2hh12_dev_id_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_dev_reset_set(lis2hh12_ctx_t *ctx, uint8_t val)
+int32_t lis2hh12_dev_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2hh12_ctrl5_t ctrl5;
   int32_t ret;
@@ -515,7 +498,7 @@ int32_t lis2hh12_dev_reset_set(lis2hh12_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_dev_reset_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2hh12_dev_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2hh12_ctrl5_t ctrl5;
   int32_t ret;
@@ -534,7 +517,7 @@ int32_t lis2hh12_dev_reset_get(lis2hh12_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_dev_boot_set(lis2hh12_ctx_t *ctx, uint8_t val)
+int32_t lis2hh12_dev_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2hh12_ctrl6_t ctrl6;
   int32_t ret;
@@ -555,7 +538,7 @@ int32_t lis2hh12_dev_boot_set(lis2hh12_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_dev_boot_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2hh12_dev_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2hh12_ctrl6_t ctrl6;
   int32_t ret;
@@ -574,7 +557,7 @@ int32_t lis2hh12_dev_boot_get(lis2hh12_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_dev_status_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_dev_status_get(stmdev_ctx_t *ctx,
                                 lis2hh12_status_reg_t *val)
 {
   lis2hh12_status_t status;
@@ -614,7 +597,7 @@ int32_t lis2hh12_dev_status_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_int_path_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_int_path_set(stmdev_ctx_t *ctx,
                                         lis2hh12_xl_hp_path_t val)
 {
   lis2hh12_ctrl2_t ctrl2;
@@ -636,7 +619,7 @@ int32_t lis2hh12_xl_filter_int_path_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_int_path_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_int_path_get(stmdev_ctx_t *ctx,
                                         lis2hh12_xl_hp_path_t *val)
 {
   lis2hh12_ctrl2_t ctrl2;
@@ -668,7 +651,7 @@ int32_t lis2hh12_xl_filter_int_path_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_out_path_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_out_path_set(stmdev_ctx_t *ctx,
                                         lis2hh12_xl_out_path_t val)
 {
   lis2hh12_ctrl1_t ctrl1;
@@ -700,7 +683,7 @@ int32_t lis2hh12_xl_filter_out_path_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_out_path_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_out_path_get(stmdev_ctx_t *ctx,
                                         lis2hh12_xl_out_path_t *val)
 {
   lis2hh12_ctrl1_t ctrl1;
@@ -739,7 +722,7 @@ int32_t lis2hh12_xl_filter_out_path_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_hp_bandwidth_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                             lis2hh12_xl_hp_bw_t val)
 {
   lis2hh12_ctrl2_t ctrl2;
@@ -763,7 +746,7 @@ int32_t lis2hh12_xl_filter_hp_bandwidth_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_hp_bandwidth_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                             lis2hh12_xl_hp_bw_t *val)
 {
   lis2hh12_ctrl2_t ctrl2;
@@ -811,7 +794,7 @@ int32_t lis2hh12_xl_filter_hp_bandwidth_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_low_bandwidth_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_low_bandwidth_set(stmdev_ctx_t *ctx,
                                              lis2hh12_xl_lp_bw_t val)
 {
   lis2hh12_ctrl2_t ctrl2;
@@ -834,7 +817,7 @@ int32_t lis2hh12_xl_filter_low_bandwidth_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_low_bandwidth_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_low_bandwidth_get(stmdev_ctx_t *ctx,
                                              lis2hh12_xl_lp_bw_t *val)
 {
   lis2hh12_ctrl2_t ctrl2;
@@ -869,7 +852,7 @@ int32_t lis2hh12_xl_filter_low_bandwidth_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_aalias_bandwidth_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_aalias_bandwidth_set(stmdev_ctx_t *ctx,
                                                 lis2hh12_xl_filt_aa_bw_t val)
 {
   lis2hh12_ctrl4_t ctrl4;
@@ -892,7 +875,7 @@ int32_t lis2hh12_xl_filter_aalias_bandwidth_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_aalias_bandwidth_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_aalias_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lis2hh12_xl_filt_aa_bw_t *val)
 {
   lis2hh12_ctrl4_t ctrl4;
@@ -930,7 +913,7 @@ int32_t lis2hh12_xl_filter_aalias_bandwidth_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_reference_set(lis2hh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2hh12_xl_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2hh12_write_reg(ctx, LIS2HH12_XL_REFERENCE, buff, 6);
@@ -945,7 +928,7 @@ int32_t lis2hh12_xl_filter_reference_set(lis2hh12_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_filter_reference_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
+int32_t lis2hh12_xl_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2hh12_read_reg(ctx, LIS2HH12_XL_REFERENCE, buff, 6);
@@ -973,7 +956,7 @@ int32_t lis2hh12_xl_filter_reference_get(lis2hh12_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_spi_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_sim_t val)
+int32_t lis2hh12_spi_mode_set(stmdev_ctx_t *ctx, lis2hh12_sim_t val)
 {
   lis2hh12_ctrl4_t ctrl4;
   int32_t ret;
@@ -994,7 +977,7 @@ int32_t lis2hh12_spi_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_spi_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_sim_t *val)
+int32_t lis2hh12_spi_mode_get(stmdev_ctx_t *ctx, lis2hh12_sim_t *val)
 {
   lis2hh12_ctrl4_t ctrl4;
   int32_t ret;
@@ -1022,7 +1005,7 @@ int32_t lis2hh12_spi_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_i2c_interface_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_i2c_interface_set(stmdev_ctx_t *ctx,
                                    lis2hh12_i2c_dis_t val)
 {
   lis2hh12_ctrl4_t ctrl4;
@@ -1044,7 +1027,7 @@ int32_t lis2hh12_i2c_interface_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_i2c_interface_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_i2c_interface_get(stmdev_ctx_t *ctx,
                                    lis2hh12_i2c_dis_t *val)
 {
   lis2hh12_ctrl4_t ctrl4;
@@ -1074,7 +1057,7 @@ int32_t lis2hh12_i2c_interface_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_auto_increment_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_auto_increment_set(stmdev_ctx_t *ctx,
                                     lis2hh12_auto_inc_t val)
 {
   lis2hh12_ctrl4_t ctrl4;
@@ -1097,7 +1080,7 @@ int32_t lis2hh12_auto_increment_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_auto_increment_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_auto_increment_get(stmdev_ctx_t *ctx,
                                     lis2hh12_auto_inc_t *val)
 {
   lis2hh12_ctrl4_t ctrl4;
@@ -1139,7 +1122,7 @@ int32_t lis2hh12_auto_increment_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_int1_route_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     lis2hh12_pin_int1_route_t val)
 {
   lis2hh12_ctrl3_t ctrl3;
@@ -1166,7 +1149,7 @@ int32_t lis2hh12_pin_int1_route_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_int1_route_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     lis2hh12_pin_int1_route_t *val)
 {
   lis2hh12_ctrl3_t ctrl3;
@@ -1191,7 +1174,7 @@ int32_t lis2hh12_pin_int1_route_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t val)
+int32_t lis2hh12_pin_mode_set(stmdev_ctx_t *ctx, lis2hh12_pp_od_t val)
 {
   lis2hh12_ctrl5_t ctrl5;
   int32_t ret;
@@ -1212,7 +1195,7 @@ int32_t lis2hh12_pin_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t *val)
+int32_t lis2hh12_pin_mode_get(stmdev_ctx_t *ctx, lis2hh12_pp_od_t *val)
 {
   lis2hh12_ctrl5_t ctrl5;
   int32_t ret;
@@ -1240,7 +1223,7 @@ int32_t lis2hh12_pin_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_polarity_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_polarity_set(stmdev_ctx_t *ctx,
                                   lis2hh12_pin_pol_t val)
 {
   lis2hh12_ctrl5_t ctrl5;
@@ -1262,7 +1245,7 @@ int32_t lis2hh12_pin_polarity_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_polarity_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_polarity_get(stmdev_ctx_t *ctx,
                                   lis2hh12_pin_pol_t *val)
 {
   lis2hh12_ctrl5_t ctrl5;
@@ -1291,7 +1274,7 @@ int32_t lis2hh12_pin_polarity_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_int2_route_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     lis2hh12_pin_int2_route_t val)
 {
   lis2hh12_ctrl6_t ctrl6;
@@ -1318,7 +1301,7 @@ int32_t lis2hh12_pin_int2_route_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_int2_route_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     lis2hh12_pin_int2_route_t *val)
 {
   lis2hh12_ctrl6_t ctrl6;
@@ -1342,7 +1325,7 @@ int32_t lis2hh12_pin_int2_route_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_notification_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_notification_set(stmdev_ctx_t *ctx,
                                       lis2hh12_lir_t val)
 {
   lis2hh12_ctrl7_t ctrl7;
@@ -1364,7 +1347,7 @@ int32_t lis2hh12_pin_notification_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_notification_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_notification_get(stmdev_ctx_t *ctx,
                                       lis2hh12_lir_t *val)
 {
   lis2hh12_ctrl7_t ctrl7;
@@ -1393,7 +1376,7 @@ int32_t lis2hh12_pin_notification_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_logic_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_logic_set(stmdev_ctx_t *ctx,
                                lis2hh12_pin_logic_t val)
 {
   lis2hh12_ig_cfg1_t ig_cfg1;
@@ -1424,7 +1407,7 @@ int32_t lis2hh12_pin_logic_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_pin_logic_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_logic_get(stmdev_ctx_t *ctx,
                                lis2hh12_pin_logic_t *val)
 {
   lis2hh12_ig_cfg1_t ig_cfg1;
@@ -1477,7 +1460,7 @@ int32_t lis2hh12_pin_logic_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_mode_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_mode_set(stmdev_ctx_t *ctx,
                                     lis2hh12_dcrm_t val)
 {
   lis2hh12_ctrl7_t ctrl7;
@@ -1499,7 +1482,7 @@ int32_t lis2hh12_xl_trshld_mode_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_mode_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_mode_get(stmdev_ctx_t *ctx,
                                     lis2hh12_dcrm_t *val)
 {
   lis2hh12_ctrl7_t ctrl7;
@@ -1529,7 +1512,7 @@ int32_t lis2hh12_xl_trshld_mode_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_axis_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_axis_set(stmdev_ctx_t *ctx,
                                     lis2hh12_xl_trshld_en_t val)
 {
   lis2hh12_ig_cfg1_t ig_cfg1;
@@ -1570,7 +1553,7 @@ int32_t lis2hh12_xl_trshld_axis_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_axis_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_axis_get(stmdev_ctx_t *ctx,
                                     lis2hh12_xl_trshld_en_t *val)
 {
   lis2hh12_ig_cfg1_t ig_cfg1;
@@ -1606,7 +1589,7 @@ int32_t lis2hh12_xl_trshld_axis_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_src_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_src_get(stmdev_ctx_t *ctx,
                                    lis2hh12_xl_trshld_src_t *val)
 {
   lis2hh12_ig_src1_t ig_src1;
@@ -1643,7 +1626,7 @@ int32_t lis2hh12_xl_trshld_src_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_set(lis2hh12_ctx_t *ctx, uint8_t ig1_x,
+int32_t lis2hh12_xl_trshld_set(stmdev_ctx_t *ctx, uint8_t ig1_x,
                                uint8_t ig1_y, uint8_t ig1_z,
                                uint8_t ig2_xyz)
 {
@@ -1671,7 +1654,7 @@ int32_t lis2hh12_xl_trshld_set(lis2hh12_ctx_t *ctx, uint8_t ig1_x,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_get(lis2hh12_ctx_t *ctx, uint8_t *ig1_x,
+int32_t lis2hh12_xl_trshld_get(stmdev_ctx_t *ctx, uint8_t *ig1_x,
                                uint8_t *ig1_y, uint8_t *ig1_z,
                                uint8_t *ig2_xyz)
 {
@@ -1699,7 +1682,7 @@ int32_t lis2hh12_xl_trshld_get(lis2hh12_ctx_t *ctx, uint8_t *ig1_x,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_min_sample_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_min_sample_set(stmdev_ctx_t *ctx,
                                           uint8_t ig1_sam, uint8_t ig2_sam)
 {
   lis2hh12_ig_dur1_t ig_dur1;
@@ -1742,7 +1725,7 @@ int32_t lis2hh12_xl_trshld_min_sample_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_trshld_min_sample_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_min_sample_get(stmdev_ctx_t *ctx,
                                           uint8_t *ig1_sam, uint8_t *ig2_sam)
 {
   lis2hh12_ig_dur1_t ig_dur1;
@@ -1781,7 +1764,7 @@ int32_t lis2hh12_xl_trshld_min_sample_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_act_threshold_set(lis2hh12_ctx_t *ctx, uint8_t val)
+int32_t lis2hh12_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2hh12_act_ths_t act_ths;
   int32_t ret;
@@ -1802,7 +1785,7 @@ int32_t lis2hh12_act_threshold_set(lis2hh12_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_act_threshold_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2hh12_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2hh12_act_ths_t act_ths;
   int32_t ret;
@@ -1821,7 +1804,7 @@ int32_t lis2hh12_act_threshold_get(lis2hh12_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_act_duration_set(lis2hh12_ctx_t *ctx, uint8_t val)
+int32_t lis2hh12_act_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2hh12_act_dur_t act_dur;
   int32_t ret;
@@ -1842,7 +1825,7 @@ int32_t lis2hh12_act_duration_set(lis2hh12_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_act_duration_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2hh12_act_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2hh12_act_dur_t act_dur;
   int32_t ret;
@@ -1874,7 +1857,7 @@ int32_t lis2hh12_act_duration_get(lis2hh12_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_6d_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t val)
+int32_t lis2hh12_6d_mode_set(stmdev_ctx_t *ctx, lis2hh12_6d_mode_t val)
 {
   lis2hh12_ig_cfg1_t ig_cfg1;
   lis2hh12_ig_cfg2_t ig_cfg2;
@@ -1912,7 +1895,7 @@ int32_t lis2hh12_6d_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_6d_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t *val)
+int32_t lis2hh12_6d_mode_get(stmdev_ctx_t *ctx, lis2hh12_6d_mode_t *val)
 {
   lis2hh12_ig_cfg1_t ig_cfg1;
   lis2hh12_ig_cfg2_t ig_cfg2;
@@ -1972,7 +1955,7 @@ int32_t lis2hh12_6d_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_fifo_watermark_set(lis2hh12_ctx_t *ctx, uint8_t val)
+int32_t lis2hh12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2hh12_fifo_ctrl_t fifo_ctrl;
   lis2hh12_ctrl3_t ctrl3;
@@ -2006,7 +1989,7 @@ int32_t lis2hh12_fifo_watermark_set(lis2hh12_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_fifo_watermark_get(lis2hh12_ctx_t *ctx, uint8_t *val)
+int32_t lis2hh12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
 
   lis2hh12_fifo_ctrl_t fifo_ctrl;
@@ -2026,7 +2009,7 @@ int32_t lis2hh12_fifo_watermark_get(lis2hh12_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_fifo_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t val)
+int32_t lis2hh12_fifo_mode_set(stmdev_ctx_t *ctx, lis2hh12_fifo_md_t val)
 {
   lis2hh12_fifo_ctrl_t fifo_ctrl;
   lis2hh12_ctrl3_t ctrl3;
@@ -2055,7 +2038,7 @@ int32_t lis2hh12_fifo_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_fifo_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t *val)
+int32_t lis2hh12_fifo_mode_get(stmdev_ctx_t *ctx, lis2hh12_fifo_md_t *val)
 {
   lis2hh12_fifo_ctrl_t fifo_ctrl;
   lis2hh12_ctrl3_t ctrl3;
@@ -2103,7 +2086,7 @@ int32_t lis2hh12_fifo_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_fifo_status_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis2hh12_fifo_stat_t *val)
 {
   lis2hh12_fifo_src_t fifo_src;
@@ -2138,7 +2121,7 @@ int32_t lis2hh12_fifo_status_get(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_self_test_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_self_test_set(stmdev_ctx_t *ctx,
                                   lis2hh12_xl_st_t val)
 {
   lis2hh12_ctrl5_t ctrl5;
@@ -2160,7 +2143,7 @@ int32_t lis2hh12_xl_self_test_set(lis2hh12_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis2hh12_xl_self_test_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_self_test_get(stmdev_ctx_t *ctx,
                                   lis2hh12_xl_st_t *val)
 {
   lis2hh12_ctrl5_t ctrl5;

--- a/sensor/stmemsc/lis2hh12_STdC/driver/lis2hh12_reg.h
+++ b/sensor/stmemsc/lis2hh12_STdC/driver/lis2hh12_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef LIS2HH12_REGS_H
 #define LIS2HH12_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS2HH12_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LIS2HH12_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -125,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis2hh12_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis2hh12_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis2hh12_write_ptr  write_reg;
-  lis2hh12_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis2hh12_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -385,9 +358,9 @@ typedef union{
   *
   */
 
-int32_t lis2hh12_read_reg(lis2hh12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2hh12_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lis2hh12_write_reg(lis2hh12_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2hh12_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t lis2hh12_from_fs2g_to_mg(int16_t lsb);
@@ -400,11 +373,11 @@ typedef struct {
   uint8_t yen              : 1;
   uint8_t zen              : 1;
 } lis2hh12_xl_axis_t;
-int32_t lis2hh12_xl_axis_set(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t val);
-int32_t lis2hh12_xl_axis_get(lis2hh12_ctx_t *ctx, lis2hh12_xl_axis_t *val);
+int32_t lis2hh12_xl_axis_set(stmdev_ctx_t *ctx, lis2hh12_xl_axis_t val);
+int32_t lis2hh12_xl_axis_get(stmdev_ctx_t *ctx, lis2hh12_xl_axis_t *val);
 
-int32_t lis2hh12_block_data_update_set(lis2hh12_ctx_t *ctx, uint8_t val);
-int32_t lis2hh12_block_data_update_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2hh12_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2HH12_XL_ODR_OFF      = 0x00,
@@ -415,9 +388,9 @@ typedef enum {
   LIS2HH12_XL_ODR_400Hz    = 0x05,
   LIS2HH12_XL_ODR_800Hz    = 0x06,
 } lis2hh12_xl_data_rate_t;
-int32_t lis2hh12_xl_data_rate_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_data_rate_set(stmdev_ctx_t *ctx,
                                   lis2hh12_xl_data_rate_t val);
-int32_t lis2hh12_xl_data_rate_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_data_rate_get(stmdev_ctx_t *ctx,
                                   lis2hh12_xl_data_rate_t *val);
 
 typedef enum {
@@ -426,9 +399,9 @@ typedef enum {
   LIS2HH12_4g              = 0x02,
   LIS2HH12_8g              = 0x03,
 } lis2hh12_xl_fs_t;
-int32_t lis2hh12_xl_full_scale_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_full_scale_set(stmdev_ctx_t *ctx,
                                    lis2hh12_xl_fs_t val);
-int32_t lis2hh12_xl_full_scale_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_full_scale_get(stmdev_ctx_t *ctx,
                                    lis2hh12_xl_fs_t *val);
 
 typedef enum {
@@ -437,22 +410,22 @@ typedef enum {
   LIS2HH12_EVERY_4_SAMPLES = 0x02,
   LIS2HH12_EVERY_8_SAMPLES = 0x03,
 } lis2hh12_dec_t;
-int32_t lis2hh12_xl_decimation_set(lis2hh12_ctx_t *ctx, lis2hh12_dec_t val);
-int32_t lis2hh12_xl_decimation_get(lis2hh12_ctx_t *ctx, lis2hh12_dec_t *val);
+int32_t lis2hh12_xl_decimation_set(stmdev_ctx_t *ctx, lis2hh12_dec_t val);
+int32_t lis2hh12_xl_decimation_get(stmdev_ctx_t *ctx, lis2hh12_dec_t *val);
 
-int32_t lis2hh12_xl_flag_data_ready_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2hh12_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2hh12_temperature_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2hh12_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2hh12_acceleration_raw_get(lis2hh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2hh12_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2hh12_dev_id_get(lis2hh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2hh12_dev_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2hh12_dev_reset_set(lis2hh12_ctx_t *ctx, uint8_t val);
-int32_t lis2hh12_dev_reset_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2hh12_dev_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_dev_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2hh12_dev_boot_set(lis2hh12_ctx_t *ctx, uint8_t val);
-int32_t lis2hh12_dev_boot_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2hh12_dev_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_dev_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t xda              : 1;
@@ -464,7 +437,7 @@ typedef struct {
   uint8_t zor              : 1;
   uint8_t zyxor            : 1;
 } lis2hh12_status_reg_t;
-int32_t lis2hh12_dev_status_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_dev_status_get(stmdev_ctx_t *ctx,
                                 lis2hh12_status_reg_t *val);
 
 typedef enum {
@@ -473,9 +446,9 @@ typedef enum {
   LIS2HH12_HP_ON_INT_GEN_2 = 0x01,
   LIS2HH12_HP_ON_BOTH_GEN  = 0x03,
 } lis2hh12_xl_hp_path_t;
-int32_t lis2hh12_xl_filter_int_path_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_int_path_set(stmdev_ctx_t *ctx,
                                         lis2hh12_xl_hp_path_t val);
-int32_t lis2hh12_xl_filter_int_path_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_int_path_get(stmdev_ctx_t *ctx,
                                         lis2hh12_xl_hp_path_t *val);
 
 typedef enum {
@@ -483,9 +456,9 @@ typedef enum {
   LIS2HH12_FILT_HP         = 0x02,
   LIS2HH12_FILT_LP         = 0x01,
 } lis2hh12_xl_out_path_t;
-int32_t lis2hh12_xl_filter_out_path_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_out_path_set(stmdev_ctx_t *ctx,
                                         lis2hh12_xl_out_path_t val);
-int32_t lis2hh12_xl_filter_out_path_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_out_path_get(stmdev_ctx_t *ctx,
                                         lis2hh12_xl_out_path_t *val);
 
 typedef enum {
@@ -498,9 +471,9 @@ typedef enum {
   LIS2HH12_HP_ODR_DIV_9_REF_MD    = 0x21,
   LIS2HH12_HP_ODR_DIV_400_REF_MD  = 0x31,
 } lis2hh12_xl_hp_bw_t;
-int32_t lis2hh12_xl_filter_hp_bandwidth_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                             lis2hh12_xl_hp_bw_t val);
-int32_t lis2hh12_xl_filter_hp_bandwidth_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                             lis2hh12_xl_hp_bw_t *val);
 
 typedef enum {
@@ -509,9 +482,9 @@ typedef enum {
   LIS2HH12_LP_ODR_DIV_9    = 2,
   LIS2HH12_LP_ODR_DIV_400  = 3,
 } lis2hh12_xl_lp_bw_t;
-int32_t lis2hh12_xl_filter_low_bandwidth_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_low_bandwidth_set(stmdev_ctx_t *ctx,
                                              lis2hh12_xl_lp_bw_t val);
-int32_t lis2hh12_xl_filter_low_bandwidth_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_low_bandwidth_get(stmdev_ctx_t *ctx,
                                              lis2hh12_xl_lp_bw_t *val);
 
 typedef enum {
@@ -521,37 +494,37 @@ typedef enum {
   LIS2HH12_105Hz     = 0x12,
   LIS2HH12_50Hz      = 0x13,
 } lis2hh12_xl_filt_aa_bw_t;
-int32_t lis2hh12_xl_filter_aalias_bandwidth_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_aalias_bandwidth_set(stmdev_ctx_t *ctx,
                                                 lis2hh12_xl_filt_aa_bw_t val);
-int32_t lis2hh12_xl_filter_aalias_bandwidth_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_filter_aalias_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lis2hh12_xl_filt_aa_bw_t *val);
 
-int32_t lis2hh12_xl_filter_reference_set(lis2hh12_ctx_t *ctx, uint8_t *buff);
-int32_t lis2hh12_xl_filter_reference_get(lis2hh12_ctx_t *ctx, uint8_t *buff);
+int32_t lis2hh12_xl_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2hh12_xl_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS2HH12_SPI_4_WIRE = 0x00,
   LIS2HH12_SPI_3_WIRE = 0x01,
 } lis2hh12_sim_t;
-int32_t lis2hh12_spi_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_sim_t val);
-int32_t lis2hh12_spi_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_sim_t *val);
+int32_t lis2hh12_spi_mode_set(stmdev_ctx_t *ctx, lis2hh12_sim_t val);
+int32_t lis2hh12_spi_mode_get(stmdev_ctx_t *ctx, lis2hh12_sim_t *val);
 
 typedef enum {
   LIS2HH12_I2C_ENABLE  = 0x00,
   LIS2HH12_I2C_DISABLE = 0x01,
 } lis2hh12_i2c_dis_t;
-int32_t lis2hh12_i2c_interface_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_i2c_interface_set(stmdev_ctx_t *ctx,
                                    lis2hh12_i2c_dis_t val);
-int32_t lis2hh12_i2c_interface_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_i2c_interface_get(stmdev_ctx_t *ctx,
                                    lis2hh12_i2c_dis_t *val);
 
 typedef enum {
   LIS2HH12_DISABLE = 0x00,
   LIS2HH12_ENABLE  = 0x01,
 } lis2hh12_auto_inc_t;
-int32_t lis2hh12_auto_increment_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_auto_increment_set(stmdev_ctx_t *ctx,
                                     lis2hh12_auto_inc_t val);
-int32_t lis2hh12_auto_increment_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_auto_increment_get(stmdev_ctx_t *ctx,
                                     lis2hh12_auto_inc_t *val);
 
 typedef struct {
@@ -562,25 +535,25 @@ typedef struct {
   uint8_t int1_ig2             : 1;
   uint8_t int1_inact           : 1;
 } lis2hh12_pin_int1_route_t;
-int32_t lis2hh12_pin_int1_route_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     lis2hh12_pin_int1_route_t val);
-int32_t lis2hh12_pin_int1_route_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     lis2hh12_pin_int1_route_t *val);
 
 typedef enum {
   LIS2HH12_PUSH_PULL       = 0x00,
   LIS2HH12_OPEN_DRAIN      = 0x01,
 } lis2hh12_pp_od_t;
-int32_t lis2hh12_pin_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t val);
-int32_t lis2hh12_pin_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_pp_od_t *val);
+int32_t lis2hh12_pin_mode_set(stmdev_ctx_t *ctx, lis2hh12_pp_od_t val);
+int32_t lis2hh12_pin_mode_get(stmdev_ctx_t *ctx, lis2hh12_pp_od_t *val);
 
 typedef enum {
   LIS2HH12_ACTIVE_HIGH     = 0x00,
   LIS2HH12_ACTIVE_LOW      = 0x01,
 } lis2hh12_pin_pol_t;
-int32_t lis2hh12_pin_polarity_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_polarity_set(stmdev_ctx_t *ctx,
                                   lis2hh12_pin_pol_t val);
-int32_t lis2hh12_pin_polarity_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_polarity_get(stmdev_ctx_t *ctx,
                                   lis2hh12_pin_pol_t *val);
 
 typedef struct {
@@ -591,18 +564,18 @@ typedef struct {
   uint8_t int2_ig2             : 1;
   uint8_t int2_boot            : 1;
 } lis2hh12_pin_int2_route_t;
-int32_t lis2hh12_pin_int2_route_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     lis2hh12_pin_int2_route_t val);
-int32_t lis2hh12_pin_int2_route_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     lis2hh12_pin_int2_route_t *val);
 
 typedef enum {
   LIS2HH12_INT_PULSED      = 0x00,
   LIS2HH12_INT_LATCHED     = 0x01,
 } lis2hh12_lir_t;
-int32_t lis2hh12_pin_notification_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_notification_set(stmdev_ctx_t *ctx,
                                       lis2hh12_lir_t val);
-int32_t lis2hh12_pin_notification_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_notification_get(stmdev_ctx_t *ctx,
                                       lis2hh12_lir_t *val);
 typedef enum {
   LIS2HH12_IG1_OR_IG2_OR   = 0x00,
@@ -610,18 +583,18 @@ typedef enum {
   LIS2HH12_IG1_OR_IG2_AND  = 0x10,
   LIS2HH12_IG1_AND_IG2_AND = 0x11,
 } lis2hh12_pin_logic_t;
-int32_t lis2hh12_pin_logic_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_logic_set(stmdev_ctx_t *ctx,
                                lis2hh12_pin_logic_t val);
-int32_t lis2hh12_pin_logic_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_pin_logic_get(stmdev_ctx_t *ctx,
                                lis2hh12_pin_logic_t *val);
 
 typedef enum {
   LIS2HH12_RESET_MODE      = 0x00,
   LIS2HH12_DECREMENT_MODE  = 0x01,
 } lis2hh12_dcrm_t;
-int32_t lis2hh12_xl_trshld_mode_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_mode_set(stmdev_ctx_t *ctx,
                                     lis2hh12_dcrm_t val);
-int32_t lis2hh12_xl_trshld_mode_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_mode_get(stmdev_ctx_t *ctx,
                                     lis2hh12_dcrm_t *val);
 
 typedef struct {
@@ -638,9 +611,9 @@ typedef struct {
   uint16_t ig2_zlie             : 1;
   uint16_t ig2_zhie             : 1;
 } lis2hh12_xl_trshld_en_t;
-int32_t lis2hh12_xl_trshld_axis_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_axis_set(stmdev_ctx_t *ctx,
                                     lis2hh12_xl_trshld_en_t val);
-int32_t lis2hh12_xl_trshld_axis_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_axis_get(stmdev_ctx_t *ctx,
                                     lis2hh12_xl_trshld_en_t *val);
 
 typedef struct {
@@ -659,26 +632,26 @@ typedef struct {
   uint16_t ig2_zh             : 1;
   uint16_t ig2_ia             : 1;
 } lis2hh12_xl_trshld_src_t;
-int32_t lis2hh12_xl_trshld_src_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_src_get(stmdev_ctx_t *ctx,
                                    lis2hh12_xl_trshld_src_t *val);
 
-int32_t lis2hh12_xl_trshld_set(lis2hh12_ctx_t *ctx, uint8_t ig1_x,
+int32_t lis2hh12_xl_trshld_set(stmdev_ctx_t *ctx, uint8_t ig1_x,
                                uint8_t ig1_y, uint8_t ig1_z,
                                uint8_t ig2_xyz);
-int32_t lis2hh12_xl_trshld_get(lis2hh12_ctx_t *ctx, uint8_t *ig1_x,
+int32_t lis2hh12_xl_trshld_get(stmdev_ctx_t *ctx, uint8_t *ig1_x,
                                uint8_t *ig1_y, uint8_t *ig1_z,
                                uint8_t *ig2_xyz);
 
-int32_t lis2hh12_xl_trshld_min_sample_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_min_sample_set(stmdev_ctx_t *ctx,
                                           uint8_t ig1_sam, uint8_t ig2_sam);
-int32_t lis2hh12_xl_trshld_min_sample_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_trshld_min_sample_get(stmdev_ctx_t *ctx,
                                           uint8_t *ig1_sam, uint8_t *ig2_sam);
 
-int32_t lis2hh12_act_threshold_set(lis2hh12_ctx_t *ctx, uint8_t val);
-int32_t lis2hh12_act_threshold_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2hh12_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2hh12_act_duration_set(lis2hh12_ctx_t *ctx, uint8_t val);
-int32_t lis2hh12_act_duration_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2hh12_act_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_act_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2HH12_6D_4D_DISABLE       = 0x00,
@@ -687,11 +660,11 @@ typedef enum {
   LIS2HH12_ENABLE_ON_IG1_4D    = 0x11,
   LIS2HH12_ENABLE_ON_IG2_4D    = 0x12,
 } lis2hh12_6d_mode_t;
-int32_t lis2hh12_6d_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t val);
-int32_t lis2hh12_6d_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_6d_mode_t *val);
+int32_t lis2hh12_6d_mode_set(stmdev_ctx_t *ctx, lis2hh12_6d_mode_t val);
+int32_t lis2hh12_6d_mode_get(stmdev_ctx_t *ctx, lis2hh12_6d_mode_t *val);
 
-int32_t lis2hh12_fifo_watermark_set(lis2hh12_ctx_t *ctx, uint8_t val);
-int32_t lis2hh12_fifo_watermark_get(lis2hh12_ctx_t *ctx, uint8_t *val);
+int32_t lis2hh12_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2hh12_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2HH12_FIFO_OFF               = 0x00,
@@ -702,15 +675,15 @@ typedef enum {
   LIS2HH12_BYPASS_TO_STREAM_MODE = 0x14,
   LIS2HH12_BYPASS_TO_FIFO_MODE   = 0x17,
 } lis2hh12_fifo_md_t;
-int32_t lis2hh12_fifo_mode_set(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t val);
-int32_t lis2hh12_fifo_mode_get(lis2hh12_ctx_t *ctx, lis2hh12_fifo_md_t *val);
+int32_t lis2hh12_fifo_mode_set(stmdev_ctx_t *ctx, lis2hh12_fifo_md_t val);
+int32_t lis2hh12_fifo_mode_get(stmdev_ctx_t *ctx, lis2hh12_fifo_md_t *val);
 
 typedef struct {
   uint8_t fss             : 1;
   uint8_t empty           : 1;
   uint8_t ovr             : 1;
 } lis2hh12_fifo_stat_t;
-int32_t lis2hh12_fifo_status_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis2hh12_fifo_stat_t *val);
 
 typedef enum {
@@ -718,9 +691,9 @@ typedef enum {
   LIS2HH12_ST_POSITIVE   = 0x01,
   LIS2HH12_ST_NEGATIVE   = 0x02,
 } lis2hh12_xl_st_t;
-int32_t lis2hh12_xl_self_test_set(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_self_test_set(stmdev_ctx_t *ctx,
                                   lis2hh12_xl_st_t val);
-int32_t lis2hh12_xl_self_test_get(lis2hh12_ctx_t *ctx,
+int32_t lis2hh12_xl_self_test_get(stmdev_ctx_t *ctx,
                                   lis2hh12_xl_st_t *val);
 
 /**

--- a/sensor/stmemsc/lis2mdl_STdC/driver/lis2mdl_reg.c
+++ b/sensor/stmemsc/lis2mdl_STdC/driver/lis2mdl_reg.c
@@ -6,33 +6,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
+
 #include "lis2mdl_reg.h"
 
 /**
@@ -62,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_read_reg(lis2mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2mdl_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -80,7 +64,7 @@ int32_t lis2mdl_read_reg(lis2mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_write_reg(lis2mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis2mdl_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -134,7 +118,7 @@ float_t lis2mdl_from_lsb_to_celsius(int16_t lsb)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_mag_user_offset_set(lis2mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis2mdl_mag_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2mdl_write_reg(ctx, LIS2MDL_OFFSET_X_REG_L, buff, 6);
@@ -153,7 +137,7 @@ int32_t lis2mdl_mag_user_offset_set(lis2mdl_ctx_t *ctx, uint8_t *buff)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_mag_user_offset_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis2mdl_mag_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2mdl_read_reg(ctx, LIS2MDL_OFFSET_X_REG_L, buff, 6);
@@ -168,18 +152,18 @@ int32_t lis2mdl_mag_user_offset_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
   * @retval        interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_operating_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_md_t val)
+int32_t lis2mdl_operating_mode_set(stmdev_ctx_t *ctx, lis2mdl_md_t val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.md = (uint8_t)val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -191,7 +175,7 @@ int32_t lis2mdl_operating_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_md_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_operating_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_md_t *val)
+int32_t lis2mdl_operating_mode_get(stmdev_ctx_t *ctx, lis2mdl_md_t *val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
@@ -210,43 +194,43 @@ int32_t lis2mdl_operating_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_md_t *val)
     default:
       *val = LIS2MDL_POWER_DOWN;
       break;
-  }  
+  }
 
   return ret;
 }
 
 /**
-  * @brief  Output data rate selection.[set] 
+  * @brief  Output data rate selection.[set]
   *
   * @param  ctx   read / write interface definitions.(ptr)
   * @param  val   change the values of odr in reg CFG_REG_A
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_data_rate_set(lis2mdl_ctx_t *ctx, lis2mdl_odr_t val)
+int32_t lis2mdl_data_rate_set(stmdev_ctx_t *ctx, lis2mdl_odr_t val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.odr = (uint8_t)val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
 /**
-  * @brief  Output data rate selection.[get] 
+  * @brief  Output data rate selection.[get]
   *
   * @param  ctx   read / write interface definitions.(ptr)
   * @param  val   Get the values of odr in reg CFG_REG_A.(ptr)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_data_rate_get(lis2mdl_ctx_t *ctx, lis2mdl_odr_t *val)
+int32_t lis2mdl_data_rate_get(stmdev_ctx_t *ctx, lis2mdl_odr_t *val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
@@ -280,18 +264,18 @@ int32_t lis2mdl_data_rate_get(lis2mdl_ctx_t *ctx, lis2mdl_odr_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_power_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_lp_t val)
+int32_t lis2mdl_power_mode_set(stmdev_ctx_t *ctx, lis2mdl_lp_t val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.lp = (uint8_t)val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -303,7 +287,7 @@ int32_t lis2mdl_power_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_lp_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_power_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_lp_t *val)
+int32_t lis2mdl_power_mode_get(stmdev_ctx_t *ctx, lis2mdl_lp_t *val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
@@ -324,25 +308,25 @@ int32_t lis2mdl_power_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_lp_t *val)
 }
 
 /**
-  * @brief  Enables the magnetometer temperature compensation.[set] 
+  * @brief  Enables the magnetometer temperature compensation.[set]
   *
   * @param  ctx   read / write interface definitions.(ptr)
   * @param  val   change the values of comp_temp_en in reg CFG_REG_A
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_offset_temp_comp_set(lis2mdl_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.comp_temp_en = val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -354,7 +338,7 @@ int32_t lis2mdl_offset_temp_comp_set(lis2mdl_ctx_t *ctx, uint8_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_offset_temp_comp_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
@@ -373,19 +357,19 @@ int32_t lis2mdl_offset_temp_comp_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_low_pass_bandwidth_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                        lis2mdl_lpf_t val)
 {
   lis2mdl_cfg_reg_b_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.lpf = (uint8_t)val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -397,7 +381,7 @@ int32_t lis2mdl_low_pass_bandwidth_set(lis2mdl_ctx_t *ctx,
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_low_pass_bandwidth_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                        lis2mdl_lpf_t *val)
 {
   lis2mdl_cfg_reg_b_t reg;
@@ -426,18 +410,18 @@ int32_t lis2mdl_low_pass_bandwidth_get(lis2mdl_ctx_t *ctx,
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_set_rst_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_set_rst_t val)
+int32_t lis2mdl_set_rst_mode_set(stmdev_ctx_t *ctx, lis2mdl_set_rst_t val)
 {
   lis2mdl_cfg_reg_b_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.set_rst = (uint8_t)val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -449,7 +433,7 @@ int32_t lis2mdl_set_rst_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_set_rst_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_set_rst_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_set_rst_t *val)
+int32_t lis2mdl_set_rst_mode_get(stmdev_ctx_t *ctx, lis2mdl_set_rst_t *val)
 {
   lis2mdl_cfg_reg_b_t reg;
   int32_t ret;
@@ -473,7 +457,7 @@ int32_t lis2mdl_set_rst_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_set_rst_t *val)
 }
 
 /**
-  * @brief  Enables offset cancellation in single measurement mode. 
+  * @brief  Enables offset cancellation in single measurement mode.
   *         The OFF_CANC bit must be set to 1 when enabling offset
   *         cancellation in single measurement mode this means a
   *         call function: set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
@@ -484,23 +468,23 @@ int32_t lis2mdl_set_rst_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_set_rst_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_set_rst_sensor_single_set(lis2mdl_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_set_rst_sensor_single_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2mdl_cfg_reg_b_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.off_canc_one_shot = val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
 /**
-  * @brief  Enables offset cancellation in single measurement mode. 
+  * @brief  Enables offset cancellation in single measurement mode.
   *         The OFF_CANC bit must be set to 1 when enabling offset
   *         cancellation in single measurement mode this means a
   *         call function: set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
@@ -511,7 +495,7 @@ int32_t lis2mdl_set_rst_sensor_single_set(lis2mdl_ctx_t *ctx, uint8_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_set_rst_sensor_single_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_set_rst_sensor_single_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_cfg_reg_b_t reg;
   int32_t ret;
@@ -530,18 +514,18 @@ int32_t lis2mdl_set_rst_sensor_single_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_block_data_update_set(lis2mdl_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.bdu = val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -553,7 +537,7 @@ int32_t lis2mdl_block_data_update_set(lis2mdl_ctx_t *ctx, uint8_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_block_data_update_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
@@ -572,7 +556,7 @@ int32_t lis2mdl_block_data_update_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_mag_data_ready_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_mag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_status_reg_t reg;
   int32_t ret;
@@ -591,7 +575,7 @@ int32_t lis2mdl_mag_data_ready_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_mag_data_ovr_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_mag_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_status_reg_t reg;
   int32_t ret;
@@ -610,7 +594,7 @@ int32_t lis2mdl_mag_data_ovr_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_magnetic_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis2mdl_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2mdl_read_reg(ctx, LIS2MDL_OUTX_L_REG, buff, 6);
@@ -625,7 +609,7 @@ int32_t lis2mdl_magnetic_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_temperature_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis2mdl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2mdl_read_reg(ctx, LIS2MDL_TEMP_OUT_L_REG, buff, 2);
@@ -652,7 +636,7 @@ int32_t lis2mdl_temperature_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_device_id_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis2mdl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2mdl_read_reg(ctx, LIS2MDL_WHO_AM_I, buff, 1);
@@ -667,18 +651,18 @@ int32_t lis2mdl_device_id_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_reset_set(lis2mdl_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.soft_rst = val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -690,7 +674,7 @@ int32_t lis2mdl_reset_set(lis2mdl_ctx_t *ctx, uint8_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_reset_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
@@ -702,25 +686,25 @@ int32_t lis2mdl_reset_get(lis2mdl_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  Reboot memory content. Reload the calibration parameters.[set] 
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
   *
   * @param  ctx   read / write interface definitions.(ptr)
   * @param  val   change the values of reboot in reg CFG_REG_A
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_boot_set(lis2mdl_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.reboot = val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_A, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -732,7 +716,7 @@ int32_t lis2mdl_boot_set(lis2mdl_ctx_t *ctx, uint8_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_boot_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_cfg_reg_a_t reg;
   int32_t ret;
@@ -751,18 +735,18 @@ int32_t lis2mdl_boot_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_self_test_set(lis2mdl_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.self_test = val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -774,7 +758,7 @@ int32_t lis2mdl_self_test_set(lis2mdl_ctx_t *ctx, uint8_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_self_test_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
@@ -793,18 +777,18 @@ int32_t lis2mdl_self_test_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_data_format_set(lis2mdl_ctx_t *ctx, lis2mdl_ble_t val)
+int32_t lis2mdl_data_format_set(stmdev_ctx_t *ctx, lis2mdl_ble_t val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.ble = (uint8_t)val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -816,7 +800,7 @@ int32_t lis2mdl_data_format_set(lis2mdl_ctx_t *ctx, lis2mdl_ble_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_data_format_get(lis2mdl_ctx_t *ctx, lis2mdl_ble_t *val)
+int32_t lis2mdl_data_format_get(stmdev_ctx_t *ctx, lis2mdl_ble_t *val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
@@ -844,7 +828,7 @@ int32_t lis2mdl_data_format_get(lis2mdl_ctx_t *ctx, lis2mdl_ble_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_status_get(lis2mdl_ctx_t *ctx, lis2mdl_status_reg_t *val)
+int32_t lis2mdl_status_get(stmdev_ctx_t *ctx, lis2mdl_status_reg_t *val)
 {
   int32_t ret;
   ret = lis2mdl_read_reg(ctx, LIS2MDL_STATUS_REG, (uint8_t*) val, 1);
@@ -872,19 +856,19 @@ int32_t lis2mdl_status_get(lis2mdl_ctx_t *ctx, lis2mdl_status_reg_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_offset_int_conf_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_offset_int_conf_set(stmdev_ctx_t *ctx,
                                     lis2mdl_int_on_dataoff_t val)
 {
   lis2mdl_cfg_reg_b_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.int_on_dataoff = (uint8_t)val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_B, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -897,7 +881,7 @@ int32_t lis2mdl_offset_int_conf_set(lis2mdl_ctx_t *ctx,
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_offset_int_conf_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_offset_int_conf_get(stmdev_ctx_t *ctx,
                                     lis2mdl_int_on_dataoff_t *val)
 {
   lis2mdl_cfg_reg_b_t reg;
@@ -926,18 +910,18 @@ int32_t lis2mdl_offset_int_conf_get(lis2mdl_ctx_t *ctx,
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_drdy_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.drdy_on_pin = val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -949,7 +933,7 @@ int32_t lis2mdl_drdy_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_drdy_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
@@ -968,18 +952,18 @@ int32_t lis2mdl_drdy_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_int_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val)
+int32_t lis2mdl_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.int_on_pin = val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -991,7 +975,7 @@ int32_t lis2mdl_int_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_int_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis2mdl_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
@@ -1010,7 +994,7 @@ int32_t lis2mdl_int_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_int_gen_conf_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_int_gen_conf_set(stmdev_ctx_t *ctx,
                                  lis2mdl_int_crtl_reg_t *val)
 {
   int32_t ret;
@@ -1026,7 +1010,7 @@ int32_t lis2mdl_int_gen_conf_set(lis2mdl_ctx_t *ctx,
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_int_gen_conf_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_int_gen_conf_get(stmdev_ctx_t *ctx,
                                  lis2mdl_int_crtl_reg_t *val)
 {
   int32_t ret;
@@ -1042,7 +1026,7 @@ int32_t lis2mdl_int_gen_conf_get(lis2mdl_ctx_t *ctx,
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_int_gen_source_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_int_gen_source_get(stmdev_ctx_t *ctx,
                                    lis2mdl_int_source_reg_t *val)
 {
   int32_t ret;
@@ -1060,7 +1044,7 @@ int32_t lis2mdl_int_gen_source_get(lis2mdl_ctx_t *ctx,
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_int_gen_treshold_set(lis2mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis2mdl_int_gen_treshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2mdl_write_reg(ctx, LIS2MDL_INT_THS_L_REG, buff, 2);
@@ -1077,7 +1061,7 @@ int32_t lis2mdl_int_gen_treshold_set(lis2mdl_ctx_t *ctx, uint8_t *buff)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_int_gen_treshold_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis2mdl_int_gen_treshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis2mdl_read_reg(ctx, LIS2MDL_INT_THS_L_REG, buff, 2);
@@ -1098,6 +1082,57 @@ int32_t lis2mdl_int_gen_treshold_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
   */
 
 /**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of 4wspi in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_spi_mode_set(stmdev_ctx_t *ctx, lis2mdl_sim_t val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+
+  if(ret == 0){
+    reg._4wspi = (uint8_t)val;
+    ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of 4wspi in reg CFG_REG_C
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lis2mdl_spi_mode_get(stmdev_ctx_t *ctx, lis2mdl_sim_t *val)
+{
+  lis2mdl_cfg_reg_c_t reg;
+  int32_t ret;
+
+  ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
+  switch (reg._4wspi){
+    case LIS2MDL_SPI_4_WIRE:
+      *val = LIS2MDL_SPI_4_WIRE;
+      break;
+    case LIS2MDL_SPI_3_WIRE:
+      *val = LIS2MDL_SPI_3_WIRE;
+      break;
+    default:
+      *val = LIS2MDL_SPI_3_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
   * @brief  Enable/Disable I2C interface.[set]
   *
   * @param  ctx   read / write interface definitions.(ptr)
@@ -1105,18 +1140,18 @@ int32_t lis2mdl_int_gen_treshold_get(lis2mdl_ctx_t *ctx, uint8_t *buff)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_i2c_interface_set(lis2mdl_ctx_t *ctx, lis2mdl_i2c_dis_t val)
+int32_t lis2mdl_i2c_interface_set(stmdev_ctx_t *ctx, lis2mdl_i2c_dis_t val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
-  
+
   if(ret == 0){
     reg.i2c_dis = (uint8_t)val;
     ret = lis2mdl_write_reg(ctx, LIS2MDL_CFG_REG_C, (uint8_t*)&reg, 1);
   }
-  
+
   return ret;
 }
 
@@ -1128,7 +1163,7 @@ int32_t lis2mdl_i2c_interface_set(lis2mdl_ctx_t *ctx, lis2mdl_i2c_dis_t val)
   * @retval       interface status.(MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis2mdl_i2c_interface_get(lis2mdl_ctx_t *ctx, lis2mdl_i2c_dis_t *val)
+int32_t lis2mdl_i2c_interface_get(stmdev_ctx_t *ctx, lis2mdl_i2c_dis_t *val)
 {
   lis2mdl_cfg_reg_c_t reg;
   int32_t ret;

--- a/sensor/stmemsc/lis2mdl_STdC/driver/lis2mdl_reg.h
+++ b/sensor/stmemsc/lis2mdl_STdC/driver/lis2mdl_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef LIS2MDL_REGS_H
 #define LIS2MDL_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS2MDL_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,31 +57,57 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
-  /** @addtogroup  LIS2MDL_Interfaces_Functions
-    * @brief       This section provide a set of functions used to read and
-    *              write a generic register of the device.
-    *              MANDATORY: return 0 -> no Error.
-    * @{
-    *
-    */
+#endif /* MEMS_SHARED_TYPES */
 
-typedef int32_t (*lis2mdl_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis2mdl_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
 
 typedef struct {
-  /** Component mandatory fields **/
-  lis2mdl_write_ptr  write_reg;
-  lis2mdl_read_ptr   read_reg;
-  /** Customizable optional pointer **/
-  void *handle;
-} lis2mdl_ctx_t;
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -187,7 +160,7 @@ typedef struct {
 typedef struct {
   uint8_t drdy_on_pin            : 1;
   uint8_t self_test              : 1;
-  uint8_t not_used_01            : 1;
+  uint8_t _4wspi                 : 1;
   uint8_t ble                    : 1;
   uint8_t bdu                    : 1;
   uint8_t i2c_dis                : 1;
@@ -269,24 +242,24 @@ typedef union{
   *
   */
 
-int32_t lis2mdl_read_reg(lis2mdl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2mdl_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lis2mdl_write_reg(lis2mdl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis2mdl_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-                          
+                       
 extern float_t lis2mdl_from_lsb_to_mgauss(int16_t lsb);
 extern float_t lis2mdl_from_lsb_to_celsius(int16_t lsb);
 
-int32_t lis2mdl_mag_user_offset_set(lis2mdl_ctx_t *ctx, uint8_t *buff);
-int32_t lis2mdl_mag_user_offset_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_mag_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_mag_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS2MDL_CONTINUOUS_MODE  = 0,
   LIS2MDL_SINGLE_TRIGGER   = 1,
   LIS2MDL_POWER_DOWN       = 2,
 } lis2mdl_md_t;
-int32_t lis2mdl_operating_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_md_t val);
-int32_t lis2mdl_operating_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_md_t *val);
+int32_t lis2mdl_operating_mode_set(stmdev_ctx_t *ctx, lis2mdl_md_t val);
+int32_t lis2mdl_operating_mode_get(stmdev_ctx_t *ctx, lis2mdl_md_t *val);
 
 typedef enum {
   LIS2MDL_ODR_10Hz   = 0,
@@ -294,26 +267,26 @@ typedef enum {
   LIS2MDL_ODR_50Hz   = 2,
   LIS2MDL_ODR_100Hz  = 3,
 } lis2mdl_odr_t;
-int32_t lis2mdl_data_rate_set(lis2mdl_ctx_t *ctx, lis2mdl_odr_t val);
-int32_t lis2mdl_data_rate_get(lis2mdl_ctx_t *ctx, lis2mdl_odr_t *val);
+int32_t lis2mdl_data_rate_set(stmdev_ctx_t *ctx, lis2mdl_odr_t val);
+int32_t lis2mdl_data_rate_get(stmdev_ctx_t *ctx, lis2mdl_odr_t *val);
 
 typedef enum {
   LIS2MDL_HIGH_RESOLUTION  = 0,
   LIS2MDL_LOW_POWER        = 1,
 } lis2mdl_lp_t;
-int32_t lis2mdl_power_mode_set(lis2mdl_ctx_t *ctx, lis2mdl_lp_t val);
-int32_t lis2mdl_power_mode_get(lis2mdl_ctx_t *ctx, lis2mdl_lp_t *val);
+int32_t lis2mdl_power_mode_set(stmdev_ctx_t *ctx, lis2mdl_lp_t val);
+int32_t lis2mdl_power_mode_get(stmdev_ctx_t *ctx, lis2mdl_lp_t *val);
 
-int32_t lis2mdl_offset_temp_comp_set(lis2mdl_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_offset_temp_comp_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2MDL_ODR_DIV_2  = 0,
   LIS2MDL_ODR_DIV_4  = 1,
 } lis2mdl_lpf_t;
-int32_t lis2mdl_low_pass_bandwidth_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                        lis2mdl_lpf_t val);
-int32_t lis2mdl_low_pass_bandwidth_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                        lis2mdl_lpf_t *val);
 
 typedef enum {
@@ -321,80 +294,87 @@ typedef enum {
   LIS2MDL_SENS_OFF_CANC_EVERY_ODR    = 1,
   LIS2MDL_SET_SENS_ONLY_AT_POWER_ON  = 2,
 } lis2mdl_set_rst_t;
-int32_t lis2mdl_set_rst_mode_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_set_rst_mode_set(stmdev_ctx_t *ctx,
                                  lis2mdl_set_rst_t val);
-int32_t lis2mdl_set_rst_mode_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_set_rst_mode_get(stmdev_ctx_t *ctx,
                                  lis2mdl_set_rst_t *val);
 
-int32_t lis2mdl_set_rst_sensor_single_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_set_rst_sensor_single_set(stmdev_ctx_t *ctx,
                                           uint8_t val);
-int32_t lis2mdl_set_rst_sensor_single_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_set_rst_sensor_single_get(stmdev_ctx_t *ctx,
                                           uint8_t *val);
 
-int32_t lis2mdl_block_data_update_set(lis2mdl_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_block_data_update_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2mdl_mag_data_ready_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_mag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2mdl_mag_data_ovr_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_mag_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2mdl_magnetic_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2mdl_temperature_raw_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2mdl_device_id_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis2mdl_reset_set(lis2mdl_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_reset_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2mdl_boot_set(lis2mdl_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_boot_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2mdl_self_test_set(lis2mdl_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_self_test_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_self_test_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_self_test_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS2MDL_LSB_AT_LOW_ADD  = 0,
   LIS2MDL_MSB_AT_LOW_ADD  = 1,
 } lis2mdl_ble_t;
-int32_t lis2mdl_data_format_set(lis2mdl_ctx_t *ctx, lis2mdl_ble_t val);
-int32_t lis2mdl_data_format_get(lis2mdl_ctx_t *ctx, lis2mdl_ble_t *val);
+int32_t lis2mdl_data_format_set(stmdev_ctx_t *ctx, lis2mdl_ble_t val);
+int32_t lis2mdl_data_format_get(stmdev_ctx_t *ctx, lis2mdl_ble_t *val);
 
-int32_t lis2mdl_status_get(lis2mdl_ctx_t *ctx, lis2mdl_status_reg_t *val);
+int32_t lis2mdl_status_get(stmdev_ctx_t *ctx, lis2mdl_status_reg_t *val);
 
 typedef enum {
   LIS2MDL_CHECK_BEFORE  = 0,
   LIS2MDL_CHECK_AFTER   = 1,
 } lis2mdl_int_on_dataoff_t;
-int32_t lis2mdl_offset_int_conf_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_offset_int_conf_set(stmdev_ctx_t *ctx,
                                     lis2mdl_int_on_dataoff_t val);
-int32_t lis2mdl_offset_int_conf_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_offset_int_conf_get(stmdev_ctx_t *ctx,
                                     lis2mdl_int_on_dataoff_t *val);
 
-int32_t lis2mdl_drdy_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_drdy_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2mdl_int_on_pin_set(lis2mdl_ctx_t *ctx, uint8_t val);
-int32_t lis2mdl_int_on_pin_get(lis2mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis2mdl_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis2mdl_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis2mdl_int_gen_conf_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_int_gen_conf_set(stmdev_ctx_t *ctx,
                                  lis2mdl_int_crtl_reg_t *val);
-int32_t lis2mdl_int_gen_conf_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_int_gen_conf_get(stmdev_ctx_t *ctx,
                                  lis2mdl_int_crtl_reg_t *val);
 
-int32_t lis2mdl_int_gen_source_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_int_gen_source_get(stmdev_ctx_t *ctx,
                                    lis2mdl_int_source_reg_t *val);
 
-int32_t lis2mdl_int_gen_treshold_set(lis2mdl_ctx_t *ctx, uint8_t *buff);
-int32_t lis2mdl_int_gen_treshold_get(lis2mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_int_gen_treshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis2mdl_int_gen_treshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LIS2MDL_SPI_4_WIRE   = 1,
+  LIS2MDL_SPI_3_WIRE   = 0,
+} lis2mdl_sim_t;
+int32_t lis2mdl_spi_mode_set(stmdev_ctx_t *ctx, lis2mdl_sim_t val);
+int32_t lis2mdl_spi_mode_get(stmdev_ctx_t *ctx, lis2mdl_sim_t *val);
 
 typedef enum {
   LIS2MDL_I2C_ENABLE   = 0,
   LIS2MDL_I2C_DISABLE  = 1,
 } lis2mdl_i2c_dis_t;
-int32_t lis2mdl_i2c_interface_set(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_i2c_interface_set(stmdev_ctx_t *ctx,
                                   lis2mdl_i2c_dis_t val);
-int32_t lis2mdl_i2c_interface_get(lis2mdl_ctx_t *ctx,
+int32_t lis2mdl_i2c_interface_get(stmdev_ctx_t *ctx,
                                   lis2mdl_i2c_dis_t *val);
 
 /**

--- a/sensor/stmemsc/lis331dlh_STdC/driver/lis331dlh_reg.c
+++ b/sensor/stmemsc/lis331dlh_STdC/driver/lis331dlh_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis331dlh_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis331dlh_read_reg(lis331dlh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis331dlh_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lis331dlh_read_reg(lis331dlh_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis331dlh_write_reg(lis331dlh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis331dlh_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                             uint16_t len)
 {
   int32_t ret;
@@ -136,7 +119,7 @@ float lis331dlh_from_fs8_to_mg(int16_t lsb)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t lis331dlh_axis_x_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -157,7 +140,7 @@ int32_t lis331dlh_axis_x_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of xen in reg CTRL_REG1
   *
   */
-int32_t lis331dlh_axis_x_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -175,7 +158,7 @@ int32_t lis331dlh_axis_x_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t lis331dlh_axis_y_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -196,7 +179,7 @@ int32_t lis331dlh_axis_y_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of yen in reg CTRL_REG1
   *
   */
-int32_t lis331dlh_axis_y_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -214,7 +197,7 @@ int32_t lis331dlh_axis_y_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t lis331dlh_axis_z_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -235,7 +218,7 @@ int32_t lis331dlh_axis_z_data_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of zen in reg CTRL_REG1
   *
   */
-int32_t lis331dlh_axis_z_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -253,7 +236,7 @@ int32_t lis331dlh_axis_z_data_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of dr in reg CTRL_REG1
   *
   */
-int32_t lis331dlh_data_rate_set(lis331dlh_ctx_t *ctx, lis331dlh_dr_t val)
+int32_t lis331dlh_data_rate_set(stmdev_ctx_t *ctx, lis331dlh_dr_t val)
 {
   lis331dlh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -276,7 +259,7 @@ int32_t lis331dlh_data_rate_set(lis331dlh_ctx_t *ctx, lis331dlh_dr_t val)
   * @param  val         Get the values of dr in reg CTRL_REG1
   *
   */
-int32_t lis331dlh_data_rate_get(lis331dlh_ctx_t *ctx, lis331dlh_dr_t *val)
+int32_t lis331dlh_data_rate_get(stmdev_ctx_t *ctx, lis331dlh_dr_t *val)
 {
   lis331dlh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -331,7 +314,7 @@ int32_t lis331dlh_data_rate_get(lis331dlh_ctx_t *ctx, lis331dlh_dr_t *val)
   * @param  val         change the values of hpm in reg CTRL_REG2
   *
   */
-int32_t lis331dlh_reference_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_reference_mode_set(stmdev_ctx_t *ctx,
                                      lis331dlh_hpm_t val)
 {
   lis331dlh_ctrl_reg2_t ctrl_reg2;
@@ -353,7 +336,7 @@ int32_t lis331dlh_reference_mode_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of hpm in reg CTRL_REG2
   *
   */
-int32_t lis331dlh_reference_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_reference_mode_get(stmdev_ctx_t *ctx,
                                      lis331dlh_hpm_t *val)
 {
   lis331dlh_ctrl_reg2_t ctrl_reg2;
@@ -384,7 +367,7 @@ int32_t lis331dlh_reference_mode_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of fs in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_full_scale_set(lis331dlh_ctx_t *ctx, lis331dlh_fs_t val)
+int32_t lis331dlh_full_scale_set(stmdev_ctx_t *ctx, lis331dlh_fs_t val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -405,7 +388,7 @@ int32_t lis331dlh_full_scale_set(lis331dlh_ctx_t *ctx, lis331dlh_fs_t val)
   * @param  val         Get the values of fs in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_full_scale_get(lis331dlh_ctx_t *ctx, lis331dlh_fs_t *val)
+int32_t lis331dlh_full_scale_get(stmdev_ctx_t *ctx, lis331dlh_fs_t *val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -438,7 +421,7 @@ int32_t lis331dlh_full_scale_get(lis331dlh_ctx_t *ctx, lis331dlh_fs_t *val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_block_data_update_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -459,7 +442,7 @@ int32_t lis331dlh_block_data_update_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of bdu in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_block_data_update_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -477,7 +460,7 @@ int32_t lis331dlh_block_data_update_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         registers STATUS_REG
   *
   */
-int32_t lis331dlh_status_reg_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_status_reg_get(stmdev_ctx_t *ctx,
                                  lis331dlh_status_reg_t *val)
 {
   int32_t ret;
@@ -492,7 +475,7 @@ int32_t lis331dlh_status_reg_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of zyxda in reg STATUS_REG
   *
   */
-int32_t lis331dlh_flag_data_ready_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_status_reg_t status_reg;
   int32_t ret;
@@ -524,7 +507,7 @@ int32_t lis331dlh_flag_data_ready_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lis331dlh_acceleration_raw_get(lis331dlh_ctx_t *ctx, uint8_t *buff)
+int32_t lis331dlh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis331dlh_read_reg(ctx, LIS331DLH_OUT_X_L, buff, 6);
@@ -550,7 +533,7 @@ int32_t lis331dlh_acceleration_raw_get(lis331dlh_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lis331dlh_device_id_get(lis331dlh_ctx_t *ctx, uint8_t *buff)
+int32_t lis331dlh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis331dlh_read_reg(ctx, LIS331DLH_WHO_AM_I, buff, 1);
@@ -564,7 +547,7 @@ int32_t lis331dlh_device_id_get(lis331dlh_ctx_t *ctx, uint8_t *buff)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t lis331dlh_boot_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -585,7 +568,7 @@ int32_t lis331dlh_boot_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of boot in reg CTRL_REG2
   *
   */
-int32_t lis331dlh_boot_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -603,7 +586,7 @@ int32_t lis331dlh_boot_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of st in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_self_test_set(lis331dlh_ctx_t *ctx, lis331dlh_st_t val)
+int32_t lis331dlh_self_test_set(stmdev_ctx_t *ctx, lis331dlh_st_t val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -624,7 +607,7 @@ int32_t lis331dlh_self_test_set(lis331dlh_ctx_t *ctx, lis331dlh_st_t val)
   * @param  val         Get the values of st in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_self_test_get(lis331dlh_ctx_t *ctx, lis331dlh_st_t *val)
+int32_t lis331dlh_self_test_get(stmdev_ctx_t *ctx, lis331dlh_st_t *val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -657,7 +640,7 @@ int32_t lis331dlh_self_test_get(lis331dlh_ctx_t *ctx, lis331dlh_st_t *val)
   * @param  val         change the values of ble in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_data_format_set(lis331dlh_ctx_t *ctx, lis331dlh_ble_t val)
+int32_t lis331dlh_data_format_set(stmdev_ctx_t *ctx, lis331dlh_ble_t val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -678,7 +661,7 @@ int32_t lis331dlh_data_format_set(lis331dlh_ctx_t *ctx, lis331dlh_ble_t val)
   * @param  val         Get the values of ble in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_data_format_get(lis331dlh_ctx_t *ctx, lis331dlh_ble_t *val)
+int32_t lis331dlh_data_format_get(stmdev_ctx_t *ctx, lis331dlh_ble_t *val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -721,7 +704,7 @@ int32_t lis331dlh_data_format_get(lis331dlh_ctx_t *ctx, lis331dlh_ble_t *val)
   * @param  val         change the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t lis331dlh_hp_bandwidth_set(lis331dlh_ctx_t *ctx, lis331dlh_hpcf_t val)
+int32_t lis331dlh_hp_bandwidth_set(stmdev_ctx_t *ctx, lis331dlh_hpcf_t val)
 {
   lis331dlh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -742,7 +725,7 @@ int32_t lis331dlh_hp_bandwidth_set(lis331dlh_ctx_t *ctx, lis331dlh_hpcf_t val)
   * @param  val         Get the values of hpcf in reg CTRL_REG2
   *
   */
-int32_t lis331dlh_hp_bandwidth_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    lis331dlh_hpcf_t *val)
 {
   lis331dlh_ctrl_reg2_t ctrl_reg2;
@@ -779,7 +762,7 @@ int32_t lis331dlh_hp_bandwidth_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of hpen in reg CTRL_REG2
   *
   */
-int32_t lis331dlh_hp_path_set(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t val)
+int32_t lis331dlh_hp_path_set(stmdev_ctx_t *ctx, lis331dlh_hpen_t val)
 {
   lis331dlh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -801,7 +784,7 @@ int32_t lis331dlh_hp_path_set(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t val)
   * @param  val         Get the values of hpen in reg CTRL_REG2
   *
   */
-int32_t lis331dlh_hp_path_get(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t *val)
+int32_t lis331dlh_hp_path_get(stmdev_ctx_t *ctx, lis331dlh_hpen_t *val)
 {
   lis331dlh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -852,7 +835,7 @@ int32_t lis331dlh_hp_path_get(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t *val)
   * @param  ctx         read / write interface definitions(ptr)
   *
   */
-int32_t lis331dlh_hp_reset_get(lis331dlh_ctx_t *ctx)
+int32_t lis331dlh_hp_reset_get(stmdev_ctx_t *ctx)
 {
   uint8_t dummy;
   int32_t ret;
@@ -868,7 +851,7 @@ int32_t lis331dlh_hp_reset_get(lis331dlh_ctx_t *ctx)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t lis331dlh_hp_reference_value_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
   ret = lis331dlh_write_reg(ctx, LIS331DLH_REFERENCE, (uint8_t*)&val, 1);
@@ -882,7 +865,7 @@ int32_t lis331dlh_hp_reference_value_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ref in reg REFERENCE
   *
   */
-int32_t lis331dlh_hp_reference_value_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
   ret = lis331dlh_read_reg(ctx, LIS331DLH_REFERENCE, val, 1);
@@ -909,7 +892,7 @@ int32_t lis331dlh_hp_reference_value_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of sim in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_spi_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_sim_t val)
+int32_t lis331dlh_spi_mode_set(stmdev_ctx_t *ctx, lis331dlh_sim_t val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -930,7 +913,7 @@ int32_t lis331dlh_spi_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_sim_t val)
   * @param  val         Get the values of sim in reg CTRL_REG4
   *
   */
-int32_t lis331dlh_spi_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_sim_t *val)
+int32_t lis331dlh_spi_mode_get(stmdev_ctx_t *ctx, lis331dlh_sim_t *val)
 {
   lis331dlh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -973,7 +956,7 @@ int32_t lis331dlh_spi_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_sim_t *val)
   * @param  val         change the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_pin_int1_route_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      lis331dlh_i1_cfg_t val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
@@ -995,7 +978,7 @@ int32_t lis331dlh_pin_int1_route_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of i1_cfg in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_pin_int1_route_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      lis331dlh_i1_cfg_t *val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
@@ -1033,7 +1016,7 @@ int32_t lis331dlh_pin_int1_route_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_int1_notification_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_notification_set(stmdev_ctx_t *ctx,
                                         lis331dlh_lir1_t val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
@@ -1056,7 +1039,7 @@ int32_t lis331dlh_int1_notification_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of lir1 in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_int1_notification_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_notification_get(stmdev_ctx_t *ctx,
                                         lis331dlh_lir1_t *val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
@@ -1087,7 +1070,7 @@ int32_t lis331dlh_int1_notification_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_pin_int2_route_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      lis331dlh_i2_cfg_t val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
@@ -1109,7 +1092,7 @@ int32_t lis331dlh_pin_int2_route_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of i2_cfg in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_pin_int2_route_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      lis331dlh_i2_cfg_t *val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
@@ -1147,7 +1130,7 @@ int32_t lis331dlh_pin_int2_route_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_int2_notification_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_notification_set(stmdev_ctx_t *ctx,
                                         lis331dlh_lir2_t val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
@@ -1170,7 +1153,7 @@ int32_t lis331dlh_int2_notification_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of lir2 in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_int2_notification_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_notification_get(stmdev_ctx_t *ctx,
                                         lis331dlh_lir2_t *val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
@@ -1201,7 +1184,7 @@ int32_t lis331dlh_int2_notification_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_pin_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t val)
+int32_t lis331dlh_pin_mode_set(stmdev_ctx_t *ctx, lis331dlh_pp_od_t val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1222,7 +1205,7 @@ int32_t lis331dlh_pin_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t val)
   * @param  val         Get the values of pp_od in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_pin_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t *val)
+int32_t lis331dlh_pin_mode_get(stmdev_ctx_t *ctx, lis331dlh_pp_od_t *val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1252,7 +1235,7 @@ int32_t lis331dlh_pin_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t *val)
   * @param  val         change the values of ihl in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_pin_polarity_set(lis331dlh_ctx_t *ctx, lis331dlh_ihl_t val)
+int32_t lis331dlh_pin_polarity_set(stmdev_ctx_t *ctx, lis331dlh_ihl_t val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1273,7 +1256,7 @@ int32_t lis331dlh_pin_polarity_set(lis331dlh_ctx_t *ctx, lis331dlh_ihl_t val)
   * @param  val         Get the values of ihl in reg CTRL_REG3
   *
   */
-int32_t lis331dlh_pin_polarity_get(lis331dlh_ctx_t *ctx, lis331dlh_ihl_t *val)
+int32_t lis331dlh_pin_polarity_get(stmdev_ctx_t *ctx, lis331dlh_ihl_t *val)
 {
   lis331dlh_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1316,7 +1299,7 @@ int32_t lis331dlh_pin_polarity_get(lis331dlh_ctx_t *ctx, lis331dlh_ihl_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t lis331dlh_int1_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                               int1_on_th_conf_t val)
 {
   lis331dlh_int1_cfg_t int1_cfg;
@@ -1343,7 +1326,7 @@ int32_t lis331dlh_int1_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t lis331dlh_int1_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                              int1_on_th_conf_t *val)
 {
   lis331dlh_int1_cfg_t int1_cfg;
@@ -1367,7 +1350,7 @@ int32_t lis331dlh_int1_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT1_CFG
   *
   */
-int32_t lis331dlh_int1_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              lis331dlh_int1_aoi_t val)
 {
   lis331dlh_int1_cfg_t int1_cfg;
@@ -1389,7 +1372,7 @@ int32_t lis331dlh_int1_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT1_CFG
   *
   */
-int32_t lis331dlh_int1_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              lis331dlh_int1_aoi_t *val)
 {
   lis331dlh_int1_cfg_t int1_cfg;
@@ -1420,7 +1403,7 @@ int32_t lis331dlh_int1_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t lis331dlh_int1_src_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_src_get(stmdev_ctx_t *ctx,
                                lis331dlh_int1_src_t *val)
 {
   int32_t ret;
@@ -1435,7 +1418,7 @@ int32_t lis331dlh_int1_src_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t lis331dlh_int1_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_int1_ths_t int1_ths;
   int32_t ret;
@@ -1456,7 +1439,7 @@ int32_t lis331dlh_int1_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t lis331dlh_int1_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_int1_ths_t int1_ths;
   int32_t ret;
@@ -1474,7 +1457,7 @@ int32_t lis331dlh_int1_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t lis331dlh_int1_dur_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_int1_duration_t int1_duration;
   int32_t ret;
@@ -1496,7 +1479,7 @@ int32_t lis331dlh_int1_dur_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT1_DURATION
   *
   */
-int32_t lis331dlh_int1_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_int1_duration_t int1_duration;
   int32_t ret;
@@ -1515,7 +1498,7 @@ int32_t lis331dlh_int1_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t lis331dlh_int2_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                               int2_on_th_conf_t val)
 {
   lis331dlh_int2_cfg_t int2_cfg;
@@ -1543,7 +1526,7 @@ int32_t lis331dlh_int2_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
   * @param  val         enable sign and axis for interrupt on threshold
   *
   */
-int32_t lis331dlh_int2_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                               int2_on_th_conf_t *val)
 {
   lis331dlh_int2_cfg_t int2_cfg;
@@ -1567,7 +1550,7 @@ int32_t lis331dlh_int2_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of aoi in reg INT2_CFG
   *
   */
-int32_t lis331dlh_int2_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              lis331dlh_int2_aoi_t val)
 {
   lis331dlh_int2_cfg_t int2_cfg;
@@ -1589,7 +1572,7 @@ int32_t lis331dlh_int2_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of aoi in reg INT2_CFG
   *
   */
-int32_t lis331dlh_int2_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              lis331dlh_int2_aoi_t *val)
 {
   lis331dlh_int2_cfg_t int2_cfg;
@@ -1620,7 +1603,7 @@ int32_t lis331dlh_int2_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t lis331dlh_int2_src_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_src_get(stmdev_ctx_t *ctx,
                                lis331dlh_int2_src_t *val)
 {
   int32_t ret;
@@ -1635,7 +1618,7 @@ int32_t lis331dlh_int2_src_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t lis331dlh_int2_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_int2_ths_t int2_ths;
   int32_t ret;
@@ -1656,7 +1639,7 @@ int32_t lis331dlh_int2_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t lis331dlh_int2_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_int2_ths_t int2_ths;
   int32_t ret;
@@ -1674,7 +1657,7 @@ int32_t lis331dlh_int2_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t lis331dlh_int2_dur_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_int2_duration_t int2_duration;
   int32_t ret;
@@ -1696,7 +1679,7 @@ int32_t lis331dlh_int2_dur_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of d in reg INT2_DURATION
   *
   */
-int32_t lis331dlh_int2_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_int2_duration_t int2_duration;
   int32_t ret;
@@ -1728,7 +1711,7 @@ int32_t lis331dlh_int2_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t lis331dlh_wkup_to_sleep_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1749,7 +1732,7 @@ int32_t lis331dlh_wkup_to_sleep_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of turnon in reg CTRL_REG5
   *
   */
-int32_t lis331dlh_wkup_to_sleep_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1780,7 +1763,7 @@ int32_t lis331dlh_wkup_to_sleep_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of 6d in reg INT1_CFG
   *
   */
-int32_t lis331dlh_int1_6d_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_6d_mode_set(stmdev_ctx_t *ctx,
                                    lis331dlh_int1_6d_t val)
 {
   lis331dlh_int1_cfg_t int1_cfg;
@@ -1802,7 +1785,7 @@ int32_t lis331dlh_int1_6d_mode_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of 6d in reg INT1_CFG
   *
   */
-int32_t lis331dlh_int1_6d_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_6d_mode_get(stmdev_ctx_t *ctx,
                                    lis331dlh_int1_6d_t *val)
 {
   lis331dlh_int1_cfg_t int1_cfg;
@@ -1836,7 +1819,7 @@ int32_t lis331dlh_int1_6d_mode_get(lis331dlh_ctx_t *ctx,
   * @param  val         registers INT1_SRC
   *
   */
-int32_t lis331dlh_int1_6d_src_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_6d_src_get(stmdev_ctx_t *ctx,
                                   lis331dlh_int1_src_t *val)
 {
   int32_t ret;
@@ -1851,7 +1834,7 @@ int32_t lis331dlh_int1_6d_src_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t lis331dlh_int1_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_int1_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_int1_ths_t int1_ths;
   int32_t ret;
@@ -1871,7 +1854,7 @@ int32_t lis331dlh_int1_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT1_THS
   *
   */
-int32_t lis331dlh_int1_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_int1_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_int1_ths_t int1_ths;
   int32_t ret;
@@ -1889,7 +1872,7 @@ int32_t lis331dlh_int1_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
   * @param  val         change the values of 6d in reg INT2_CFG
   *
   */
-int32_t lis331dlh_int2_6d_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_6d_mode_set(stmdev_ctx_t *ctx,
                                    lis331dlh_int2_6d_t val)
 {
   lis331dlh_int2_cfg_t int2_cfg;
@@ -1912,7 +1895,7 @@ int32_t lis331dlh_int2_6d_mode_set(lis331dlh_ctx_t *ctx,
   * @param  val         Get the values of 6d in reg INT2_CFG
   *
   */
-int32_t lis331dlh_int2_6d_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_6d_mode_get(stmdev_ctx_t *ctx,
                                    lis331dlh_int2_6d_t *val)
 {
   lis331dlh_int2_cfg_t int2_cfg;
@@ -1946,7 +1929,7 @@ int32_t lis331dlh_int2_6d_mode_get(lis331dlh_ctx_t *ctx,
   * @param  val         registers INT2_SRC
   *
   */
-int32_t lis331dlh_int2_6d_src_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_6d_src_get(stmdev_ctx_t *ctx,
                                   lis331dlh_int2_src_t *val)
 {
   int32_t ret;
@@ -1961,7 +1944,7 @@ int32_t lis331dlh_int2_6d_src_get(lis331dlh_ctx_t *ctx,
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t lis331dlh_int2_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
+int32_t lis331dlh_int2_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis331dlh_int2_ths_t int2_ths;
   int32_t ret;
@@ -1982,7 +1965,7 @@ int32_t lis331dlh_int2_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val)
   * @param  val         change the values of ths in reg INT2_THS
   *
   */
-int32_t lis331dlh_int2_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val)
+int32_t lis331dlh_int2_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis331dlh_int2_ths_t int2_ths;
   int32_t ret;

--- a/sensor/stmemsc/lis331dlh_STdC/driver/lis331dlh_reg.h
+++ b/sensor/stmemsc/lis331dlh_STdC/driver/lis331dlh_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS331DLH_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LIS331DLH_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis331dlh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis331dlh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis331dlh_write_ptr  write_reg;
-  lis331dlh_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis331dlh_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -356,23 +328,23 @@ typedef union{
   *
   */
 
-int32_t lis331dlh_read_reg(lis331dlh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis331dlh_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
-int32_t lis331dlh_write_reg(lis331dlh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis331dlh_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                             uint16_t len);
 
 extern float lis331dlh_from_fs2_to_mg(int16_t lsb);
 extern float lis331dlh_from_fs4_to_mg(int16_t lsb);
 extern float lis331dlh_from_fs8_to_mg(int16_t lsb);
 
-int32_t lis331dlh_axis_x_data_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_axis_x_data_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis331dlh_axis_y_data_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_axis_y_data_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis331dlh_axis_z_data_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_axis_z_data_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS331DLH_ODR_OFF   = 0x00,
@@ -386,16 +358,16 @@ typedef enum {
   LIS331DLH_ODR_400Hz = 0x21,
   LIS331DLH_ODR_1kHz  = 0x31,
 } lis331dlh_dr_t;
-int32_t lis331dlh_data_rate_set(lis331dlh_ctx_t *ctx, lis331dlh_dr_t val);
-int32_t lis331dlh_data_rate_get(lis331dlh_ctx_t *ctx, lis331dlh_dr_t *val);
+int32_t lis331dlh_data_rate_set(stmdev_ctx_t *ctx, lis331dlh_dr_t val);
+int32_t lis331dlh_data_rate_get(stmdev_ctx_t *ctx, lis331dlh_dr_t *val);
 
 typedef enum {
   LIS331DLH_NORMAL_MODE      = 0,
   LIS331DLH_REF_MODE_ENABLE  = 1,
 } lis331dlh_hpm_t;
-int32_t lis331dlh_reference_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_reference_mode_set(stmdev_ctx_t *ctx,
                                      lis331dlh_hpm_t val);
-int32_t lis331dlh_reference_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_reference_mode_get(stmdev_ctx_t *ctx,
                                      lis331dlh_hpm_t *val);
 
 typedef enum {
@@ -403,39 +375,39 @@ typedef enum {
   LIS331DLH_4g  = 1,
   LIS331DLH_8g  = 3,
 } lis331dlh_fs_t;
-int32_t lis331dlh_full_scale_set(lis331dlh_ctx_t *ctx, lis331dlh_fs_t val);
-int32_t lis331dlh_full_scale_get(lis331dlh_ctx_t *ctx, lis331dlh_fs_t *val);
+int32_t lis331dlh_full_scale_set(stmdev_ctx_t *ctx, lis331dlh_fs_t val);
+int32_t lis331dlh_full_scale_get(stmdev_ctx_t *ctx, lis331dlh_fs_t *val);
 
-int32_t lis331dlh_block_data_update_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_block_data_update_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis331dlh_status_reg_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_status_reg_get(stmdev_ctx_t *ctx,
                                  lis331dlh_status_reg_t *val);
 
-int32_t lis331dlh_flag_data_ready_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_flag_data_ready_get(stmdev_ctx_t *ctx,
                                       uint8_t *val);
 
-int32_t lis331dlh_acceleration_raw_get(lis331dlh_ctx_t *ctx, uint8_t *buff);
+int32_t lis331dlh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis331dlh_device_id_get(lis331dlh_ctx_t *ctx, uint8_t *buff);
+int32_t lis331dlh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis331dlh_boot_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_boot_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS331DLH_ST_DISABLE   = 0,
   LIS331DLH_ST_POSITIVE  = 1,
   LIS331DLH_ST_NEGATIVE  = 5,
 } lis331dlh_st_t;
-int32_t lis331dlh_self_test_set(lis331dlh_ctx_t *ctx, lis331dlh_st_t val);
-int32_t lis331dlh_self_test_get(lis331dlh_ctx_t *ctx, lis331dlh_st_t *val);
+int32_t lis331dlh_self_test_set(stmdev_ctx_t *ctx, lis331dlh_st_t val);
+int32_t lis331dlh_self_test_get(stmdev_ctx_t *ctx, lis331dlh_st_t *val);
 
 typedef enum {
   LIS331DLH_LSB_AT_LOW_ADD  = 0,
   LIS331DLH_MSB_AT_LOW_ADD  = 1,
 } lis331dlh_ble_t;
-int32_t lis331dlh_data_format_set(lis331dlh_ctx_t *ctx, lis331dlh_ble_t val);
-int32_t lis331dlh_data_format_get(lis331dlh_ctx_t *ctx, lis331dlh_ble_t *val);
+int32_t lis331dlh_data_format_set(stmdev_ctx_t *ctx, lis331dlh_ble_t val);
+int32_t lis331dlh_data_format_get(stmdev_ctx_t *ctx, lis331dlh_ble_t *val);
 
 typedef enum {
   LIS331DLH_CUT_OFF_8Hz   = 0,
@@ -443,9 +415,9 @@ typedef enum {
   LIS331DLH_CUT_OFF_32Hz  = 2,
   LIS331DLH_CUT_OFF_64Hz  = 3,
 } lis331dlh_hpcf_t;
-int32_t lis331dlh_hp_bandwidth_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                    lis331dlh_hpcf_t val);
-int32_t lis331dlh_hp_bandwidth_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                    lis331dlh_hpcf_t *val);
 
 typedef enum {
@@ -458,20 +430,20 @@ typedef enum {
   LIS331DLH_HP_ON_INT2_OUT        = 6,
   LIS331DLH_HP_ON_INT1_OUT        = 5,
 } lis331dlh_hpen_t;
-int32_t lis331dlh_hp_path_set(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t val);
-int32_t lis331dlh_hp_path_get(lis331dlh_ctx_t *ctx, lis331dlh_hpen_t *val);
+int32_t lis331dlh_hp_path_set(stmdev_ctx_t *ctx, lis331dlh_hpen_t val);
+int32_t lis331dlh_hp_path_get(stmdev_ctx_t *ctx, lis331dlh_hpen_t *val);
 
-int32_t lis331dlh_hp_reset_get(lis331dlh_ctx_t *ctx);
+int32_t lis331dlh_hp_reset_get(stmdev_ctx_t *ctx);
 
-int32_t lis331dlh_hp_reference_value_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_hp_reference_value_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_hp_reference_value_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_hp_reference_value_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS331DLH_SPI_4_WIRE  = 0,
   LIS331DLH_SPI_3_WIRE  = 1,
 } lis331dlh_sim_t;
-int32_t lis331dlh_spi_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_sim_t val);
-int32_t lis331dlh_spi_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_sim_t *val);
+int32_t lis331dlh_spi_mode_set(stmdev_ctx_t *ctx, lis331dlh_sim_t val);
+int32_t lis331dlh_spi_mode_get(stmdev_ctx_t *ctx, lis331dlh_sim_t *val);
 
 typedef enum {
   LIS331DLH_PAD1_INT1_SRC           = 0,
@@ -479,18 +451,18 @@ typedef enum {
   LIS331DLH_PAD1_DRDY               = 2,
   LIS331DLH_PAD1_BOOT               = 3,
 } lis331dlh_i1_cfg_t;
-int32_t lis331dlh_pin_int1_route_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_int1_route_set(stmdev_ctx_t *ctx,
                                      lis331dlh_i1_cfg_t val);
-int32_t lis331dlh_pin_int1_route_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_int1_route_get(stmdev_ctx_t *ctx,
                                      lis331dlh_i1_cfg_t *val);
 
 typedef enum {
   LIS331DLH_INT1_PULSED   = 0,
   LIS331DLH_INT1_LATCHED  = 1,
 } lis331dlh_lir1_t;
-int32_t lis331dlh_int1_notification_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_notification_set(stmdev_ctx_t *ctx,
                                         lis331dlh_lir1_t val);
-int32_t lis331dlh_int1_notification_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_notification_get(stmdev_ctx_t *ctx,
                                         lis331dlh_lir1_t *val);
 
 typedef enum {
@@ -499,34 +471,34 @@ typedef enum {
   LIS331DLH_PAD2_DRDY               = 2,
   LIS331DLH_PAD2_BOOT               = 3,
 } lis331dlh_i2_cfg_t;
-int32_t lis331dlh_pin_int2_route_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_int2_route_set(stmdev_ctx_t *ctx,
                                      lis331dlh_i2_cfg_t val);
-int32_t lis331dlh_pin_int2_route_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_int2_route_get(stmdev_ctx_t *ctx,
                                      lis331dlh_i2_cfg_t *val);
 
 typedef enum {
   LIS331DLH_INT2_PULSED   = 0,
   LIS331DLH_INT2_LATCHED  = 1,
 } lis331dlh_lir2_t;
-int32_t lis331dlh_int2_notification_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_notification_set(stmdev_ctx_t *ctx,
                                         lis331dlh_lir2_t val);
-int32_t lis331dlh_int2_notification_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_notification_get(stmdev_ctx_t *ctx,
                                         lis331dlh_lir2_t *val);
 
 typedef enum {
   LIS331DLH_PUSH_PULL   = 0,
   LIS331DLH_OPEN_DRAIN  = 1,
 } lis331dlh_pp_od_t;
-int32_t lis331dlh_pin_mode_set(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t val);
-int32_t lis331dlh_pin_mode_get(lis331dlh_ctx_t *ctx, lis331dlh_pp_od_t *val);
+int32_t lis331dlh_pin_mode_set(stmdev_ctx_t *ctx, lis331dlh_pp_od_t val);
+int32_t lis331dlh_pin_mode_get(stmdev_ctx_t *ctx, lis331dlh_pp_od_t *val);
 
 typedef enum {
   LIS331DLH_ACTIVE_HIGH  = 0,
   LIS331DLH_ACTIVE_LOW   = 1,
 } lis331dlh_ihl_t;
-int32_t lis331dlh_pin_polarity_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_polarity_set(stmdev_ctx_t *ctx,
                                    lis331dlh_ihl_t val);
-int32_t lis331dlh_pin_polarity_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_pin_polarity_get(stmdev_ctx_t *ctx,
                                    lis331dlh_ihl_t *val);
 
 typedef struct {
@@ -537,28 +509,28 @@ typedef struct {
   uint8_t int1_zlie             : 1;
   uint8_t int1_zhie             : 1;
 } int1_on_th_conf_t;
-int32_t lis331dlh_int1_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                              int1_on_th_conf_t val);
-int32_t lis331dlh_int1_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                              int1_on_th_conf_t *val);
 
 typedef enum {
   LIS331DLH_INT1_ON_THRESHOLD_OR   = 0,
   LIS331DLH_INT1_ON_THRESHOLD_AND  = 1,
 } lis331dlh_int1_aoi_t;
-int32_t lis331dlh_int1_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              lis331dlh_int1_aoi_t val);
-int32_t lis331dlh_int1_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              lis331dlh_int1_aoi_t *val);
 
-int32_t lis331dlh_int1_src_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_src_get(stmdev_ctx_t *ctx,
                                lis331dlh_int1_src_t *val);
 
-int32_t lis331dlh_int1_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_int1_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_int1_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int1_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis331dlh_int1_dur_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_int1_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_int1_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int1_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t int2_xlie             : 1;
@@ -568,63 +540,63 @@ typedef struct {
   uint8_t int2_zlie             : 1;
   uint8_t int2_zhie             : 1;
 } int2_on_th_conf_t;
-int32_t lis331dlh_int2_on_threshold_conf_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_on_threshold_conf_set(stmdev_ctx_t *ctx,
                                              int2_on_th_conf_t val);
-int32_t lis331dlh_int2_on_threshold_conf_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_on_threshold_conf_get(stmdev_ctx_t *ctx,
                                              int2_on_th_conf_t *val);
 
 typedef enum {
   LIS331DLH_INT2_ON_THRESHOLD_OR   = 0,
   LIS331DLH_INT2_ON_THRESHOLD_AND  = 1,
 } lis331dlh_int2_aoi_t;
-int32_t lis331dlh_int2_on_threshold_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_on_threshold_mode_set(stmdev_ctx_t *ctx,
                                              lis331dlh_int2_aoi_t val);
-int32_t lis331dlh_int2_on_threshold_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_on_threshold_mode_get(stmdev_ctx_t *ctx,
                                              lis331dlh_int2_aoi_t *val);
 
-int32_t lis331dlh_int2_src_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_src_get(stmdev_ctx_t *ctx,
                                lis331dlh_int2_src_t *val);
 
-int32_t lis331dlh_int2_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_int2_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_int2_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int2_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis331dlh_int2_dur_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_int2_dur_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_int2_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int2_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis331dlh_wkup_to_sleep_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_wkup_to_sleep_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_wkup_to_sleep_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_wkup_to_sleep_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS331DLH_6D_INT1_DISABLE   = 0,
   LIS331DLH_6D_INT1_MOVEMENT  = 1,
   LIS331DLH_6D_INT1_POSITION  = 3,
 } lis331dlh_int1_6d_t;
-int32_t lis331dlh_int1_6d_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_6d_mode_set(stmdev_ctx_t *ctx,
                                    lis331dlh_int1_6d_t val);
-int32_t lis331dlh_int1_6d_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_6d_mode_get(stmdev_ctx_t *ctx,
                                    lis331dlh_int1_6d_t *val);
 
-int32_t lis331dlh_int1_6d_src_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int1_6d_src_get(stmdev_ctx_t *ctx,
                                   lis331dlh_int1_src_t *val);
 
-int32_t lis331dlh_int1_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_int1_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_int1_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int1_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS331DLH_6D_INT2_DISABLE   = 0,
   LIS331DLH_6D_INT2_MOVEMENT  = 1,
   LIS331DLH_6D_INT2_POSITION  = 3,
 } lis331dlh_int2_6d_t;
-int32_t lis331dlh_int2_6d_mode_set(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_6d_mode_set(stmdev_ctx_t *ctx,
                                    lis331dlh_int2_6d_t val);
-int32_t lis331dlh_int2_6d_mode_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_6d_mode_get(stmdev_ctx_t *ctx,
                                    lis331dlh_int2_6d_t *val);
 
-int32_t lis331dlh_int2_6d_src_get(lis331dlh_ctx_t *ctx,
+int32_t lis331dlh_int2_6d_src_get(stmdev_ctx_t *ctx,
                                   lis331dlh_int2_src_t *val);
 
-int32_t lis331dlh_int2_6d_treshold_set(lis331dlh_ctx_t *ctx, uint8_t val);
-int32_t lis331dlh_int2_6d_treshold_get(lis331dlh_ctx_t *ctx, uint8_t *val);
+int32_t lis331dlh_int2_6d_treshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis331dlh_int2_6d_treshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/lis3de_STdC/driver/lis3de_reg.c
+++ b/sensor/stmemsc/lis3de_STdC/driver/lis3de_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis3de_reg.h"
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_read_reg(lis3de_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis3de_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lis3de_read_reg(lis3de_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_write_reg(lis3de_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis3de_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -146,7 +129,7 @@ float lis3de_from_lsb_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_temp_status_reg_get(lis3de_ctx_t *ctx, uint8_t *buff)
+int32_t lis3de_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3de_read_reg(ctx, LIS3DE_STATUS_REG_AUX, buff, 1);
@@ -160,7 +143,7 @@ int32_t lis3de_temp_status_reg_get(lis3de_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_temp_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -179,7 +162,7 @@ int32_t lis3de_temp_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_temp_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -198,7 +181,7 @@ int32_t lis3de_temp_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_temperature_raw_get(lis3de_ctx_t *ctx, uint8_t *buff)
+int32_t lis3de_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3de_read_reg(ctx, LIS3DE_OUT_ADC1_H, buff, 1);
@@ -225,7 +208,7 @@ int32_t lis3de_temperature_raw_get(lis3de_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_adc_raw_get(lis3de_ctx_t *ctx, uint8_t *buff)
+int32_t lis3de_adc_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3de_read_reg(ctx, LIS3DE_OUT_ADC1_L, buff, 6);
@@ -240,7 +223,7 @@ int32_t lis3de_adc_raw_get(lis3de_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_aux_adc_set(lis3de_ctx_t *ctx, lis3de_temp_en_t val)
+int32_t lis3de_aux_adc_set(stmdev_ctx_t *ctx, lis3de_temp_en_t val)
 {
   lis3de_temp_cfg_reg_t temp_cfg_reg;
   int32_t ret;
@@ -269,7 +252,7 @@ int32_t lis3de_aux_adc_set(lis3de_ctx_t *ctx, lis3de_temp_en_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_aux_adc_get(lis3de_ctx_t *ctx, lis3de_temp_en_t *val)
+int32_t lis3de_aux_adc_get(stmdev_ctx_t *ctx, lis3de_temp_en_t *val)
 {
   lis3de_temp_cfg_reg_t temp_cfg_reg;
   int32_t ret;
@@ -295,7 +278,7 @@ int32_t lis3de_aux_adc_get(lis3de_ctx_t *ctx, lis3de_temp_en_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_operating_mode_set(lis3de_ctx_t *ctx, lis3de_op_md_t val)
+int32_t lis3de_operating_mode_set(stmdev_ctx_t *ctx, lis3de_op_md_t val)
 {
   lis3de_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -316,7 +299,7 @@ int32_t lis3de_operating_mode_set(lis3de_ctx_t *ctx, lis3de_op_md_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_operating_mode_get(lis3de_ctx_t *ctx, lis3de_op_md_t *val)
+int32_t lis3de_operating_mode_get(stmdev_ctx_t *ctx, lis3de_op_md_t *val)
 {
   lis3de_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -342,7 +325,7 @@ int32_t lis3de_operating_mode_get(lis3de_ctx_t *ctx, lis3de_op_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_data_rate_set(lis3de_ctx_t *ctx, lis3de_odr_t val)
+int32_t lis3de_data_rate_set(stmdev_ctx_t *ctx, lis3de_odr_t val)
 {
   lis3de_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -363,7 +346,7 @@ int32_t lis3de_data_rate_set(lis3de_ctx_t *ctx, lis3de_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_data_rate_get(lis3de_ctx_t *ctx, lis3de_odr_t *val)
+int32_t lis3de_data_rate_get(stmdev_ctx_t *ctx, lis3de_odr_t *val)
 {
   lis3de_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -416,7 +399,7 @@ int32_t lis3de_data_rate_get(lis3de_ctx_t *ctx, lis3de_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_high_pass_on_outputs_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -438,7 +421,7 @@ int32_t lis3de_high_pass_on_outputs_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_high_pass_on_outputs_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -463,7 +446,7 @@ int32_t lis3de_high_pass_on_outputs_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_high_pass_bandwidth_set(lis3de_ctx_t *ctx,
+int32_t lis3de_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis3de_hpcf_t val)
 {
   lis3de_ctrl_reg2_t ctrl_reg2;
@@ -491,7 +474,7 @@ int32_t lis3de_high_pass_bandwidth_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_high_pass_bandwidth_get(lis3de_ctx_t *ctx,
+int32_t lis3de_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis3de_hpcf_t *val)
 {
   lis3de_ctrl_reg2_t ctrl_reg2;
@@ -526,7 +509,7 @@ int32_t lis3de_high_pass_bandwidth_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_high_pass_mode_set(lis3de_ctx_t *ctx, lis3de_hpm_t val)
+int32_t lis3de_high_pass_mode_set(stmdev_ctx_t *ctx, lis3de_hpm_t val)
 {
   lis3de_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -547,7 +530,7 @@ int32_t lis3de_high_pass_mode_set(lis3de_ctx_t *ctx, lis3de_hpm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_high_pass_mode_get(lis3de_ctx_t *ctx, lis3de_hpm_t *val)
+int32_t lis3de_high_pass_mode_get(stmdev_ctx_t *ctx, lis3de_hpm_t *val)
 {
   lis3de_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -581,7 +564,7 @@ int32_t lis3de_high_pass_mode_get(lis3de_ctx_t *ctx, lis3de_hpm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_full_scale_set(lis3de_ctx_t *ctx, lis3de_fs_t val)
+int32_t lis3de_full_scale_set(stmdev_ctx_t *ctx, lis3de_fs_t val)
 {
   lis3de_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -602,7 +585,7 @@ int32_t lis3de_full_scale_set(lis3de_ctx_t *ctx, lis3de_fs_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_full_scale_get(lis3de_ctx_t *ctx, lis3de_fs_t *val)
+int32_t lis3de_full_scale_get(stmdev_ctx_t *ctx, lis3de_fs_t *val)
 {
   lis3de_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -636,7 +619,7 @@ int32_t lis3de_full_scale_get(lis3de_ctx_t *ctx, lis3de_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_block_data_update_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -657,7 +640,7 @@ int32_t lis3de_block_data_update_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_block_data_update_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -677,7 +660,7 @@ int32_t lis3de_block_data_update_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_filter_reference_set(lis3de_ctx_t *ctx, uint8_t *buff)
+int32_t lis3de_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3de_write_reg(ctx, LIS3DE_REFERENCE, buff, 1);
@@ -693,7 +676,7 @@ int32_t lis3de_filter_reference_set(lis3de_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_filter_reference_get(lis3de_ctx_t *ctx, uint8_t *buff)
+int32_t lis3de_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3de_read_reg(ctx, LIS3DE_REFERENCE, buff, 1);
@@ -707,7 +690,7 @@ int32_t lis3de_filter_reference_get(lis3de_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_xl_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_status_reg_t status_reg;
   int32_t ret;
@@ -725,7 +708,7 @@ int32_t lis3de_xl_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_xl_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_status_reg_t status_reg;
   int32_t ret;
@@ -743,7 +726,7 @@ int32_t lis3de_xl_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_acceleration_raw_get(lis3de_ctx_t *ctx, int16_t *buff)
+int32_t lis3de_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *buff)
 {
   int32_t ret;
   int8_t dummy;
@@ -780,7 +763,7 @@ int32_t lis3de_acceleration_raw_get(lis3de_ctx_t *ctx, int16_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_device_id_get(lis3de_ctx_t *ctx, uint8_t *buff)
+int32_t lis3de_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3de_read_reg(ctx, LIS3DE_WHO_AM_I, buff, 1);
@@ -794,7 +777,7 @@ int32_t lis3de_device_id_get(lis3de_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_self_test_set(lis3de_ctx_t *ctx, lis3de_st_t val)
+int32_t lis3de_self_test_set(stmdev_ctx_t *ctx, lis3de_st_t val)
 {
   lis3de_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -815,7 +798,7 @@ int32_t lis3de_self_test_set(lis3de_ctx_t *ctx, lis3de_st_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_self_test_get(lis3de_ctx_t *ctx, lis3de_st_t *val)
+int32_t lis3de_self_test_get(stmdev_ctx_t *ctx, lis3de_st_t *val)
 {
   lis3de_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -846,7 +829,7 @@ int32_t lis3de_self_test_get(lis3de_ctx_t *ctx, lis3de_st_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_boot_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -867,7 +850,7 @@ int32_t lis3de_boot_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_boot_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -886,7 +869,7 @@ int32_t lis3de_boot_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_status_get(lis3de_ctx_t *ctx, lis3de_status_reg_t *val)
+int32_t lis3de_status_get(stmdev_ctx_t *ctx, lis3de_status_reg_t *val)
 {
   int32_t ret;
   ret = lis3de_read_reg(ctx, LIS3DE_STATUS_REG, (uint8_t*) val, 1);
@@ -913,7 +896,7 @@ int32_t lis3de_status_get(lis3de_ctx_t *ctx, lis3de_status_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_gen_conf_set(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis3de_ig1_cfg_t *val)
 {
   int32_t ret;
@@ -929,7 +912,7 @@ int32_t lis3de_int1_gen_conf_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_gen_conf_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis3de_ig1_cfg_t *val)
 {
   int32_t ret;
@@ -945,7 +928,7 @@ int32_t lis3de_int1_gen_conf_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_gen_source_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_gen_source_get(stmdev_ctx_t *ctx,
                                      lis3de_ig1_source_t *val)
 {
   int32_t ret;
@@ -962,7 +945,7 @@ int32_t lis3de_int1_gen_source_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ig1_ths_t int1_ths;
   int32_t ret;
@@ -985,7 +968,7 @@ int32_t lis3de_int1_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ig1_ths_t int1_ths;
   int32_t ret;
@@ -1005,7 +988,7 @@ int32_t lis3de_int1_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ig1_duration_t int1_duration;
   int32_t ret;
@@ -1027,7 +1010,7 @@ int32_t lis3de_int1_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ig1_duration_t int1_duration;
   int32_t ret;
@@ -1059,7 +1042,7 @@ int32_t lis3de_int1_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_gen_conf_set(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis3de_ig2_cfg_t *val)
 {
   int32_t ret;
@@ -1075,7 +1058,7 @@ int32_t lis3de_int2_gen_conf_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_gen_conf_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis3de_ig2_cfg_t *val)
 {
   int32_t ret;
@@ -1090,7 +1073,7 @@ int32_t lis3de_int2_gen_conf_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_gen_source_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_gen_source_get(stmdev_ctx_t *ctx,
                                      lis3de_ig2_source_t *val)
 {
   int32_t ret;
@@ -1107,7 +1090,7 @@ int32_t lis3de_int2_gen_source_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ig2_ths_t int2_ths;
   int32_t ret;
@@ -1130,7 +1113,7 @@ int32_t lis3de_int2_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ig2_ths_t int2_ths;
   int32_t ret;
@@ -1150,7 +1133,7 @@ int32_t lis3de_int2_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ig2_duration_t int2_duration;
   int32_t ret;
@@ -1172,7 +1155,7 @@ int32_t lis3de_int2_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ig2_duration_t int2_duration;
   int32_t ret;
@@ -1203,7 +1186,7 @@ int32_t lis3de_int2_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_high_pass_int_conf_set(lis3de_ctx_t *ctx,
+int32_t lis3de_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                         lis3de_hp_t val)
 {
   lis3de_ctrl_reg2_t ctrl_reg2;
@@ -1225,7 +1208,7 @@ int32_t lis3de_high_pass_int_conf_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_high_pass_int_conf_get(lis3de_ctx_t *ctx,
+int32_t lis3de_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                         lis3de_hp_t *val)
 {
   lis3de_ctrl_reg2_t ctrl_reg2;
@@ -1272,7 +1255,7 @@ int32_t lis3de_high_pass_int_conf_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_pin_int1_config_set(lis3de_ctx_t *ctx,
+int32_t lis3de_pin_int1_config_set(stmdev_ctx_t *ctx,
                                      lis3de_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1288,7 +1271,7 @@ int32_t lis3de_pin_int1_config_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_pin_int1_config_get(lis3de_ctx_t *ctx,
+int32_t lis3de_pin_int1_config_get(stmdev_ctx_t *ctx,
                                      lis3de_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1305,7 +1288,7 @@ int32_t lis3de_pin_int1_config_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1327,7 +1310,7 @@ int32_t lis3de_int2_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1348,7 +1331,7 @@ int32_t lis3de_int2_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_pin_notification_mode_set(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis3de_lir_int2_t val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
@@ -1372,7 +1355,7 @@ int32_t lis3de_int2_pin_notification_mode_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int2_pin_notification_mode_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis3de_lir_int2_t *val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
@@ -1402,7 +1385,7 @@ int32_t lis3de_int2_pin_notification_mode_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1424,7 +1407,7 @@ int32_t lis3de_int1_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1444,7 +1427,7 @@ int32_t lis3de_int1_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_pin_notification_mode_set(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis3de_lir_int1_t val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
@@ -1467,7 +1450,7 @@ int32_t lis3de_int1_pin_notification_mode_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_int1_pin_notification_mode_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis3de_lir_int1_t *val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
@@ -1496,7 +1479,7 @@ int32_t lis3de_int1_pin_notification_mode_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_pin_int2_config_set(lis3de_ctx_t *ctx,
+int32_t lis3de_pin_int2_config_set(stmdev_ctx_t *ctx,
                                      lis3de_ctrl_reg6_t *val)
 {
   int32_t ret;
@@ -1512,7 +1495,7 @@ int32_t lis3de_pin_int2_config_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_pin_int2_config_get(lis3de_ctx_t *ctx,
+int32_t lis3de_pin_int2_config_get(stmdev_ctx_t *ctx,
                                      lis3de_ctrl_reg6_t *val)
 {
   int32_t ret;
@@ -1539,7 +1522,7 @@ int32_t lis3de_pin_int2_config_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1560,7 +1543,7 @@ int32_t lis3de_fifo_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1579,7 +1562,7 @@ int32_t lis3de_fifo_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_watermark_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1600,7 +1583,7 @@ int32_t lis3de_fifo_watermark_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_watermark_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1619,7 +1602,7 @@ int32_t lis3de_fifo_watermark_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_trigger_event_set(lis3de_ctx_t *ctx,
+int32_t lis3de_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lis3de_tr_t val)
 {
   lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
@@ -1641,7 +1624,7 @@ int32_t lis3de_fifo_trigger_event_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_trigger_event_get(lis3de_ctx_t *ctx,
+int32_t lis3de_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                         lis3de_tr_t *val)
 {
   lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
@@ -1670,7 +1653,7 @@ int32_t lis3de_fifo_trigger_event_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_mode_set(lis3de_ctx_t *ctx, lis3de_fm_t val)
+int32_t lis3de_fifo_mode_set(stmdev_ctx_t *ctx, lis3de_fm_t val)
 {
   lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1691,7 +1674,7 @@ int32_t lis3de_fifo_mode_set(lis3de_ctx_t *ctx, lis3de_fm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_mode_get(lis3de_ctx_t *ctx, lis3de_fm_t *val)
+int32_t lis3de_fifo_mode_get(stmdev_ctx_t *ctx, lis3de_fm_t *val)
 {
   lis3de_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1725,7 +1708,7 @@ int32_t lis3de_fifo_mode_get(lis3de_ctx_t *ctx, lis3de_fm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_status_get(lis3de_ctx_t *ctx,
+int32_t lis3de_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis3de_fifo_src_reg_t *val)
 {
   int32_t ret;
@@ -1740,7 +1723,7 @@ int32_t lis3de_fifo_status_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_data_level_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1758,7 +1741,7 @@ int32_t lis3de_fifo_data_level_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_empty_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1776,7 +1759,7 @@ int32_t lis3de_fifo_empty_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_ovr_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1794,7 +1777,7 @@ int32_t lis3de_fifo_ovr_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_fifo_fth_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1825,7 +1808,7 @@ int32_t lis3de_fifo_fth_flag_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_tap_conf_set(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val)
+int32_t lis3de_tap_conf_set(stmdev_ctx_t *ctx, lis3de_click_cfg_t *val)
 {
   int32_t ret;
   ret = lis3de_write_reg(ctx, LIS3DE_CLICK_CFG, (uint8_t*) val, 1);
@@ -1840,7 +1823,7 @@ int32_t lis3de_tap_conf_set(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_tap_conf_get(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val)
+int32_t lis3de_tap_conf_get(stmdev_ctx_t *ctx, lis3de_click_cfg_t *val)
 {
   int32_t ret;
   ret = lis3de_read_reg(ctx, LIS3DE_CLICK_CFG, (uint8_t*) val, 1);
@@ -1854,7 +1837,7 @@ int32_t lis3de_tap_conf_get(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_tap_source_get(lis3de_ctx_t *ctx, lis3de_click_src_t *val)
+int32_t lis3de_tap_source_get(stmdev_ctx_t *ctx, lis3de_click_src_t *val)
 {
   int32_t ret;
   ret = lis3de_read_reg(ctx, LIS3DE_CLICK_SRC, (uint8_t*) val, 1);
@@ -1869,7 +1852,7 @@ int32_t lis3de_tap_source_get(lis3de_ctx_t *ctx, lis3de_click_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_tap_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_click_ths_t click_ths;
   int32_t ret;
@@ -1891,7 +1874,7 @@ int32_t lis3de_tap_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_tap_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_click_ths_t click_ths;
   int32_t ret;
@@ -1913,7 +1896,7 @@ int32_t lis3de_tap_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_tap_notification_mode_set(lis3de_ctx_t *ctx,
+int32_t lis3de_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis3de_lir_t val)
 {
   lis3de_click_ths_t click_ths;
@@ -1938,7 +1921,7 @@ int32_t lis3de_tap_notification_mode_set(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_tap_notification_mode_get(lis3de_ctx_t *ctx,
+int32_t lis3de_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis3de_lir_t *val)
 {
   lis3de_click_ths_t click_ths;
@@ -1969,7 +1952,7 @@ int32_t lis3de_tap_notification_mode_get(lis3de_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_shock_dur_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_time_limit_t time_limit;
   int32_t ret;
@@ -1992,7 +1975,7 @@ int32_t lis3de_shock_dur_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_shock_dur_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_time_limit_t time_limit;
   int32_t ret;
@@ -2014,7 +1997,7 @@ int32_t lis3de_shock_dur_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_quiet_dur_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_time_latency_t time_latency;
   int32_t ret;
@@ -2038,7 +2021,7 @@ int32_t lis3de_quiet_dur_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_quiet_dur_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_time_latency_t time_latency;
   int32_t ret;
@@ -2060,7 +2043,7 @@ int32_t lis3de_quiet_dur_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_double_tap_timeout_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_time_window_t time_window;
   int32_t ret;
@@ -2084,7 +2067,7 @@ int32_t lis3de_double_tap_timeout_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_double_tap_timeout_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_time_window_t time_window;
   int32_t ret;
@@ -2118,7 +2101,7 @@ int32_t lis3de_double_tap_timeout_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_act_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_act_ths_t act_ths;
   int32_t ret;
@@ -2141,7 +2124,7 @@ int32_t lis3de_act_threshold_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_act_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_act_ths_t act_ths;
   int32_t ret;
@@ -2161,7 +2144,7 @@ int32_t lis3de_act_threshold_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_act_timeout_set(lis3de_ctx_t *ctx, uint8_t val)
+int32_t lis3de_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3de_act_dur_t act_dur;
   int32_t ret;
@@ -2183,7 +2166,7 @@ int32_t lis3de_act_timeout_set(lis3de_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_act_timeout_get(lis3de_ctx_t *ctx, uint8_t *val)
+int32_t lis3de_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3de_act_dur_t act_dur;
   int32_t ret;
@@ -2215,7 +2198,7 @@ int32_t lis3de_act_timeout_get(lis3de_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_spi_mode_set(lis3de_ctx_t *ctx, lis3de_sim_t val)
+int32_t lis3de_spi_mode_set(stmdev_ctx_t *ctx, lis3de_sim_t val)
 {
   lis3de_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -2236,7 +2219,7 @@ int32_t lis3de_spi_mode_set(lis3de_ctx_t *ctx, lis3de_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3de_spi_mode_get(lis3de_ctx_t *ctx, lis3de_sim_t *val)
+int32_t lis3de_spi_mode_get(stmdev_ctx_t *ctx, lis3de_sim_t *val)
 {
   lis3de_ctrl_reg4_t ctrl_reg4;
   int32_t ret;

--- a/sensor/stmemsc/lis3de_STdC/driver/lis3de_reg.h
+++ b/sensor/stmemsc/lis3de_STdC/driver/lis3de_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS3DE_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup LIS3MDL_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis3de_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis3de_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis3de_write_ptr  write_reg;
-  lis3de_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis3de_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -457,9 +429,9 @@ typedef union{
   *
   */
 
-int32_t lis3de_read_reg(lis3de_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis3de_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lis3de_write_reg(lis3de_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis3de_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float lis3de_from_fs2_to_mg(int16_t lsb);
@@ -468,28 +440,28 @@ extern float lis3de_from_fs8_to_mg(int16_t lsb);
 extern float lis3de_from_fs16_to_mg(int16_t lsb);
 extern float lis3de_from_lsb_to_celsius(int16_t lsb);
 
-int32_t lis3de_temp_status_reg_get(lis3de_ctx_t *ctx, uint8_t *buff);
-int32_t lis3de_temp_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_temp_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_temperature_raw_get(lis3de_ctx_t *ctx, uint8_t *buff);
-int32_t lis3de_adc_raw_get(lis3de_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_adc_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS3DE_AUX_DISABLE          = 0,
   LIS3DE_AUX_ON_TEMPERATURE   = 3,
   LIS3DE_AUX_ON_PADS          = 1,
 } lis3de_temp_en_t;
-int32_t lis3de_aux_adc_set(lis3de_ctx_t *ctx, lis3de_temp_en_t val);
-int32_t lis3de_aux_adc_get(lis3de_ctx_t *ctx, lis3de_temp_en_t *val);
+int32_t lis3de_aux_adc_set(stmdev_ctx_t *ctx, lis3de_temp_en_t val);
+int32_t lis3de_aux_adc_get(stmdev_ctx_t *ctx, lis3de_temp_en_t *val);
 
 typedef enum {
   LIS3DE_NM    = 0,
   LIS3DE_LP    = 1,
 } lis3de_op_md_t;
-int32_t lis3de_operating_mode_set(lis3de_ctx_t *ctx, lis3de_op_md_t val);
-int32_t lis3de_operating_mode_get(lis3de_ctx_t *ctx, lis3de_op_md_t *val);
+int32_t lis3de_operating_mode_set(stmdev_ctx_t *ctx, lis3de_op_md_t val);
+int32_t lis3de_operating_mode_get(stmdev_ctx_t *ctx, lis3de_op_md_t *val);
 
 typedef enum {
   LIS3DE_POWER_DOWN                      = 0x00,
@@ -503,11 +475,11 @@ typedef enum {
   LIS3DE_ODR_1kHz6                       = 0x08,
   LIS3DE_ODR_5kHz376_LP_1kHz344_NM       = 0x09,
 } lis3de_odr_t;
-int32_t lis3de_data_rate_set(lis3de_ctx_t *ctx, lis3de_odr_t val);
-int32_t lis3de_data_rate_get(lis3de_ctx_t *ctx, lis3de_odr_t *val);
+int32_t lis3de_data_rate_set(stmdev_ctx_t *ctx, lis3de_odr_t val);
+int32_t lis3de_data_rate_get(stmdev_ctx_t *ctx, lis3de_odr_t *val);
 
-int32_t lis3de_high_pass_on_outputs_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_high_pass_on_outputs_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DE_AGGRESSIVE  = 0,
@@ -515,9 +487,9 @@ typedef enum {
   LIS3DE_MEDIUM      = 2,
   LIS3DE_LIGHT       = 3,
 } lis3de_hpcf_t;
-int32_t lis3de_high_pass_bandwidth_set(lis3de_ctx_t *ctx,
+int32_t lis3de_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis3de_hpcf_t val);
-int32_t lis3de_high_pass_bandwidth_get(lis3de_ctx_t *ctx,
+int32_t lis3de_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis3de_hpcf_t *val);
 
 typedef enum {
@@ -526,8 +498,8 @@ typedef enum {
   LIS3DE_NORMAL           = 2,
   LIS3DE_AUTORST_ON_INT   = 3,
 } lis3de_hpm_t;
-int32_t lis3de_high_pass_mode_set(lis3de_ctx_t *ctx, lis3de_hpm_t val);
-int32_t lis3de_high_pass_mode_get(lis3de_ctx_t *ctx, lis3de_hpm_t *val);
+int32_t lis3de_high_pass_mode_set(stmdev_ctx_t *ctx, lis3de_hpm_t val);
+int32_t lis3de_high_pass_mode_get(stmdev_ctx_t *ctx, lis3de_hpm_t *val);
 
 typedef enum {
   LIS3DE_2g   = 0,
@@ -535,63 +507,63 @@ typedef enum {
   LIS3DE_8g   = 2,
   LIS3DE_16g  = 3,
 } lis3de_fs_t;
-int32_t lis3de_full_scale_set(lis3de_ctx_t *ctx, lis3de_fs_t val);
-int32_t lis3de_full_scale_get(lis3de_ctx_t *ctx, lis3de_fs_t *val);
+int32_t lis3de_full_scale_set(stmdev_ctx_t *ctx, lis3de_fs_t val);
+int32_t lis3de_full_scale_get(stmdev_ctx_t *ctx, lis3de_fs_t *val);
 
-int32_t lis3de_block_data_update_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_block_data_update_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_filter_reference_set(lis3de_ctx_t *ctx, uint8_t *buff);
-int32_t lis3de_filter_reference_get(lis3de_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis3de_xl_data_ready_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_xl_data_ovr_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_acceleration_raw_get(lis3de_ctx_t *ctx, int16_t *buff);
+int32_t lis3de_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *buff);
 
-int32_t lis3de_device_id_get(lis3de_ctx_t *ctx, uint8_t *buff);
+int32_t lis3de_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS3DE_ST_DISABLE   = 0,
   LIS3DE_ST_POSITIVE  = 1,
   LIS3DE_ST_NEGATIVE  = 2,
 } lis3de_st_t;
-int32_t lis3de_self_test_set(lis3de_ctx_t *ctx, lis3de_st_t val);
-int32_t lis3de_self_test_get(lis3de_ctx_t *ctx, lis3de_st_t *val);
+int32_t lis3de_self_test_set(stmdev_ctx_t *ctx, lis3de_st_t val);
+int32_t lis3de_self_test_get(stmdev_ctx_t *ctx, lis3de_st_t *val);
 
-int32_t lis3de_boot_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_boot_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_status_get(lis3de_ctx_t *ctx, lis3de_status_reg_t *val);
+int32_t lis3de_status_get(stmdev_ctx_t *ctx, lis3de_status_reg_t *val);
 
-int32_t lis3de_int1_gen_conf_set(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis3de_ig1_cfg_t *val);
-int32_t lis3de_int1_gen_conf_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis3de_ig1_cfg_t *val);
 
-int32_t lis3de_int1_gen_source_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_gen_source_get(stmdev_ctx_t *ctx,
                                      lis3de_ig1_source_t *val);
 
-int32_t lis3de_int1_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_int1_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_int1_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_int1_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_int2_gen_conf_set(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis3de_ig2_cfg_t *val);
-int32_t lis3de_int2_gen_conf_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis3de_ig2_cfg_t *val);
 
-int32_t lis3de_int2_gen_source_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_gen_source_get(stmdev_ctx_t *ctx,
                                      lis3de_ig2_source_t *val);
 
-int32_t lis3de_int2_gen_threshold_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_int2_gen_threshold_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_int2_gen_duration_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_int2_gen_duration_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DE_DISC_FROM_INT_GENERATOR  = 0,
@@ -603,58 +575,58 @@ typedef enum {
   LIS3DE_ON_INT2_TAP_GEN          = 6,
   LIS3DE_ON_INT1_INT2_TAP_GEN     = 7,
 } lis3de_hp_t;
-int32_t lis3de_high_pass_int_conf_set(lis3de_ctx_t *ctx,
+int32_t lis3de_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                         lis3de_hp_t val);
-int32_t lis3de_high_pass_int_conf_get(lis3de_ctx_t *ctx,
+int32_t lis3de_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                         lis3de_hp_t *val);
 
-int32_t lis3de_pin_int1_config_set(lis3de_ctx_t *ctx,
+int32_t lis3de_pin_int1_config_set(stmdev_ctx_t *ctx,
                                      lis3de_ctrl_reg3_t *val);
-int32_t lis3de_pin_int1_config_get(lis3de_ctx_t *ctx,
+int32_t lis3de_pin_int1_config_get(stmdev_ctx_t *ctx,
                                      lis3de_ctrl_reg3_t *val);
 
-int32_t lis3de_int2_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_int2_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DE_INT2_PULSED   = 0,
   LIS3DE_INT2_LATCHED  = 1,
 } lis3de_lir_int2_t;
-int32_t lis3de_int2_pin_notification_mode_set(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis3de_lir_int2_t val);
-int32_t lis3de_int2_pin_notification_mode_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis3de_lir_int2_t *val);
 
-int32_t lis3de_int1_pin_detect_4d_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_int1_pin_detect_4d_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DE_INT1_PULSED   = 0,
   LIS3DE_INT1_LATCHED  = 1,
 } lis3de_lir_int1_t;
-int32_t lis3de_int1_pin_notification_mode_set(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis3de_lir_int1_t val);
-int32_t lis3de_int1_pin_notification_mode_get(lis3de_ctx_t *ctx,
+int32_t lis3de_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis3de_lir_int1_t *val);
 
-int32_t lis3de_pin_int2_config_set(lis3de_ctx_t *ctx,
+int32_t lis3de_pin_int2_config_set(stmdev_ctx_t *ctx,
                                      lis3de_ctrl_reg6_t *val);
-int32_t lis3de_pin_int2_config_get(lis3de_ctx_t *ctx,
+int32_t lis3de_pin_int2_config_get(stmdev_ctx_t *ctx,
                                      lis3de_ctrl_reg6_t *val);
 
-int32_t lis3de_fifo_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_fifo_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_fifo_watermark_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_fifo_watermark_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DE_INT1_GEN = 0,
   LIS3DE_INT2_GEN = 1,
 } lis3de_tr_t;
-int32_t lis3de_fifo_trigger_event_set(lis3de_ctx_t *ctx,
+int32_t lis3de_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lis3de_tr_t val);
-int32_t lis3de_fifo_trigger_event_get(lis3de_ctx_t *ctx,
+int32_t lis3de_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                         lis3de_tr_t *val);
 
 typedef enum {
@@ -663,59 +635,59 @@ typedef enum {
   LIS3DE_DYNAMIC_STREAM_MODE   = 2,
   LIS3DE_STREAM_TO_FIFO_MODE   = 3,
 } lis3de_fm_t;
-int32_t lis3de_fifo_mode_set(lis3de_ctx_t *ctx, lis3de_fm_t val);
-int32_t lis3de_fifo_mode_get(lis3de_ctx_t *ctx, lis3de_fm_t *val);
+int32_t lis3de_fifo_mode_set(stmdev_ctx_t *ctx, lis3de_fm_t val);
+int32_t lis3de_fifo_mode_get(stmdev_ctx_t *ctx, lis3de_fm_t *val);
 
-int32_t lis3de_fifo_status_get(lis3de_ctx_t *ctx,
+int32_t lis3de_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis3de_fifo_src_reg_t *val);
 
-int32_t lis3de_fifo_data_level_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_fifo_empty_flag_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_fifo_ovr_flag_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_fifo_fth_flag_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_tap_conf_set(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val);
-int32_t lis3de_tap_conf_get(lis3de_ctx_t *ctx, lis3de_click_cfg_t *val);
+int32_t lis3de_tap_conf_set(stmdev_ctx_t *ctx, lis3de_click_cfg_t *val);
+int32_t lis3de_tap_conf_get(stmdev_ctx_t *ctx, lis3de_click_cfg_t *val);
 
-int32_t lis3de_tap_source_get(lis3de_ctx_t *ctx,
+int32_t lis3de_tap_source_get(stmdev_ctx_t *ctx,
                                 lis3de_click_src_t *val);
 
-int32_t lis3de_tap_threshold_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_tap_threshold_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DE_TAP_PULSED   = 0,
   LIS3DE_TAP_LATCHED  = 1,
 } lis3de_lir_t;
-int32_t lis3de_tap_notification_mode_set(lis3de_ctx_t *ctx,
+int32_t lis3de_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis3de_lir_t val);
-int32_t lis3de_tap_notification_mode_get(lis3de_ctx_t *ctx,
+int32_t lis3de_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis3de_lir_t *val);
 
-int32_t lis3de_shock_dur_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_shock_dur_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_quiet_dur_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_quiet_dur_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_double_tap_timeout_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_double_tap_timeout_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_act_threshold_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_act_threshold_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3de_act_timeout_set(lis3de_ctx_t *ctx, uint8_t val);
-int32_t lis3de_act_timeout_get(lis3de_ctx_t *ctx, uint8_t *val);
+int32_t lis3de_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3de_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DE_SPI_4_WIRE = 0,
   LIS3DE_SPI_3_WIRE = 1,
 } lis3de_sim_t;
-int32_t lis3de_spi_mode_set(lis3de_ctx_t *ctx, lis3de_sim_t val);
-int32_t lis3de_spi_mode_get(lis3de_ctx_t *ctx, lis3de_sim_t *val);
+int32_t lis3de_spi_mode_set(stmdev_ctx_t *ctx, lis3de_sim_t val);
+int32_t lis3de_spi_mode_get(stmdev_ctx_t *ctx, lis3de_sim_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/lis3dh_STdC/driver/lis3dh_reg.c
+++ b/sensor/stmemsc/lis3dh_STdC/driver/lis3dh_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis3dh_reg.h"
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_read_reg(lis3dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis3dh_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lis3dh_read_reg(lis3dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_write_reg(lis3dh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis3dh_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -196,7 +179,7 @@ float lis3dh_from_lsb_lp_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_temp_status_reg_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dh_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG_AUX, buff, 1);
@@ -210,7 +193,7 @@ int32_t lis3dh_temp_status_reg_get(lis3dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_temp_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -229,7 +212,7 @@ int32_t lis3dh_temp_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_temp_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_status_reg_aux_t status_reg_aux;
   int32_t ret;
@@ -248,10 +231,14 @@ int32_t lis3dh_temp_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_temperature_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dh_temperature_raw_get(stmdev_ctx_t *ctx, uint16_t *buff)
 {
   int32_t ret;
-  ret = lis3dh_read_reg(ctx, LIS3DH_OUT_ADC1_H, buff, 1);
+  uint8_t dummy[2];
+  ret = lis3dh_read_reg(ctx, LIS3DH_OUT_ADC3_L, dummy, 2);
+  *buff = dummy[1];
+  *buff = *buff * 256;
+  *buff += dummy[0];
   return ret;
 }
 
@@ -275,7 +262,7 @@ int32_t lis3dh_temperature_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_adc_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dh_adc_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dh_read_reg(ctx, LIS3DH_OUT_ADC1_L, buff, 6);
@@ -290,7 +277,7 @@ int32_t lis3dh_adc_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_aux_adc_set(lis3dh_ctx_t *ctx, lis3dh_temp_en_t val)
+int32_t lis3dh_aux_adc_set(stmdev_ctx_t *ctx, lis3dh_temp_en_t val)
 {
   lis3dh_temp_cfg_reg_t temp_cfg_reg;
   int32_t ret;
@@ -319,7 +306,7 @@ int32_t lis3dh_aux_adc_set(lis3dh_ctx_t *ctx, lis3dh_temp_en_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_aux_adc_get(lis3dh_ctx_t *ctx, lis3dh_temp_en_t *val)
+int32_t lis3dh_aux_adc_get(stmdev_ctx_t *ctx, lis3dh_temp_en_t *val)
 {
   lis3dh_temp_cfg_reg_t temp_cfg_reg;
   int32_t ret;
@@ -346,7 +333,7 @@ int32_t lis3dh_aux_adc_get(lis3dh_ctx_t *ctx, lis3dh_temp_en_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_operating_mode_set(lis3dh_ctx_t *ctx, lis3dh_op_md_t val)
+int32_t lis3dh_operating_mode_set(stmdev_ctx_t *ctx, lis3dh_op_md_t val)
 {
   lis3dh_ctrl_reg1_t ctrl_reg1;
   lis3dh_ctrl_reg4_t ctrl_reg4;
@@ -387,7 +374,7 @@ int32_t lis3dh_operating_mode_set(lis3dh_ctx_t *ctx, lis3dh_op_md_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_operating_mode_get(lis3dh_ctx_t *ctx, lis3dh_op_md_t *val)
+int32_t lis3dh_operating_mode_get(stmdev_ctx_t *ctx, lis3dh_op_md_t *val)
 {
   lis3dh_ctrl_reg1_t ctrl_reg1;
   lis3dh_ctrl_reg4_t ctrl_reg4;
@@ -415,7 +402,7 @@ int32_t lis3dh_operating_mode_get(lis3dh_ctx_t *ctx, lis3dh_op_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_data_rate_set(lis3dh_ctx_t *ctx, lis3dh_odr_t val)
+int32_t lis3dh_data_rate_set(stmdev_ctx_t *ctx, lis3dh_odr_t val)
 {
   lis3dh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -436,7 +423,7 @@ int32_t lis3dh_data_rate_set(lis3dh_ctx_t *ctx, lis3dh_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_data_rate_get(lis3dh_ctx_t *ctx, lis3dh_odr_t *val)
+int32_t lis3dh_data_rate_get(stmdev_ctx_t *ctx, lis3dh_odr_t *val)
 {
   lis3dh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -489,7 +476,7 @@ int32_t lis3dh_data_rate_get(lis3dh_ctx_t *ctx, lis3dh_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_high_pass_on_outputs_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -511,7 +498,7 @@ int32_t lis3dh_high_pass_on_outputs_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_high_pass_on_outputs_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -536,7 +523,7 @@ int32_t lis3dh_high_pass_on_outputs_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_high_pass_bandwidth_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis3dh_hpcf_t val)
 {
   lis3dh_ctrl_reg2_t ctrl_reg2;
@@ -564,7 +551,7 @@ int32_t lis3dh_high_pass_bandwidth_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_high_pass_bandwidth_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis3dh_hpcf_t *val)
 {
   lis3dh_ctrl_reg2_t ctrl_reg2;
@@ -599,7 +586,7 @@ int32_t lis3dh_high_pass_bandwidth_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_high_pass_mode_set(lis3dh_ctx_t *ctx, lis3dh_hpm_t val)
+int32_t lis3dh_high_pass_mode_set(stmdev_ctx_t *ctx, lis3dh_hpm_t val)
 {
   lis3dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -620,7 +607,7 @@ int32_t lis3dh_high_pass_mode_set(lis3dh_ctx_t *ctx, lis3dh_hpm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_high_pass_mode_get(lis3dh_ctx_t *ctx, lis3dh_hpm_t *val)
+int32_t lis3dh_high_pass_mode_get(stmdev_ctx_t *ctx, lis3dh_hpm_t *val)
 {
   lis3dh_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -654,7 +641,7 @@ int32_t lis3dh_high_pass_mode_get(lis3dh_ctx_t *ctx, lis3dh_hpm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_full_scale_set(lis3dh_ctx_t *ctx, lis3dh_fs_t val)
+int32_t lis3dh_full_scale_set(stmdev_ctx_t *ctx, lis3dh_fs_t val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -675,7 +662,7 @@ int32_t lis3dh_full_scale_set(lis3dh_ctx_t *ctx, lis3dh_fs_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_full_scale_get(lis3dh_ctx_t *ctx, lis3dh_fs_t *val)
+int32_t lis3dh_full_scale_get(stmdev_ctx_t *ctx, lis3dh_fs_t *val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -709,7 +696,7 @@ int32_t lis3dh_full_scale_get(lis3dh_ctx_t *ctx, lis3dh_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_block_data_update_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -730,7 +717,7 @@ int32_t lis3dh_block_data_update_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_block_data_update_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -750,7 +737,7 @@ int32_t lis3dh_block_data_update_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_filter_reference_set(lis3dh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dh_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dh_write_reg(ctx, LIS3DH_REFERENCE, buff, 1);
@@ -766,7 +753,7 @@ int32_t lis3dh_filter_reference_set(lis3dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_filter_reference_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dh_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dh_read_reg(ctx, LIS3DH_REFERENCE, buff, 1);
@@ -780,7 +767,7 @@ int32_t lis3dh_filter_reference_get(lis3dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_xl_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_status_reg_t status_reg;
   int32_t ret;
@@ -798,7 +785,7 @@ int32_t lis3dh_xl_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_xl_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_status_reg_t status_reg;
   int32_t ret;
@@ -816,7 +803,7 @@ int32_t lis3dh_xl_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_acceleration_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dh_read_reg(ctx, LIS3DH_OUT_X_L, buff, 6);
@@ -842,7 +829,7 @@ int32_t lis3dh_acceleration_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_device_id_get(lis3dh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dh_read_reg(ctx, LIS3DH_WHO_AM_I, buff, 1);
@@ -856,7 +843,7 @@ int32_t lis3dh_device_id_get(lis3dh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_self_test_set(lis3dh_ctx_t *ctx, lis3dh_st_t val)
+int32_t lis3dh_self_test_set(stmdev_ctx_t *ctx, lis3dh_st_t val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -877,7 +864,7 @@ int32_t lis3dh_self_test_set(lis3dh_ctx_t *ctx, lis3dh_st_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_self_test_get(lis3dh_ctx_t *ctx, lis3dh_st_t *val)
+int32_t lis3dh_self_test_get(stmdev_ctx_t *ctx, lis3dh_st_t *val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -908,7 +895,7 @@ int32_t lis3dh_self_test_get(lis3dh_ctx_t *ctx, lis3dh_st_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_data_format_set(lis3dh_ctx_t *ctx, lis3dh_ble_t val)
+int32_t lis3dh_data_format_set(stmdev_ctx_t *ctx, lis3dh_ble_t val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -929,7 +916,7 @@ int32_t lis3dh_data_format_set(lis3dh_ctx_t *ctx, lis3dh_ble_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_data_format_get(lis3dh_ctx_t *ctx, lis3dh_ble_t *val)
+int32_t lis3dh_data_format_get(stmdev_ctx_t *ctx, lis3dh_ble_t *val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -957,7 +944,7 @@ int32_t lis3dh_data_format_get(lis3dh_ctx_t *ctx, lis3dh_ble_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_boot_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -978,7 +965,7 @@ int32_t lis3dh_boot_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_boot_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -997,7 +984,7 @@ int32_t lis3dh_boot_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_status_get(lis3dh_ctx_t *ctx, lis3dh_status_reg_t *val)
+int32_t lis3dh_status_get(stmdev_ctx_t *ctx, lis3dh_status_reg_t *val)
 {
   int32_t ret;
   ret = lis3dh_read_reg(ctx, LIS3DH_STATUS_REG, (uint8_t*) val, 1);
@@ -1024,7 +1011,7 @@ int32_t lis3dh_status_get(lis3dh_ctx_t *ctx, lis3dh_status_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_gen_conf_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis3dh_int1_cfg_t *val)
 {
   int32_t ret;
@@ -1040,7 +1027,7 @@ int32_t lis3dh_int1_gen_conf_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_gen_conf_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis3dh_int1_cfg_t *val)
 {
   int32_t ret;
@@ -1056,7 +1043,7 @@ int32_t lis3dh_int1_gen_conf_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_gen_source_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_gen_source_get(stmdev_ctx_t *ctx,
                                      lis3dh_int1_src_t *val)
 {
   int32_t ret;
@@ -1073,7 +1060,7 @@ int32_t lis3dh_int1_gen_source_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_int1_ths_t int1_ths;
   int32_t ret;
@@ -1096,7 +1083,7 @@ int32_t lis3dh_int1_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_int1_ths_t int1_ths;
   int32_t ret;
@@ -1116,7 +1103,7 @@ int32_t lis3dh_int1_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_int1_duration_t int1_duration;
   int32_t ret;
@@ -1138,7 +1125,7 @@ int32_t lis3dh_int1_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_int1_duration_t int1_duration;
   int32_t ret;
@@ -1170,7 +1157,7 @@ int32_t lis3dh_int1_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_gen_conf_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis3dh_int2_cfg_t *val)
 {
   int32_t ret;
@@ -1186,7 +1173,7 @@ int32_t lis3dh_int2_gen_conf_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_gen_conf_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis3dh_int2_cfg_t *val)
 {
   int32_t ret;
@@ -1201,7 +1188,7 @@ int32_t lis3dh_int2_gen_conf_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_gen_source_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_gen_source_get(stmdev_ctx_t *ctx,
                                      lis3dh_int2_src_t *val)
 {
   int32_t ret;
@@ -1218,7 +1205,7 @@ int32_t lis3dh_int2_gen_source_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_int2_ths_t int2_ths;
   int32_t ret;
@@ -1241,7 +1228,7 @@ int32_t lis3dh_int2_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_int2_ths_t int2_ths;
   int32_t ret;
@@ -1261,7 +1248,7 @@ int32_t lis3dh_int2_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_int2_duration_t int2_duration;
   int32_t ret;
@@ -1283,7 +1270,7 @@ int32_t lis3dh_int2_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_int2_duration_t int2_duration;
   int32_t ret;
@@ -1314,7 +1301,7 @@ int32_t lis3dh_int2_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_high_pass_int_conf_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                         lis3dh_hp_t val)
 {
   lis3dh_ctrl_reg2_t ctrl_reg2;
@@ -1336,7 +1323,7 @@ int32_t lis3dh_high_pass_int_conf_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_high_pass_int_conf_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                         lis3dh_hp_t *val)
 {
   lis3dh_ctrl_reg2_t ctrl_reg2;
@@ -1383,7 +1370,7 @@ int32_t lis3dh_high_pass_int_conf_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_pin_int1_config_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_int1_config_set(stmdev_ctx_t *ctx,
                                      lis3dh_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1399,7 +1386,7 @@ int32_t lis3dh_pin_int1_config_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_pin_int1_config_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_int1_config_get(stmdev_ctx_t *ctx,
                                      lis3dh_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1416,7 +1403,7 @@ int32_t lis3dh_pin_int1_config_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1438,7 +1425,7 @@ int32_t lis3dh_int2_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1459,7 +1446,7 @@ int32_t lis3dh_int2_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_pin_notification_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis3dh_lir_int2_t val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
@@ -1483,7 +1470,7 @@ int32_t lis3dh_int2_pin_notification_mode_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int2_pin_notification_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis3dh_lir_int2_t *val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
@@ -1513,7 +1500,7 @@ int32_t lis3dh_int2_pin_notification_mode_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1535,7 +1522,7 @@ int32_t lis3dh_int1_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1555,7 +1542,7 @@ int32_t lis3dh_int1_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_pin_notification_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis3dh_lir_int1_t val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
@@ -1578,7 +1565,7 @@ int32_t lis3dh_int1_pin_notification_mode_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_int1_pin_notification_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis3dh_lir_int1_t *val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
@@ -1607,7 +1594,7 @@ int32_t lis3dh_int1_pin_notification_mode_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_pin_int2_config_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_int2_config_set(stmdev_ctx_t *ctx,
                                      lis3dh_ctrl_reg6_t *val)
 {
   int32_t ret;
@@ -1623,7 +1610,7 @@ int32_t lis3dh_pin_int2_config_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_pin_int2_config_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_int2_config_get(stmdev_ctx_t *ctx,
                                      lis3dh_ctrl_reg6_t *val)
 {
   int32_t ret;
@@ -1650,7 +1637,7 @@ int32_t lis3dh_pin_int2_config_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1671,7 +1658,7 @@ int32_t lis3dh_fifo_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1690,7 +1677,7 @@ int32_t lis3dh_fifo_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_watermark_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1711,7 +1698,7 @@ int32_t lis3dh_fifo_watermark_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_watermark_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1730,7 +1717,7 @@ int32_t lis3dh_fifo_watermark_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_trigger_event_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lis3dh_tr_t val)
 {
   lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
@@ -1752,7 +1739,7 @@ int32_t lis3dh_fifo_trigger_event_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_trigger_event_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                         lis3dh_tr_t *val)
 {
   lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
@@ -1781,7 +1768,7 @@ int32_t lis3dh_fifo_trigger_event_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_mode_set(lis3dh_ctx_t *ctx, lis3dh_fm_t val)
+int32_t lis3dh_fifo_mode_set(stmdev_ctx_t *ctx, lis3dh_fm_t val)
 {
   lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1802,7 +1789,7 @@ int32_t lis3dh_fifo_mode_set(lis3dh_ctx_t *ctx, lis3dh_fm_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_mode_get(lis3dh_ctx_t *ctx, lis3dh_fm_t *val)
+int32_t lis3dh_fifo_mode_get(stmdev_ctx_t *ctx, lis3dh_fm_t *val)
 {
   lis3dh_fifo_ctrl_reg_t fifo_ctrl_reg;
   int32_t ret;
@@ -1836,7 +1823,7 @@ int32_t lis3dh_fifo_mode_get(lis3dh_ctx_t *ctx, lis3dh_fm_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_status_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis3dh_fifo_src_reg_t *val)
 {
   int32_t ret;
@@ -1851,7 +1838,7 @@ int32_t lis3dh_fifo_status_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_data_level_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1869,7 +1856,7 @@ int32_t lis3dh_fifo_data_level_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_empty_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1887,7 +1874,7 @@ int32_t lis3dh_fifo_empty_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_ovr_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1905,7 +1892,7 @@ int32_t lis3dh_fifo_ovr_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_fifo_fth_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_fifo_src_reg_t fifo_src_reg;
   int32_t ret;
@@ -1936,7 +1923,7 @@ int32_t lis3dh_fifo_fth_flag_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_tap_conf_set(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val)
+int32_t lis3dh_tap_conf_set(stmdev_ctx_t *ctx, lis3dh_click_cfg_t *val)
 {
   int32_t ret;
   ret = lis3dh_write_reg(ctx, LIS3DH_CLICK_CFG, (uint8_t*) val, 1);
@@ -1951,7 +1938,7 @@ int32_t lis3dh_tap_conf_set(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_tap_conf_get(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val)
+int32_t lis3dh_tap_conf_get(stmdev_ctx_t *ctx, lis3dh_click_cfg_t *val)
 {
   int32_t ret;
   ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_CFG, (uint8_t*) val, 1);
@@ -1965,7 +1952,7 @@ int32_t lis3dh_tap_conf_get(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_tap_source_get(lis3dh_ctx_t *ctx, lis3dh_click_src_t *val)
+int32_t lis3dh_tap_source_get(stmdev_ctx_t *ctx, lis3dh_click_src_t *val)
 {
   int32_t ret;
   ret = lis3dh_read_reg(ctx, LIS3DH_CLICK_SRC, (uint8_t*) val, 1);
@@ -1980,7 +1967,7 @@ int32_t lis3dh_tap_source_get(lis3dh_ctx_t *ctx, lis3dh_click_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_tap_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_click_ths_t click_ths;
   int32_t ret;
@@ -2002,7 +1989,7 @@ int32_t lis3dh_tap_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_tap_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_click_ths_t click_ths;
   int32_t ret;
@@ -2024,7 +2011,7 @@ int32_t lis3dh_tap_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_tap_notification_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis3dh_lir_click_t val)
 {
   lis3dh_click_ths_t click_ths;
@@ -2049,7 +2036,7 @@ int32_t lis3dh_tap_notification_mode_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_tap_notification_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis3dh_lir_click_t *val)
 {
   lis3dh_click_ths_t click_ths;
@@ -2080,7 +2067,7 @@ int32_t lis3dh_tap_notification_mode_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_shock_dur_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_time_limit_t time_limit;
   int32_t ret;
@@ -2103,7 +2090,7 @@ int32_t lis3dh_shock_dur_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_shock_dur_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_time_limit_t time_limit;
   int32_t ret;
@@ -2125,7 +2112,7 @@ int32_t lis3dh_shock_dur_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_quiet_dur_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_time_latency_t time_latency;
   int32_t ret;
@@ -2149,7 +2136,7 @@ int32_t lis3dh_quiet_dur_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_quiet_dur_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_time_latency_t time_latency;
   int32_t ret;
@@ -2171,7 +2158,7 @@ int32_t lis3dh_quiet_dur_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_double_tap_timeout_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_time_window_t time_window;
   int32_t ret;
@@ -2195,7 +2182,7 @@ int32_t lis3dh_double_tap_timeout_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_double_tap_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_time_window_t time_window;
   int32_t ret;
@@ -2229,7 +2216,7 @@ int32_t lis3dh_double_tap_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_act_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_act_ths_t act_ths;
   int32_t ret;
@@ -2252,7 +2239,7 @@ int32_t lis3dh_act_threshold_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_act_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_act_ths_t act_ths;
   int32_t ret;
@@ -2272,7 +2259,7 @@ int32_t lis3dh_act_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_act_timeout_set(lis3dh_ctx_t *ctx, uint8_t val)
+int32_t lis3dh_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dh_act_dur_t act_dur;
   int32_t ret;
@@ -2294,7 +2281,7 @@ int32_t lis3dh_act_timeout_set(lis3dh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_act_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dh_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dh_act_dur_t act_dur;
   int32_t ret;
@@ -2326,7 +2313,7 @@ int32_t lis3dh_act_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_pin_sdo_sa0_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                       lis3dh_sdo_pu_disc_t val)
 {
   lis3dh_ctrl_reg0_t ctrl_reg0;
@@ -2348,7 +2335,7 @@ int32_t lis3dh_pin_sdo_sa0_mode_set(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_pin_sdo_sa0_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                       lis3dh_sdo_pu_disc_t *val)
 {
   lis3dh_ctrl_reg0_t ctrl_reg0;
@@ -2377,7 +2364,7 @@ int32_t lis3dh_pin_sdo_sa0_mode_get(lis3dh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_spi_mode_set(lis3dh_ctx_t *ctx, lis3dh_sim_t val)
+int32_t lis3dh_spi_mode_set(stmdev_ctx_t *ctx, lis3dh_sim_t val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -2398,7 +2385,7 @@ int32_t lis3dh_spi_mode_set(lis3dh_ctx_t *ctx, lis3dh_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dh_spi_mode_get(lis3dh_ctx_t *ctx, lis3dh_sim_t *val)
+int32_t lis3dh_spi_mode_get(stmdev_ctx_t *ctx, lis3dh_sim_t *val)
 {
   lis3dh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;

--- a/sensor/stmemsc/lis3dh_STdC/driver/lis3dh_reg.h
+++ b/sensor/stmemsc/lis3dh_STdC/driver/lis3dh_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS3DH_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup LIS3MDL_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis3dh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis3dh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis3dh_write_ptr  write_reg;
-  lis3dh_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis3dh_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -214,7 +186,7 @@ typedef struct {
   uint8_t not_used_01       : 1;
   uint8_t i1_overrun        : 1;
   uint8_t i1_wtm            : 1;
-  uint8_t not_used_02       : 1;
+  uint8_t i1_321da          : 1;
   uint8_t i1_zyxda          : 1;
   uint8_t i1_ia2            : 1;
   uint8_t i1_ia1            : 1;
@@ -466,9 +438,9 @@ typedef union{
   *
   */
 
-int32_t lis3dh_read_reg(lis3dh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis3dh_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lis3dh_write_reg(lis3dh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis3dh_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float lis3dh_from_fs2_hr_to_mg(int16_t lsb);
@@ -489,31 +461,31 @@ extern float lis3dh_from_fs8_lp_to_mg(int16_t lsb);
 extern float lis3dh_from_fs16_lp_to_mg(int16_t lsb);
 extern float lis3dh_from_lsb_lp_to_celsius(int16_t lsb);
 
-int32_t lis3dh_temp_status_reg_get(lis3dh_ctx_t *ctx, uint8_t *buff);
-int32_t lis3dh_temp_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_temp_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_temperature_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_temperature_raw_get(stmdev_ctx_t *ctx, uint16_t *buff);
 
-int32_t lis3dh_adc_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_adc_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS3DH_AUX_DISABLE          = 0,
   LIS3DH_AUX_ON_TEMPERATURE   = 3,
   LIS3DH_AUX_ON_PADS          = 1,
 } lis3dh_temp_en_t;
-int32_t lis3dh_aux_adc_set(lis3dh_ctx_t *ctx, lis3dh_temp_en_t val);
-int32_t lis3dh_aux_adc_get(lis3dh_ctx_t *ctx, lis3dh_temp_en_t *val);
+int32_t lis3dh_aux_adc_set(stmdev_ctx_t *ctx, lis3dh_temp_en_t val);
+int32_t lis3dh_aux_adc_get(stmdev_ctx_t *ctx, lis3dh_temp_en_t *val);
 
 typedef enum {
   LIS3DH_HR_12bit   = 0,
   LIS3DH_NM_10bit   = 1,
   LIS3DH_LP_8bit    = 2,
 } lis3dh_op_md_t;
-int32_t lis3dh_operating_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_operating_mode_set(stmdev_ctx_t *ctx,
                                     lis3dh_op_md_t val);
-int32_t lis3dh_operating_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_operating_mode_get(stmdev_ctx_t *ctx,
                                     lis3dh_op_md_t *val);
 
 typedef enum {
@@ -528,11 +500,11 @@ typedef enum {
   LIS3DH_ODR_1kHz620_LP                  = 0x08,
   LIS3DH_ODR_5kHz376_LP_1kHz344_NM_HP    = 0x09,
 } lis3dh_odr_t;
-int32_t lis3dh_data_rate_set(lis3dh_ctx_t *ctx, lis3dh_odr_t val);
-int32_t lis3dh_data_rate_get(lis3dh_ctx_t *ctx, lis3dh_odr_t *val);
+int32_t lis3dh_data_rate_set(stmdev_ctx_t *ctx, lis3dh_odr_t val);
+int32_t lis3dh_data_rate_get(stmdev_ctx_t *ctx, lis3dh_odr_t *val);
 
-int32_t lis3dh_high_pass_on_outputs_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_high_pass_on_outputs_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_high_pass_on_outputs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_high_pass_on_outputs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DH_AGGRESSIVE  = 0,
@@ -540,9 +512,9 @@ typedef enum {
   LIS3DH_MEDIUM      = 2,
   LIS3DH_LIGHT       = 3,
 } lis3dh_hpcf_t;
-int32_t lis3dh_high_pass_bandwidth_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                          lis3dh_hpcf_t val);
-int32_t lis3dh_high_pass_bandwidth_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                          lis3dh_hpcf_t *val);
 
 typedef enum {
@@ -551,8 +523,8 @@ typedef enum {
   LIS3DH_NORMAL           = 2,
   LIS3DH_AUTORST_ON_INT   = 3,
 } lis3dh_hpm_t;
-int32_t lis3dh_high_pass_mode_set(lis3dh_ctx_t *ctx, lis3dh_hpm_t val);
-int32_t lis3dh_high_pass_mode_get(lis3dh_ctx_t *ctx, lis3dh_hpm_t *val);
+int32_t lis3dh_high_pass_mode_set(stmdev_ctx_t *ctx, lis3dh_hpm_t val);
+int32_t lis3dh_high_pass_mode_get(stmdev_ctx_t *ctx, lis3dh_hpm_t *val);
 
 typedef enum {
   LIS3DH_2g   = 0,
@@ -560,70 +532,70 @@ typedef enum {
   LIS3DH_8g   = 2,
   LIS3DH_16g  = 3,
 } lis3dh_fs_t;
-int32_t lis3dh_full_scale_set(lis3dh_ctx_t *ctx, lis3dh_fs_t val);
-int32_t lis3dh_full_scale_get(lis3dh_ctx_t *ctx, lis3dh_fs_t *val);
+int32_t lis3dh_full_scale_set(stmdev_ctx_t *ctx, lis3dh_fs_t val);
+int32_t lis3dh_full_scale_get(stmdev_ctx_t *ctx, lis3dh_fs_t *val);
 
-int32_t lis3dh_block_data_update_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_block_data_update_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_filter_reference_set(lis3dh_ctx_t *ctx, uint8_t *buff);
-int32_t lis3dh_filter_reference_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis3dh_xl_data_ready_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_xl_data_ovr_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_acceleration_raw_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis3dh_device_id_get(lis3dh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LIS3DH_ST_DISABLE   = 0,
   LIS3DH_ST_POSITIVE  = 1,
   LIS3DH_ST_NEGATIVE  = 2,
 } lis3dh_st_t;
-int32_t lis3dh_self_test_set(lis3dh_ctx_t *ctx, lis3dh_st_t val);
-int32_t lis3dh_self_test_get(lis3dh_ctx_t *ctx, lis3dh_st_t *val);
+int32_t lis3dh_self_test_set(stmdev_ctx_t *ctx, lis3dh_st_t val);
+int32_t lis3dh_self_test_get(stmdev_ctx_t *ctx, lis3dh_st_t *val);
 
 typedef enum {
   LIS3DH_LSB_AT_LOW_ADD = 0,
   LIS3DH_MSB_AT_LOW_ADD = 1,
 } lis3dh_ble_t;
-int32_t lis3dh_data_format_set(lis3dh_ctx_t *ctx, lis3dh_ble_t val);
-int32_t lis3dh_data_format_get(lis3dh_ctx_t *ctx, lis3dh_ble_t *val);
+int32_t lis3dh_data_format_set(stmdev_ctx_t *ctx, lis3dh_ble_t val);
+int32_t lis3dh_data_format_get(stmdev_ctx_t *ctx, lis3dh_ble_t *val);
 
-int32_t lis3dh_boot_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_boot_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_status_get(lis3dh_ctx_t *ctx, lis3dh_status_reg_t *val);
+int32_t lis3dh_status_get(stmdev_ctx_t *ctx, lis3dh_status_reg_t *val);
 
-int32_t lis3dh_int1_gen_conf_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis3dh_int1_cfg_t *val);
-int32_t lis3dh_int1_gen_conf_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis3dh_int1_cfg_t *val);
 
-int32_t lis3dh_int1_gen_source_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_gen_source_get(stmdev_ctx_t *ctx,
                                      lis3dh_int1_src_t *val);
 
-int32_t lis3dh_int1_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_int1_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_int1_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_int1_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_int1_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_int2_gen_conf_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                    lis3dh_int2_cfg_t *val);
-int32_t lis3dh_int2_gen_conf_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                    lis3dh_int2_cfg_t *val);
 
-int32_t lis3dh_int2_gen_source_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_gen_source_get(stmdev_ctx_t *ctx,
                                      lis3dh_int2_src_t *val);
 
-int32_t lis3dh_int2_gen_threshold_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_int2_gen_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_int2_gen_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_gen_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_int2_gen_duration_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_int2_gen_duration_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DH_DISC_FROM_INT_GENERATOR  = 0,
@@ -635,58 +607,58 @@ typedef enum {
   LIS3DH_ON_INT2_TAP_GEN          = 6,
   LIS3DH_ON_INT1_INT2_TAP_GEN     = 7,
 } lis3dh_hp_t;
-int32_t lis3dh_high_pass_int_conf_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                         lis3dh_hp_t val);
-int32_t lis3dh_high_pass_int_conf_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                         lis3dh_hp_t *val);
 
-int32_t lis3dh_pin_int1_config_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_int1_config_set(stmdev_ctx_t *ctx,
                                      lis3dh_ctrl_reg3_t *val);
-int32_t lis3dh_pin_int1_config_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_int1_config_get(stmdev_ctx_t *ctx,
                                      lis3dh_ctrl_reg3_t *val);
 
-int32_t lis3dh_int2_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_int2_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_int2_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int2_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DH_INT2_PULSED   = 0,
   LIS3DH_INT2_LATCHED  = 1,
 } lis3dh_lir_int2_t;
-int32_t lis3dh_int2_pin_notification_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis3dh_lir_int2_t val);
-int32_t lis3dh_int2_pin_notification_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int2_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis3dh_lir_int2_t *val);
 
-int32_t lis3dh_int1_pin_detect_4d_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_int1_pin_detect_4d_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DH_INT1_PULSED   = 0,
   LIS3DH_INT1_LATCHED  = 1,
 } lis3dh_lir_int1_t;
-int32_t lis3dh_int1_pin_notification_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                 lis3dh_lir_int1_t val);
-int32_t lis3dh_int1_pin_notification_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_int1_pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lis3dh_lir_int1_t *val);
 
-int32_t lis3dh_pin_int2_config_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_int2_config_set(stmdev_ctx_t *ctx,
                                      lis3dh_ctrl_reg6_t *val);
-int32_t lis3dh_pin_int2_config_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_int2_config_get(stmdev_ctx_t *ctx,
                                      lis3dh_ctrl_reg6_t *val);
 
-int32_t lis3dh_fifo_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_fifo_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_fifo_watermark_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_fifo_watermark_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DH_INT1_GEN = 0,
   LIS3DH_INT2_GEN = 1,
 } lis3dh_tr_t;
-int32_t lis3dh_fifo_trigger_event_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lis3dh_tr_t val);
-int32_t lis3dh_fifo_trigger_event_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                         lis3dh_tr_t *val);
 
 typedef enum {
@@ -695,68 +667,68 @@ typedef enum {
   LIS3DH_DYNAMIC_STREAM_MODE   = 2,
   LIS3DH_STREAM_TO_FIFO_MODE   = 3,
 } lis3dh_fm_t;
-int32_t lis3dh_fifo_mode_set(lis3dh_ctx_t *ctx, lis3dh_fm_t val);
-int32_t lis3dh_fifo_mode_get(lis3dh_ctx_t *ctx, lis3dh_fm_t *val);
+int32_t lis3dh_fifo_mode_set(stmdev_ctx_t *ctx, lis3dh_fm_t val);
+int32_t lis3dh_fifo_mode_get(stmdev_ctx_t *ctx, lis3dh_fm_t *val);
 
-int32_t lis3dh_fifo_status_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_fifo_status_get(stmdev_ctx_t *ctx,
                                  lis3dh_fifo_src_reg_t *val);
 
-int32_t lis3dh_fifo_data_level_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_fifo_empty_flag_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_fifo_ovr_flag_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_fifo_fth_flag_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_tap_conf_set(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val);
-int32_t lis3dh_tap_conf_get(lis3dh_ctx_t *ctx, lis3dh_click_cfg_t *val);
+int32_t lis3dh_tap_conf_set(stmdev_ctx_t *ctx, lis3dh_click_cfg_t *val);
+int32_t lis3dh_tap_conf_get(stmdev_ctx_t *ctx, lis3dh_click_cfg_t *val);
 
-int32_t lis3dh_tap_source_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_tap_source_get(stmdev_ctx_t *ctx,
                                 lis3dh_click_src_t *val);
 
-int32_t lis3dh_tap_threshold_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_tap_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DH_TAP_PULSED   = 0,
   LIS3DH_TAP_LATCHED  = 1,
 } lis3dh_lir_click_t;
-int32_t lis3dh_tap_notification_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_tap_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis3dh_lir_click_t val);
-int32_t lis3dh_tap_notification_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_tap_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis3dh_lir_click_t *val);
 
-int32_t lis3dh_shock_dur_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_shock_dur_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_quiet_dur_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_quiet_dur_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_double_tap_timeout_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_double_tap_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_act_threshold_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_act_threshold_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dh_act_timeout_set(lis3dh_ctx_t *ctx, uint8_t val);
-int32_t lis3dh_act_timeout_get(lis3dh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dh_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dh_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DH_PULL_UP_DISCONNECT  = 0,
   LIS3DH_PULL_UP_CONNECT     = 1,
 } lis3dh_sdo_pu_disc_t;
-int32_t lis3dh_pin_sdo_sa0_mode_set(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                       lis3dh_sdo_pu_disc_t val);
-int32_t lis3dh_pin_sdo_sa0_mode_get(lis3dh_ctx_t *ctx,
+int32_t lis3dh_pin_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                       lis3dh_sdo_pu_disc_t *val);
 
 typedef enum {
   LIS3DH_SPI_4_WIRE = 0,
   LIS3DH_SPI_3_WIRE = 1,
 } lis3dh_sim_t;
-int32_t lis3dh_spi_mode_set(lis3dh_ctx_t *ctx, lis3dh_sim_t val);
-int32_t lis3dh_spi_mode_get(lis3dh_ctx_t *ctx, lis3dh_sim_t *val);
+int32_t lis3dh_spi_mode_set(stmdev_ctx_t *ctx, lis3dh_sim_t val);
+int32_t lis3dh_spi_mode_get(stmdev_ctx_t *ctx, lis3dh_sim_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.c
+++ b/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.c
@@ -1,37 +1,20 @@
 /*
  ******************************************************************************
  * @file    lis3dhh_reg.c
- * @author  Sensor Solutions Software Team
+ * @author  Sensors Software Solution Team
  * @brief   LIS3DHH driver file
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis3dhh_reg.h"
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dhh_read_reg(lis3dhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis3dhh_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lis3dhh_read_reg(lis3dhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3dhh_write_reg(lis3dhh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis3dhh_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -132,7 +115,7 @@ float_t lis3dhh_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_block_data_update_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -154,7 +137,7 @@ int32_t lis3dhh_block_data_update_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_block_data_update_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -173,7 +156,7 @@ int32_t lis3dhh_block_data_update_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_data_rate_set(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t val)
+int32_t lis3dhh_data_rate_set(stmdev_ctx_t *ctx, lis3dhh_norm_mod_en_t val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -195,7 +178,7 @@ int32_t lis3dhh_data_rate_set(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_data_rate_get(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t *val)
+int32_t lis3dhh_data_rate_get(stmdev_ctx_t *ctx, lis3dhh_norm_mod_en_t *val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -218,47 +201,6 @@ int32_t lis3dhh_data_rate_get(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t *val)
 }
 
 /**
-  * @brief  Offset temperature compensation enable.[set]
-  *
-  * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Change the values of off_tcomp_en in reg CTRL_REG4
-  * @retval        Interface status (MANDATORY: return 0 -> no Error).
-  *
-  */
-int32_t lis3dhh_offset_temp_comp_set(lis3dhh_ctx_t *ctx, uint8_t val)
-{
-  lis3dhh_ctrl_reg4_t ctrl_reg4;
-  int32_t ret;
-
-  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
-  if(ret == 0){
-    ctrl_reg4.off_tcomp_en = val;
-    ret = lis3dhh_write_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
-  }
-
-  return ret;
-}
-
-/**
-  * @brief  Offset temperature compensation enable.[get]
-  *
-  * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Get the values of off_tcomp_en in reg CTRL_REG4.(ptr)
-  * @retval        Interface status (MANDATORY: return 0 -> no Error).
-  *
-  */
-int32_t lis3dhh_offset_temp_comp_get(lis3dhh_ctx_t *ctx, uint8_t *val)
-{
-  lis3dhh_ctrl_reg4_t ctrl_reg4;
-  int32_t ret;
-
-  ret = lis3dhh_read_reg(ctx, LIS3DHH_CTRL_REG4, (uint8_t*)&ctrl_reg4, 1);
-  *val = ctrl_reg4.off_tcomp_en;
-
-  return ret;
-}
-
-/**
   * @brief  Temperature output value.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
@@ -266,7 +208,7 @@ int32_t lis3dhh_offset_temp_comp_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_temperature_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dhh_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dhh_read_reg(ctx, LIS3DHH_OUT_TEMP_L, buff, 2);
@@ -281,7 +223,7 @@ int32_t lis3dhh_temperature_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_acceleration_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dhh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dhh_read_reg(ctx, LIS3DHH_OUT_X_L_XL, buff, 6);
@@ -296,7 +238,7 @@ int32_t lis3dhh_acceleration_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_xl_data_ready_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_status_t status;
   int32_t ret;
@@ -315,7 +257,7 @@ int32_t lis3dhh_xl_data_ready_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_xl_data_ovr_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_status_t status;
   int32_t ret;
@@ -346,40 +288,10 @@ int32_t lis3dhh_xl_data_ovr_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_device_id_get(lis3dhh_ctx_t *ctx, uint8_t *buff)
+int32_t lis3dhh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3dhh_read_reg(ctx, LIS3DHH_WHO_AM_I, buff, 1);
-  return ret;
-}
-
-/**
-  * @brief  Asic identification.[get]
-  *
-  * @param  ctx    Read / write interface definitions.(ptr)
-  * @param  val    Get the values of asic_id in reg ID_REG.(ptr)
-  * @retval        Interface status (MANDATORY: return 0 -> no Error).
-  *
-  */
-int32_t lis3dhh_asic_id_get(lis3dhh_ctx_t *ctx, lis3dhh_asic_id_t *val)
-{
-  lis3dhh_id_reg_t id_reg;
-  int32_t ret;
-
-  ret = lis3dhh_read_reg(ctx, LIS3DHH_ID_REG, (uint8_t*)&id_reg, 1);
-
-  switch (id_reg.asic_id){
-    case LIS3DHH_VER_A:
-      *val = LIS3DHH_VER_A;
-      break;
-    case LIS3DHH_VER_B:
-      *val = LIS3DHH_VER_B;
-      break;
-    default:
-      *val = LIS3DHH_VER_A;
-      break;
-  }
-
   return ret;
 }
 
@@ -391,7 +303,7 @@ int32_t lis3dhh_asic_id_get(lis3dhh_ctx_t *ctx, lis3dhh_asic_id_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_reset_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -413,7 +325,7 @@ int32_t lis3dhh_reset_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_reset_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -432,7 +344,7 @@ int32_t lis3dhh_reset_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_boot_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -454,7 +366,7 @@ int32_t lis3dhh_boot_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_boot_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -473,7 +385,7 @@ int32_t lis3dhh_boot_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_self_test_set(lis3dhh_ctx_t *ctx, lis3dhh_st_t val)
+int32_t lis3dhh_self_test_set(stmdev_ctx_t *ctx, lis3dhh_st_t val)
 {
   lis3dhh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -495,7 +407,7 @@ int32_t lis3dhh_self_test_set(lis3dhh_ctx_t *ctx, lis3dhh_st_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_self_test_get(lis3dhh_ctx_t *ctx, lis3dhh_st_t *val)
+int32_t lis3dhh_self_test_get(stmdev_ctx_t *ctx, lis3dhh_st_t *val)
 {
   lis3dhh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -528,7 +440,7 @@ int32_t lis3dhh_self_test_get(lis3dhh_ctx_t *ctx, lis3dhh_st_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_filter_config_set(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t val)
+int32_t lis3dhh_filter_config_set(stmdev_ctx_t *ctx, lis3dhh_dsp_t val)
 {
   lis3dhh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -550,7 +462,7 @@ int32_t lis3dhh_filter_config_set(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_filter_config_get(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t *val)
+int32_t lis3dhh_filter_config_get(stmdev_ctx_t *ctx, lis3dhh_dsp_t *val)
 {
   lis3dhh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -586,7 +498,7 @@ int32_t lis3dhh_filter_config_get(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_status_get(lis3dhh_ctx_t *ctx, lis3dhh_status_t *val)
+int32_t lis3dhh_status_get(stmdev_ctx_t *ctx, lis3dhh_status_t *val)
 {
   int32_t ret;
   ret = lis3dhh_read_reg(ctx, LIS3DHH_STATUS, (uint8_t*) val, 1);
@@ -613,7 +525,7 @@ int32_t lis3dhh_status_get(lis3dhh_ctx_t *ctx, lis3dhh_status_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_drdy_notification_mode_set(lis3dhh_ctx_t *ctx,
+int32_t lis3dhh_drdy_notification_mode_set(stmdev_ctx_t *ctx,
                                             lis3dhh_drdy_pulse_t val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
@@ -636,7 +548,7 @@ int32_t lis3dhh_drdy_notification_mode_set(lis3dhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_drdy_notification_mode_get(lis3dhh_ctx_t *ctx,
+int32_t lis3dhh_drdy_notification_mode_get(stmdev_ctx_t *ctx,
                                             lis3dhh_drdy_pulse_t *val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
@@ -668,7 +580,7 @@ int32_t lis3dhh_drdy_notification_mode_get(lis3dhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_int1_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t val)
+int32_t lis3dhh_int1_mode_set(stmdev_ctx_t *ctx, lis3dhh_int1_ext_t val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -691,7 +603,7 @@ int32_t lis3dhh_int1_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_int1_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t *val)
+int32_t lis3dhh_int1_mode_get(stmdev_ctx_t *ctx, lis3dhh_int1_ext_t *val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -721,7 +633,7 @@ int32_t lis3dhh_int1_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_threshold_on_int1_set(lis3dhh_ctx_t *ctx,
+int32_t lis3dhh_fifo_threshold_on_int1_set(stmdev_ctx_t *ctx,
                                            uint8_t val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
@@ -744,7 +656,7 @@ int32_t lis3dhh_fifo_threshold_on_int1_set(lis3dhh_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_threshold_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_threshold_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -763,7 +675,7 @@ int32_t lis3dhh_fifo_threshold_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_full_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_fifo_full_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -785,7 +697,7 @@ int32_t lis3dhh_fifo_full_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_full_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_full_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -804,7 +716,7 @@ int32_t lis3dhh_fifo_full_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_ovr_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_fifo_ovr_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -826,7 +738,7 @@ int32_t lis3dhh_fifo_ovr_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_ovr_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_ovr_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -845,7 +757,7 @@ int32_t lis3dhh_fifo_ovr_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_boot_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_boot_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -867,7 +779,7 @@ int32_t lis3dhh_boot_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_boot_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_boot_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -886,7 +798,7 @@ int32_t lis3dhh_boot_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_drdy_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -908,7 +820,7 @@ int32_t lis3dhh_drdy_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_drdy_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int1_ctrl_t int1_ctrl;
   int32_t ret;
@@ -927,7 +839,7 @@ int32_t lis3dhh_drdy_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_threshold_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_fifo_threshold_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -949,7 +861,7 @@ int32_t lis3dhh_fifo_threshold_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_threshold_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_threshold_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -968,7 +880,7 @@ int32_t lis3dhh_fifo_threshold_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_full_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_fifo_full_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -990,7 +902,7 @@ int32_t lis3dhh_fifo_full_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_full_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_full_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -1009,7 +921,7 @@ int32_t lis3dhh_fifo_full_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_ovr_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_fifo_ovr_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -1031,7 +943,7 @@ int32_t lis3dhh_fifo_ovr_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_ovr_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_ovr_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -1050,7 +962,7 @@ int32_t lis3dhh_fifo_ovr_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_boot_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_boot_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -1072,7 +984,7 @@ int32_t lis3dhh_boot_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_boot_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_boot_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -1091,7 +1003,7 @@ int32_t lis3dhh_boot_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_drdy_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -1113,7 +1025,7 @@ int32_t lis3dhh_drdy_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_drdy_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_int2_ctrl_t int2_ctrl;
   int32_t ret;
@@ -1132,7 +1044,7 @@ int32_t lis3dhh_drdy_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_pin_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t val)
+int32_t lis3dhh_pin_mode_set(stmdev_ctx_t *ctx, lis3dhh_pp_od_t val)
 {
   lis3dhh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -1154,7 +1066,7 @@ int32_t lis3dhh_pin_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_pin_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t *val)
+int32_t lis3dhh_pin_mode_get(stmdev_ctx_t *ctx, lis3dhh_pp_od_t *val)
 {
   lis3dhh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -1203,7 +1115,7 @@ int32_t lis3dhh_pin_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -1225,7 +1137,7 @@ int32_t lis3dhh_fifo_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -1247,7 +1159,7 @@ int32_t lis3dhh_fifo_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_block_spi_hs_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_fifo_block_spi_hs_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1272,7 +1184,7 @@ int32_t lis3dhh_fifo_block_spi_hs_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_block_spi_hs_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_block_spi_hs_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -1291,7 +1203,7 @@ int32_t lis3dhh_fifo_block_spi_hs_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_watermark_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1313,7 +1225,7 @@ int32_t lis3dhh_fifo_watermark_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_watermark_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1332,7 +1244,7 @@ int32_t lis3dhh_fifo_watermark_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t val)
+int32_t lis3dhh_fifo_mode_set(stmdev_ctx_t *ctx, lis3dhh_fmode_t val)
 {
   lis3dhh_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1354,7 +1266,7 @@ int32_t lis3dhh_fifo_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t *val)
+int32_t lis3dhh_fifo_mode_get(stmdev_ctx_t *ctx, lis3dhh_fmode_t *val)
 {
   lis3dhh_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1393,7 +1305,7 @@ int32_t lis3dhh_fifo_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_status_get(lis3dhh_ctx_t *ctx, lis3dhh_fifo_src_t *val)
+int32_t lis3dhh_fifo_status_get(stmdev_ctx_t *ctx, lis3dhh_fifo_src_t *val)
 {
   int32_t ret;
   ret = lis3dhh_read_reg(ctx, LIS3DHH_FIFO_SRC, (uint8_t*) val, 1);
@@ -1408,7 +1320,7 @@ int32_t lis3dhh_fifo_status_get(lis3dhh_ctx_t *ctx, lis3dhh_fifo_src_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_full_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_fifo_src_t fifo_src;
   int32_t ret;
@@ -1427,7 +1339,7 @@ int32_t lis3dhh_fifo_full_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_ovr_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_fifo_src_t fifo_src;
   int32_t ret;
@@ -1446,7 +1358,7 @@ int32_t lis3dhh_fifo_ovr_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_fifo_fth_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_fifo_src_t fifo_src;
   int32_t ret;
@@ -1479,7 +1391,7 @@ int32_t lis3dhh_fifo_fth_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_auto_add_inc_set(lis3dhh_ctx_t *ctx, uint8_t val)
+int32_t lis3dhh_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -1502,7 +1414,7 @@ int32_t lis3dhh_auto_add_inc_set(lis3dhh_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lis3dhh_auto_add_inc_get(lis3dhh_ctx_t *ctx, uint8_t *val)
+int32_t lis3dhh_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3dhh_ctrl_reg1_t ctrl_reg1;
   int32_t ret;

--- a/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.h
+++ b/sensor/stmemsc/lis3dhh_STdC/driver/lis3dhh_reg.h
@@ -1,38 +1,21 @@
 /*
  ******************************************************************************
- * @file    li3dhh_reg.h
+ * @file    lis3dhh_reg.h
  * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
- *          li3dhh_reg.c driver.
+ *          lis3dhh_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LIS3DHH_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LIS3DHH_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis3dhh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis3dhh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis3dhh_write_ptr  write_reg;
-  lis3dhh_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis3dhh_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -156,12 +128,6 @@ typedef struct {
   */
 
 #define LIS3DHH_WHO_AM_I      0x0FU
-#define LIS3DHH_ID_REG        0x1BU
-typedef struct {
-  uint8_t not_used_01      : 7;
-  uint8_t asic_id          : 1;
-} lis3dhh_id_reg_t;
-
 #define LIS3DHH_CTRL_REG1     0x20U
 typedef struct {
   uint8_t bdu              : 1;
@@ -196,7 +162,7 @@ typedef struct {
 
 #define LIS3DHH_CTRL_REG4     0x23U
 typedef struct {
-  uint8_t off_tcomp_en     : 1;
+  uint8_t not_used_01      : 1;
   uint8_t fifo_en          : 1;
   uint8_t pp_od            : 2;
   uint8_t st               : 2;
@@ -255,7 +221,6 @@ typedef struct {
   *
   */
 typedef union{
-  lis3dhh_id_reg_t       id_reg;
   lis3dhh_ctrl_reg1_t    ctrl_reg1;
   lis3dhh_int1_ctrl_t    int1_ctrl;
   lis3dhh_int2_ctrl_t    int2_ctrl;
@@ -273,55 +238,46 @@ typedef union{
   *
   */
 
-int32_t lis3dhh_read_reg(lis3dhh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis3dhh_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lis3dhh_write_reg(lis3dhh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis3dhh_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float_t lis3dhh_from_lsb_to_mg(int16_t lsb);
 extern float_t lis3dhh_from_lsb_to_celsius(int16_t lsb);
 
-int32_t lis3dhh_block_data_update_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_block_data_update_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DHH_POWER_DOWN  = 0,
   LIS3DHH_1kHz1       = 1,
 } lis3dhh_norm_mod_en_t;
-int32_t lis3dhh_data_rate_set(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t val);
-int32_t lis3dhh_data_rate_get(lis3dhh_ctx_t *ctx, lis3dhh_norm_mod_en_t *val);
+int32_t lis3dhh_data_rate_set(stmdev_ctx_t *ctx, lis3dhh_norm_mod_en_t val);
+int32_t lis3dhh_data_rate_get(stmdev_ctx_t *ctx, lis3dhh_norm_mod_en_t *val);
 
-int32_t lis3dhh_offset_temp_comp_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_offset_temp_comp_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dhh_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis3dhh_temperature_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff);
-int32_t lis3dhh_acceleration_raw_get(lis3dhh_ctx_t *ctx, uint8_t *buff);
+int32_t lis3dhh_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_xl_data_ready_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_xl_data_ovr_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis3dhh_device_id_get(lis3dhh_ctx_t *ctx, uint8_t *buff);
-typedef enum {
-  LIS3DHH_VER_A   = 0,
-  LIS3DHH_VER_B   = 1,
-} lis3dhh_asic_id_t;
-int32_t lis3dhh_asic_id_get(lis3dhh_ctx_t *ctx, lis3dhh_asic_id_t *val);
+int32_t lis3dhh_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-
-int32_t lis3dhh_reset_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_reset_get(lis3dhh_ctx_t *ctx, uint8_t *val);
-
-int32_t lis3dhh_boot_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_boot_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DHH_ST_DISABLE   = 0,
   LIS3DHH_ST_POSITIVE  = 1,
   LIS3DHH_ST_NEGATIVE  = 2,
 } lis3dhh_st_t;
-int32_t lis3dhh_self_test_set(lis3dhh_ctx_t *ctx, lis3dhh_st_t val);
-int32_t lis3dhh_self_test_get(lis3dhh_ctx_t *ctx, lis3dhh_st_t *val);
+int32_t lis3dhh_self_test_set(stmdev_ctx_t *ctx, lis3dhh_st_t val);
+int32_t lis3dhh_self_test_get(stmdev_ctx_t *ctx, lis3dhh_st_t *val);
 
 typedef enum {
   LIS3DHH_LINEAR_PHASE_440Hz      = 0,
@@ -329,18 +285,18 @@ typedef enum {
   LIS3DHH_NO_LINEAR_PHASE_440Hz   = 2,
   LIS3DHH_NO_LINEAR_PHASE_235Hz   = 3,
 } lis3dhh_dsp_t;
-int32_t lis3dhh_filter_config_set(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t val);
-int32_t lis3dhh_filter_config_get(lis3dhh_ctx_t *ctx, lis3dhh_dsp_t *val);
+int32_t lis3dhh_filter_config_set(stmdev_ctx_t *ctx, lis3dhh_dsp_t val);
+int32_t lis3dhh_filter_config_get(stmdev_ctx_t *ctx, lis3dhh_dsp_t *val);
 
-int32_t lis3dhh_status_get(lis3dhh_ctx_t *ctx, lis3dhh_status_t *val);
+int32_t lis3dhh_status_get(stmdev_ctx_t *ctx, lis3dhh_status_t *val);
 
 typedef enum {
   LIS3DHH_LATCHED  = 0,
   LIS3DHH_PULSED   = 1,
 } lis3dhh_drdy_pulse_t;
-int32_t lis3dhh_drdy_notification_mode_set(lis3dhh_ctx_t *ctx,
+int32_t lis3dhh_drdy_notification_mode_set(stmdev_ctx_t *ctx,
                                            lis3dhh_drdy_pulse_t val);
-int32_t lis3dhh_drdy_notification_mode_get(lis3dhh_ctx_t *ctx,
+int32_t lis3dhh_drdy_notification_mode_get(stmdev_ctx_t *ctx,
                                            lis3dhh_drdy_pulse_t *val);
 
 
@@ -348,39 +304,39 @@ typedef enum {
   LIS3DHH_PIN_AS_INTERRUPT   = 0,
   LIS3DHH_PIN_AS_TRIGGER     = 1,
 } lis3dhh_int1_ext_t;
-int32_t lis3dhh_int1_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t val);
-int32_t lis3dhh_int1_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_int1_ext_t *val);
+int32_t lis3dhh_int1_mode_set(stmdev_ctx_t *ctx, lis3dhh_int1_ext_t val);
+int32_t lis3dhh_int1_mode_get(stmdev_ctx_t *ctx, lis3dhh_int1_ext_t *val);
 
 
-int32_t lis3dhh_fifo_threshold_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_threshold_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_threshold_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_threshold_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_full_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_full_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_full_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_full_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_ovr_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_ovr_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_ovr_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_ovr_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_boot_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_boot_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_boot_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_boot_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_drdy_on_int1_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_drdy_on_int1_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_threshold_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_threshold_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_threshold_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_threshold_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_full_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_full_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_full_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_full_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_ovr_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_ovr_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_ovr_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_ovr_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_boot_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_boot_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_boot_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_boot_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_drdy_on_int2_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_drdy_on_int2_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DHH_ALL_PUSH_PULL    = 0,
@@ -388,17 +344,17 @@ typedef enum {
   LIS3DHH_INT1_PP_INT2_OD  = 2,
   LIS3DHH_ALL_OPEN_DRAIN   = 3,
 } lis3dhh_pp_od_t;
-int32_t lis3dhh_pin_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t val);
-int32_t lis3dhh_pin_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_pp_od_t *val);
+int32_t lis3dhh_pin_mode_set(stmdev_ctx_t *ctx, lis3dhh_pp_od_t val);
+int32_t lis3dhh_pin_mode_get(stmdev_ctx_t *ctx, lis3dhh_pp_od_t *val);
 
-int32_t lis3dhh_fifo_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_block_spi_hs_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_block_spi_hs_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_block_spi_hs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_block_spi_hs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_watermark_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_fifo_watermark_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LIS3DHH_BYPASS_MODE             = 0,
@@ -407,19 +363,19 @@ typedef enum {
   LIS3DHH_BYPASS_TO_STREAM_MODE   = 4,
   LIS3DHH_DYNAMIC_STREAM_MODE     = 6,
 } lis3dhh_fmode_t;
-int32_t lis3dhh_fifo_mode_set(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t val);
-int32_t lis3dhh_fifo_mode_get(lis3dhh_ctx_t *ctx, lis3dhh_fmode_t *val);
+int32_t lis3dhh_fifo_mode_set(stmdev_ctx_t *ctx, lis3dhh_fmode_t val);
+int32_t lis3dhh_fifo_mode_get(stmdev_ctx_t *ctx, lis3dhh_fmode_t *val);
 
-int32_t lis3dhh_fifo_status_get(lis3dhh_ctx_t *ctx, lis3dhh_fifo_src_t *val);
+int32_t lis3dhh_fifo_status_get(stmdev_ctx_t *ctx, lis3dhh_fifo_src_t *val);
 
-int32_t lis3dhh_fifo_full_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_ovr_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_fifo_fth_flag_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3dhh_auto_add_inc_set(lis3dhh_ctx_t *ctx, uint8_t val);
-int32_t lis3dhh_auto_add_inc_get(lis3dhh_ctx_t *ctx, uint8_t *val);
+int32_t lis3dhh_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3dhh_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/lis3mdl_STdC/driver/lis3mdl_reg.c
+++ b/sensor/stmemsc/lis3mdl_STdC/driver/lis3mdl_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions 
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright 
- *      notice, this list of conditions and the following disclaimer in the 
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its 
- *      contributors may be used to endorse or promote products derived from 
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lis3mdl_reg.h"
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_read_reg(lis3mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis3mdl_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lis3mdl_read_reg(lis3mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_write_reg(lis3mdl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lis3mdl_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -147,7 +130,7 @@ float lis3mdl_from_lsb_to_celsius(int16_t lsb)
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_data_rate_set(lis3mdl_ctx_t *ctx, lis3mdl_om_t val)
+int32_t lis3mdl_data_rate_set(stmdev_ctx_t *ctx, lis3mdl_om_t val)
 {
   lis3mdl_ctrl_reg1_t ctrl_reg1;
   lis3mdl_ctrl_reg4_t ctrl_reg4;
@@ -184,7 +167,7 @@ int32_t lis3mdl_data_rate_set(lis3mdl_ctx_t *ctx, lis3mdl_om_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_data_rate_get(lis3mdl_ctx_t *ctx, lis3mdl_om_t *val)
+int32_t lis3mdl_data_rate_get(stmdev_ctx_t *ctx, lis3mdl_om_t *val)
 {
   lis3mdl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -308,7 +291,7 @@ int32_t lis3mdl_data_rate_get(lis3mdl_ctx_t *ctx, lis3mdl_om_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_temperature_meas_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_temperature_meas_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -330,7 +313,7 @@ int32_t lis3mdl_temperature_meas_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_temperature_meas_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_temperature_meas_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -349,7 +332,7 @@ int32_t lis3mdl_temperature_meas_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_full_scale_set(lis3mdl_ctx_t *ctx, lis3mdl_fs_t val)
+int32_t lis3mdl_full_scale_set(stmdev_ctx_t *ctx, lis3mdl_fs_t val)
 {
   lis3mdl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -371,7 +354,7 @@ int32_t lis3mdl_full_scale_set(lis3mdl_ctx_t *ctx, lis3mdl_fs_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_full_scale_get(lis3mdl_ctx_t *ctx, lis3mdl_fs_t *val)
+int32_t lis3mdl_full_scale_get(stmdev_ctx_t *ctx, lis3mdl_fs_t *val)
 {
   lis3mdl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -407,7 +390,7 @@ int32_t lis3mdl_full_scale_get(lis3mdl_ctx_t *ctx, lis3mdl_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_operating_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_md_t val)
+int32_t lis3mdl_operating_mode_set(stmdev_ctx_t *ctx, lis3mdl_md_t val)
 {
   lis3mdl_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -430,7 +413,7 @@ int32_t lis3mdl_operating_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_md_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_operating_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_md_t *val)
+int32_t lis3mdl_operating_mode_get(stmdev_ctx_t *ctx, lis3mdl_md_t *val)
 {
   lis3mdl_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -462,7 +445,7 @@ int32_t lis3mdl_operating_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_fast_low_power_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_fast_low_power_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -484,7 +467,7 @@ int32_t lis3mdl_fast_low_power_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_fast_low_power_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_fast_low_power_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -503,7 +486,7 @@ int32_t lis3mdl_fast_low_power_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_block_data_update_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -525,7 +508,7 @@ int32_t lis3mdl_block_data_update_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_block_data_update_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -545,7 +528,7 @@ int32_t lis3mdl_block_data_update_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_high_part_cycle_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_high_part_cycle_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -569,7 +552,7 @@ int32_t lis3mdl_high_part_cycle_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_high_part_cycle_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_high_part_cycle_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_ctrl_reg5_t ctrl_reg5;
   int32_t ret;
@@ -588,7 +571,7 @@ int32_t lis3mdl_high_part_cycle_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_mag_data_ready_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_mag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_status_reg_t status_reg;
   int32_t ret;
@@ -607,7 +590,7 @@ int32_t lis3mdl_mag_data_ready_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_mag_data_ovr_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_mag_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_status_reg_t status_reg;
   int32_t ret;
@@ -625,7 +608,7 @@ int32_t lis3mdl_mag_data_ovr_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_magnetic_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis3mdl_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lis3mdl_read_reg(ctx, LIS3MDL_OUT_X_L, (uint8_t*) buff, 6);
@@ -639,7 +622,7 @@ int32_t lis3mdl_magnetic_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_temperature_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis3mdl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;  
   ret = lis3mdl_read_reg(ctx, LIS3MDL_TEMP_OUT_L, (uint8_t*) buff, 2);
@@ -665,7 +648,7 @@ int32_t lis3mdl_temperature_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_device_id_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis3mdl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;  
   ret = lis3mdl_read_reg(ctx, LIS3MDL_WHO_AM_I, (uint8_t*) buff, 1);
@@ -679,7 +662,7 @@ int32_t lis3mdl_device_id_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_self_test_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -701,7 +684,7 @@ int32_t lis3mdl_self_test_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_self_test_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -720,7 +703,7 @@ int32_t lis3mdl_self_test_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_reset_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -742,7 +725,7 @@ int32_t lis3mdl_reset_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_reset_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -761,7 +744,7 @@ int32_t lis3mdl_reset_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_boot_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -784,7 +767,7 @@ int32_t lis3mdl_boot_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_boot_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -803,7 +786,7 @@ int32_t lis3mdl_boot_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_data_format_set(lis3mdl_ctx_t *ctx, lis3mdl_ble_t val)
+int32_t lis3mdl_data_format_set(stmdev_ctx_t *ctx, lis3mdl_ble_t val)
 {
   lis3mdl_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -825,7 +808,7 @@ int32_t lis3mdl_data_format_set(lis3mdl_ctx_t *ctx, lis3mdl_ble_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_data_format_get(lis3mdl_ctx_t *ctx, lis3mdl_ble_t *val)
+int32_t lis3mdl_data_format_get(stmdev_ctx_t *ctx, lis3mdl_ble_t *val)
 {
   lis3mdl_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -854,7 +837,7 @@ int32_t lis3mdl_data_format_get(lis3mdl_ctx_t *ctx, lis3mdl_ble_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_status_get(lis3mdl_ctx_t *ctx, lis3mdl_status_reg_t *val)
+int32_t lis3mdl_status_get(stmdev_ctx_t *ctx, lis3mdl_status_reg_t *val)
 {
   return lis3mdl_read_reg(ctx, LIS3MDL_STATUS_REG, (uint8_t*) val, 1);
 }
@@ -878,7 +861,7 @@ int32_t lis3mdl_status_get(lis3mdl_ctx_t *ctx, lis3mdl_status_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_config_set(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val)
+int32_t lis3mdl_int_config_set(stmdev_ctx_t *ctx, lis3mdl_int_cfg_t *val)
 {
   return lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*) val, 1);
 }
@@ -891,7 +874,7 @@ int32_t lis3mdl_int_config_set(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_config_get(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val)
+int32_t lis3mdl_int_config_get(stmdev_ctx_t *ctx, lis3mdl_int_cfg_t *val)
 {
   return lis3mdl_read_reg(ctx, LIS3MDL_INT_CFG, (uint8_t*) val, 1);
 }
@@ -903,7 +886,7 @@ int32_t lis3mdl_int_config_get(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_generation_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_int_generation_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -926,7 +909,7 @@ int32_t lis3mdl_int_generation_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_generation_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -946,7 +929,7 @@ int32_t lis3mdl_int_generation_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_notification_mode_set(lis3mdl_ctx_t *ctx,
+int32_t lis3mdl_int_notification_mode_set(stmdev_ctx_t *ctx,
     lis3mdl_lir_t val)
 {
   lis3mdl_int_cfg_t int_cfg;
@@ -970,7 +953,7 @@ int32_t lis3mdl_int_notification_mode_set(lis3mdl_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_notification_mode_get(lis3mdl_ctx_t *ctx,
+int32_t lis3mdl_int_notification_mode_get(stmdev_ctx_t *ctx,
     lis3mdl_lir_t *val)
 {
   lis3mdl_int_cfg_t int_cfg;
@@ -1001,7 +984,7 @@ int32_t lis3mdl_int_notification_mode_get(lis3mdl_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_polarity_set(lis3mdl_ctx_t *ctx, lis3mdl_iea_t val)
+int32_t lis3mdl_int_polarity_set(stmdev_ctx_t *ctx, lis3mdl_iea_t val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -1024,7 +1007,7 @@ int32_t lis3mdl_int_polarity_set(lis3mdl_ctx_t *ctx, lis3mdl_iea_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_polarity_get(lis3mdl_ctx_t *ctx, lis3mdl_iea_t *val)
+int32_t lis3mdl_int_polarity_get(stmdev_ctx_t *ctx, lis3mdl_iea_t *val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -1053,7 +1036,7 @@ int32_t lis3mdl_int_polarity_get(lis3mdl_ctx_t *ctx, lis3mdl_iea_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_on_z_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_int_on_z_ax_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -1075,7 +1058,7 @@ int32_t lis3mdl_int_on_z_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_on_z_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_on_z_ax_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -1094,7 +1077,7 @@ int32_t lis3mdl_int_on_z_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_on_y_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_int_on_y_ax_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -1116,7 +1099,7 @@ int32_t lis3mdl_int_on_y_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_on_y_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_on_y_ax_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -1135,7 +1118,7 @@ int32_t lis3mdl_int_on_y_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_on_x_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
+int32_t lis3mdl_int_on_x_ax_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -1158,7 +1141,7 @@ int32_t lis3mdl_int_on_x_ax_set(lis3mdl_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_on_x_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_on_x_ax_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_cfg_t int_cfg;
   int32_t ret;
@@ -1177,7 +1160,7 @@ int32_t lis3mdl_int_on_x_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_source_get(lis3mdl_ctx_t *ctx, lis3mdl_int_src_t *val)
+int32_t lis3mdl_int_source_get(stmdev_ctx_t *ctx, lis3mdl_int_src_t *val)
 {
   return lis3mdl_read_reg(ctx, LIS3MDL_INT_SRC, (uint8_t*) val, 1);
 }
@@ -1190,7 +1173,7 @@ int32_t lis3mdl_int_source_get(lis3mdl_ctx_t *ctx, lis3mdl_int_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_interrupt_event_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_interrupt_event_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_src_t int_src;
   int32_t ret;
@@ -1209,7 +1192,7 @@ int32_t lis3mdl_interrupt_event_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_mag_over_range_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_mag_over_range_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_src_t int_src;
   int32_t ret;
@@ -1228,7 +1211,7 @@ int32_t lis3mdl_int_mag_over_range_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_neg_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_neg_z_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_src_t int_src;
   int32_t ret;
@@ -1247,7 +1230,7 @@ int32_t lis3mdl_int_neg_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_neg_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_neg_y_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_src_t int_src;
   int32_t ret;
@@ -1265,7 +1248,7 @@ int32_t lis3mdl_int_neg_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_neg_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_neg_x_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_src_t int_src;
   int32_t ret;
@@ -1283,7 +1266,7 @@ int32_t lis3mdl_int_neg_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_pos_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_pos_z_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_src_t int_src;
   int32_t ret;
@@ -1301,7 +1284,7 @@ int32_t lis3mdl_int_pos_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_pos_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_pos_y_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_src_t int_src;
   int32_t ret;
@@ -1319,7 +1302,7 @@ int32_t lis3mdl_int_pos_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_pos_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
+int32_t lis3mdl_int_pos_x_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lis3mdl_int_src_t int_src;
   int32_t ret;
@@ -1337,7 +1320,7 @@ int32_t lis3mdl_int_pos_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_threshold_set(lis3mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis3mdl_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   return lis3mdl_read_reg(ctx, LIS3MDL_INT_THS_L, buff, 2);
 }
@@ -1350,7 +1333,7 @@ int32_t lis3mdl_int_threshold_set(lis3mdl_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_int_threshold_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
+int32_t lis3mdl_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   return lis3mdl_read_reg(ctx, LIS3MDL_INT_THS_L, buff, 2);
 }
@@ -1375,7 +1358,7 @@ int32_t lis3mdl_int_threshold_get(lis3mdl_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_spi_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_sim_t val)
+int32_t lis3mdl_spi_mode_set(stmdev_ctx_t *ctx, lis3mdl_sim_t val)
 {
   lis3mdl_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1397,7 +1380,7 @@ int32_t lis3mdl_spi_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lis3mdl_spi_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_sim_t *val)
+int32_t lis3mdl_spi_mode_get(stmdev_ctx_t *ctx, lis3mdl_sim_t *val)
 {
   lis3mdl_ctrl_reg3_t ctrl_reg3;
   int32_t ret;

--- a/sensor/stmemsc/lis3mdl_STdC/driver/lis3mdl_reg.h
+++ b/sensor/stmemsc/lis3mdl_STdC/driver/lis3mdl_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions 
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright 
- *      notice, this list of conditions and the following disclaimer in the 
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its 
- *      contributors may be used to endorse or promote products derived from 
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -40,7 +23,7 @@
 #define LIS3MDL_REGS_H
 
 #ifdef __cplusplus
-extern "C" {
+  extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -52,50 +35,13 @@ extern "C" {
   *
   */
 
-/** @defgroup LIS3MDL_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LIS3MDL_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lis3mdl_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lis3mdl_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lis3mdl_write_ptr  write_reg;
-  lis3mdl_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lis3mdl_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -307,9 +279,9 @@ typedef union{
   *
   */
 
-int32_t lis3mdl_read_reg(lis3mdl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis3mdl_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lis3mdl_write_reg(lis3mdl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lis3mdl_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float lis3mdl_from_fs4_to_gauss(int16_t lsb);
@@ -358,11 +330,11 @@ typedef enum{
   LIS3MDL_UHP_80Hz      = 0x3E,
 
 } lis3mdl_om_t;
-int32_t lis3mdl_data_rate_set(lis3mdl_ctx_t *ctx, lis3mdl_om_t val);
-int32_t lis3mdl_data_rate_get(lis3mdl_ctx_t *ctx, lis3mdl_om_t *val);
+int32_t lis3mdl_data_rate_set(stmdev_ctx_t *ctx, lis3mdl_om_t val);
+int32_t lis3mdl_data_rate_get(stmdev_ctx_t *ctx, lis3mdl_om_t *val);
 
-int32_t lis3mdl_temperature_meas_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_temperature_meas_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_temperature_meas_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_temperature_meas_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum{
   LIS3MDL_4_GAUSS   = 0,
@@ -370,114 +342,114 @@ typedef enum{
   LIS3MDL_12_GAUSS  = 2,
   LIS3MDL_16_GAUSS  = 3,
 } lis3mdl_fs_t;
-int32_t lis3mdl_full_scale_set(lis3mdl_ctx_t *ctx, lis3mdl_fs_t val);
-int32_t lis3mdl_full_scale_get(lis3mdl_ctx_t *ctx, lis3mdl_fs_t *val);
+int32_t lis3mdl_full_scale_set(stmdev_ctx_t *ctx, lis3mdl_fs_t val);
+int32_t lis3mdl_full_scale_get(stmdev_ctx_t *ctx, lis3mdl_fs_t *val);
 
 typedef enum{
   LIS3MDL_CONTINUOUS_MODE  = 0,
   LIS3MDL_SINGLE_TRIGGER   = 1,
   LIS3MDL_POWER_DOWN       = 2,
 } lis3mdl_md_t;
-int32_t lis3mdl_operating_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_md_t val);
-int32_t lis3mdl_operating_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_md_t *val);
+int32_t lis3mdl_operating_mode_set(stmdev_ctx_t *ctx, lis3mdl_md_t val);
+int32_t lis3mdl_operating_mode_get(stmdev_ctx_t *ctx, lis3mdl_md_t *val);
 
-int32_t lis3mdl_fast_low_power_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_fast_low_power_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_fast_low_power_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_fast_low_power_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_block_data_update_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_block_data_update_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_high_part_cycle_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_high_part_cycle_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_high_part_cycle_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_high_part_cycle_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_mag_data_ready_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_mag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_mag_data_ovr_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_mag_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_magnetic_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis3mdl_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis3mdl_temperature_raw_get(lis3mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis3mdl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis3mdl_device_id_get(lis3mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis3mdl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lis3mdl_self_test_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_self_test_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_self_test_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_self_test_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_reset_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_reset_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_boot_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_boot_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum{
   LIS3MDL_LSB_AT_LOW_ADD  = 0,
   LIS3MDL_MSB_AT_LOW_ADD  = 1,
 } lis3mdl_ble_t;
-int32_t lis3mdl_data_format_set(lis3mdl_ctx_t *ctx, lis3mdl_ble_t val);
-int32_t lis3mdl_data_format_get(lis3mdl_ctx_t *ctx, lis3mdl_ble_t *val);
+int32_t lis3mdl_data_format_set(stmdev_ctx_t *ctx, lis3mdl_ble_t val);
+int32_t lis3mdl_data_format_get(stmdev_ctx_t *ctx, lis3mdl_ble_t *val);
 
-int32_t lis3mdl_status_get(lis3mdl_ctx_t *ctx, lis3mdl_status_reg_t *val);
+int32_t lis3mdl_status_get(stmdev_ctx_t *ctx, lis3mdl_status_reg_t *val);
 
-int32_t lis3mdl_int_config_set(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val);
-int32_t lis3mdl_int_config_get(lis3mdl_ctx_t *ctx, lis3mdl_int_cfg_t *val);
+int32_t lis3mdl_int_config_set(stmdev_ctx_t *ctx, lis3mdl_int_cfg_t *val);
+int32_t lis3mdl_int_config_get(stmdev_ctx_t *ctx, lis3mdl_int_cfg_t *val);
 
-int32_t lis3mdl_int_generation_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_int_generation_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_generation_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum{
   LIS3MDL_INT_PULSED   = 0,
   LIS3MDL_INT_LATCHED  = 1,
 } lis3mdl_lir_t;
-int32_t lis3mdl_int_notification_mode_set(lis3mdl_ctx_t *ctx,
+int32_t lis3mdl_int_notification_mode_set(stmdev_ctx_t *ctx,
                                           lis3mdl_lir_t val);
-int32_t lis3mdl_int_notification_mode_get(lis3mdl_ctx_t *ctx,
+int32_t lis3mdl_int_notification_mode_get(stmdev_ctx_t *ctx,
                                           lis3mdl_lir_t *val);
 
 typedef enum{
   LIS3MDL_ACTIVE_HIGH  = 0,
   LIS3MDL_ACTIVE_LOW   = 1,
 } lis3mdl_iea_t;
-int32_t lis3mdl_int_polarity_set(lis3mdl_ctx_t *ctx, lis3mdl_iea_t val);
-int32_t lis3mdl_int_polarity_get(lis3mdl_ctx_t *ctx, lis3mdl_iea_t *val);
+int32_t lis3mdl_int_polarity_set(stmdev_ctx_t *ctx, lis3mdl_iea_t val);
+int32_t lis3mdl_int_polarity_get(stmdev_ctx_t *ctx, lis3mdl_iea_t *val);
 
-int32_t lis3mdl_int_on_z_ax_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_int_on_z_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_on_z_ax_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_int_on_z_ax_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_on_y_ax_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_int_on_y_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_on_y_ax_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_int_on_y_ax_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_on_x_ax_set(lis3mdl_ctx_t *ctx, uint8_t val);
-int32_t lis3mdl_int_on_x_ax_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_on_x_ax_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lis3mdl_int_on_x_ax_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_source_get(lis3mdl_ctx_t *ctx, lis3mdl_int_src_t *val);
+int32_t lis3mdl_int_source_get(stmdev_ctx_t *ctx, lis3mdl_int_src_t *val);
 
-int32_t lis3mdl_interrupt_event_flag_get(lis3mdl_ctx_t *ctx,
+int32_t lis3mdl_interrupt_event_flag_get(stmdev_ctx_t *ctx,
     uint8_t *val);
 
-int32_t lis3mdl_int_mag_over_range_flag_get(lis3mdl_ctx_t *ctx,
+int32_t lis3mdl_int_mag_over_range_flag_get(stmdev_ctx_t *ctx,
     uint8_t *val);
 
-int32_t lis3mdl_int_neg_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_neg_z_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_neg_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_neg_y_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_neg_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_neg_x_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_pos_z_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_pos_z_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_pos_y_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_pos_y_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_pos_x_flag_get(lis3mdl_ctx_t *ctx, uint8_t *val);
+int32_t lis3mdl_int_pos_x_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lis3mdl_int_threshold_set(lis3mdl_ctx_t *ctx, uint8_t *buff);
-int32_t lis3mdl_int_threshold_get(lis3mdl_ctx_t *ctx, uint8_t *buff);
+int32_t lis3mdl_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lis3mdl_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum{
   LIS3MDL_SPI_4_WIRE   = 0,
   LIS3MDL_SPI_3_WIRE   = 1,
 } lis3mdl_sim_t;
-int32_t lis3mdl_spi_mode_set(lis3mdl_ctx_t *ctx, lis3mdl_sim_t val);
-int32_t lis3mdl_spi_mode_get(lis3mdl_ctx_t *ctx, lis3mdl_sim_t *val);
+int32_t lis3mdl_spi_mode_set(stmdev_ctx_t *ctx, lis3mdl_sim_t val);
+int32_t lis3mdl_spi_mode_get(stmdev_ctx_t *ctx, lis3mdl_sim_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.c
+++ b/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lps22hb_reg.h"
@@ -62,7 +45,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hb_read_reg(lps22hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lps22hb_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -80,7 +63,7 @@ int32_t lps22hb_read_reg(lps22hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hb_write_reg(lps22hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lps22hb_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -100,7 +83,7 @@ int32_t lps22hb_write_reg(lps22hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
   *
   */
 
-float_t lps22hb_from_lsb_to_hpa(uint32_t lsb)
+float_t lps22hb_from_lsb_to_hpa(int32_t lsb)
 {
   return ( (float_t)lsb / 4096.0f );
 }
@@ -133,7 +116,7 @@ float_t lps22hb_from_lsb_to_degc(int16_t lsb)
   *
   */
 
-int32_t lps22hb_autozero_rst_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -156,7 +139,7 @@ int32_t lps22hb_autozero_rst_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_autozero_rst_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -176,7 +159,7 @@ int32_t lps22hb_autozero_rst_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_autozero_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_autozero_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -199,7 +182,7 @@ int32_t lps22hb_autozero_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_autozero_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_autozero_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -219,7 +202,7 @@ int32_t lps22hb_autozero_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_snap_rst_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -242,7 +225,7 @@ int32_t lps22hb_pressure_snap_rst_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_snap_rst_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -262,7 +245,7 @@ int32_t lps22hb_pressure_snap_rst_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_snap_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -285,7 +268,7 @@ int32_t lps22hb_pressure_snap_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_snap_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -305,7 +288,7 @@ int32_t lps22hb_pressure_snap_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_block_data_update_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -326,7 +309,7 @@ int32_t lps22hb_block_data_update_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_block_data_update_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -345,7 +328,7 @@ int32_t lps22hb_block_data_update_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_low_pass_filter_mode_set(lps22hb_ctx_t *ctx,
+int32_t lps22hb_low_pass_filter_mode_set(stmdev_ctx_t *ctx,
                                           lps22hb_lpfp_t val)
 {
   lps22hb_ctrl_reg1_t ctrl_reg1;
@@ -367,7 +350,7 @@ int32_t lps22hb_low_pass_filter_mode_set(lps22hb_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_low_pass_filter_mode_get(lps22hb_ctx_t *ctx,
+int32_t lps22hb_low_pass_filter_mode_get(stmdev_ctx_t *ctx,
                                          lps22hb_lpfp_t *val)
 {
   lps22hb_ctrl_reg1_t ctrl_reg1;
@@ -399,7 +382,7 @@ int32_t lps22hb_low_pass_filter_mode_get(lps22hb_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_data_rate_set(lps22hb_ctx_t *ctx, lps22hb_odr_t val)
+int32_t lps22hb_data_rate_set(stmdev_ctx_t *ctx, lps22hb_odr_t val)
 {
   lps22hb_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -420,7 +403,7 @@ int32_t lps22hb_data_rate_set(lps22hb_ctx_t *ctx, lps22hb_odr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_data_rate_get(lps22hb_ctx_t *ctx, lps22hb_odr_t *val)
+int32_t lps22hb_data_rate_get(stmdev_ctx_t *ctx, lps22hb_odr_t *val)
 {
   lps22hb_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -461,7 +444,7 @@ int32_t lps22hb_data_rate_get(lps22hb_ctx_t *ctx, lps22hb_odr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_one_shoot_trigger_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -482,7 +465,7 @@ int32_t lps22hb_one_shoot_trigger_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_one_shoot_trigger_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -503,7 +486,7 @@ int32_t lps22hb_one_shoot_trigger_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_ref_set(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_write_reg(ctx, LPS22HB_REF_P_XL, buff, 3);
@@ -520,7 +503,7 @@ int32_t lps22hb_pressure_ref_set(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_ref_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_REF_P_XL, buff, 3);
@@ -536,7 +519,7 @@ int32_t lps22hb_pressure_ref_get(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_offset_set(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_write_reg(ctx, LPS22HB_RPDS_L, buff, 2);
@@ -552,7 +535,7 @@ int32_t lps22hb_pressure_offset_set(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_offset_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_RPDS_L, buff, 2);
@@ -567,7 +550,7 @@ int32_t lps22hb_pressure_offset_get(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_press_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_press_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_status_t status;
   int32_t ret;
@@ -586,7 +569,7 @@ int32_t lps22hb_press_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_temp_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_status_t status;
   int32_t ret;
@@ -605,7 +588,7 @@ int32_t lps22hb_temp_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_press_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_press_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_status_t status;
   int32_t ret;
@@ -624,7 +607,7 @@ int32_t lps22hb_press_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_temp_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_status_t status;
   int32_t ret;
@@ -643,7 +626,7 @@ int32_t lps22hb_temp_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pressure_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_PRESS_OUT_XL, buff, 3);
@@ -658,7 +641,7 @@ int32_t lps22hb_pressure_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_temperature_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_TEMP_OUT_L, (uint8_t*) buff, 2);
@@ -676,7 +659,7 @@ int32_t lps22hb_temperature_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_low_pass_rst_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_low_pass_rst_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_LPFP_RES, (uint8_t*) buff, 1);
@@ -703,7 +686,7 @@ int32_t lps22hb_low_pass_rst_get(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_device_id_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_WHO_AM_I, (uint8_t*) buff, 1);
@@ -718,7 +701,7 @@ int32_t lps22hb_device_id_get(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_reset_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -739,7 +722,7 @@ int32_t lps22hb_reset_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_reset_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -758,7 +741,7 @@ int32_t lps22hb_reset_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_boot_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -779,7 +762,7 @@ int32_t lps22hb_boot_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_boot_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -798,7 +781,7 @@ int32_t lps22hb_boot_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_low_power_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_low_power_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_res_conf_t res_conf;
   int32_t ret;
@@ -819,7 +802,7 @@ int32_t lps22hb_low_power_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_low_power_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_low_power_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_res_conf_t res_conf;
   int32_t ret;
@@ -838,7 +821,7 @@ int32_t lps22hb_low_power_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_boot_status_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_boot_status_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_int_source_t int_source;
   int32_t ret;
@@ -857,7 +840,7 @@ int32_t lps22hb_boot_status_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_dev_status_get(lps22hb_ctx_t *ctx, lps22hb_dev_stat_t *val)
+int32_t lps22hb_dev_status_get(stmdev_ctx_t *ctx, lps22hb_dev_stat_t *val)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_FIFO_STATUS, (uint8_t*) val, 2);
@@ -884,7 +867,7 @@ int32_t lps22hb_dev_status_get(lps22hb_ctx_t *ctx, lps22hb_dev_stat_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_sign_of_int_threshold_set(lps22hb_ctx_t *ctx,
+int32_t lps22hb_sign_of_int_threshold_set(stmdev_ctx_t *ctx,
                                            lps22hb_pe_t val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
@@ -908,7 +891,7 @@ int32_t lps22hb_sign_of_int_threshold_set(lps22hb_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_sign_of_int_threshold_get(lps22hb_ctx_t *ctx,
+int32_t lps22hb_sign_of_int_threshold_get(stmdev_ctx_t *ctx,
                                            lps22hb_pe_t *val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
@@ -945,7 +928,7 @@ int32_t lps22hb_sign_of_int_threshold_get(lps22hb_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_notification_mode_set(lps22hb_ctx_t *ctx,
+int32_t lps22hb_int_notification_mode_set(stmdev_ctx_t *ctx,
                                            lps22hb_lir_t val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
@@ -970,7 +953,7 @@ int32_t lps22hb_int_notification_mode_set(lps22hb_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_notification_mode_get(lps22hb_ctx_t *ctx,
+int32_t lps22hb_int_notification_mode_get(stmdev_ctx_t *ctx,
                                           lps22hb_lir_t *val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
@@ -1000,7 +983,7 @@ int32_t lps22hb_int_notification_mode_get(lps22hb_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_generation_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_int_generation_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -1023,7 +1006,7 @@ int32_t lps22hb_int_generation_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_generation_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -1043,7 +1026,7 @@ int32_t lps22hb_int_generation_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_threshold_set(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_write_reg(ctx, LPS22HB_THS_P_L, (uint8_t*) buff, 2);
@@ -1058,7 +1041,7 @@ int32_t lps22hb_int_threshold_set(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_threshold_get(lps22hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hb_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_THS_P_L, (uint8_t*) buff, 2);
@@ -1073,7 +1056,7 @@ int32_t lps22hb_int_threshold_get(lps22hb_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_int_s_t val)
+int32_t lps22hb_int_pin_mode_set(stmdev_ctx_t *ctx, lps22hb_int_s_t val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1094,7 +1077,7 @@ int32_t lps22hb_int_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_int_s_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_int_s_t *val)
+int32_t lps22hb_int_pin_mode_get(stmdev_ctx_t *ctx, lps22hb_int_s_t *val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1128,7 +1111,7 @@ int32_t lps22hb_int_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_int_s_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_drdy_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1149,7 +1132,7 @@ int32_t lps22hb_drdy_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_drdy_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1168,7 +1151,7 @@ int32_t lps22hb_drdy_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_ovr_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1189,7 +1172,7 @@ int32_t lps22hb_fifo_ovr_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_ovr_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1208,7 +1191,7 @@ int32_t lps22hb_fifo_ovr_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_threshold_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1229,7 +1212,7 @@ int32_t lps22hb_fifo_threshold_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_threshold_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1248,7 +1231,7 @@ int32_t lps22hb_fifo_threshold_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_full_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1269,7 +1252,7 @@ int32_t lps22hb_fifo_full_on_int_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_full_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1288,7 +1271,7 @@ int32_t lps22hb_fifo_full_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_pp_od_t val)
+int32_t lps22hb_pin_mode_set(stmdev_ctx_t *ctx, lps22hb_pp_od_t val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1309,7 +1292,7 @@ int32_t lps22hb_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_pp_od_t *val)
+int32_t lps22hb_pin_mode_get(stmdev_ctx_t *ctx, lps22hb_pp_od_t *val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1337,7 +1320,7 @@ int32_t lps22hb_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_polarity_set(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t val)
+int32_t lps22hb_int_polarity_set(stmdev_ctx_t *ctx, lps22hb_int_h_l_t val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1358,7 +1341,7 @@ int32_t lps22hb_int_polarity_set(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_polarity_get(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t *val)
+int32_t lps22hb_int_polarity_get(stmdev_ctx_t *ctx, lps22hb_int_h_l_t *val)
 {
   lps22hb_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1386,7 +1369,7 @@ int32_t lps22hb_int_polarity_get(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_source_get(lps22hb_ctx_t *ctx, lps22hb_int_source_t *val)
+int32_t lps22hb_int_source_get(stmdev_ctx_t *ctx, lps22hb_int_source_t *val)
 {
   int32_t ret;
   ret =  lps22hb_read_reg(ctx, LPS22HB_INT_SOURCE, (uint8_t*) val, 1);
@@ -1401,7 +1384,7 @@ int32_t lps22hb_int_source_get(lps22hb_ctx_t *ctx, lps22hb_int_source_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_on_press_high_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_int_on_press_high_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_int_source_t int_source;
   int32_t ret;
@@ -1420,7 +1403,7 @@ int32_t lps22hb_int_on_press_high_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_int_on_press_low_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_int_on_press_low_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_int_source_t int_source;
   int32_t ret;
@@ -1439,7 +1422,7 @@ int32_t lps22hb_int_on_press_low_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_interrupt_event_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_interrupt_event_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_int_source_t int_source;
   int32_t ret;
@@ -1471,7 +1454,7 @@ int32_t lps22hb_interrupt_event_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_stop_on_fifo_threshold_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_stop_on_fifo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1492,7 +1475,7 @@ int32_t lps22hb_stop_on_fifo_threshold_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_stop_on_fifo_threshold_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_stop_on_fifo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1511,7 +1494,7 @@ int32_t lps22hb_stop_on_fifo_threshold_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1532,7 +1515,7 @@ int32_t lps22hb_fifo_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1551,7 +1534,7 @@ int32_t lps22hb_fifo_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_watermark_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1572,7 +1555,7 @@ int32_t lps22hb_fifo_watermark_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_watermark_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1591,7 +1574,7 @@ int32_t lps22hb_fifo_watermark_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_mode_set(lps22hb_ctx_t *ctx, lps22hb_f_mode_t val)
+int32_t lps22hb_fifo_mode_set(stmdev_ctx_t *ctx, lps22hb_f_mode_t val)
 {
   lps22hb_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1612,7 +1595,7 @@ int32_t lps22hb_fifo_mode_set(lps22hb_ctx_t *ctx, lps22hb_f_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_mode_get(lps22hb_ctx_t *ctx, lps22hb_f_mode_t *val)
+int32_t lps22hb_fifo_mode_get(stmdev_ctx_t *ctx, lps22hb_f_mode_t *val)
 {
   lps22hb_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1655,7 +1638,7 @@ int32_t lps22hb_fifo_mode_get(lps22hb_ctx_t *ctx, lps22hb_f_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_data_level_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_fifo_status_t fifo_status;
   int32_t ret;
@@ -1674,7 +1657,7 @@ int32_t lps22hb_fifo_data_level_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_ovr_flag_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_fifo_status_t fifo_status;
   int32_t ret;
@@ -1693,7 +1676,7 @@ int32_t lps22hb_fifo_ovr_flag_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_fifo_fth_flag_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_fifo_status_t fifo_status;
   int32_t ret;
@@ -1725,7 +1708,7 @@ int32_t lps22hb_fifo_fth_flag_get(lps22hb_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_spi_mode_set(lps22hb_ctx_t *ctx, lps22hb_sim_t val)
+int32_t lps22hb_spi_mode_set(stmdev_ctx_t *ctx, lps22hb_sim_t val)
 {
   lps22hb_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -1746,7 +1729,7 @@ int32_t lps22hb_spi_mode_set(lps22hb_ctx_t *ctx, lps22hb_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_spi_mode_get(lps22hb_ctx_t *ctx, lps22hb_sim_t *val)
+int32_t lps22hb_spi_mode_get(stmdev_ctx_t *ctx, lps22hb_sim_t *val)
 {
   lps22hb_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -1774,7 +1757,7 @@ int32_t lps22hb_spi_mode_get(lps22hb_ctx_t *ctx, lps22hb_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_i2c_interface_set(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t val)
+int32_t lps22hb_i2c_interface_set(stmdev_ctx_t *ctx, lps22hb_i2c_dis_t val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1795,7 +1778,7 @@ int32_t lps22hb_i2c_interface_set(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_i2c_interface_get(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t *val)
+int32_t lps22hb_i2c_interface_get(stmdev_ctx_t *ctx, lps22hb_i2c_dis_t *val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1824,7 +1807,7 @@ int32_t lps22hb_i2c_interface_get(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_auto_add_inc_set(lps22hb_ctx_t *ctx, uint8_t val)
+int32_t lps22hb_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1846,7 +1829,7 @@ int32_t lps22hb_auto_add_inc_set(lps22hb_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps22hb_auto_add_inc_get(lps22hb_ctx_t *ctx, uint8_t *val)
+int32_t lps22hb_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hb_ctrl_reg2_t ctrl_reg2;
   int32_t ret;

--- a/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.h
+++ b/sensor/stmemsc/lps22hb_STdC/driver/lps22hb_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef LPS22HB_REGS_H
 #define LPS22HB_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup LPS22HB_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LPS22HB_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -125,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lps22hb_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lps22hb_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lps22hb_write_ptr  write_reg;
-  lps22hb_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lps22hb_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -289,37 +262,37 @@ typedef union{
   *
   */
 
-int32_t lps22hb_read_reg(lps22hb_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lps22hb_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lps22hb_write_reg(lps22hb_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lps22hb_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
-extern float_t lps22hb_from_lsb_to_hpa(uint32_t lsb);
+extern float_t lps22hb_from_lsb_to_hpa(int32_t lsb);
 extern float_t lps22hb_from_lsb_to_degc(int16_t lsb);
 
-int32_t lps22hb_autozero_rst_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_autozero_rst_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_autozero_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_autozero_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_autozero_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_autozero_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_pressure_snap_rst_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_pressure_snap_rst_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_pressure_snap_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_pressure_snap_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_block_data_update_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_block_data_update_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS22HB_LPF_ODR_DIV_2  = 0,
   LPS22HB_LPF_ODR_DIV_9  = 2,
   LPS22HB_LPF_ODR_DIV_20 = 3,
 } lps22hb_lpfp_t;
-int32_t lps22hb_low_pass_filter_mode_set(lps22hb_ctx_t *ctx,
+int32_t lps22hb_low_pass_filter_mode_set(stmdev_ctx_t *ctx,
                                          lps22hb_lpfp_t val);
-int32_t lps22hb_low_pass_filter_mode_get(lps22hb_ctx_t *ctx,
+int32_t lps22hb_low_pass_filter_mode_get(stmdev_ctx_t *ctx,
                                          lps22hb_lpfp_t *val);
 
 typedef enum {
@@ -330,50 +303,50 @@ typedef enum {
   LPS22HB_ODR_50_Hz   = 4,
   LPS22HB_ODR_75_Hz   = 5,
 } lps22hb_odr_t;
-int32_t lps22hb_data_rate_set(lps22hb_ctx_t *ctx, lps22hb_odr_t val);
-int32_t lps22hb_data_rate_get(lps22hb_ctx_t *ctx, lps22hb_odr_t *val);
+int32_t lps22hb_data_rate_set(stmdev_ctx_t *ctx, lps22hb_odr_t val);
+int32_t lps22hb_data_rate_get(stmdev_ctx_t *ctx, lps22hb_odr_t *val);
 
-int32_t lps22hb_one_shoot_trigger_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_one_shoot_trigger_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_pressure_ref_set(lps22hb_ctx_t *ctx, uint8_t *buff);
-int32_t lps22hb_pressure_ref_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hb_pressure_offset_set(lps22hb_ctx_t *ctx, uint8_t *buff);
-int32_t lps22hb_pressure_offset_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hb_press_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_press_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_temp_data_ready_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_press_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_press_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_temp_data_ovr_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_pressure_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hb_temperature_raw_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hb_low_pass_rst_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_low_pass_rst_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hb_device_id_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hb_reset_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_reset_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_boot_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_boot_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_low_power_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_low_power_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_low_power_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_low_power_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_boot_status_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_boot_status_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct{
   lps22hb_fifo_status_t  fifo_status;
   lps22hb_status_t       status;
 } lps22hb_dev_stat_t;
-int32_t lps22hb_dev_status_get(lps22hb_ctx_t *ctx, lps22hb_dev_stat_t *val);
+int32_t lps22hb_dev_status_get(stmdev_ctx_t *ctx, lps22hb_dev_stat_t *val);
 
 typedef enum {
   LPS22HB_NO_THRESHOLD = 0,
@@ -381,25 +354,25 @@ typedef enum {
   LPS22HB_NEGATIVE     = 2,
   LPS22HB_BOTH         = 3,
 } lps22hb_pe_t;
-int32_t lps22hb_sign_of_int_threshold_set(lps22hb_ctx_t *ctx,
+int32_t lps22hb_sign_of_int_threshold_set(stmdev_ctx_t *ctx,
                                           lps22hb_pe_t val);
-int32_t lps22hb_sign_of_int_threshold_get(lps22hb_ctx_t *ctx,
+int32_t lps22hb_sign_of_int_threshold_get(stmdev_ctx_t *ctx,
                                           lps22hb_pe_t *val);
 
 typedef enum {
   LPS22HB_INT_PULSED  = 0,
   LPS22HB_INT_LATCHED = 1,
 } lps22hb_lir_t;
-int32_t lps22hb_int_notification_mode_set(lps22hb_ctx_t *ctx,
+int32_t lps22hb_int_notification_mode_set(stmdev_ctx_t *ctx,
                                           lps22hb_lir_t val);
-int32_t lps22hb_int_notification_mode_get(lps22hb_ctx_t *ctx,
+int32_t lps22hb_int_notification_mode_get(stmdev_ctx_t *ctx,
                                           lps22hb_lir_t *val);
 
-int32_t lps22hb_int_generation_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_int_generation_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_int_generation_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_int_threshold_set(lps22hb_ctx_t *ctx, uint8_t *buff);
-int32_t lps22hb_int_threshold_get(lps22hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hb_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LPS22HB_DRDY_OR_FIFO_FLAGS = 0,
@@ -407,51 +380,51 @@ typedef enum {
   LPS22HB_LOW_PRES_INT       = 2,
   LPS22HB_EVERY_PRES_INT     = 3,
 } lps22hb_int_s_t;
-int32_t lps22hb_int_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_int_s_t val);
-int32_t lps22hb_int_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_int_s_t *val);
+int32_t lps22hb_int_pin_mode_set(stmdev_ctx_t *ctx, lps22hb_int_s_t val);
+int32_t lps22hb_int_pin_mode_get(stmdev_ctx_t *ctx, lps22hb_int_s_t *val);
 
-int32_t lps22hb_drdy_on_int_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_drdy_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_fifo_ovr_on_int_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_fifo_ovr_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_fifo_threshold_on_int_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_fifo_threshold_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_fifo_full_on_int_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_fifo_full_on_int_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS22HB_PUSH_PULL  = 0,
   LPS22HB_OPEN_DRAIN = 1,
 } lps22hb_pp_od_t;
-int32_t lps22hb_pin_mode_set(lps22hb_ctx_t *ctx, lps22hb_pp_od_t val);
-int32_t lps22hb_pin_mode_get(lps22hb_ctx_t *ctx, lps22hb_pp_od_t *val);
+int32_t lps22hb_pin_mode_set(stmdev_ctx_t *ctx, lps22hb_pp_od_t val);
+int32_t lps22hb_pin_mode_get(stmdev_ctx_t *ctx, lps22hb_pp_od_t *val);
 
 typedef enum {
   LPS22HB_ACTIVE_HIGH = 0,
   LPS22HB_ACTIVE_LOW = 1,
 } lps22hb_int_h_l_t;
-int32_t lps22hb_int_polarity_set(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t val);
-int32_t lps22hb_int_polarity_get(lps22hb_ctx_t *ctx, lps22hb_int_h_l_t *val);
+int32_t lps22hb_int_polarity_set(stmdev_ctx_t *ctx, lps22hb_int_h_l_t val);
+int32_t lps22hb_int_polarity_get(stmdev_ctx_t *ctx, lps22hb_int_h_l_t *val);
 
-int32_t lps22hb_int_source_get(lps22hb_ctx_t *ctx, lps22hb_int_source_t *val);
+int32_t lps22hb_int_source_get(stmdev_ctx_t *ctx, lps22hb_int_source_t *val);
 
-int32_t lps22hb_int_on_press_high_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_int_on_press_high_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_int_on_press_low_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_int_on_press_low_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_interrupt_event_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_interrupt_event_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_stop_on_fifo_threshold_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_stop_on_fifo_threshold_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_stop_on_fifo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_stop_on_fifo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_fifo_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_fifo_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_fifo_watermark_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_fifo_watermark_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS22HB_BYPASS_MODE           = 0,
@@ -462,31 +435,31 @@ typedef enum {
   LPS22HB_DYNAMIC_STREAM_MODE   = 6,
   LPS22HB_BYPASS_TO_FIFO_MODE   = 7,
 } lps22hb_f_mode_t;
-int32_t lps22hb_fifo_mode_set(lps22hb_ctx_t *ctx, lps22hb_f_mode_t val);
-int32_t lps22hb_fifo_mode_get(lps22hb_ctx_t *ctx, lps22hb_f_mode_t *val);
+int32_t lps22hb_fifo_mode_set(stmdev_ctx_t *ctx, lps22hb_f_mode_t val);
+int32_t lps22hb_fifo_mode_get(stmdev_ctx_t *ctx, lps22hb_f_mode_t *val);
 
-int32_t lps22hb_fifo_data_level_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_fifo_ovr_flag_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hb_fifo_fth_flag_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS22HB_SPI_4_WIRE = 0,
   LPS22HB_SPI_3_WIRE = 1,
 } lps22hb_sim_t;
-int32_t lps22hb_spi_mode_set(lps22hb_ctx_t *ctx, lps22hb_sim_t val);
-int32_t lps22hb_spi_mode_get(lps22hb_ctx_t *ctx, lps22hb_sim_t *val);
+int32_t lps22hb_spi_mode_set(stmdev_ctx_t *ctx, lps22hb_sim_t val);
+int32_t lps22hb_spi_mode_get(stmdev_ctx_t *ctx, lps22hb_sim_t *val);
 
 typedef enum {
   LPS22HB_I2C_ENABLE = 0,
   LPS22HB_I2C_DISABLE = 1,
 } lps22hb_i2c_dis_t;
-int32_t lps22hb_i2c_interface_set(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t val);
-int32_t lps22hb_i2c_interface_get(lps22hb_ctx_t *ctx, lps22hb_i2c_dis_t *val);
+int32_t lps22hb_i2c_interface_set(stmdev_ctx_t *ctx, lps22hb_i2c_dis_t val);
+int32_t lps22hb_i2c_interface_get(stmdev_ctx_t *ctx, lps22hb_i2c_dis_t *val);
 
-int32_t lps22hb_auto_add_inc_set(lps22hb_ctx_t *ctx, uint8_t val);
-int32_t lps22hb_auto_add_inc_get(lps22hb_ctx_t *ctx, uint8_t *val);
+int32_t lps22hb_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hb_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.c
+++ b/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.c
@@ -6,33 +6,16 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 #include "lps22hh_reg.h"
 
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_read_reg(lps22hh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lps22hh_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lps22hh_read_reg(lps22hh_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_write_reg(lps22hh_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lps22hh_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -100,7 +83,7 @@ int32_t lps22hh_write_reg(lps22hh_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @{
   *
   */
-float_t lps22hh_from_lsb_to_hpa(int16_t lsb)
+float_t lps22hh_from_lsb_to_hpa(int32_t lsb)
 {
   return ( (float_t) lsb / 4096.0f );
 }
@@ -131,7 +114,7 @@ float_t lps22hh_from_lsb_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_autozero_rst_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -152,7 +135,7 @@ int32_t lps22hh_autozero_rst_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_autozero_rst_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -171,7 +154,7 @@ int32_t lps22hh_autozero_rst_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_autozero_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_autozero_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -192,7 +175,7 @@ int32_t lps22hh_autozero_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_autozero_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_autozero_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -211,7 +194,7 @@ int32_t lps22hh_autozero_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_snap_rst_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -232,7 +215,7 @@ int32_t lps22hh_pressure_snap_rst_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_snap_rst_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -251,7 +234,7 @@ int32_t lps22hh_pressure_snap_rst_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_snap_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -272,7 +255,7 @@ int32_t lps22hh_pressure_snap_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_snap_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -291,7 +274,7 @@ int32_t lps22hh_pressure_snap_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_block_data_update_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_ctrl_reg1_t reg;
   int32_t ret;
@@ -312,7 +295,7 @@ int32_t lps22hh_block_data_update_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_block_data_update_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_ctrl_reg1_t reg;
   int32_t ret;
@@ -331,7 +314,7 @@ int32_t lps22hh_block_data_update_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_data_rate_set(lps22hh_ctx_t *ctx, lps22hh_odr_t val)
+int32_t lps22hh_data_rate_set(stmdev_ctx_t *ctx, lps22hh_odr_t val)
 {
   lps22hh_ctrl_reg1_t ctrl_reg1;
   lps22hh_ctrl_reg2_t ctrl_reg2;
@@ -361,7 +344,7 @@ int32_t lps22hh_data_rate_set(lps22hh_ctx_t *ctx, lps22hh_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_data_rate_get(lps22hh_ctx_t *ctx, lps22hh_odr_t *val)
+int32_t lps22hh_data_rate_get(stmdev_ctx_t *ctx, lps22hh_odr_t *val)
 {
   lps22hh_ctrl_reg1_t ctrl_reg1;
   lps22hh_ctrl_reg2_t ctrl_reg2;
@@ -435,7 +418,7 @@ int32_t lps22hh_data_rate_get(lps22hh_ctx_t *ctx, lps22hh_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_ref_set(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lps22hh_write_reg(ctx, LPS22HH_REF_P_L, buff, 2);
@@ -453,7 +436,7 @@ int32_t lps22hh_pressure_ref_set(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_ref_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_REF_P_L, buff, 2);
@@ -470,7 +453,7 @@ int32_t lps22hh_pressure_ref_get(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_offset_set(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_write_reg(ctx, LPS22HH_RPDS_L, buff, 2);
@@ -488,7 +471,7 @@ int32_t lps22hh_pressure_offset_set(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_offset_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_RPDS_L, buff, 2);
@@ -503,7 +486,7 @@ int32_t lps22hh_pressure_offset_get(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_all_sources_get(lps22hh_ctx_t *ctx, lps22hh_all_sources_t *val)
+int32_t lps22hh_all_sources_get(stmdev_ctx_t *ctx, lps22hh_all_sources_t *val)
 {
   int32_t ret;
 
@@ -528,7 +511,7 @@ int32_t lps22hh_all_sources_get(lps22hh_ctx_t *ctx, lps22hh_all_sources_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_status_reg_get(lps22hh_ctx_t *ctx, lps22hh_status_t *val)
+int32_t lps22hh_status_reg_get(stmdev_ctx_t *ctx, lps22hh_status_t *val)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_STATUS, (uint8_t*) val, 1);
@@ -543,7 +526,7 @@ int32_t lps22hh_status_reg_get(lps22hh_ctx_t *ctx, lps22hh_status_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_press_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_press_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_status_t reg;
   int32_t ret;
@@ -562,7 +545,7 @@ int32_t lps22hh_press_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_temp_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_status_t reg;
   int32_t ret;
@@ -593,7 +576,7 @@ int32_t lps22hh_temp_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_PRESS_OUT_XL, buff, 3);
@@ -608,7 +591,7 @@ int32_t lps22hh_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_TEMP_OUT_L, buff, 2);
@@ -623,7 +606,7 @@ int32_t lps22hh_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_fifo_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_FIFO_DATA_OUT_PRESS_XL, buff, 3);
@@ -638,7 +621,7 @@ int32_t lps22hh_fifo_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_fifo_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_FIFO_DATA_OUT_TEMP_L, buff, 2);
@@ -665,7 +648,7 @@ int32_t lps22hh_fifo_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_device_id_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_WHO_AM_I, buff, 1);
@@ -681,7 +664,7 @@ int32_t lps22hh_device_id_get(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_reset_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -703,7 +686,7 @@ int32_t lps22hh_reset_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_reset_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -724,7 +707,7 @@ int32_t lps22hh_reset_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_auto_increment_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -747,7 +730,7 @@ int32_t lps22hh_auto_increment_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_auto_increment_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -767,7 +750,7 @@ int32_t lps22hh_auto_increment_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_boot_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -789,7 +772,7 @@ int32_t lps22hh_boot_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_boot_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -821,7 +804,7 @@ int32_t lps22hh_boot_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_lp_bandwidth_set(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t val)
+int32_t lps22hh_lp_bandwidth_set(stmdev_ctx_t *ctx, lps22hh_lpfp_cfg_t val)
 {
   lps22hh_ctrl_reg1_t reg;
   int32_t ret;
@@ -842,7 +825,7 @@ int32_t lps22hh_lp_bandwidth_set(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_lp_bandwidth_get(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t *val)
+int32_t lps22hh_lp_bandwidth_get(stmdev_ctx_t *ctx, lps22hh_lpfp_cfg_t *val)
 {
   lps22hh_ctrl_reg1_t reg;
   int32_t ret;
@@ -887,7 +870,7 @@ int32_t lps22hh_lp_bandwidth_get(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_i2c_interface_set(lps22hh_ctx_t *ctx,
+int32_t lps22hh_i2c_interface_set(stmdev_ctx_t *ctx,
                                   lps22hh_i2c_disable_t val)
 {
   lps22hh_if_ctrl_t reg;
@@ -909,7 +892,7 @@ int32_t lps22hh_i2c_interface_set(lps22hh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_i2c_interface_get(lps22hh_ctx_t *ctx,
+int32_t lps22hh_i2c_interface_get(stmdev_ctx_t *ctx,
                                   lps22hh_i2c_disable_t *val)
 {
   lps22hh_if_ctrl_t reg;
@@ -939,7 +922,7 @@ int32_t lps22hh_i2c_interface_get(lps22hh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_i3c_interface_set(lps22hh_ctx_t *ctx,
+int32_t lps22hh_i3c_interface_set(stmdev_ctx_t *ctx,
                                   lps22hh_i3c_disable_t val)
 {
   lps22hh_if_ctrl_t reg;
@@ -962,7 +945,7 @@ int32_t lps22hh_i3c_interface_set(lps22hh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_i3c_interface_get(lps22hh_ctx_t *ctx,
+int32_t lps22hh_i3c_interface_get(stmdev_ctx_t *ctx,
                                   lps22hh_i3c_disable_t *val)
 {
   lps22hh_if_ctrl_t reg;
@@ -995,7 +978,7 @@ int32_t lps22hh_i3c_interface_get(lps22hh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_sdo_sa0_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val)
+int32_t lps22hh_sdo_sa0_mode_set(stmdev_ctx_t *ctx, lps22hh_pu_en_t val)
 {
   lps22hh_if_ctrl_t reg;
   int32_t ret;
@@ -1016,7 +999,7 @@ int32_t lps22hh_sdo_sa0_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_sdo_sa0_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val)
+int32_t lps22hh_sdo_sa0_mode_get(stmdev_ctx_t *ctx, lps22hh_pu_en_t *val)
 {
   lps22hh_if_ctrl_t reg;
   int32_t ret;
@@ -1045,7 +1028,7 @@ int32_t lps22hh_sdo_sa0_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_sda_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val)
+int32_t lps22hh_sda_mode_set(stmdev_ctx_t *ctx, lps22hh_pu_en_t val)
 {
   lps22hh_if_ctrl_t reg;
   int32_t ret;
@@ -1066,7 +1049,7 @@ int32_t lps22hh_sda_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_sda_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val)
+int32_t lps22hh_sda_mode_get(stmdev_ctx_t *ctx, lps22hh_pu_en_t *val)
 {
   lps22hh_if_ctrl_t reg;
   int32_t ret;
@@ -1094,7 +1077,7 @@ int32_t lps22hh_sda_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_spi_mode_set(lps22hh_ctx_t *ctx, lps22hh_sim_t val)
+int32_t lps22hh_spi_mode_set(stmdev_ctx_t *ctx, lps22hh_sim_t val)
 {
   lps22hh_ctrl_reg1_t reg;
   int32_t ret;
@@ -1115,7 +1098,7 @@ int32_t lps22hh_spi_mode_set(lps22hh_ctx_t *ctx, lps22hh_sim_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_spi_mode_get(lps22hh_ctx_t *ctx, lps22hh_sim_t *val)
+int32_t lps22hh_spi_mode_get(stmdev_ctx_t *ctx, lps22hh_sim_t *val)
 {
   lps22hh_ctrl_reg1_t reg;
   int32_t ret;
@@ -1156,7 +1139,7 @@ int32_t lps22hh_spi_mode_get(lps22hh_ctx_t *ctx, lps22hh_sim_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_int_notification_set(lps22hh_ctx_t *ctx, lps22hh_lir_t val)
+int32_t lps22hh_int_notification_set(stmdev_ctx_t *ctx, lps22hh_lir_t val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -1177,7 +1160,7 @@ int32_t lps22hh_int_notification_set(lps22hh_ctx_t *ctx, lps22hh_lir_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_int_notification_get(lps22hh_ctx_t *ctx, lps22hh_lir_t *val)
+int32_t lps22hh_int_notification_get(stmdev_ctx_t *ctx, lps22hh_lir_t *val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -1206,7 +1189,7 @@ int32_t lps22hh_int_notification_get(lps22hh_ctx_t *ctx, lps22hh_lir_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pin_mode_set(lps22hh_ctx_t *ctx, lps22hh_pp_od_t val)
+int32_t lps22hh_pin_mode_set(stmdev_ctx_t *ctx, lps22hh_pp_od_t val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -1228,7 +1211,7 @@ int32_t lps22hh_pin_mode_set(lps22hh_ctx_t *ctx, lps22hh_pp_od_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pin_mode_get(lps22hh_ctx_t *ctx, lps22hh_pp_od_t *val)
+int32_t lps22hh_pin_mode_get(stmdev_ctx_t *ctx, lps22hh_pp_od_t *val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -1259,7 +1242,7 @@ int32_t lps22hh_pin_mode_get(lps22hh_ctx_t *ctx, lps22hh_pp_od_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pin_polarity_set(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t val)
+int32_t lps22hh_pin_polarity_set(stmdev_ctx_t *ctx, lps22hh_int_h_l_t val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -1281,7 +1264,7 @@ int32_t lps22hh_pin_polarity_set(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pin_polarity_get(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t *val)
+int32_t lps22hh_pin_polarity_get(stmdev_ctx_t *ctx, lps22hh_int_h_l_t *val)
 {
   lps22hh_ctrl_reg2_t reg;
   int32_t ret;
@@ -1311,7 +1294,7 @@ int32_t lps22hh_pin_polarity_get(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pin_int_route_set(lps22hh_ctx_t *ctx,
+int32_t lps22hh_pin_int_route_set(stmdev_ctx_t *ctx,
                                   lps22hh_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1327,7 +1310,7 @@ int32_t lps22hh_pin_int_route_set(lps22hh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_pin_int_route_get(lps22hh_ctx_t *ctx,
+int32_t lps22hh_pin_int_route_get(stmdev_ctx_t *ctx,
                                   lps22hh_ctrl_reg3_t *val)
 {
   int32_t ret;
@@ -1356,7 +1339,7 @@ int32_t lps22hh_pin_int_route_get(lps22hh_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_int_on_threshold_set(lps22hh_ctx_t *ctx, lps22hh_pe_t val)
+int32_t lps22hh_int_on_threshold_set(stmdev_ctx_t *ctx, lps22hh_pe_t val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -1384,7 +1367,7 @@ int32_t lps22hh_int_on_threshold_set(lps22hh_ctx_t *ctx, lps22hh_pe_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_int_on_threshold_get(lps22hh_ctx_t *ctx, lps22hh_pe_t *val)
+int32_t lps22hh_int_on_threshold_get(stmdev_ctx_t *ctx, lps22hh_pe_t *val)
 {
   lps22hh_interrupt_cfg_t reg;
   int32_t ret;
@@ -1420,7 +1403,7 @@ int32_t lps22hh_int_on_threshold_get(lps22hh_ctx_t *ctx, lps22hh_pe_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_int_treshold_set(lps22hh_ctx_t *ctx, uint16_t buff)
+int32_t lps22hh_int_treshold_set(stmdev_ctx_t *ctx, uint16_t buff)
 {
   int32_t ret;
   lps22hh_ths_p_l_t ths_p_l;
@@ -1446,7 +1429,7 @@ int32_t lps22hh_int_treshold_set(lps22hh_ctx_t *ctx, uint16_t buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_int_treshold_get(lps22hh_ctx_t *ctx, uint16_t *buff)
+int32_t lps22hh_int_treshold_get(stmdev_ctx_t *ctx, uint16_t *buff)
 {
   int32_t ret;
   lps22hh_ths_p_l_t ths_p_l;
@@ -1483,7 +1466,7 @@ int32_t lps22hh_int_treshold_get(lps22hh_ctx_t *ctx, uint16_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_mode_set(lps22hh_ctx_t *ctx, lps22hh_f_mode_t val)
+int32_t lps22hh_fifo_mode_set(stmdev_ctx_t *ctx, lps22hh_f_mode_t val)
 {
   lps22hh_fifo_ctrl_t reg;
   int32_t ret;
@@ -1504,7 +1487,7 @@ int32_t lps22hh_fifo_mode_set(lps22hh_ctx_t *ctx, lps22hh_f_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_mode_get(lps22hh_ctx_t *ctx, lps22hh_f_mode_t *val)
+int32_t lps22hh_fifo_mode_get(stmdev_ctx_t *ctx, lps22hh_f_mode_t *val)
 {
   lps22hh_fifo_ctrl_t reg;
   int32_t ret;
@@ -1550,7 +1533,7 @@ int32_t lps22hh_fifo_mode_get(lps22hh_ctx_t *ctx, lps22hh_f_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_stop_on_wtm_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_fifo_ctrl_t reg;
   int32_t ret;
@@ -1572,7 +1555,7 @@ int32_t lps22hh_fifo_stop_on_wtm_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_stop_on_wtm_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_fifo_ctrl_t reg;
   int32_t ret;
@@ -1591,7 +1574,7 @@ int32_t lps22hh_fifo_stop_on_wtm_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_watermark_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_fifo_wtm_t reg;
   int32_t ret;
@@ -1612,7 +1595,7 @@ int32_t lps22hh_fifo_watermark_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_watermark_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_fifo_wtm_t reg;
   int32_t ret;
@@ -1631,7 +1614,7 @@ int32_t lps22hh_fifo_watermark_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_data_level_get(lps22hh_ctx_t *ctx, uint8_t *buff)
+int32_t lps22hh_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_FIFO_STATUS1, buff, 1);
@@ -1646,7 +1629,7 @@ int32_t lps22hh_fifo_data_level_get(lps22hh_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_src_get(lps22hh_ctx_t *ctx, lps22hh_fifo_status2_t *val)
+int32_t lps22hh_fifo_src_get(stmdev_ctx_t *ctx, lps22hh_fifo_status2_t *val)
 {
   int32_t ret;
   ret =  lps22hh_read_reg(ctx, LPS22HH_FIFO_STATUS2, (uint8_t*) val, 1);
@@ -1661,7 +1644,7 @@ int32_t lps22hh_fifo_src_get(lps22hh_ctx_t *ctx, lps22hh_fifo_status2_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_full_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_fifo_status2_t reg;
   int32_t ret;
@@ -1680,7 +1663,7 @@ int32_t lps22hh_fifo_full_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_ovr_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_fifo_status2_t reg;
   int32_t ret;
@@ -1699,7 +1682,7 @@ int32_t lps22hh_fifo_ovr_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps22hh_fifo_wtm_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_fifo_status2_t reg;
   int32_t ret;
@@ -1713,11 +1696,11 @@ int32_t lps22hh_fifo_wtm_flag_get(lps22hh_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO overrun interrupt on INT_DRDY pin.[set]
   *
-  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  uint8_t val: change the values of f_ovr in reg CTRL_REG3
   *
   */
-int32_t lps22hh_fifo_ovr_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_ctrl_reg3_t reg;
   int32_t ret;
@@ -1733,11 +1716,11 @@ int32_t lps22hh_fifo_ovr_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
 /**
   * @brief  FIFO overrun interrupt on INT_DRDY pin.[get]
   *
-  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  uint8_t: change the values of f_ovr in reg CTRL_REG3
   *
   */
-int32_t lps22hh_fifo_ovr_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_ctrl_reg3_t reg;
   int32_t ret;
@@ -1751,11 +1734,11 @@ int32_t lps22hh_fifo_ovr_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO watermark status on INT_DRDY pin.[set]
   *
-  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  uint8_t val: change the values of f_fth in reg CTRL_REG3
   *
   */
-int32_t lps22hh_fifo_threshold_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_ctrl_reg3_t reg;
   int32_t ret;
@@ -1775,7 +1758,7 @@ int32_t lps22hh_fifo_threshold_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
   * @param  uint8_t: change the values of f_fth in reg CTRL_REG3
   *
   */
-int32_t lps22hh_fifo_threshold_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_ctrl_reg3_t reg;
   int32_t ret;
@@ -1789,11 +1772,11 @@ int32_t lps22hh_fifo_threshold_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  FIFO full flag on INT_DRDY pin.[set]
   *
-  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  uint8_t val: change the values of f_fss5 in reg CTRL_REG3
   *
   */
-int32_t lps22hh_fifo_full_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
+int32_t lps22hh_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps22hh_ctrl_reg3_t reg;
   int32_t ret;
@@ -1809,11 +1792,11 @@ int32_t lps22hh_fifo_full_on_int_set(lps22hh_ctx_t *ctx, uint8_t val)
 /**
   * @brief  FIFO full flag on INT_DRDY pin.[get]
   *
-  * @param  lps22hh_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  uint8_t: change the values of f_fss5 in reg CTRL_REG3
   *
   */
-int32_t lps22hh_fifo_full_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val)
+int32_t lps22hh_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps22hh_ctrl_reg3_t reg;
   int32_t ret;

--- a/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.h
+++ b/sensor/stmemsc/lps22hh_STdC/driver/lps22hh_reg.h
@@ -7,37 +7,20 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef LPS22HH_DRIVER_H
-#define LPS22HH_DRIVER_H
+#ifndef LPS22HH_REGS_H
+#define LPS22HH_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LPS22HH_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LPS22HH_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lps22hh_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lps22hh_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lps22hh_write_ptr  write_reg;
-  lps22hh_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lps22hh_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -312,28 +284,28 @@ typedef union{
   *
   */
 
-int32_t lps22hh_read_reg(lps22hh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lps22hh_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lps22hh_write_reg(lps22hh_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lps22hh_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
-extern float lps22hh_from_lsb_to_hpa(int16_t lsb);
-extern float lps22hh_from_lsb_to_celsius(int16_t lsb);
+extern float_t lps22hh_from_lsb_to_hpa(int32_t lsb);
+extern float_t lps22hh_from_lsb_to_celsius(int16_t lsb);
 
-int32_t lps22hh_autozero_rst_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_autozero_rst_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_autozero_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_autozero_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_autozero_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_autozero_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_pressure_snap_rst_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_pressure_snap_rst_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_pressure_snap_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_pressure_snap_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_block_data_update_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_block_data_update_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS22HH_POWER_DOWN          = 0x00,
@@ -351,63 +323,63 @@ typedef enum {
   LPS22HH_100_Hz              = 0x06,
   LPS22HH_200_Hz              = 0x07,
 } lps22hh_odr_t;
-int32_t lps22hh_data_rate_set(lps22hh_ctx_t *ctx, lps22hh_odr_t val);
-int32_t lps22hh_data_rate_get(lps22hh_ctx_t *ctx, lps22hh_odr_t *val);
+int32_t lps22hh_data_rate_set(stmdev_ctx_t *ctx, lps22hh_odr_t val);
+int32_t lps22hh_data_rate_get(stmdev_ctx_t *ctx, lps22hh_odr_t *val);
 
-int32_t lps22hh_pressure_ref_set(lps22hh_ctx_t *ctx, uint8_t *buff);
-int32_t lps22hh_pressure_ref_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hh_pressure_offset_set(lps22hh_ctx_t *ctx, uint8_t *buff);
-int32_t lps22hh_pressure_offset_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef struct{
   lps22hh_int_source_t    int_source;
   lps22hh_fifo_status2_t  fifo_status2;
   lps22hh_status_t        status;
 } lps22hh_all_sources_t;
-int32_t lps22hh_all_sources_get(lps22hh_ctx_t *ctx,
+int32_t lps22hh_all_sources_get(stmdev_ctx_t *ctx,
                                 lps22hh_all_sources_t *val);
 
-int32_t lps22hh_status_reg_get(lps22hh_ctx_t *ctx, lps22hh_status_t *val);
+int32_t lps22hh_status_reg_get(stmdev_ctx_t *ctx, lps22hh_status_t *val);
 
-int32_t lps22hh_press_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_press_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_temp_flag_data_ready_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hh_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hh_fifo_pressure_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_fifo_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hh_fifo_temperature_raw_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_fifo_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hh_device_id_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hh_reset_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_reset_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_auto_increment_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_auto_increment_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_boot_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_boot_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS22HH_LPF_ODR_DIV_2    = 0,
   LPS22HH_LPF_ODR_DIV_9    = 2,
   LPS22HH_LPF_ODR_DIV_20   = 3,
 } lps22hh_lpfp_cfg_t;
-int32_t lps22hh_lp_bandwidth_set(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t val);
-int32_t lps22hh_lp_bandwidth_get(lps22hh_ctx_t *ctx, lps22hh_lpfp_cfg_t *val);
+int32_t lps22hh_lp_bandwidth_set(stmdev_ctx_t *ctx, lps22hh_lpfp_cfg_t val);
+int32_t lps22hh_lp_bandwidth_get(stmdev_ctx_t *ctx, lps22hh_lpfp_cfg_t *val);
 
 typedef enum {
   LPS22HH_I2C_ENABLE    = 0,
   LPS22HH_I2C_DISABLE   = 1,
 } lps22hh_i2c_disable_t;
-int32_t lps22hh_i2c_interface_set(lps22hh_ctx_t *ctx,
+int32_t lps22hh_i2c_interface_set(stmdev_ctx_t *ctx,
                                   lps22hh_i2c_disable_t val);
-int32_t lps22hh_i2c_interface_get(lps22hh_ctx_t *ctx,
+int32_t lps22hh_i2c_interface_get(stmdev_ctx_t *ctx,
                                   lps22hh_i2c_disable_t *val);
 
 typedef enum {
@@ -415,51 +387,51 @@ typedef enum {
   LPS22HH_I3C_ENABLE_INT_PIN_ENABLE  = 0x10,
   LPS22HH_I3C_DISABLE                = 0x11,
 } lps22hh_i3c_disable_t;
-int32_t lps22hh_i3c_interface_set(lps22hh_ctx_t *ctx,
+int32_t lps22hh_i3c_interface_set(stmdev_ctx_t *ctx,
                                   lps22hh_i3c_disable_t val);
-int32_t lps22hh_i3c_interface_get(lps22hh_ctx_t *ctx,
+int32_t lps22hh_i3c_interface_get(stmdev_ctx_t *ctx,
                                   lps22hh_i3c_disable_t *val);
 
 typedef enum {
   LPS22HH_PULL_UP_DISCONNECT    = 0,
   LPS22HH_PULL_UP_CONNECT       = 1,
 } lps22hh_pu_en_t;
-int32_t lps22hh_sdo_sa0_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val);
-int32_t lps22hh_sdo_sa0_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val);
-int32_t lps22hh_sda_mode_set(lps22hh_ctx_t *ctx, lps22hh_pu_en_t val);
-int32_t lps22hh_sda_mode_get(lps22hh_ctx_t *ctx, lps22hh_pu_en_t *val);
+int32_t lps22hh_sdo_sa0_mode_set(stmdev_ctx_t *ctx, lps22hh_pu_en_t val);
+int32_t lps22hh_sdo_sa0_mode_get(stmdev_ctx_t *ctx, lps22hh_pu_en_t *val);
+int32_t lps22hh_sda_mode_set(stmdev_ctx_t *ctx, lps22hh_pu_en_t val);
+int32_t lps22hh_sda_mode_get(stmdev_ctx_t *ctx, lps22hh_pu_en_t *val);
 
 typedef enum {
   LPS22HH_SPI_4_WIRE  = 0,
   LPS22HH_SPI_3_WIRE  = 1,
 } lps22hh_sim_t;
-int32_t lps22hh_spi_mode_set(lps22hh_ctx_t *ctx, lps22hh_sim_t val);
-int32_t lps22hh_spi_mode_get(lps22hh_ctx_t *ctx, lps22hh_sim_t *val);
+int32_t lps22hh_spi_mode_set(stmdev_ctx_t *ctx, lps22hh_sim_t val);
+int32_t lps22hh_spi_mode_get(stmdev_ctx_t *ctx, lps22hh_sim_t *val);
 
 typedef enum {
   LPS22HH_INT_PULSED   = 0,
   LPS22HH_INT_LATCHED  = 1,
 } lps22hh_lir_t;
-int32_t lps22hh_int_notification_set(lps22hh_ctx_t *ctx, lps22hh_lir_t val);
-int32_t lps22hh_int_notification_get(lps22hh_ctx_t *ctx, lps22hh_lir_t *val);
+int32_t lps22hh_int_notification_set(stmdev_ctx_t *ctx, lps22hh_lir_t val);
+int32_t lps22hh_int_notification_get(stmdev_ctx_t *ctx, lps22hh_lir_t *val);
 
 typedef enum {
   LPS22HH_PUSH_PULL   = 0,
   LPS22HH_OPEN_DRAIN  = 1,
 } lps22hh_pp_od_t;
-int32_t lps22hh_pin_mode_set(lps22hh_ctx_t *ctx, lps22hh_pp_od_t val);
-int32_t lps22hh_pin_mode_get(lps22hh_ctx_t *ctx, lps22hh_pp_od_t *val);
+int32_t lps22hh_pin_mode_set(stmdev_ctx_t *ctx, lps22hh_pp_od_t val);
+int32_t lps22hh_pin_mode_get(stmdev_ctx_t *ctx, lps22hh_pp_od_t *val);
 
 typedef enum {
   LPS22HH_ACTIVE_HIGH = 0,
   LPS22HH_ACTIVE_LOW  = 1,
 } lps22hh_int_h_l_t;
-int32_t lps22hh_pin_polarity_set(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t val);
-int32_t lps22hh_pin_polarity_get(lps22hh_ctx_t *ctx, lps22hh_int_h_l_t *val);
+int32_t lps22hh_pin_polarity_set(stmdev_ctx_t *ctx, lps22hh_int_h_l_t val);
+int32_t lps22hh_pin_polarity_get(stmdev_ctx_t *ctx, lps22hh_int_h_l_t *val);
 
-int32_t lps22hh_pin_int_route_set(lps22hh_ctx_t *ctx,
+int32_t lps22hh_pin_int_route_set(stmdev_ctx_t *ctx,
                                   lps22hh_ctrl_reg3_t *val);
-int32_t lps22hh_pin_int_route_get(lps22hh_ctx_t *ctx,
+int32_t lps22hh_pin_int_route_get(stmdev_ctx_t *ctx,
                                   lps22hh_ctrl_reg3_t *val);
 
 typedef enum {
@@ -468,11 +440,11 @@ typedef enum {
   LPS22HH_NEGATIVE      = 2,
   LPS22HH_BOTH          = 3,
 } lps22hh_pe_t;
-int32_t lps22hh_int_on_threshold_set(lps22hh_ctx_t *ctx, lps22hh_pe_t val);
-int32_t lps22hh_int_on_threshold_get(lps22hh_ctx_t *ctx, lps22hh_pe_t *val);
+int32_t lps22hh_int_on_threshold_set(stmdev_ctx_t *ctx, lps22hh_pe_t val);
+int32_t lps22hh_int_on_threshold_get(stmdev_ctx_t *ctx, lps22hh_pe_t *val);
 
-int32_t lps22hh_int_treshold_set(lps22hh_ctx_t *ctx, uint16_t buff);
-int32_t lps22hh_int_treshold_get(lps22hh_ctx_t *ctx, uint16_t *buff);
+int32_t lps22hh_int_treshold_set(stmdev_ctx_t *ctx, uint16_t buff);
+int32_t lps22hh_int_treshold_get(stmdev_ctx_t *ctx, uint16_t *buff);
 
 typedef enum {
   LPS22HH_BYPASS_MODE            = 0,
@@ -483,33 +455,33 @@ typedef enum {
   LPS22HH_BYPASS_TO_STREAM_MODE  = 6,
   LPS22HH_STREAM_TO_FIFO_MODE    = 7,
 } lps22hh_f_mode_t;
-int32_t lps22hh_fifo_mode_set(lps22hh_ctx_t *ctx, lps22hh_f_mode_t val);
-int32_t lps22hh_fifo_mode_get(lps22hh_ctx_t *ctx, lps22hh_f_mode_t *val);
+int32_t lps22hh_fifo_mode_set(stmdev_ctx_t *ctx, lps22hh_f_mode_t val);
+int32_t lps22hh_fifo_mode_get(stmdev_ctx_t *ctx, lps22hh_f_mode_t *val);
 
-int32_t lps22hh_fifo_stop_on_wtm_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_fifo_stop_on_wtm_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_fifo_watermark_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_fifo_watermark_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_fifo_data_level_get(lps22hh_ctx_t *ctx, uint8_t *buff);
+int32_t lps22hh_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps22hh_fifo_src_get(lps22hh_ctx_t *ctx, lps22hh_fifo_status2_t *val);
+int32_t lps22hh_fifo_src_get(stmdev_ctx_t *ctx, lps22hh_fifo_status2_t *val);
 
-int32_t lps22hh_fifo_full_flag_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_fifo_ovr_flag_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_fifo_wtm_flag_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_fifo_ovr_on_int_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_fifo_ovr_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_fifo_threshold_on_int_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_fifo_threshold_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps22hh_fifo_full_on_int_set(lps22hh_ctx_t *ctx, uint8_t val);
-int32_t lps22hh_fifo_full_on_int_get(lps22hh_ctx_t *ctx, uint8_t *val);
+int32_t lps22hh_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps22hh_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/lps25hb_STdC/driver/lps25hb_reg.c
+++ b/sensor/stmemsc/lps25hb_STdC/driver/lps25hb_reg.c
@@ -1,1480 +1,1759 @@
 /*
  ******************************************************************************
  * @file    lps25hb_reg.c
- * @author  MEMS Software Solution Team
- * @date    20-September-2017
+ * @author  Sensors Software Solution Team
  * @brief   LPS25HB driver file
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lps25hb_reg.h"
 
 /**
-  * @addtogroup  lps25hb
-  * @brief  This file provides a set of functions needed to drive the
-  *         lps25hb enanced inertial module.
+  * @defgroup    LPS25HB
+  * @brief       This file provides a set of functions needed to drive the
+  *              ultra-compact piezoresistive absolute pressure sensor.
   * @{
+  *
   */
 
 /**
-  * @addtogroup  interfaces_functions
-  * @brief  This section provide a set of functions used to read and write
-  *         a generic register of the device.
+  * @defgroup    LPS25HB_Interfaces_functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
   * @{
+  *
   */
 
 /**
   * @brief  Read generic device register
   *
-  * @param  lps25hb_ctx_t* ctx: read / write interface definitions
-  * @param  uint8_t reg: register to read
-  * @param  uint8_t* data: pointer to buffer that store the data read
-  * @param  uint16_t len: number of consecutive register to read
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps25hb_read_reg(lps25hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lps25hb_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
-  return ctx->read_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @brief  Write generic device register
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t reg: register to write
-  * @param  uint8_t* data: pointer to data to write in register reg
-  * @param  uint16_t len: number of consecutive register to write
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
-*/
-int32_t lps25hb_write_reg(lps25hb_ctx_t* ctx, uint8_t reg, uint8_t* data,
+  */
+int32_t lps25hb_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
-  return ctx->write_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  data_generation_c
-  * @brief   This section group all the functions concerning data generation
+  * @defgroup    LPS25HB_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
   * @{
+  *
   */
 
-/**
-  * @brief  pressure_ref: [set]  The Reference pressure value is a 24-bit
-  *                              data expressed as 2’s complement. The value
-  *                              is used when AUTOZERO or AUTORIFP function
-  *                              is enabled.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
-  *
-  */
-int32_t lps25hb_pressure_ref_set(lps25hb_ctx_t *ctx, uint8_t *buff)
+float_t lps25hb_from_lsb_to_hpa(uint32_t lsb)
 {
-  return lps25hb_read_reg(ctx, LPS25HB_REF_P_XL,  buff, 3);
+  return ( (float_t)lsb / 4096.0f );
 }
 
-/**
-  * @brief  pressure_ref: [get]  The Reference pressure value is a 24-bit
-  *                              data expressed as 2’s complement. The value
-  *                              is used when AUTOZERO or AUTORIFP function
-  *                              is enabled.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
-  *
-  */
-int32_t lps25hb_pressure_ref_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+float_t lps25hb_from_lsb_to_degc(int16_t lsb)
 {
-  return lps25hb_read_reg(ctx, LPS25HB_REF_P_XL,  buff, 3);
-}
-
-/**
-  * @brief  pressure_avg: [set]  Pressure internal average configuration.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_avgp_t: change the values of avgp in reg RES_CONF
-  *
-  */
-int32_t lps25hb_pressure_avg_set(lps25hb_ctx_t *ctx, lps25hb_avgp_t val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
-  reg.res_conf.avgp = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  pressure_avg: [get]  Pressure internal average configuration.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_avgp_t: Get the values of avgp in reg RES_CONF
-  *
-  */
-int32_t lps25hb_pressure_avg_get(lps25hb_ctx_t *ctx, lps25hb_avgp_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
-  *val = (lps25hb_avgp_t) reg.res_conf.avgp;
-
-  return mm_error;
-}
-
-/**
-  * @brief  temperature_avg: [set]  Temperature internal average configuration.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_avgt_t: change the values of avgt in reg RES_CONF
-  *
-  */
-int32_t lps25hb_temperature_avg_set(lps25hb_ctx_t *ctx, lps25hb_avgt_t val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
-  reg.res_conf.avgt = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  temperature_avg: [get]  Temperature internal average configuration.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_avgt_t: Get the values of avgt in reg RES_CONF
-  *
-  */
-int32_t lps25hb_temperature_avg_get(lps25hb_ctx_t *ctx, lps25hb_avgt_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, &reg.byte, 1);
-  *val = (lps25hb_avgt_t) reg.res_conf.avgt;
-
-  return mm_error;
-}
-
-/**
-  * @brief  autozero_rst: [set]  Reset Autozero function.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of reset_az in reg CTRL_REG1
-  *
-  */
-int32_t lps25hb_autozero_rst_set(lps25hb_ctx_t *ctx, uint8_t val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.reset_az = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  autozero_rst: [get]  Reset Autozero function.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of reset_az in reg CTRL_REG1
-  *
-  */
-int32_t lps25hb_autozero_rst_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  *val = reg.ctrl_reg1.reset_az;
-
-  return mm_error;
-}
-
-/**
-  * @brief  block_data_update: [set] Blockdataupdate.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of bdu in reg CTRL_REG1
-  *
-  */
-int32_t lps25hb_block_data_update_set(lps25hb_ctx_t *ctx, uint8_t val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.bdu = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  block_data_update: [get] Blockdataupdate.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of bdu in reg CTRL_REG1
-  *
-  */
-int32_t lps25hb_block_data_update_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  *val = reg.ctrl_reg1.bdu;
-
-  return mm_error;
-}
-
-/**
-  * @brief  data_rate: [set]  Output data rate selection.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_odr_t: change the values of odr in reg CTRL_REG1
-  *
-  */
-int32_t lps25hb_data_rate_set(lps25hb_ctx_t *ctx, lps25hb_odr_t val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.odr = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  data_rate: [get]  Output data rate selection.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_odr_t: Get the values of odr in reg CTRL_REG1
-  *
-  */
-int32_t lps25hb_data_rate_get(lps25hb_ctx_t *ctx, lps25hb_odr_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  *val = (lps25hb_odr_t) reg.ctrl_reg1.odr;
-
-  return mm_error;
-}
-
-/**
-  * @brief  one_shoot_trigger: [set]  One-shot mode. Device perform a
-  *                                   single measure.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of one_shot in reg CTRL_REG2
-  *
-  */
-int32_t lps25hb_one_shoot_trigger_set(lps25hb_ctx_t *ctx, uint8_t val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  reg.ctrl_reg2.one_shot = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  one_shoot_trigger: [get]  One-shot mode. Device perform a
-  *                                   single measure.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of one_shot in reg CTRL_REG2
-  *
-  */
-int32_t lps25hb_one_shoot_trigger_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  *val = reg.ctrl_reg2.one_shot;
-
-  return mm_error;
-}
-
-/**
-  * @brief  autozero: [set]  Enable Autozero function.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of autozero in reg CTRL_REG2
-  *
-  */
-int32_t lps25hb_autozero_set(lps25hb_ctx_t *ctx, uint8_t val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  reg.ctrl_reg2.autozero = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief  autozero: [get]  Enable Autozero function.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of autozero in reg CTRL_REG2
-  *
-  */
-int32_t lps25hb_autozero_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  *val = reg.ctrl_reg2.autozero;
-
-  return mm_error;
-}
-
-/**
-  * @brief   fifo_mean_decimator: [set]  Enable to decimate the output
-  *                                      pressure to 1Hz with FIFO Mean mode.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of fifo_mean_dec in reg CTRL_REG2
-  *
-  */
-int32_t lps25hb_fifo_mean_decimator_set(lps25hb_ctx_t *ctx, uint8_t val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  reg.ctrl_reg2.fifo_mean_dec = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-
-  return mm_error;
-}
-
-/**
-  * @brief   fifo_mean_decimator: [get]  Enable to decimate the output
-  *                                      pressure to 1Hz with FIFO Mean mode.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_mean_dec in reg CTRL_REG2
-  *
-  */
-int32_t lps25hb_fifo_mean_decimator_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  *val = reg.ctrl_reg2.fifo_mean_dec;
-
-  return mm_error;
-}
-
-/**
-  * @brief  press_data_ready: [get]  Pressure data available.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of p_da in reg STATUS_REG
-  *
-  */
-int32_t lps25hb_press_data_ready_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, &reg.byte, 1);
-  *val = reg.status_reg.p_da;
-
-  return mm_error;
-}
-
-/**
-  * @brief  temp_data_ready: [get]  Temperature data available.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of t_da in reg STATUS_REG
-  *
-  */
-int32_t lps25hb_temp_data_ready_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, &reg.byte, 1);
-  *val = reg.status_reg.t_da;
-
-  return mm_error;
-}
-
-/**
-  * @brief  temp_data_ovr: [get]   Temperature data overrun.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of t_or in reg STATUS_REG
-  *
-  */
-int32_t lps25hb_temp_data_ovr_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, &reg.byte, 1);
-  *val = reg.status_reg.t_or;
-
-  return mm_error;
-}
-
-/**
-  * @brief  press_data_ovr: [get]   Pressure data overrun.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of p_or in reg STATUS_REG
-  *
-  */
-int32_t lps25hb_press_data_ovr_get(lps25hb_ctx_t *ctx, uint8_t *val)
-{
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, &reg.byte, 1);
-  *val = reg.status_reg.p_or;
-
-  return mm_error;
-}
-
-/**
-  * @brief  pressure_raw: [get]  Pressure output value.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
-  *
-  */
-int32_t lps25hb_pressure_raw_get(lps25hb_ctx_t *ctx, uint8_t *buff)
-{
-  return lps25hb_read_reg(ctx, LPS25HB_PRESS_OUT_XL,  buff, 3);
-}
-
-/**
-  * @brief  temperature_raw: [get]  Temperature output value.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
-  *
-  */
-int32_t lps25hb_temperature_raw_get(lps25hb_ctx_t *ctx, uint8_t *buff)
-{
-  return lps25hb_read_reg(ctx, LPS25HB_TEMP_OUT_L,  buff, 2);
-}
-
-/**
-  * @brief  pressure_offset: [set]  The pressure offset value is 16-bit
-  *                                 data that can be used to implement
-  *                                 one-point calibration (OPC)
-  *                                 after soldering.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
-  *
-  */
-int32_t lps25hb_pressure_offset_set(lps25hb_ctx_t *ctx, uint8_t *buff)
-{
-  return lps25hb_read_reg(ctx, LPS25HB_RPDS_L,  buff, 2);
-}
-
-/**
-  * @brief  pressure_offset: [get]  The pressure offset value is 16-bit
-  *                                 data that can be used to implement
-  *                                 one-point calibration (OPC) after
-  *                                 soldering.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
-  *
-  */
-int32_t lps25hb_pressure_offset_get(lps25hb_ctx_t *ctx, uint8_t *buff)
-{
-  return lps25hb_read_reg(ctx, LPS25HB_RPDS_L,  buff, 2);
+  return ( (float_t)lsb / 480.0f ) + 42.5f ;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  common
-  * @brief   This section group common usefull functions
+  * @defgroup   LPS25HB_data_generation_c
+  * @brief      This section group all the functions concerning data generation
   * @{
+  *
   */
 
 /**
-  * @brief  device_id: [get] DeviceWhoamI.
+  * @brief  The Reference pressure value is a 24-bit data expressed as 2’s
+  *         complement. The value is used when AUTOZERO or AUTORIFP function
+  *         is enabled.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_device_id_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps25hb_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lps25hb_read_reg(ctx, LPS25HB_WHO_AM_I,  buff, 1);
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_REF_P_XL,  buff, 3);
+  return ret;
 }
 
 /**
-  * @brief  reset: [set]  Software reset. Restore the default values
-  *                       in user registers
+  * @brief  The Reference pressure value is a 24-bit data expressed as 2’s
+  *         complement. The value is used when AUTOZERO or AUTORIFP function
+  *         is enabled.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of swreset in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_reset_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  reg.ctrl_reg2.swreset = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-
-  return mm_error;
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_REF_P_XL,  buff, 3);
+  return ret;
 }
 
 /**
-  * @brief  reset: [get]  Software reset. Restore the default values
-  *                       in user registers
+  * @brief  Pressure internal average configuration.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of swreset in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of avgp in reg RES_CONF
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_reset_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_pressure_avg_set(stmdev_ctx_t *ctx, lps25hb_avgp_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_res_conf_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  *val = reg.ctrl_reg2.swreset;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.avgp = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_RES_CONF, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  boot: [set]  Reboot memory content. Reload the calibration
-  *                      parameters
+  * @brief  Pressure internal average configuration.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of boot in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of avgp in reg RES_CONF.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_boot_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_pressure_avg_get(stmdev_ctx_t *ctx, lps25hb_avgp_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_res_conf_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  reg.ctrl_reg2.boot = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, (uint8_t*)&reg, 1);
+  switch (reg.avgp){
+    case LPS25HB_P_AVG_8:
+      *val = LPS25HB_P_AVG_8;
+      break;
+    case LPS25HB_P_AVG_16:
+      *val = LPS25HB_P_AVG_16;
+      break;
+    case LPS25HB_P_AVG_32:
+      *val = LPS25HB_P_AVG_32;
+      break;
+    case LPS25HB_P_AVG_64:
+      *val = LPS25HB_P_AVG_64;
+      break;
+    default:
+      *val = LPS25HB_P_AVG_8;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  boot: [get]  Reboot memory content. Reload the calibration
-  *                      parameters
+  * @brief  Temperature internal average configuration.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of boot in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of avgt in reg RES_CONF
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_boot_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_temperature_avg_set(stmdev_ctx_t *ctx, lps25hb_avgt_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_res_conf_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  *val = reg.ctrl_reg2.boot;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.avgt = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_RES_CONF, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  status: [get]
+  * @brief  Temperature internal average configuration.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_: registers STATUS_REG.
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of avgt in reg RES_CONF.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_status_get(lps25hb_ctx_t *ctx, lps25hb_status_reg_t *val)
+int32_t lps25hb_temperature_avg_get(stmdev_ctx_t *ctx, lps25hb_avgt_t *val)
 {
-  return lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, (uint8_t*) val, 1);
+  lps25hb_res_conf_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_RES_CONF, (uint8_t*)&reg, 1);
+  switch (reg.avgt){
+    case LPS25HB_T_AVG_8:
+      *val = LPS25HB_T_AVG_8;
+      break;
+    case LPS25HB_T_AVG_16:
+      *val = LPS25HB_T_AVG_16;
+      break;
+    case LPS25HB_T_AVG_32:
+      *val = LPS25HB_T_AVG_32;
+      break;
+    case LPS25HB_T_AVG_64:
+      *val = LPS25HB_T_AVG_64;
+      break;
+    default:
+      *val = LPS25HB_T_AVG_8;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Autozero function. [set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of reset_az in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.reset_az = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Autozero function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of reset_az in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  *val = reg.reset_az;
+
+  return ret;
+}
+
+/**
+  * @brief  Blockdataupdate.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.bdu = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief Blockdataupdate. [get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdu in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_data_rate_set(stmdev_ctx_t *ctx, lps25hb_odr_t val)
+{
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.odr = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_data_rate_get(stmdev_ctx_t *ctx, lps25hb_odr_t *val)
+{
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  switch (reg.odr){
+    case LPS25HB_POWER_DOWN:
+      *val = LPS25HB_POWER_DOWN;
+      break;
+    case LPS25HB_ODR_1Hz:
+      *val = LPS25HB_ODR_1Hz;
+      break;
+    case LPS25HB_ODR_7Hz:
+      *val = LPS25HB_ODR_7Hz;
+      break;
+    case LPS25HB_ODR_12Hz5:
+      *val = LPS25HB_ODR_12Hz5;
+      break;
+    case LPS25HB_ODR_25Hz:
+      *val = LPS25HB_ODR_25Hz;
+      break;
+    case LPS25HB_ONE_SHOT:
+      *val = LPS25HB_ONE_SHOT;
+      break;
+    default:
+      *val = LPS25HB_POWER_DOWN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of one_shot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.one_shot = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of one_shot in reg CTRL_REG2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  *val = reg.one_shot;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of autozero in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_autozero_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.autozero = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of autozero in reg CTRL_REG2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_autozero_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  *val = reg.autozero;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable to decimate the output pressure to 1Hz
+  *         with FIFO Mean mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_mean_dec in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_fifo_mean_decimator_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.fifo_mean_dec = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable to decimate the output pressure to 1Hz
+  *         with FIFO Mean mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_mean_dec in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_fifo_mean_decimator_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_mean_dec;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of p_da in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_press_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_status_reg_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.p_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of t_da in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_status_reg_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.t_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of t_or in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_status_reg_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.t_or;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of p_or in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_press_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_status_reg_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, (uint8_t*)&reg, 1);
+  *val = reg.p_or;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure output value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_PRESS_OUT_XL,  buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_TEMP_OUT_L,  buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data that can be used to
+  *         implement one-point calibration (OPC) after soldering.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_RPDS_L,  buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data that can be used to
+  *         implement one-point calibration (OPC) after soldering.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_RPDS_L,  buff, 2);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  interrupts
-  * @brief   This section group all the functions that manage interrupts
+  * @defgroup   LPS25HB_common
+  * @brief      This section group common usefull functions
   * @{
+  *
   */
 
 /**
-  * @brief  int_generation: [set]  Enable interrupt generation.
+  * @brief  DeviceWhoamI.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of diff_en in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_generation_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.diff_en = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-
-  return mm_error;
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_WHO_AM_I,  buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_generation: [get]  Enable interrupt generation.
+  * @brief  Software reset. Restore the default values in user registers[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of diff_en in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of swreset in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_generation_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  *val = reg.ctrl_reg1.diff_en;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.swreset = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  int_pin_mode: [set]  Data signal on INT_DRDY pin control bits.
+  * @brief  Software reset. Restore the default values in user registers[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_int_s_t: change the values of int_s in reg CTRL_REG3
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of swreset in reg CTRL_REG2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_pin_mode_set(lps25hb_ctx_t *ctx, lps25hb_int_s_t val)
+int32_t lps25hb_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
-  reg.ctrl_reg3.int_s = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  *val = reg.swreset;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_pin_mode: [get]  Data signal on INT_DRDY pin control bits.
+  * @brief  Reboot memory content. Reload the calibration parameters[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_int_s_t: Get the values of int_s in reg CTRL_REG3
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_pin_mode_get(lps25hb_ctx_t *ctx, lps25hb_int_s_t *val)
+int32_t lps25hb_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
-  *val = (lps25hb_int_s_t) reg.ctrl_reg3.int_s;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.boot = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_mode: [set]  Push-pull/open drain selection on interrupt pads.
+  * @brief  Reboot memory content. Reload the calibration parameters[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_pp_od_t: change the values of pp_od in reg CTRL_REG3
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL_REG2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_pin_mode_set(lps25hb_ctx_t *ctx, lps25hb_pp_od_t val)
+int32_t lps25hb_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
-  reg.ctrl_reg3.pp_od = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  *val = reg.boot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_mode: [get]  Push-pull/open drain selection on interrupt pads.
+  * @brief  Status: [get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_pp_od_t: Get the values of pp_od in reg CTRL_REG3
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_pin_mode_get(lps25hb_ctx_t *ctx, lps25hb_pp_od_t *val)
+int32_t lps25hb_status_get(stmdev_ctx_t *ctx, lps25hb_status_reg_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
-
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
-  *val = (lps25hb_pp_od_t) reg.ctrl_reg3.pp_od;
-
-  return mm_error;
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_polarity: [set]  Interrupt active-high/low.
-  *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_int_h_l_t: change the values of int_h_l in reg CTRL_REG3
+  * @}
   *
   */
-int32_t lps25hb_int_polarity_set(lps25hb_ctx_t *ctx, lps25hb_int_h_l_t val)
+
+/**
+  * @defgroup   LPS25HB_interrupts
+  * @brief      This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable interrupt generation.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of diff_en in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_int_generation_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
-  reg.ctrl_reg3.int_h_l = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.diff_en = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  int_polarity: [get]  Interrupt active-high/low.
+  * @brief  Enable interrupt generation.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_int_h_l_t: Get the values of int_h_l in reg CTRL_REG3
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of diff_en in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_polarity_get(lps25hb_ctx_t *ctx, lps25hb_int_h_l_t *val)
+int32_t lps25hb_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, &reg.byte, 1);
-  *val = (lps25hb_int_h_l_t) reg.ctrl_reg3.int_h_l;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  *val = reg.diff_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_int: [set]  Data-ready signal on INT_DRDY pin.
+  * @brief  Data signal on INT_DRDY pin control bits.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of drdy in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int_s in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_drdy_on_int_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_int_pin_mode_set(stmdev_ctx_t *ctx, lps25hb_int_s_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg3_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.drdy = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.int_s = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_int: [get]  Data-ready signal on INT_DRDY pin.
+  * @brief  Data signal on INT_DRDY pin control bits.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of drdy in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_s in reg CTRL_REG3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_drdy_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_int_pin_mode_get(stmdev_ctx_t *ctx, lps25hb_int_s_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg3_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-  *val = reg.ctrl_reg4.drdy;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  switch (reg.int_s){
+    case LPS25HB_DRDY_OR_FIFO_FLAGS:
+      *val = LPS25HB_DRDY_OR_FIFO_FLAGS;
+      break;
+    case LPS25HB_HIGH_PRES_INT:
+      *val = LPS25HB_HIGH_PRES_INT;
+      break;
+    case LPS25HB_LOW_PRES_INT:
+      *val = LPS25HB_LOW_PRES_INT;
+      break;
+    case LPS25HB_EVERY_PRES_INT:
+      *val = LPS25HB_EVERY_PRES_INT;
+      break;
+    default:
+      *val = LPS25HB_DRDY_OR_FIFO_FLAGS;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_on_int: [set]  FIFO overrun interrupt on INT_DRDY pin.
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of f_ovr in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_ovr_on_int_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_pin_mode_set(stmdev_ctx_t *ctx, lps25hb_pp_od_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg3_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.f_ovr = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.pp_od = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_on_int: [get]  FIFO overrun interrupt on INT_DRDY pin.
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of f_ovr in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL_REG3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_ovr_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_pin_mode_get(stmdev_ctx_t *ctx, lps25hb_pp_od_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg3_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-  *val = reg.ctrl_reg4.f_ovr;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  switch (reg.pp_od){
+    case LPS25HB_PUSH_PULL:
+      *val = LPS25HB_PUSH_PULL;
+      break;
+    case LPS25HB_OPEN_DRAIN:
+      *val = LPS25HB_OPEN_DRAIN;
+      break;
+    default:
+      *val = LPS25HB_PUSH_PULL;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief   fifo_threshold_on_int: [set]  FIFO watermark status
-  *                                        on INT_DRDY pin.
+  * @brief  Interrupt active-high/low.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of f_fth in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int_h_l in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_threshold_on_int_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_int_polarity_set(stmdev_ctx_t *ctx, lps25hb_int_h_l_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg3_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.f_fth = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.int_h_l = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief   fifo_threshold_on_int: [get]  FIFO watermark status
-  *                                        on INT_DRDY pin.
+  * @brief  Interrupt active-high/low.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of f_fth in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_h_l in reg CTRL_REG3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_threshold_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_int_polarity_get(stmdev_ctx_t *ctx, lps25hb_int_h_l_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg3_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-  *val = reg.ctrl_reg4.f_fth;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG3, (uint8_t*)&reg, 1);
+  switch (reg.int_h_l){
+    case LPS25HB_ACTIVE_HIGH:
+      *val = LPS25HB_ACTIVE_HIGH;
+      break;
+    case LPS25HB_ACTIVE_LOW:
+      *val = LPS25HB_ACTIVE_LOW;
+      break;
+    default:
+      *val = LPS25HB_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_empty_on_int: [set]  FIFO empty flag on INT_DRDY pin.
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of f_empty in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_empty_on_int_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg4_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-  reg.ctrl_reg4.f_empty = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.drdy = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_empty_on_int: [get]  FIFO empty flag on INT_DRDY pin.
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of f_empty in reg CTRL_REG4
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_empty_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg4_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, &reg.byte, 1);
-  *val = reg.ctrl_reg4.f_empty;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  *val = reg.drdy;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   sign_of_int_threshold: [set]  Enable interrupt generation on
-  *                                        pressure low/high event.
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_pe_t: change the values of pe in reg INTERRUPT_CFG
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of f_ovr in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_sign_of_int_threshold_set(lps25hb_ctx_t *ctx,
+int32_t lps25hb_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_ctrl_reg4_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.f_ovr = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of f_ovr in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_ctrl_reg4_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  *val = reg.f_ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of f_fth in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_ctrl_reg4_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.f_fth = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of f_fth in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_ctrl_reg4_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  *val = reg.f_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO empty flag on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of f_empty in reg CTRL_REG4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_fifo_empty_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps25hb_ctrl_reg4_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.f_empty = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO empty flag on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of f_empty in reg CTRL_REG4.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_fifo_empty_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps25hb_ctrl_reg4_t reg;
+  int32_t ret;
+
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG4, (uint8_t*)&reg, 1);
+  *val = reg.f_empty;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pe in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps25hb_sign_of_int_threshold_set(stmdev_ctx_t *ctx,
                                           lps25hb_pe_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_interrupt_cfg_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
-  reg.interrupt_cfg.pe = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.pe = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_INTERRUPT_CFG, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief   sign_of_int_threshold: [get]  Enable interrupt generation on
-  *                                        pressure low/high event.
+  * @brief  Enable interrupt generation on pressure low/high event.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_pe_t: Get the values of pe in reg INTERRUPT_CFG
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pe in reg INTERRUPT_CFG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_sign_of_int_threshold_get(lps25hb_ctx_t *ctx,
+int32_t lps25hb_sign_of_int_threshold_get(stmdev_ctx_t *ctx,
                                           lps25hb_pe_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_interrupt_cfg_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
-  *val = (lps25hb_pe_t) reg.interrupt_cfg.pe;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, (uint8_t*)&reg, 1);
+  switch (reg.pe){
+    case LPS25HB_NO_THRESHOLD:
+      *val = LPS25HB_NO_THRESHOLD;
+      break;
+    case LPS25HB_POSITIVE:
+      *val = LPS25HB_POSITIVE;
+      break;
+    case LPS25HB_NEGATIVE:
+      *val = LPS25HB_NEGATIVE;
+      break;
+    case LPS25HB_BOTH:
+      *val = LPS25HB_BOTH;
+      break;
+    default:
+      *val = LPS25HB_NO_THRESHOLD;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief   int_notification_mode: [set]  Interrupt request to the
-  *                                        INT_SOURCE (25h) register
-  *                                        mode (pulsed / latched)
+  * @brief  Interrupt request to the INT_SOURCE (25h) register mode.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_lir_t: change the values of lir in reg INTERRUPT_CFG
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_notification_mode_set(lps25hb_ctx_t *ctx,
+int32_t lps25hb_int_notification_mode_set(stmdev_ctx_t *ctx,
                                           lps25hb_lir_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_interrupt_cfg_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
-  reg.interrupt_cfg.lir = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.lir = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_INTERRUPT_CFG, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief   int_notification_mode: [get]  Interrupt request to the
-  *                                        INT_SOURCE (25h) register mode
-  *                                        (pulsed / latched)
+  * @brief  Interrupt request to the  INT_SOURCE (25h) register mode.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_lir_t: Get the values of lir in reg INTERRUPT_CFG
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg INTERRUPT_CFG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_notification_mode_get(lps25hb_ctx_t *ctx,
+int32_t lps25hb_int_notification_mode_get(stmdev_ctx_t *ctx,
                                           lps25hb_lir_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_interrupt_cfg_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, &reg.byte, 1);
-  *val = (lps25hb_lir_t) reg.interrupt_cfg.lir;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_INTERRUPT_CFG, (uint8_t*)&reg, 1);
+  switch (reg.lir){
+    case LPS25HB_INT_PULSED:
+      *val = LPS25HB_INT_PULSED;
+      break;
+    case LPS25HB_INT_LATCHED:
+      *val = LPS25HB_INT_LATCHED;
+      break;
+    default:
+      *val = LPS25HB_INT_PULSED;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  int_source: [get]  Interrupt source register
+  * @brief  Interrupt source register[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_int_source_t: registers INT_SOURCE
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers INT_SOURCE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_source_get(lps25hb_ctx_t *ctx, lps25hb_int_source_t *val)
+int32_t lps25hb_int_source_get(stmdev_ctx_t *ctx, lps25hb_int_source_t *val)
 {
-  return lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_on_press_high: [get]  Differential pressure high
-  *                                   interrupt flag.
+  * @brief  Differential pressure high interrupt flag.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ph in reg INT_SOURCE
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ph in reg INT_SOURCE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_on_press_high_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_int_on_press_high_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_int_source_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, &reg.byte, 1);
-  *val = reg.int_source.ph;
+  ret = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, (uint8_t*)&reg, 1);
+  *val = reg.ph;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_on_press_low: [get]  Differential pressure low
-  *                                  interrupt flag.
+  * @brief  Differential pressure low interrupt flag.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of pl in reg INT_SOURCE
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pl in reg INT_SOURCE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_on_press_low_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_int_on_press_low_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_int_source_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, &reg.byte, 1);
-  *val = reg.int_source.pl;
+  ret = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, (uint8_t*)&reg, 1);
+  *val = reg.pl;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  interrupt_event: [get]  Interrupt active flag.
+  * @brief  Interrupt active flag.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ia in reg INT_SOURCE
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ia in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_interrupt_event_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_interrupt_event_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_int_source_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, &reg.byte, 1);
-  *val = reg.int_source.ia;
+  ret = lps25hb_read_reg(ctx, LPS25HB_INT_SOURCE, (uint8_t*)&reg, 1);
+  *val = reg.ia;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_threshold: [set]  User-defined threshold value for
-  *                              pressure interrupt event
+  * @brief  User-defined threshold value for pressure interrupt event[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_threshold_set(lps25hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps25hb_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lps25hb_read_reg(ctx, LPS25HB_THS_P_L,  buff, 2);
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_THS_P_L,  buff, 2);
+  return ret;
 }
 
 /**
-  * @brief  int_threshold: [get]  User-defined threshold value for
-  *                              pressure interrupt event
+  * @brief  User-defined threshold value for pressure interrupt event[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_int_threshold_get(lps25hb_ctx_t *ctx, uint8_t *buff)
+int32_t lps25hb_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lps25hb_read_reg(ctx, LPS25HB_THS_P_L,  buff, 2);
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_THS_P_L,  buff, 2);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  fifo
+  * @defgroup   LPS25HB_fifo
   * @brief   This section group all the functions concerning the fifo usage
   * @{
+  *
   */
 
 /**
-  * @brief   stop_on_fifo_threshold: [set]  Stop on FIFO watermark.
-  *                                         Enable FIFO watermark level use.
+  * @brief  Stop on FIFO watermark. Enable FIFO watermark level use.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of stop_on_fth in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_fth in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_stop_on_fifo_threshold_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_stop_on_fifo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  reg.ctrl_reg2.stop_on_fth = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.stop_on_fth = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief   stop_on_fifo_threshold: [get]  Stop on FIFO watermark.
-  *                                         Enable FIFO watermark
-  *                                         level use.
+  * @brief  Stop on FIFO watermark. Enable FIFO watermark level use.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of stop_on_fth in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of stop_on_fth in reg CTRL_REG2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_stop_on_fifo_threshold_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_stop_on_fifo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  *val = reg.ctrl_reg2.stop_on_fth;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  *val = reg.stop_on_fth;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo: [set] FIFOenable.
+  * @brief  FIFOenable.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of fifo_en in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_en in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  reg.ctrl_reg2.fifo_en = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.fifo_en = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo: [get] FIFOenable.
+  * @brief  FIFOenable.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_en in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_en in reg CTRL_REG2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  *val = reg.ctrl_reg2.fifo_en;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of wtm_point in reg FIFO_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm_point in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_watermark_set(lps25hb_ctx_t *ctx, uint8_t val)
+int32_t lps25hb_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_fifo_ctrl_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
-  reg.fifo_ctrl.wtm_point = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.wtm_point = val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_FIFO_CTRL, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of wtm_point in reg FIFO_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wtm_point in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_watermark_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_fifo_ctrl_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
-  *val = reg.fifo_ctrl.wtm_point;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, (uint8_t*)&reg, 1);
+  *val = reg.wtm_point;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [set]  FIFO mode selection.
+  * @brief  FIFO mode selection.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_f_mode_t: change the values of f_mode in reg FIFO_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of f_mode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_mode_set(lps25hb_ctx_t *ctx, lps25hb_f_mode_t val)
+int32_t lps25hb_fifo_mode_set(stmdev_ctx_t *ctx, lps25hb_f_mode_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_fifo_ctrl_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
-  reg.fifo_ctrl.f_mode = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.f_mode = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_FIFO_CTRL, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [get]  FIFO mode selection.
+  * @brief  FIFO mode selection.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_f_mode_t: Get the values of f_mode in reg FIFO_CTRL
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of f_mode in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_mode_get(lps25hb_ctx_t *ctx, lps25hb_f_mode_t *val)
+int32_t lps25hb_fifo_mode_get(stmdev_ctx_t *ctx, lps25hb_f_mode_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_fifo_ctrl_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, &reg.byte, 1);
-  *val = (lps25hb_f_mode_t) reg.fifo_ctrl.f_mode;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_CTRL, (uint8_t*)&reg, 1);
+  switch (reg.f_mode){
+    case LPS25HB_BYPASS_MODE:
+      *val = LPS25HB_BYPASS_MODE;
+      break;
+    case LPS25HB_FIFO_MODE:
+      *val = LPS25HB_FIFO_MODE;
+      break;
+    case LPS25HB_STREAM_MODE:
+      *val = LPS25HB_STREAM_MODE;
+      break;
+    case LPS25HB_Stream_to_FIFO_mode:
+      *val = LPS25HB_Stream_to_FIFO_mode;
+      break;
+    case LPS25HB_BYPASS_TO_STREAM_MODE:
+      *val = LPS25HB_BYPASS_TO_STREAM_MODE;
+      break;
+    case LPS25HB_MEAN_MODE:
+      *val = LPS25HB_MEAN_MODE;
+      break;
+    case LPS25HB_BYPASS_TO_FIFO_MODE:
+      *val = LPS25HB_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LPS25HB_BYPASS_MODE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_status: [get]  FIFO status register.
+  * @brief  FIFO status register. [get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_: registers FIFO_STATUS
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  lps25hb_: registers FIFO_STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_status_get(lps25hb_ctx_t *ctx, lps25hb_fifo_status_t *val)
+int32_t lps25hb_fifo_status_get(stmdev_ctx_t *ctx,
+                                lps25hb_fifo_status_t *val)
 {
-  return lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  fifo_data_level: [get]  FIFO stored data level.
+  * @brief  FIFO stored data level.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fss in reg FIFO_STATUS
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fss in reg FIFO_STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_data_level_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_fifo_status_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, &reg.byte, 1);
-  *val = reg.fifo_status.fss;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, (uint8_t*)&reg, 1);
+  *val = reg.fss;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_empty_flag: [get]  Empty FIFO status flag.
+  * @brief  Empty FIFO status flag.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of empty_fifo in reg FIFO_STATUS
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of empty_fifo in reg FIFO_STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_empty_flag_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_fifo_status_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, &reg.byte, 1);
-  *val = reg.fifo_status.empty_fifo;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, (uint8_t*)&reg, 1);
+  *val = reg.empty_fifo;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_flag: [get]  FIFO overrun status flag.
+  * @brief  FIFO overrun status flag.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ovr in reg FIFO_STATUS
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ovr in reg FIFO_STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_ovr_flag_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_fifo_status_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, &reg.byte, 1);
-  *val = reg.fifo_status.ovr;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, (uint8_t*)&reg, 1);
+  *val = reg.ovr;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_fth_flag: [get]  FIFO watermark status.
+  * @brief  FIFO watermark status.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fth_fifo in reg FIFO_STATUS
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fth_fifo in reg FIFO_STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_fifo_fth_flag_get(lps25hb_ctx_t *ctx, uint8_t *val)
+int32_t lps25hb_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_fifo_status_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, &reg.byte, 1);
-  *val = reg.fifo_status.fth_fifo;
+  ret = lps25hb_read_reg(ctx, LPS25HB_FIFO_STATUS, (uint8_t*)&reg, 1);
+  *val = reg.fth_fifo;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  serial_interface
-  * @brief   This section group all the functions concerning serial
-  *          interface management
+  * @defgroup   LPS25HB_serial_interface
+  * @brief      This section group all the functions concerning serial
+  *             interface management
   * @{
+  *
   */
 
 /**
-  * @brief  spi_mode: [set]  SPI Serial Interface Mode selection.
+  * @brief  SPI Serial Interface Mode selection.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_sim_t: change the values of sim in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_spi_mode_set(lps25hb_ctx_t *ctx, lps25hb_sim_t val)
+int32_t lps25hb_spi_mode_set(stmdev_ctx_t *ctx, lps25hb_sim_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  reg.ctrl_reg1.sim = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.sim = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  spi_mode: [get]  SPI Serial Interface Mode selection.
+  * @brief  SPI Serial Interface Mode selection.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_sim_t: Get the values of sim in reg CTRL_REG1
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL_REG1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_spi_mode_get(lps25hb_ctx_t *ctx, lps25hb_sim_t *val)
+int32_t lps25hb_spi_mode_get(stmdev_ctx_t *ctx, lps25hb_sim_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg1_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, &reg.byte, 1);
-  *val = (lps25hb_sim_t) reg.ctrl_reg1.sim;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG1, (uint8_t*)&reg, 1);
+  switch (reg.sim){
+    case LPS25HB_SPI_4_WIRE:
+      *val = LPS25HB_SPI_4_WIRE;
+      break;
+    case LPS25HB_SPI_3_WIRE:
+      *val = LPS25HB_SPI_3_WIRE;
+      break;
+    default:
+      *val = LPS25HB_SPI_4_WIRE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [set]  Disable I2C interface.
+  * @brief  Disable I2C interface.[set]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_i2c_dis_t: change the values of i2c_dis in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_dis in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_i2c_interface_set(lps25hb_ctx_t *ctx, lps25hb_i2c_dis_t val)
+int32_t lps25hb_i2c_interface_set(stmdev_ctx_t *ctx, lps25hb_i2c_dis_t val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  reg.ctrl_reg2.i2c_dis = val;
-  mm_error = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  if(ret == 0){
+    reg.i2c_dis = (uint8_t)val;
+    ret = lps25hb_write_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  }
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [get]  Disable I2C interface.
+  * @brief  Disable I2C interface.[get]
   *
-  * @param  lps25hb_ctx_t *ctx: read / write interface definitions
-  * @param  lps25hb_i2c_dis_t: Get the values of i2c_dis in reg CTRL_REG2
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_dis in reg CTRL_REG2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps25hb_i2c_interface_get(lps25hb_ctx_t *ctx, lps25hb_i2c_dis_t *val)
+int32_t lps25hb_i2c_interface_get(stmdev_ctx_t *ctx, lps25hb_i2c_dis_t *val)
 {
-  lps25hb_reg_t reg;
-  int32_t mm_error;
+  lps25hb_ctrl_reg2_t reg;
+  int32_t ret;
 
-  mm_error = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, &reg.byte, 1);
-  *val = (lps25hb_i2c_dis_t) reg.ctrl_reg2.i2c_dis;
-
-  return mm_error;
+  ret = lps25hb_read_reg(ctx, LPS25HB_CTRL_REG2, (uint8_t*)&reg, 1);
+  switch (reg.i2c_dis){
+    case LPS25HB_I2C_ENABLE:
+      *val = LPS25HB_I2C_ENABLE;
+      break;
+    case LPS25HB_I2C_DISABLE:
+      *val = LPS25HB_I2C_DISABLE;
+      break;
+    default:
+      *val = LPS25HB_I2C_ENABLE;
+      break;
+  }
+  return ret;
 }
 
 /**
   * @}
+  *
+  */
+
+/**
+  * @}
+  *
   */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps25hb_STdC/driver/lps25hb_reg.h
+++ b/sensor/stmemsc/lps25hb_STdC/driver/lps25hb_reg.h
@@ -1,42 +1,26 @@
 /*
  ******************************************************************************
  * @file    lps25hb_reg.h
- * @author  MEMS Software Solution Team
- * @date    20-September-2017
+ * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
  *          lps25hb_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __LPS25HB_DRIVER__H
-#define __LPS25HB_DRIVER__H
+#ifndef LPS25HB_REGS_H
+#define LPS25HB_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -51,33 +35,13 @@
   *
   */
 
-/** @defgroup LPS25HB_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -93,71 +57,92 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
-/** @defgroup lps25hb_interface
-  * @{
-  */
+#endif /* MEMS_SHARED_TYPES */
 
-typedef int32_t (*lps25hb_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lps25hb_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
 
 typedef struct {
-  /** Component mandatory fields **/
-  lps25hb_write_ptr  write_reg;
-  lps25hb_read_ptr   read_reg;
-  /** Customizable optional pointer **/
-  void *handle;
-} lps25hb_ctx_t;
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
 
 /**
   * @}
+  *
   */
 
+#endif /* MEMS_UCF_SHARED_TYPES */
 
-/** @defgroup lps25hb_Infos
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LPS25HB_Infos
   * @{
+  *
   */
-  /** I2C Device Address 8 bit format if SA0=0 -> B9 if SA0=1 -> BB **/
-#define LPS25HB_I2C_ADD_L    0xB9
-#define LPS25HB_I2C_ADD_H    0xBB
+
+/** I2C Device Address 8 bit format if SA0=0 -> B9 if SA0=1 -> BB **/
+#define LPS25HB_I2C_ADD_L    0xB9U
+#define LPS25HB_I2C_ADD_H    0xBBU
 
 /** Device Identification (Who am I) **/
-#define LPS25HB_ID             0xBD
+#define LPS25HB_ID             0xBDU
 
 /**
   * @}
+  *
   */
 
-/**
-  * @defgroup lps25hb_Sensitivity
-  * @{
-  */
-
-#define LPS25HB_FROM_LSB_TO_hPa(lsb)      (float)( lsb / 4096.0f )
-#define LPS25HB_FROM_LSB_TO_degC(lsb)    ((float)( lsb / 480.0f ) + 42.5f )
-
-/**
-  * @}
-  */
-
-#define LPS25HB_REF_P_XL        0x08
-#define LPS25HB_REF_P_L         0x09
-#define LPS25HB_REF_P_H         0x0A
-#define LPS25HB_WHO_AM_I        0x0F
-#define LPS25HB_RES_CONF        0x10
+#define LPS25HB_REF_P_XL        0x08U
+#define LPS25HB_REF_P_L         0x09U
+#define LPS25HB_REF_P_H         0x0AU
+#define LPS25HB_WHO_AM_I        0x0FU
+#define LPS25HB_RES_CONF        0x10U
 typedef struct {
   uint8_t avgp             : 2;
   uint8_t avgt             : 2;
   uint8_t not_used_01      : 4;
 } lps25hb_res_conf_t;
 
-#define LPS25HB_CTRL_REG1       0x20
+#define LPS25HB_CTRL_REG1       0x20U
 typedef struct {
   uint8_t sim              : 1;
   uint8_t reset_az         : 1;
@@ -166,7 +151,7 @@ typedef struct {
   uint8_t odr              : 4; /* pd + odr -> odr */
 } lps25hb_ctrl_reg1_t;
 
-#define LPS25HB_CTRL_REG2       0x21
+#define LPS25HB_CTRL_REG2       0x21U
 typedef struct {
   uint8_t one_shot         : 1;
   uint8_t autozero         : 1;
@@ -178,7 +163,7 @@ typedef struct {
   uint8_t boot             : 1;
 } lps25hb_ctrl_reg2_t;
 
-#define LPS25HB_CTRL_REG3       0x22
+#define LPS25HB_CTRL_REG3       0x22U
 typedef struct {
   uint8_t int_s           : 2;
   uint8_t not_used_01     : 4;
@@ -186,7 +171,7 @@ typedef struct {
   uint8_t int_h_l         : 1;
 } lps25hb_ctrl_reg3_t;
 
-#define LPS25HB_CTRL_REG4       0x23
+#define LPS25HB_CTRL_REG4       0x23U
 typedef struct {
   uint8_t drdy            : 1;
   uint8_t f_ovr           : 1;
@@ -195,14 +180,14 @@ typedef struct {
   uint8_t not_used_01     : 4;
 } lps25hb_ctrl_reg4_t;
 
-#define LPS25HB_INTERRUPT_CFG   0x24
+#define LPS25HB_INTERRUPT_CFG   0x24U
 typedef struct {
   uint8_t pe              : 2;  /* pl_e + ph_e -> pe */
   uint8_t lir             : 1;
   uint8_t not_used_01     : 5;
 } lps25hb_interrupt_cfg_t;
 
-#define LPS25HB_INT_SOURCE      0x25
+#define LPS25HB_INT_SOURCE      0x25U
 typedef struct {
   uint8_t ph              : 1;
   uint8_t pl              : 1;
@@ -210,7 +195,7 @@ typedef struct {
   uint8_t not_used_01     : 5;
 } lps25hb_int_source_t;
 
-#define LPS25HB_STATUS_REG      0x27
+#define LPS25HB_STATUS_REG      0x27U
 typedef struct {
   uint8_t t_da            : 1;
   uint8_t p_da            : 1;
@@ -220,18 +205,18 @@ typedef struct {
   uint8_t not_used_02     : 2;
 } lps25hb_status_reg_t;
 
-#define LPS25HB_PRESS_OUT_XL    0x28
-#define LPS25HB_PRESS_OUT_L     0x29
-#define LPS25HB_PRESS_OUT_H     0x2A
-#define LPS25HB_TEMP_OUT_L      0x2B
-#define LPS25HB_TEMP_OUT_H      0x2C
-#define LPS25HB_FIFO_CTRL       0x2E
+#define LPS25HB_PRESS_OUT_XL    0x28U
+#define LPS25HB_PRESS_OUT_L     0x29U
+#define LPS25HB_PRESS_OUT_H     0x2AU
+#define LPS25HB_TEMP_OUT_L      0x2BU
+#define LPS25HB_TEMP_OUT_H      0x2CU
+#define LPS25HB_FIFO_CTRL       0x2EU
 typedef struct {
   uint8_t wtm_point       : 5;
   uint8_t f_mode          : 3;
 } lps25hb_fifo_ctrl_t;
 
-#define LPS25HB_FIFO_STATUS     0x2F
+#define LPS25HB_FIFO_STATUS     0x2FU
 typedef struct {
   uint8_t fss             : 5;
   uint8_t empty_fifo      : 1;
@@ -239,11 +224,23 @@ typedef struct {
   uint8_t fth_fifo        : 1;
 } lps25hb_fifo_status_t;
 
-#define LPS25HB_THS_P_L         0x30
-#define LPS25HB_THS_P_H         0x31
-#define LPS25HB_RPDS_L          0x39
-#define LPS25HB_RPDS_H          0x3A
+#define LPS25HB_THS_P_L         0x30U
+#define LPS25HB_THS_P_H         0x31U
+#define LPS25HB_RPDS_L          0x39U
+#define LPS25HB_RPDS_H          0x3AU
 
+/**
+  * @defgroup LPS25HB_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
 typedef union{
   lps25hb_res_conf_t            res_conf;
   lps25hb_ctrl_reg1_t           ctrl_reg1;
@@ -259,11 +256,21 @@ typedef union{
   uint8_t                       byte;
 } lps25hb_reg_t;
 
-int32_t lps25hb_read_reg(lps25hb_ctx_t *ctx, uint8_t reg, uint8_t* data, uint16_t len);
-int32_t lps25hb_write_reg(lps25hb_ctx_t *ctx, uint8_t reg, uint8_t* data, uint16_t len);
+/**
+  * @}
+  *
+  */
 
-int32_t lps25hb_pressure_ref_set(lps25hb_ctx_t *ctx, uint8_t *buff);
-int32_t lps25hb_pressure_ref_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lps25hb_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lps25hb_from_lsb_to_hpa(uint32_t lsb);
+extern float_t lps25hb_from_lsb_to_degc(int16_t lsb);
+
+int32_t lps25hb_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LPS25HB_P_AVG_8  = 0,
@@ -271,8 +278,8 @@ typedef enum {
   LPS25HB_P_AVG_32 = 2,
   LPS25HB_P_AVG_64 = 3,
 } lps25hb_avgp_t;
-int32_t lps25hb_pressure_avg_set(lps25hb_ctx_t *ctx, lps25hb_avgp_t val);
-int32_t lps25hb_pressure_avg_get(lps25hb_ctx_t *ctx, lps25hb_avgp_t *val);
+int32_t lps25hb_pressure_avg_set(stmdev_ctx_t *ctx, lps25hb_avgp_t val);
+int32_t lps25hb_pressure_avg_get(stmdev_ctx_t *ctx, lps25hb_avgp_t *val);
 
 typedef enum {
   LPS25HB_T_AVG_8  = 0,
@@ -280,14 +287,14 @@ typedef enum {
   LPS25HB_T_AVG_32 = 2,
   LPS25HB_T_AVG_64 = 3,
 } lps25hb_avgt_t;
-int32_t lps25hb_temperature_avg_set(lps25hb_ctx_t *ctx, lps25hb_avgt_t val);
-int32_t lps25hb_temperature_avg_get(lps25hb_ctx_t *ctx, lps25hb_avgt_t *val);
+int32_t lps25hb_temperature_avg_set(stmdev_ctx_t *ctx, lps25hb_avgt_t val);
+int32_t lps25hb_temperature_avg_get(stmdev_ctx_t *ctx, lps25hb_avgt_t *val);
 
-int32_t lps25hb_autozero_rst_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_autozero_rst_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_block_data_update_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_block_data_update_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS25HB_POWER_DOWN = 0,
@@ -297,45 +304,45 @@ typedef enum {
   LPS25HB_ODR_25Hz   = 13,
   LPS25HB_ONE_SHOT   = 8,
 } lps25hb_odr_t;
-int32_t lps25hb_data_rate_set(lps25hb_ctx_t *ctx, lps25hb_odr_t val);
-int32_t lps25hb_data_rate_get(lps25hb_ctx_t *ctx, lps25hb_odr_t *val);
+int32_t lps25hb_data_rate_set(stmdev_ctx_t *ctx, lps25hb_odr_t val);
+int32_t lps25hb_data_rate_get(stmdev_ctx_t *ctx, lps25hb_odr_t *val);
 
-int32_t lps25hb_one_shoot_trigger_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_one_shoot_trigger_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_autozero_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_autozero_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_autozero_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_autozero_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_mean_decimator_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_fifo_mean_decimator_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_mean_decimator_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_mean_decimator_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_press_data_ready_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_press_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_temp_data_ready_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_temp_data_ovr_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_press_data_ovr_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_press_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_pressure_raw_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps25hb_temperature_raw_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps25hb_pressure_offset_set(lps25hb_ctx_t *ctx, uint8_t *buff);
-int32_t lps25hb_pressure_offset_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps25hb_device_id_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps25hb_reset_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_reset_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_boot_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_boot_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_status_get(lps25hb_ctx_t *ctx, lps25hb_status_reg_t *val);
+int32_t lps25hb_status_get(stmdev_ctx_t *ctx, lps25hb_status_reg_t *val);
 
-int32_t lps25hb_int_generation_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_int_generation_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_int_generation_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS25HB_DRDY_OR_FIFO_FLAGS  = 0,
@@ -343,34 +350,34 @@ typedef enum {
   LPS25HB_LOW_PRES_INT        = 2,
   LPS25HB_EVERY_PRES_INT      = 3,
 } lps25hb_int_s_t;
-int32_t lps25hb_int_pin_mode_set(lps25hb_ctx_t *ctx, lps25hb_int_s_t val);
-int32_t lps25hb_int_pin_mode_get(lps25hb_ctx_t *ctx, lps25hb_int_s_t *val);
+int32_t lps25hb_int_pin_mode_set(stmdev_ctx_t *ctx, lps25hb_int_s_t val);
+int32_t lps25hb_int_pin_mode_get(stmdev_ctx_t *ctx, lps25hb_int_s_t *val);
 
 typedef enum {
   LPS25HB_PUSH_PULL   = 0,
   LPS25HB_OPEN_DRAIN  = 1,
 } lps25hb_pp_od_t;
-int32_t lps25hb_pin_mode_set(lps25hb_ctx_t *ctx, lps25hb_pp_od_t val);
-int32_t lps25hb_pin_mode_get(lps25hb_ctx_t *ctx, lps25hb_pp_od_t *val);
+int32_t lps25hb_pin_mode_set(stmdev_ctx_t *ctx, lps25hb_pp_od_t val);
+int32_t lps25hb_pin_mode_get(stmdev_ctx_t *ctx, lps25hb_pp_od_t *val);
 
 typedef enum {
   LPS25HB_ACTIVE_HIGH = 0,
   LPS25HB_ACTIVE_LOW  = 1,
 } lps25hb_int_h_l_t;
-int32_t lps25hb_int_polarity_set(lps25hb_ctx_t *ctx, lps25hb_int_h_l_t val);
-int32_t lps25hb_int_polarity_get(lps25hb_ctx_t *ctx, lps25hb_int_h_l_t *val);
+int32_t lps25hb_int_polarity_set(stmdev_ctx_t *ctx, lps25hb_int_h_l_t val);
+int32_t lps25hb_int_polarity_get(stmdev_ctx_t *ctx, lps25hb_int_h_l_t *val);
 
-int32_t lps25hb_drdy_on_int_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_drdy_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_ovr_on_int_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_fifo_ovr_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_threshold_on_int_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_fifo_threshold_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_empty_on_int_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_fifo_empty_on_int_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_empty_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_empty_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS25HB_NO_THRESHOLD = 0,
@@ -378,35 +385,39 @@ typedef enum {
   LPS25HB_NEGATIVE     = 2,
   LPS25HB_BOTH         = 3,
 } lps25hb_pe_t;
-int32_t lps25hb_sign_of_int_threshold_set(lps25hb_ctx_t *ctx, lps25hb_pe_t val);
-int32_t lps25hb_sign_of_int_threshold_get(lps25hb_ctx_t *ctx, lps25hb_pe_t *val);
+int32_t lps25hb_sign_of_int_threshold_set(stmdev_ctx_t *ctx,
+                                          lps25hb_pe_t val);
+int32_t lps25hb_sign_of_int_threshold_get(stmdev_ctx_t *ctx,
+                                          lps25hb_pe_t *val);
 
 typedef enum {
   LPS25HB_INT_PULSED = 0,
   LPS25HB_INT_LATCHED = 1,
 } lps25hb_lir_t;
-int32_t lps25hb_int_notification_mode_set(lps25hb_ctx_t *ctx, lps25hb_lir_t val);
-int32_t lps25hb_int_notification_mode_get(lps25hb_ctx_t *ctx, lps25hb_lir_t *val);
+int32_t lps25hb_int_notification_mode_set(stmdev_ctx_t *ctx,
+                                          lps25hb_lir_t val);
+int32_t lps25hb_int_notification_mode_get(stmdev_ctx_t *ctx,
+                                          lps25hb_lir_t *val);
 
-int32_t lps25hb_int_source_get(lps25hb_ctx_t *ctx, lps25hb_int_source_t *val);
+int32_t lps25hb_int_source_get(stmdev_ctx_t *ctx, lps25hb_int_source_t *val);
 
-int32_t lps25hb_int_on_press_high_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_int_on_press_high_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_int_on_press_low_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_int_on_press_low_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_interrupt_event_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_interrupt_event_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_int_threshold_set(lps25hb_ctx_t *ctx, uint8_t *buff);
-int32_t lps25hb_int_threshold_get(lps25hb_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps25hb_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps25hb_stop_on_fifo_threshold_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_stop_on_fifo_threshold_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_stop_on_fifo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_stop_on_fifo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_fifo_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_watermark_set(lps25hb_ctx_t *ctx, uint8_t val);
-int32_t lps25hb_fifo_watermark_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps25hb_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS25HB_BYPASS_MODE               = 0,
@@ -417,41 +428,43 @@ typedef enum {
   LPS25HB_MEAN_MODE                 = 6,
   LPS25HB_BYPASS_TO_FIFO_MODE      = 7,
 } lps25hb_f_mode_t;
-int32_t lps25hb_fifo_mode_set(lps25hb_ctx_t *ctx, lps25hb_f_mode_t val);
-int32_t lps25hb_fifo_mode_get(lps25hb_ctx_t *ctx, lps25hb_f_mode_t *val);
+int32_t lps25hb_fifo_mode_set(stmdev_ctx_t *ctx, lps25hb_f_mode_t val);
+int32_t lps25hb_fifo_mode_get(stmdev_ctx_t *ctx, lps25hb_f_mode_t *val);
 
-int32_t lps25hb_fifo_status_get(lps25hb_ctx_t *ctx, lps25hb_fifo_status_t *val);
+int32_t lps25hb_fifo_status_get(stmdev_ctx_t *ctx,
+                                lps25hb_fifo_status_t *val);
 
-int32_t lps25hb_fifo_data_level_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_empty_flag_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_ovr_flag_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps25hb_fifo_fth_flag_get(lps25hb_ctx_t *ctx, uint8_t *val);
+int32_t lps25hb_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS25HB_SPI_4_WIRE = 0,
   LPS25HB_SPI_3_WIRE = 1,
 } lps25hb_sim_t;
-int32_t lps25hb_spi_mode_set(lps25hb_ctx_t *ctx, lps25hb_sim_t val);
-int32_t lps25hb_spi_mode_get(lps25hb_ctx_t *ctx, lps25hb_sim_t *val);
+int32_t lps25hb_spi_mode_set(stmdev_ctx_t *ctx, lps25hb_sim_t val);
+int32_t lps25hb_spi_mode_get(stmdev_ctx_t *ctx, lps25hb_sim_t *val);
 
 typedef enum {
   LPS25HB_I2C_ENABLE  = 0,
   LPS25HB_I2C_DISABLE = 1,
 } lps25hb_i2c_dis_t;
-int32_t lps25hb_i2c_interface_set(lps25hb_ctx_t *ctx, lps25hb_i2c_dis_t val);
-int32_t lps25hb_i2c_interface_get(lps25hb_ctx_t *ctx, lps25hb_i2c_dis_t *val);
+int32_t lps25hb_i2c_interface_set(stmdev_ctx_t *ctx, lps25hb_i2c_dis_t val);
+int32_t lps25hb_i2c_interface_get(stmdev_ctx_t *ctx, lps25hb_i2c_dis_t *val);
 
 /**
-  * @}
+  *@}
+  *
   */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /*__LPS25HB_DRIVER__H */
+#endif /* LPS25HB_REGS_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps27hhw_STdC/driver/lps27hhw_reg.c
+++ b/sensor/stmemsc/lps27hhw_STdC/driver/lps27hhw_reg.c
@@ -1,0 +1,1812 @@
+/*
+ ******************************************************************************
+ * @file    lps27hhw_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LPS27HHW driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "lps27hhw_reg.h"
+
+/**
+  * @defgroup  LPS27HHW
+  * @brief     This file provides a set of functions needed to drive the
+  *            lps27hhw enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup  LPS27HHW_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS27HHW_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+float_t lps27hhw_from_lsb_to_hpa(int32_t lsb)
+{
+  return ( (float_t) lsb / 4096.0f );
+}
+
+float_t lps27hhw_from_lsb_to_celsius(int16_t lsb)
+{
+  return ( (float_t) lsb / 100.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS27HHW_Data_Generation
+  * @brief     This section groups all the functions concerning
+  *            data generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Reset Autozero function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reset_az in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.reset_az = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Autozero function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reset_az in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  *val = reg.reset_az;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of autozero in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_autozero_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.autozero = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of autozero in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_autozero_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  *val = reg.autozero;
+
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.reset_arp = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  *val = reg.reset_arp;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRefP function.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of autorefp in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.autorefp = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRefP function.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of autorefp in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  *val = reg.autorefp;
+
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.bdu = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block Data Update.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of bdu in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  *val = reg.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_data_rate_set(stmdev_ctx_t *ctx, lps27hhw_odr_t val)
+{
+  lps27hhw_ctrl_reg1_t ctrl_reg1;
+  lps27hhw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  if (ret == 0) {
+    ctrl_reg1.odr = (uint8_t)val & 0x07U;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  if (ret == 0) {
+    ctrl_reg2.low_noise_en = ((uint8_t)val & 0x10U) >> 4;
+    ctrl_reg2.one_shot = ((uint8_t)val & 0x08U) >> 3;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of odr in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_data_rate_get(stmdev_ctx_t *ctx, lps27hhw_odr_t *val)
+{
+  lps27hhw_ctrl_reg1_t ctrl_reg1;
+  lps27hhw_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if (ret == 0) {
+    ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  if (ret == 0) {
+    ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+    switch (((ctrl_reg2.low_noise_en << 4) + (ctrl_reg2.one_shot << 3) +
+            ctrl_reg1.odr )) {
+      case LPS27HHW_POWER_DOWN:
+        *val = LPS27HHW_POWER_DOWN;
+        break;
+      case LPS27HHW_ONE_SHOOT:
+        *val = LPS27HHW_ONE_SHOOT;
+        break;
+      case LPS27HHW_1_Hz:
+        *val = LPS27HHW_1_Hz;
+        break;
+      case LPS27HHW_10_Hz:
+        *val = LPS27HHW_10_Hz;
+        break;
+      case LPS27HHW_25_Hz:
+        *val = LPS27HHW_25_Hz;
+        break;
+      case LPS27HHW_50_Hz:
+        *val = LPS27HHW_50_Hz;
+        break;
+      case LPS27HHW_75_Hz:
+        *val = LPS27HHW_75_Hz;
+        break;
+      case LPS27HHW_1_Hz_LOW_NOISE:
+        *val = LPS27HHW_1_Hz_LOW_NOISE;
+        break;
+      case LPS27HHW_10_Hz_LOW_NOISE:
+        *val = LPS27HHW_10_Hz_LOW_NOISE;
+        break;
+      case LPS27HHW_25_Hz_LOW_NOISE:
+        *val = LPS27HHW_25_Hz_LOW_NOISE;
+        break;
+      case LPS27HHW_50_Hz_LOW_NOISE:
+        *val = LPS27HHW_50_Hz_LOW_NOISE;
+        break;
+      case LPS27HHW_75_Hz_LOW_NOISE:
+        *val = LPS27HHW_75_Hz_LOW_NOISE;
+        break;
+      case LPS27HHW_100_Hz:
+        *val = LPS27HHW_100_Hz;
+        break;
+      case LPS27HHW_200_Hz:
+        *val = LPS27HHW_200_Hz;
+        break;
+      default:
+        *val = LPS27HHW_POWER_DOWN;
+        break;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  The Reference pressure value is a 16-bit data
+  *         expressed as 2’s complement. The value is used
+  *         when AUTOZERO or AUTORIFP function is enabled.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lps27hhw_write_reg(ctx, LPS27HHW_REF_P_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The Reference pressure value is a 16-bit
+  *         data expressed as 2’s complement.
+  *         The value is used when AUTOZERO or AUTORIFP
+  *         function is enabled.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_REF_P_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data
+  *         that can be used to implement one-point
+  *         calibration (OPC) after soldering.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_write_reg(ctx, LPS27HHW_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit
+  *         data that can be used to implement
+  *         one-point calibration (OPC) after
+  *         soldering.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers STATUS,FIFO_STATUS2,INT_SOURCE
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_all_sources_get(stmdev_ctx_t *ctx, lps27hhw_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INT_SOURCE,
+                         (uint8_t*) &(val->int_source), 1);
+  if (ret == 0) {
+    ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_STATUS2,
+                           (uint8_t*) &(val->fifo_status2), 1);
+  }
+  if (ret == 0) {
+    ret = lps27hhw_read_reg(ctx, LPS27HHW_STATUS,
+                           (uint8_t*) &(val->status), 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      structure of registers from STATUS to STATUS_REG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_status_reg_get(stmdev_ctx_t *ctx, lps27hhw_status_t *val)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_STATUS, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Pressure new data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of p_da in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_press_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_status_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_STATUS, (uint8_t*) &reg, 1);
+  *val = reg.p_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of t_da in reg STATUS
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_status_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_STATUS, (uint8_t*) &reg, 1);
+  *val = reg.t_da;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS27HHW_Data_Output
+  * @brief     This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Pressure output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_PRESS_OUT_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Temperature output value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_TEMP_OUT_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Pressure output from FIFO value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_FIFO_DATA_OUT_PRESS_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Temperature output from FIFO value.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_FIFO_DATA_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS27HHW_Common
+  * @brief     This section groups common useful functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DeviceWhoamI[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values
+  *         in user registers.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of swreset in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.swreset = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Software reset. Restore the default values
+  *          in user registers.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of swreset in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.swreset;
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically
+  *         incremented during a multiple byte access
+  *         with a serial interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.if_add_inc = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically
+  *         incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of if_add_inc in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration
+  *         parameters.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.boot = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration
+  *         parameters.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of boot in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  *val = reg.boot;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS27HHW_Filters
+  * @brief     This section group all the functions concerning the
+  *            filters configuration.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Low-pass bandwidth selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lpfp_cfg in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_lp_bandwidth_set(stmdev_ctx_t *ctx, lps27hhw_lpfp_cfg_t val)
+{
+  lps27hhw_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lpfp_cfg = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lpfp_cfg in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_lp_bandwidth_get(stmdev_ctx_t *ctx, lps27hhw_lpfp_cfg_t *val)
+{
+  lps27hhw_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  switch (reg.lpfp_cfg) {
+      case LPS27HHW_LPF_ODR_DIV_2:
+        *val = LPS27HHW_LPF_ODR_DIV_2;
+        break;
+      case LPS27HHW_LPF_ODR_DIV_9:
+        *val = LPS27HHW_LPF_ODR_DIV_9;
+        break;
+      case LPS27HHW_LPF_ODR_DIV_20:
+        *val = LPS27HHW_LPF_ODR_DIV_20;
+        break;
+      default:
+        *val = LPS27HHW_LPF_ODR_DIV_2;
+        break;
+    }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS27HHW_Serial_Interface
+  * @brief     This section groups all the functions concerning serial
+  *            interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable/Disable I2C interface.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of i2c_disable in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_i2c_interface_set(stmdev_ctx_t *ctx,
+                                  lps27hhw_i2c_disable_t val)
+{
+  lps27hhw_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i2c_disable = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable I2C interface.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of i2c_disable in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_i2c_interface_get(stmdev_ctx_t *ctx,
+                                  lps27hhw_i2c_disable_t *val)
+{
+  lps27hhw_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  switch (reg.i2c_disable) {
+      case LPS27HHW_I2C_ENABLE:
+        *val = LPS27HHW_I2C_ENABLE;
+        break;
+      case LPS27HHW_I2C_DISABLE:
+        *val = LPS27HHW_I2C_DISABLE;
+        break;
+      default:
+        *val = LPS27HHW_I2C_ENABLE;
+        break;
+    }
+
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_en_i3c in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_i3c_interface_set(stmdev_ctx_t *ctx,
+                                  lps27hhw_i3c_disable_t val)
+{
+  lps27hhw_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.i3c_disable = ((uint8_t)val & 0x01u);
+    reg.int_en_i3c = ((uint8_t)val & 0x10U) >> 4;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_en_i3c in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_i3c_interface_get(stmdev_ctx_t *ctx,
+                                  lps27hhw_i3c_disable_t *val)
+{
+  lps27hhw_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+
+  switch ((reg.int_en_i3c << 4) + reg.int_en_i3c) {
+    case LPS27HHW_I3C_ENABLE:
+      *val = LPS27HHW_I3C_ENABLE;
+      break;
+    case LPS27HHW_I3C_ENABLE_INT_PIN_ENABLE:
+      *val = LPS27HHW_I3C_ENABLE_INT_PIN_ENABLE;
+      break;
+    case LPS27HHW_I3C_DISABLE:
+      *val = LPS27HHW_I3C_DISABLE;
+      break;
+    default:
+      *val = LPS27HHW_I3C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable pull-up on SDO pin.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sdo_pu_en in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_sdo_sa0_mode_set(stmdev_ctx_t *ctx, lps27hhw_pu_en_t val)
+{
+  lps27hhw_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sdo_pu_en = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable/Disable pull-up on SDO pin.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sdo_pu_en in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_sdo_sa0_mode_get(stmdev_ctx_t *ctx, lps27hhw_pu_en_t *val)
+{
+  lps27hhw_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  switch (reg.sdo_pu_en) {
+    case LPS27HHW_PULL_UP_DISCONNECT:
+      *val = LPS27HHW_PULL_UP_DISCONNECT;
+      break;
+    case LPS27HHW_PULL_UP_CONNECT:
+      *val = LPS27HHW_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LPS27HHW_PULL_UP_DISCONNECT;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sda_pu_en in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_sda_mode_set(stmdev_ctx_t *ctx, lps27hhw_pu_en_t val)
+{
+  lps27hhw_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sda_pu_en = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sda_pu_en in reg IF_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_sda_mode_get(stmdev_ctx_t *ctx, lps27hhw_pu_en_t *val)
+{
+  lps27hhw_if_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_IF_CTRL, (uint8_t*) &reg, 1);
+  switch (reg.sda_pu_en) {
+    case LPS27HHW_PULL_UP_DISCONNECT:
+      *val = LPS27HHW_PULL_UP_DISCONNECT;
+      break;
+    case LPS27HHW_PULL_UP_CONNECT:
+      *val = LPS27HHW_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LPS27HHW_PULL_UP_DISCONNECT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of sim in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_spi_mode_set(stmdev_ctx_t *ctx, lps27hhw_sim_t val)
+{
+  lps27hhw_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.sim = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of sim in reg CTRL_REG1
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_spi_mode_get(stmdev_ctx_t *ctx, lps27hhw_sim_t *val)
+{
+  lps27hhw_ctrl_reg1_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG1, (uint8_t*) &reg, 1);
+  switch (reg.sim) {
+    case LPS27HHW_SPI_4_WIRE:
+      *val = LPS27HHW_SPI_4_WIRE;
+      break;
+    case LPS27HHW_SPI_3_WIRE:
+      *val = LPS27HHW_SPI_3_WIRE;
+      break;
+    default:
+      *val = LPS27HHW_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS27HHW_Interrupt_Pins
+  * @brief     This section groups all the functions that manage
+  *            interrupt pins.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Latch interrupt request to the INT_SOURCE (24h) register.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of lir in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_int_notification_set(stmdev_ctx_t *ctx, lps27hhw_lir_t val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.lir = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latch interrupt request to the INT_SOURCE (24h) register.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of lir in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_int_notification_get(stmdev_ctx_t *ctx, lps27hhw_lir_t *val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+
+  switch (reg.lir) {
+    case LPS27HHW_INT_PULSED:
+      *val = LPS27HHW_INT_PULSED;
+      break;
+    case LPS27HHW_INT_LATCHED:
+      *val = LPS27HHW_INT_LATCHED;
+      break;
+    default:
+      *val = LPS27HHW_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pp_od in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pin_mode_set(stmdev_ctx_t *ctx, lps27hhw_pp_od_t val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.pp_od = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pp_od in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pin_mode_get(stmdev_ctx_t *ctx, lps27hhw_pp_od_t *val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+
+
+  switch (reg.pp_od) {
+    case LPS27HHW_PUSH_PULL:
+      *val = LPS27HHW_PUSH_PULL;
+      break;
+    case LPS27HHW_OPEN_DRAIN:
+      *val = LPS27HHW_OPEN_DRAIN;
+      break;
+    default:
+      *val = LPS27HHW_PUSH_PULL;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of int_h_l in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pin_polarity_set(stmdev_ctx_t *ctx, lps27hhw_int_h_l_t val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.int_h_l = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of int_h_l in reg CTRL_REG2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pin_polarity_get(stmdev_ctx_t *ctx, lps27hhw_int_h_l_t *val)
+{
+  lps27hhw_ctrl_reg2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG2, (uint8_t*) &reg, 1);
+
+  switch (reg.int_h_l) {
+    case LPS27HHW_ACTIVE_HIGH:
+      *val = LPS27HHW_ACTIVE_HIGH;
+      break;
+    case LPS27HHW_ACTIVE_LOW:
+      *val = LPS27HHW_ACTIVE_LOW;
+      break;
+    default:
+      *val = LPS27HHW_ACTIVE_HIGH;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int pad.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pin_int_route_set(stmdev_ctx_t *ctx,
+                                  lps27hhw_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret =  lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int pad.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers CTRL_REG3
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_pin_int_route_get(stmdev_ctx_t *ctx,
+                                  lps27hhw_ctrl_reg3_t *val)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LPS27HHW_Interrupt_on_Threshold
+  * @brief      This section groups all the functions that manage the
+  *             interrupt on threshold event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief   Enable interrupt generation on pressure low/high event.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of pe in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_int_on_threshold_set(stmdev_ctx_t *ctx, lps27hhw_pe_t val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.pe = (uint8_t)val;
+
+    if (val == LPS27HHW_NO_THRESHOLD){
+      reg.diff_en = PROPERTY_DISABLE;
+    }
+    else{
+      reg.diff_en = PROPERTY_ENABLE;
+    }
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of pe in reg INTERRUPT_CFG
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_int_on_threshold_get(stmdev_ctx_t *ctx, lps27hhw_pe_t *val)
+{
+  lps27hhw_interrupt_cfg_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_INTERRUPT_CFG, (uint8_t*) &reg, 1);
+
+  switch (reg.pe) {
+    case LPS27HHW_NO_THRESHOLD:
+      *val = LPS27HHW_NO_THRESHOLD;
+      break;
+    case LPS27HHW_POSITIVE:
+      *val = LPS27HHW_POSITIVE;
+      break;
+    case LPS27HHW_NEGATIVE:
+      *val = LPS27HHW_NEGATIVE;
+      break;
+    case LPS27HHW_BOTH:
+      *val = LPS27HHW_BOTH;
+      break;
+    default:
+      *val = LPS27HHW_NO_THRESHOLD;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that contains data to write
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_int_treshold_set(stmdev_ctx_t *ctx, uint16_t buff)
+{
+  int32_t ret;
+  lps27hhw_ths_p_l_t ths_p_l;
+  lps27hhw_ths_p_h_t ths_p_h;
+  ths_p_l.ths = (uint8_t)(buff & 0x00FFU);
+  ths_p_h.ths = (uint8_t)((buff & 0x7F00U) >> 8);
+  ret =  lps27hhw_write_reg(ctx, LPS27HHW_THS_P_L,
+                           (uint8_t*)&ths_p_l, 1);
+  if (ret == 0) {
+      ret =  lps27hhw_write_reg(ctx, LPS27HHW_THS_P_H,
+                                (uint8_t*)&ths_p_h, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   User-defined threshold value for pressure interrupt event.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_int_treshold_get(stmdev_ctx_t *ctx, uint16_t *buff)
+{
+  int32_t ret;
+  lps27hhw_ths_p_l_t ths_p_l;
+  lps27hhw_ths_p_h_t ths_p_h;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_THS_P_L,
+                           (uint8_t*)&ths_p_l, 1);
+  if (ret == 0) {
+      ret =  lps27hhw_read_reg(ctx, LPS27HHW_THS_P_H,
+                               (uint8_t*)&ths_p_h, 1);
+      *buff = (uint16_t)ths_p_h.ths << 8;
+      *buff |= (uint16_t)ths_p_l.ths;
+  } 
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup  LPS27HHW_Fifo
+  * @brief   This section group all the functions concerning the fifo usage.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Fifo Mode selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of f_mode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_mode_set(stmdev_ctx_t *ctx, lps27hhw_f_mode_t val)
+{
+  lps27hhw_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.f_mode = (uint8_t)val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_FIFO_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Fifo Mode selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      Get the values of f_mode in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_mode_get(stmdev_ctx_t *ctx, lps27hhw_f_mode_t *val)
+{
+  lps27hhw_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_CTRL, (uint8_t*) &reg, 1);
+
+  switch (reg.f_mode) {
+    case LPS27HHW_BYPASS_MODE:
+      *val = LPS27HHW_BYPASS_MODE;
+      break;
+    case LPS27HHW_FIFO_MODE:
+      *val = LPS27HHW_FIFO_MODE;
+      break;
+    case LPS27HHW_STREAM_MODE:
+      *val = LPS27HHW_STREAM_MODE;
+      break;
+    case LPS27HHW_DYNAMIC_STREAM_MODE:
+      *val = LPS27HHW_DYNAMIC_STREAM_MODE;
+      break;
+    case LPS27HHW_BYPASS_TO_FIFO_MODE:
+      *val = LPS27HHW_BYPASS_TO_FIFO_MODE;
+      break;
+    case LPS27HHW_BYPASS_TO_STREAM_MODE:
+      *val = LPS27HHW_BYPASS_TO_STREAM_MODE;
+      break;
+    case LPS27HHW_STREAM_TO_FIFO_MODE:
+      *val = LPS27HHW_STREAM_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LPS27HHW_BYPASS_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at
+  *         threshold level.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of stop_on_wtm in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_CTRL, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.stop_on_wtm = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_FIFO_CTRL, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensing chain FIFO stop values memorization at threshold
+  *          level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of stop_on_wtm in reg FIFO_CTRL
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_fifo_ctrl_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_CTRL, (uint8_t*) &reg, 1);
+  *val = reg.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_WTM
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_fifo_wtm_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_WTM, (uint8_t*) &reg, 1);
+  if (ret == 0) {
+    reg.wtm = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_FIFO_WTM, (uint8_t*) &reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of wtm in reg FIFO_WTM
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_fifo_wtm_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_WTM, (uint8_t*) &reg, 1);
+  *val = reg.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  buff     buffer that stores data read
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_FIFO_STATUS1, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Read all the FIFO status flag of the device.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      registers FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_src_get(stmdev_ctx_t *ctx, lps27hhw_fifo_status2_t *val)
+{
+  int32_t ret;
+  ret =  lps27hhw_read_reg(ctx, LPS27HHW_FIFO_STATUS2, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO full status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_STATUS2, (uint8_t*) &reg, 1);
+  *val = reg.fifo_full_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_ovr_ia in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_STATUS2, (uint8_t*) &reg, 1);
+  *val = reg.fifo_ovr_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx      read / write interface definitions
+  * @param  val      change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval          interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps27hhw_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_fifo_status2_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_FIFO_STATUS2, (uint8_t*)&reg, 1);
+  *val = reg.fifo_wtm_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[set]
+  *
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_ovr in reg CTRL_REG3
+  *
+  */
+int32_t lps27hhw_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int_f_ovr = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[get]
+  *
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_ovr in reg CTRL_REG3
+  *
+  */
+int32_t lps27hhw_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  *val = reg.int_f_ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[set]
+  *
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_fth in reg CTRL_REG3
+  *
+  */
+int32_t lps27hhw_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int_f_wtm = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[get]
+  *
+  * @param  lps22hb_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_fth in reg CTRL_REG3
+  *
+  */
+int32_t lps27hhw_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  *val = reg.int_f_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[set]
+  *
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t val: change the values of f_fss5 in reg CTRL_REG3
+  *
+  */
+int32_t lps27hhw_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps27hhw_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  if (ret == 0) {
+    reg.int_f_full = val;
+    ret = lps27hhw_write_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[get]
+  *
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
+  * @param  uint8_t: change the values of f_fss5 in reg CTRL_REG3
+  *
+  */
+int32_t lps27hhw_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps27hhw_ctrl_reg3_t reg;
+  int32_t ret;
+
+  ret = lps27hhw_read_reg(ctx, LPS27HHW_CTRL_REG3, (uint8_t*)&reg, 1);
+  *val = reg.int_f_full;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps27hhw_STdC/driver/lps27hhw_reg.h
+++ b/sensor/stmemsc/lps27hhw_STdC/driver/lps27hhw_reg.h
@@ -1,0 +1,497 @@
+/*
+ ******************************************************************************
+ * @file    lps27hhw_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lps27hhw_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LPS27HHW_DRIVER_H
+#define LPS27HHW_DRIVER_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LPS27HHW
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LPS27HHW_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> B9 if SA0=1 -> BB **/
+#define LPS27HHW_I2C_ADD_H                       0xBBU
+#define LPS27HHW_I2C_ADD_L                       0xB9U
+
+/** Device Identification (Who am I) **/
+#define LPS27HHW_ID                              0xB3U
+
+/**
+  * @}
+  *
+  */
+
+#define LPS27HHW_INTERRUPT_CFG                   0x0BU
+typedef struct {
+  uint8_t pe                              : 2;  /* ple + phe */
+  uint8_t lir                             : 1;
+  uint8_t diff_en                         : 1;
+  uint8_t reset_az                        : 1;
+  uint8_t autozero                        : 1;
+  uint8_t reset_arp                       : 1;
+  uint8_t autorefp                        : 1;
+} lps27hhw_interrupt_cfg_t;
+
+#define LPS27HHW_THS_P_L                         0x0CU
+typedef struct {
+  uint8_t ths                             : 8;
+} lps27hhw_ths_p_l_t;
+
+#define LPS27HHW_THS_P_H                         0x0DU
+typedef struct {
+  uint8_t ths                             : 7;
+  uint8_t not_used_01                     : 1;
+} lps27hhw_ths_p_h_t;
+
+#define LPS27HHW_IF_CTRL                         0x0EU
+typedef struct {
+  uint8_t i2c_disable                     : 1;
+  uint8_t i3c_disable                     : 1;
+  uint8_t pd_dis_int1                     : 1;
+  uint8_t sdo_pu_en                       : 1;
+  uint8_t sda_pu_en                       : 1;
+  uint8_t not_used_01                     : 2;
+  uint8_t int_en_i3c                      : 1;
+} lps27hhw_if_ctrl_t;
+
+#define LPS27HHW_WHO_AM_I                        0x0FU
+#define LPS27HHW_CTRL_REG1                       0x10U
+typedef struct {
+  uint8_t sim                             : 1;
+  uint8_t bdu                             : 1;
+  uint8_t lpfp_cfg                        : 2;  /* en_lpfp + lpfp_cfg */
+  uint8_t odr                             : 3;
+  uint8_t not_used_01                     : 1;
+} lps27hhw_ctrl_reg1_t;
+
+#define LPS27HHW_CTRL_REG2                       0x11U
+typedef struct {
+  uint8_t one_shot                        : 1;
+  uint8_t low_noise_en                    : 1;
+  uint8_t swreset                         : 1;
+  uint8_t not_used_01                     : 1;
+  uint8_t if_add_inc                      : 1;
+  uint8_t pp_od                           : 1;
+  uint8_t int_h_l                         : 1;
+  uint8_t boot                            : 1;
+} lps27hhw_ctrl_reg2_t;
+
+#define LPS27HHW_CTRL_REG3                       0x12U
+typedef struct {
+  uint8_t int_s                           : 2;
+  uint8_t drdy                            : 1;
+  uint8_t int_f_ovr                       : 1;
+  uint8_t int_f_wtm                       : 1;
+  uint8_t int_f_full                      : 1;
+  uint8_t not_used_01                     : 2;
+} lps27hhw_ctrl_reg3_t;
+
+#define LPS27HHW_FIFO_CTRL                       0x13U
+typedef struct {
+  uint8_t f_mode                          : 3;  /* f_mode + trig_modes */
+  uint8_t stop_on_wtm                     : 1;
+  uint8_t not_used_01                     : 4;
+} lps27hhw_fifo_ctrl_t;
+
+#define LPS27HHW_FIFO_WTM                        0x14U
+typedef struct {
+  uint8_t wtm                             : 7;
+  uint8_t not_used_01                     : 1;
+} lps27hhw_fifo_wtm_t;
+
+#define LPS27HHW_REF_P_L                         0x15U
+#define LPS27HHW_REF_P_H                         0x16U
+#define LPS27HHW_RPDS_L                          0x18U
+#define LPS27HHW_RPDS_H                          0x19U
+#define LPS27HHW_INT_SOURCE                      0x24U
+typedef struct {
+  uint8_t ph                              : 1;
+  uint8_t pl                              : 1;
+  uint8_t ia                              : 1;
+  uint8_t not_used_01                     : 4;
+  uint8_t boot_on                         : 1;
+} lps27hhw_int_source_t;
+
+#define LPS27HHW_FIFO_STATUS1                    0x25U
+#define LPS27HHW_FIFO_STATUS2                    0x26U
+typedef struct {
+  uint8_t not_used_01                     : 5;
+  uint8_t fifo_full_ia                    : 1;
+  uint8_t fifo_ovr_ia                     : 1;
+  uint8_t fifo_wtm_ia                     : 1;
+} lps27hhw_fifo_status2_t;
+
+#define LPS27HHW_STATUS                          0x27U
+typedef struct {
+  uint8_t p_da                            : 1;
+  uint8_t t_da                            : 1;
+  uint8_t not_used_01                     : 2;
+  uint8_t p_or                            : 1;
+  uint8_t t_or                            : 1;
+  uint8_t not_used_02                     : 2;
+} lps27hhw_status_t;
+
+#define LPS27HHW_PRESS_OUT_XL                    0x28U
+#define LPS27HHW_PRESS_OUT_L                     0x29U
+#define LPS27HHW_PRESS_OUT_H                     0x2AU
+#define LPS27HHW_TEMP_OUT_L                      0x2BU
+#define LPS27HHW_TEMP_OUT_H                      0x2CU
+#define LPS27HHW_FIFO_DATA_OUT_PRESS_XL          0x78U
+#define LPS27HHW_FIFO_DATA_OUT_PRESS_L           0x79U
+#define LPS27HHW_FIFO_DATA_OUT_PRESS_H           0x7AU
+#define LPS27HHW_FIFO_DATA_OUT_TEMP_L            0x7BU
+#define LPS27HHW_FIFO_DATA_OUT_TEMP_H            0x7CU
+
+/**
+  * @defgroup LPS27HHW_Register_Union
+  * @brief    This union group all the registers that has a bitfield
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lps27hhw_interrupt_cfg_t        interrupt_cfg;
+  lps27hhw_if_ctrl_t              if_ctrl;
+  lps27hhw_ctrl_reg1_t            ctrl_reg1;
+  lps27hhw_ctrl_reg2_t            ctrl_reg2;
+  lps27hhw_ctrl_reg3_t            ctrl_reg3;
+  lps27hhw_fifo_ctrl_t            fifo_ctrl;
+  lps27hhw_fifo_wtm_t             fifo_wtm;
+  lps27hhw_int_source_t           int_source;
+  lps27hhw_fifo_status2_t         fifo_status2;
+  lps27hhw_status_t               status;
+  bitwise_t                       bitwise;
+  uint8_t                         byte;
+} lps27hhw_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lps27hhw_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lps27hhw_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lps27hhw_from_lsb_to_hpa(int32_t lsb);
+extern float_t lps27hhw_from_lsb_to_celsius(int16_t lsb);
+
+int32_t lps27hhw_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_autozero_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_autozero_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS27HHW_POWER_DOWN          = 0x00,
+  LPS27HHW_ONE_SHOOT           = 0x08,
+  LPS27HHW_1_Hz                = 0x01,
+  LPS27HHW_10_Hz               = 0x02,
+  LPS27HHW_25_Hz               = 0x03,
+  LPS27HHW_50_Hz               = 0x04,
+  LPS27HHW_75_Hz               = 0x05,
+  LPS27HHW_1_Hz_LOW_NOISE      = 0x11,
+  LPS27HHW_10_Hz_LOW_NOISE     = 0x12,
+  LPS27HHW_25_Hz_LOW_NOISE     = 0x13,
+  LPS27HHW_50_Hz_LOW_NOISE     = 0x14,
+  LPS27HHW_75_Hz_LOW_NOISE     = 0x15,
+  LPS27HHW_100_Hz              = 0x06,
+  LPS27HHW_200_Hz              = 0x07,
+} lps27hhw_odr_t;
+int32_t lps27hhw_data_rate_set(stmdev_ctx_t *ctx, lps27hhw_odr_t val);
+int32_t lps27hhw_data_rate_get(stmdev_ctx_t *ctx, lps27hhw_odr_t *val);
+
+int32_t lps27hhw_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps27hhw_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps27hhw_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps27hhw_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef struct{
+  lps27hhw_int_source_t    int_source;
+  lps27hhw_fifo_status2_t  fifo_status2;
+  lps27hhw_status_t        status;
+} lps27hhw_all_sources_t;
+int32_t lps27hhw_all_sources_get(stmdev_ctx_t *ctx,
+                                lps27hhw_all_sources_t *val);
+
+int32_t lps27hhw_status_reg_get(stmdev_ctx_t *ctx, lps27hhw_status_t *val);
+
+int32_t lps27hhw_press_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps27hhw_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps27hhw_fifo_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps27hhw_fifo_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps27hhw_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps27hhw_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS27HHW_LPF_ODR_DIV_2    = 0,
+  LPS27HHW_LPF_ODR_DIV_9    = 2,
+  LPS27HHW_LPF_ODR_DIV_20   = 3,
+} lps27hhw_lpfp_cfg_t;
+int32_t lps27hhw_lp_bandwidth_set(stmdev_ctx_t *ctx, lps27hhw_lpfp_cfg_t val);
+int32_t lps27hhw_lp_bandwidth_get(stmdev_ctx_t *ctx, lps27hhw_lpfp_cfg_t *val);
+
+typedef enum {
+  LPS27HHW_I2C_ENABLE    = 0,
+  LPS27HHW_I2C_DISABLE   = 1,
+} lps27hhw_i2c_disable_t;
+int32_t lps27hhw_i2c_interface_set(stmdev_ctx_t *ctx,
+                                  lps27hhw_i2c_disable_t val);
+int32_t lps27hhw_i2c_interface_get(stmdev_ctx_t *ctx,
+                                  lps27hhw_i2c_disable_t *val);
+
+typedef enum {
+  LPS27HHW_I3C_ENABLE                 = 0x00,
+  LPS27HHW_I3C_ENABLE_INT_PIN_ENABLE  = 0x10,
+  LPS27HHW_I3C_DISABLE                = 0x11,
+} lps27hhw_i3c_disable_t;
+int32_t lps27hhw_i3c_interface_set(stmdev_ctx_t *ctx,
+                                  lps27hhw_i3c_disable_t val);
+int32_t lps27hhw_i3c_interface_get(stmdev_ctx_t *ctx,
+                                  lps27hhw_i3c_disable_t *val);
+
+typedef enum {
+  LPS27HHW_PULL_UP_DISCONNECT    = 0,
+  LPS27HHW_PULL_UP_CONNECT       = 1,
+} lps27hhw_pu_en_t;
+int32_t lps27hhw_sdo_sa0_mode_set(stmdev_ctx_t *ctx, lps27hhw_pu_en_t val);
+int32_t lps27hhw_sdo_sa0_mode_get(stmdev_ctx_t *ctx, lps27hhw_pu_en_t *val);
+int32_t lps27hhw_sda_mode_set(stmdev_ctx_t *ctx, lps27hhw_pu_en_t val);
+int32_t lps27hhw_sda_mode_get(stmdev_ctx_t *ctx, lps27hhw_pu_en_t *val);
+
+typedef enum {
+  LPS27HHW_SPI_4_WIRE  = 0,
+  LPS27HHW_SPI_3_WIRE  = 1,
+} lps27hhw_sim_t;
+int32_t lps27hhw_spi_mode_set(stmdev_ctx_t *ctx, lps27hhw_sim_t val);
+int32_t lps27hhw_spi_mode_get(stmdev_ctx_t *ctx, lps27hhw_sim_t *val);
+
+typedef enum {
+  LPS27HHW_INT_PULSED   = 0,
+  LPS27HHW_INT_LATCHED  = 1,
+} lps27hhw_lir_t;
+int32_t lps27hhw_int_notification_set(stmdev_ctx_t *ctx, lps27hhw_lir_t val);
+int32_t lps27hhw_int_notification_get(stmdev_ctx_t *ctx, lps27hhw_lir_t *val);
+
+typedef enum {
+  LPS27HHW_PUSH_PULL   = 0,
+  LPS27HHW_OPEN_DRAIN  = 1,
+} lps27hhw_pp_od_t;
+int32_t lps27hhw_pin_mode_set(stmdev_ctx_t *ctx, lps27hhw_pp_od_t val);
+int32_t lps27hhw_pin_mode_get(stmdev_ctx_t *ctx, lps27hhw_pp_od_t *val);
+
+typedef enum {
+  LPS27HHW_ACTIVE_HIGH = 0,
+  LPS27HHW_ACTIVE_LOW  = 1,
+} lps27hhw_int_h_l_t;
+int32_t lps27hhw_pin_polarity_set(stmdev_ctx_t *ctx, lps27hhw_int_h_l_t val);
+int32_t lps27hhw_pin_polarity_get(stmdev_ctx_t *ctx, lps27hhw_int_h_l_t *val);
+
+int32_t lps27hhw_pin_int_route_set(stmdev_ctx_t *ctx,
+                                  lps27hhw_ctrl_reg3_t *val);
+int32_t lps27hhw_pin_int_route_get(stmdev_ctx_t *ctx,
+                                  lps27hhw_ctrl_reg3_t *val);
+
+typedef enum {
+  LPS27HHW_NO_THRESHOLD  = 0,
+  LPS27HHW_POSITIVE      = 1,
+  LPS27HHW_NEGATIVE      = 2,
+  LPS27HHW_BOTH          = 3,
+} lps27hhw_pe_t;
+int32_t lps27hhw_int_on_threshold_set(stmdev_ctx_t *ctx, lps27hhw_pe_t val);
+int32_t lps27hhw_int_on_threshold_get(stmdev_ctx_t *ctx, lps27hhw_pe_t *val);
+
+int32_t lps27hhw_int_treshold_set(stmdev_ctx_t *ctx, uint16_t buff);
+int32_t lps27hhw_int_treshold_get(stmdev_ctx_t *ctx, uint16_t *buff);
+
+typedef enum {
+  LPS27HHW_BYPASS_MODE            = 0,
+  LPS27HHW_FIFO_MODE              = 1,
+  LPS27HHW_STREAM_MODE            = 2,
+  LPS27HHW_DYNAMIC_STREAM_MODE    = 3,
+  LPS27HHW_BYPASS_TO_FIFO_MODE    = 5,
+  LPS27HHW_BYPASS_TO_STREAM_MODE  = 6,
+  LPS27HHW_STREAM_TO_FIFO_MODE    = 7,
+} lps27hhw_f_mode_t;
+int32_t lps27hhw_fifo_mode_set(stmdev_ctx_t *ctx, lps27hhw_f_mode_t val);
+int32_t lps27hhw_fifo_mode_get(stmdev_ctx_t *ctx, lps27hhw_f_mode_t *val);
+
+int32_t lps27hhw_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps27hhw_fifo_src_get(stmdev_ctx_t *ctx, lps27hhw_fifo_status2_t *val);
+
+int32_t lps27hhw_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps27hhw_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps27hhw_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*LPS27HHW_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps33hw_STdC/driver/lps33hw_reg.c
+++ b/sensor/stmemsc/lps33hw_STdC/driver/lps33hw_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lps33hw_reg.h"
@@ -62,7 +45,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps33hw_read_reg(lps33hw_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lps33hw_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -80,7 +63,7 @@ int32_t lps33hw_read_reg(lps33hw_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lps33hw_write_reg(lps33hw_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lps33hw_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -100,7 +83,7 @@ int32_t lps33hw_write_reg(lps33hw_ctx_t* ctx, uint8_t reg, uint8_t* data,
   *
   */
 
-float_t lps33hw_from_lsb_to_hpa(int16_t lsb)
+float_t lps33hw_from_lsb_to_hpa(int32_t lsb)
 {
   return ( (float_t)lsb / 4096.0f );
 }
@@ -133,7 +116,7 @@ float_t lps33hw_from_lsb_to_degc(int16_t lsb)
   *
   */
 
-int32_t lps33hw_autozero_rst_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -156,7 +139,7 @@ int32_t lps33hw_autozero_rst_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_autozero_rst_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -176,7 +159,7 @@ int32_t lps33hw_autozero_rst_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_autozero_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_autozero_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -199,7 +182,7 @@ int32_t lps33hw_autozero_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_autozero_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_autozero_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -219,7 +202,7 @@ int32_t lps33hw_autozero_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_snap_rst_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -242,7 +225,7 @@ int32_t lps33hw_pressure_snap_rst_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_snap_rst_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -262,7 +245,7 @@ int32_t lps33hw_pressure_snap_rst_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_snap_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -285,7 +268,7 @@ int32_t lps33hw_pressure_snap_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_snap_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -305,7 +288,7 @@ int32_t lps33hw_pressure_snap_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_block_data_update_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -326,7 +309,7 @@ int32_t lps33hw_block_data_update_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_block_data_update_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -345,7 +328,7 @@ int32_t lps33hw_block_data_update_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_low_pass_filter_mode_set(lps33hw_ctx_t *ctx,
+int32_t lps33hw_low_pass_filter_mode_set(stmdev_ctx_t *ctx,
                                           lps33hw_lpfp_t val)
 {
   lps33hw_ctrl_reg1_t ctrl_reg1;
@@ -367,7 +350,7 @@ int32_t lps33hw_low_pass_filter_mode_set(lps33hw_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_low_pass_filter_mode_get(lps33hw_ctx_t *ctx,
+int32_t lps33hw_low_pass_filter_mode_get(stmdev_ctx_t *ctx,
                                          lps33hw_lpfp_t *val)
 {
   lps33hw_ctrl_reg1_t ctrl_reg1;
@@ -399,7 +382,7 @@ int32_t lps33hw_low_pass_filter_mode_get(lps33hw_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_data_rate_set(lps33hw_ctx_t *ctx, lps33hw_odr_t val)
+int32_t lps33hw_data_rate_set(stmdev_ctx_t *ctx, lps33hw_odr_t val)
 {
   lps33hw_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -420,7 +403,7 @@ int32_t lps33hw_data_rate_set(lps33hw_ctx_t *ctx, lps33hw_odr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_data_rate_get(lps33hw_ctx_t *ctx, lps33hw_odr_t *val)
+int32_t lps33hw_data_rate_get(stmdev_ctx_t *ctx, lps33hw_odr_t *val)
 {
   lps33hw_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -461,7 +444,7 @@ int32_t lps33hw_data_rate_get(lps33hw_ctx_t *ctx, lps33hw_odr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_one_shoot_trigger_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -482,7 +465,7 @@ int32_t lps33hw_one_shoot_trigger_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_one_shoot_trigger_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -503,7 +486,7 @@ int32_t lps33hw_one_shoot_trigger_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_ref_set(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_write_reg(ctx, LPS33HW_REF_P_XL, buff, 3);
@@ -520,7 +503,7 @@ int32_t lps33hw_pressure_ref_set(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_ref_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_REF_P_XL, buff, 3);
@@ -536,7 +519,7 @@ int32_t lps33hw_pressure_ref_get(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_offset_set(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_write_reg(ctx, LPS33HW_RPDS_L, buff, 2);
@@ -552,7 +535,7 @@ int32_t lps33hw_pressure_offset_set(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_offset_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_RPDS_L, buff, 2);
@@ -567,7 +550,7 @@ int32_t lps33hw_pressure_offset_get(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_press_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_press_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_status_t status;
   int32_t ret;
@@ -586,7 +569,7 @@ int32_t lps33hw_press_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_temp_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_status_t status;
   int32_t ret;
@@ -605,7 +588,7 @@ int32_t lps33hw_temp_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_press_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_press_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_status_t status;
   int32_t ret;
@@ -624,7 +607,7 @@ int32_t lps33hw_press_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_temp_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_status_t status;
   int32_t ret;
@@ -643,7 +626,7 @@ int32_t lps33hw_temp_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pressure_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_PRESS_OUT_XL, buff, 3);
@@ -658,7 +641,7 @@ int32_t lps33hw_pressure_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_temperature_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_TEMP_OUT_L, (uint8_t*) buff, 2);
@@ -676,7 +659,7 @@ int32_t lps33hw_temperature_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_low_pass_rst_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_low_pass_rst_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_LPFP_RES, (uint8_t*) buff, 1);
@@ -703,7 +686,7 @@ int32_t lps33hw_low_pass_rst_get(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_device_id_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_WHO_AM_I, (uint8_t*) buff, 1);
@@ -718,7 +701,7 @@ int32_t lps33hw_device_id_get(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_reset_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -739,7 +722,7 @@ int32_t lps33hw_reset_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_reset_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -758,7 +741,7 @@ int32_t lps33hw_reset_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_boot_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -779,7 +762,7 @@ int32_t lps33hw_boot_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_boot_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -798,7 +781,7 @@ int32_t lps33hw_boot_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_low_power_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_low_power_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_res_conf_t res_conf;
   int32_t ret;
@@ -819,7 +802,7 @@ int32_t lps33hw_low_power_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_low_power_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_low_power_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_res_conf_t res_conf;
   int32_t ret;
@@ -838,7 +821,7 @@ int32_t lps33hw_low_power_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_boot_status_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_boot_status_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_int_source_t int_source;
   int32_t ret;
@@ -857,7 +840,7 @@ int32_t lps33hw_boot_status_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_dev_status_get(lps33hw_ctx_t *ctx, lps33hw_dev_stat_t *val)
+int32_t lps33hw_dev_status_get(stmdev_ctx_t *ctx, lps33hw_dev_stat_t *val)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_FIFO_STATUS, (uint8_t*) val, 2);
@@ -884,7 +867,7 @@ int32_t lps33hw_dev_status_get(lps33hw_ctx_t *ctx, lps33hw_dev_stat_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_sign_of_int_threshold_set(lps33hw_ctx_t *ctx,
+int32_t lps33hw_sign_of_int_threshold_set(stmdev_ctx_t *ctx,
                                            lps33hw_pe_t val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
@@ -908,7 +891,7 @@ int32_t lps33hw_sign_of_int_threshold_set(lps33hw_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_sign_of_int_threshold_get(lps33hw_ctx_t *ctx,
+int32_t lps33hw_sign_of_int_threshold_get(stmdev_ctx_t *ctx,
                                            lps33hw_pe_t *val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
@@ -945,7 +928,7 @@ int32_t lps33hw_sign_of_int_threshold_get(lps33hw_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_notification_mode_set(lps33hw_ctx_t *ctx,
+int32_t lps33hw_int_notification_mode_set(stmdev_ctx_t *ctx,
                                            lps33hw_lir_t val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
@@ -970,7 +953,7 @@ int32_t lps33hw_int_notification_mode_set(lps33hw_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_notification_mode_get(lps33hw_ctx_t *ctx,
+int32_t lps33hw_int_notification_mode_get(stmdev_ctx_t *ctx,
                                           lps33hw_lir_t *val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
@@ -1000,7 +983,7 @@ int32_t lps33hw_int_notification_mode_get(lps33hw_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_generation_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_int_generation_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -1023,7 +1006,7 @@ int32_t lps33hw_int_generation_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_generation_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_interrupt_cfg_t interrupt_cfg;
   int32_t ret;
@@ -1043,7 +1026,7 @@ int32_t lps33hw_int_generation_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_threshold_set(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_write_reg(ctx, LPS33HW_THS_P_L, (uint8_t*) buff, 2);
@@ -1058,7 +1041,7 @@ int32_t lps33hw_int_threshold_set(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_threshold_get(lps33hw_ctx_t *ctx, uint8_t *buff)
+int32_t lps33hw_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_THS_P_L, (uint8_t*) buff, 2);
@@ -1073,7 +1056,7 @@ int32_t lps33hw_int_threshold_get(lps33hw_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_int_s_t val)
+int32_t lps33hw_int_pin_mode_set(stmdev_ctx_t *ctx, lps33hw_int_s_t val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1094,7 +1077,7 @@ int32_t lps33hw_int_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_int_s_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_int_s_t *val)
+int32_t lps33hw_int_pin_mode_get(stmdev_ctx_t *ctx, lps33hw_int_s_t *val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1128,7 +1111,7 @@ int32_t lps33hw_int_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_int_s_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_drdy_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1149,7 +1132,7 @@ int32_t lps33hw_drdy_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_drdy_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1168,7 +1151,7 @@ int32_t lps33hw_drdy_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_ovr_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1189,7 +1172,7 @@ int32_t lps33hw_fifo_ovr_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_ovr_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1208,7 +1191,7 @@ int32_t lps33hw_fifo_ovr_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_threshold_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1229,7 +1212,7 @@ int32_t lps33hw_fifo_threshold_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_threshold_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1248,7 +1231,7 @@ int32_t lps33hw_fifo_threshold_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_full_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1269,7 +1252,7 @@ int32_t lps33hw_fifo_full_on_int_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_full_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1288,7 +1271,7 @@ int32_t lps33hw_fifo_full_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_pp_od_t val)
+int32_t lps33hw_pin_mode_set(stmdev_ctx_t *ctx, lps33hw_pp_od_t val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1309,7 +1292,7 @@ int32_t lps33hw_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_pp_od_t *val)
+int32_t lps33hw_pin_mode_get(stmdev_ctx_t *ctx, lps33hw_pp_od_t *val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1337,7 +1320,7 @@ int32_t lps33hw_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_polarity_set(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t val)
+int32_t lps33hw_int_polarity_set(stmdev_ctx_t *ctx, lps33hw_int_h_l_t val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1358,7 +1341,7 @@ int32_t lps33hw_int_polarity_set(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_polarity_get(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t *val)
+int32_t lps33hw_int_polarity_get(stmdev_ctx_t *ctx, lps33hw_int_h_l_t *val)
 {
   lps33hw_ctrl_reg3_t ctrl_reg3;
   int32_t ret;
@@ -1386,7 +1369,7 @@ int32_t lps33hw_int_polarity_get(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_source_get(lps33hw_ctx_t *ctx, lps33hw_int_source_t *val)
+int32_t lps33hw_int_source_get(stmdev_ctx_t *ctx, lps33hw_int_source_t *val)
 {
   int32_t ret;
   ret =  lps33hw_read_reg(ctx, LPS33HW_INT_SOURCE, (uint8_t*) val, 1);
@@ -1401,7 +1384,7 @@ int32_t lps33hw_int_source_get(lps33hw_ctx_t *ctx, lps33hw_int_source_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_on_press_high_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_int_on_press_high_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_int_source_t int_source;
   int32_t ret;
@@ -1420,7 +1403,7 @@ int32_t lps33hw_int_on_press_high_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_int_on_press_low_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_int_on_press_low_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_int_source_t int_source;
   int32_t ret;
@@ -1439,7 +1422,7 @@ int32_t lps33hw_int_on_press_low_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_interrupt_event_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_interrupt_event_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_int_source_t int_source;
   int32_t ret;
@@ -1471,7 +1454,7 @@ int32_t lps33hw_interrupt_event_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_stop_on_fifo_threshold_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_stop_on_fifo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1492,7 +1475,7 @@ int32_t lps33hw_stop_on_fifo_threshold_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_stop_on_fifo_threshold_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_stop_on_fifo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1511,7 +1494,7 @@ int32_t lps33hw_stop_on_fifo_threshold_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1532,7 +1515,7 @@ int32_t lps33hw_fifo_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1551,7 +1534,7 @@ int32_t lps33hw_fifo_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_watermark_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1572,7 +1555,7 @@ int32_t lps33hw_fifo_watermark_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_watermark_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1591,7 +1574,7 @@ int32_t lps33hw_fifo_watermark_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_mode_set(lps33hw_ctx_t *ctx, lps33hw_f_mode_t val)
+int32_t lps33hw_fifo_mode_set(stmdev_ctx_t *ctx, lps33hw_f_mode_t val)
 {
   lps33hw_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1612,7 +1595,7 @@ int32_t lps33hw_fifo_mode_set(lps33hw_ctx_t *ctx, lps33hw_f_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_mode_get(lps33hw_ctx_t *ctx, lps33hw_f_mode_t *val)
+int32_t lps33hw_fifo_mode_get(stmdev_ctx_t *ctx, lps33hw_f_mode_t *val)
 {
   lps33hw_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -1655,7 +1638,7 @@ int32_t lps33hw_fifo_mode_get(lps33hw_ctx_t *ctx, lps33hw_f_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_data_level_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_fifo_status_t fifo_status;
   int32_t ret;
@@ -1674,7 +1657,7 @@ int32_t lps33hw_fifo_data_level_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_ovr_flag_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_fifo_status_t fifo_status;
   int32_t ret;
@@ -1693,7 +1676,7 @@ int32_t lps33hw_fifo_ovr_flag_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_fifo_fth_flag_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_fifo_status_t fifo_status;
   int32_t ret;
@@ -1725,7 +1708,7 @@ int32_t lps33hw_fifo_fth_flag_get(lps33hw_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_spi_mode_set(lps33hw_ctx_t *ctx, lps33hw_sim_t val)
+int32_t lps33hw_spi_mode_set(stmdev_ctx_t *ctx, lps33hw_sim_t val)
 {
   lps33hw_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -1746,7 +1729,7 @@ int32_t lps33hw_spi_mode_set(lps33hw_ctx_t *ctx, lps33hw_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_spi_mode_get(lps33hw_ctx_t *ctx, lps33hw_sim_t *val)
+int32_t lps33hw_spi_mode_get(stmdev_ctx_t *ctx, lps33hw_sim_t *val)
 {
   lps33hw_ctrl_reg1_t ctrl_reg1;
   int32_t ret;
@@ -1774,7 +1757,7 @@ int32_t lps33hw_spi_mode_get(lps33hw_ctx_t *ctx, lps33hw_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_i2c_interface_set(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t val)
+int32_t lps33hw_i2c_interface_set(stmdev_ctx_t *ctx, lps33hw_i2c_dis_t val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1795,7 +1778,7 @@ int32_t lps33hw_i2c_interface_set(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_i2c_interface_get(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t *val)
+int32_t lps33hw_i2c_interface_get(stmdev_ctx_t *ctx, lps33hw_i2c_dis_t *val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1824,7 +1807,7 @@ int32_t lps33hw_i2c_interface_get(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_auto_add_inc_set(lps33hw_ctx_t *ctx, uint8_t val)
+int32_t lps33hw_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;
@@ -1846,7 +1829,7 @@ int32_t lps33hw_auto_add_inc_set(lps33hw_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lps33hw_auto_add_inc_get(lps33hw_ctx_t *ctx, uint8_t *val)
+int32_t lps33hw_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lps33hw_ctrl_reg2_t ctrl_reg2;
   int32_t ret;

--- a/sensor/stmemsc/lps33hw_STdC/driver/lps33hw_reg.h
+++ b/sensor/stmemsc/lps33hw_STdC/driver/lps33hw_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef LPS33HW_REGS_H
 #define LPS33HW_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup LPS33HW_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LPS33HW_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -125,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lps33hw_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lps33hw_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lps33hw_write_ptr  write_reg;
-  lps33hw_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lps33hw_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -289,37 +262,37 @@ typedef union{
   *
   */
 
-int32_t lps33hw_read_reg(lps33hw_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lps33hw_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lps33hw_write_reg(lps33hw_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lps33hw_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
-extern float_t lps33hw_from_lsb_to_hpa(int16_t lsb);
+extern float_t lps33hw_from_lsb_to_hpa(int32_t lsb);
 extern float_t lps33hw_from_lsb_to_degc(int16_t lsb);
 
-int32_t lps33hw_autozero_rst_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_autozero_rst_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_autozero_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_autozero_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_autozero_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_autozero_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_pressure_snap_rst_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_pressure_snap_rst_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_pressure_snap_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_pressure_snap_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_block_data_update_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_block_data_update_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS33HW_LPF_ODR_DIV_2  = 0,
   LPS33HW_LPF_ODR_DIV_9  = 2,
   LPS33HW_LPF_ODR_DIV_20 = 3,
 } lps33hw_lpfp_t;
-int32_t lps33hw_low_pass_filter_mode_set(lps33hw_ctx_t *ctx,
+int32_t lps33hw_low_pass_filter_mode_set(stmdev_ctx_t *ctx,
                                          lps33hw_lpfp_t val);
-int32_t lps33hw_low_pass_filter_mode_get(lps33hw_ctx_t *ctx,
+int32_t lps33hw_low_pass_filter_mode_get(stmdev_ctx_t *ctx,
                                          lps33hw_lpfp_t *val);
 
 typedef enum {
@@ -330,50 +303,50 @@ typedef enum {
   LPS33HW_ODR_50_Hz   = 4,
   LPS33HW_ODR_75_Hz   = 5,
 } lps33hw_odr_t;
-int32_t lps33hw_data_rate_set(lps33hw_ctx_t *ctx, lps33hw_odr_t val);
-int32_t lps33hw_data_rate_get(lps33hw_ctx_t *ctx, lps33hw_odr_t *val);
+int32_t lps33hw_data_rate_set(stmdev_ctx_t *ctx, lps33hw_odr_t val);
+int32_t lps33hw_data_rate_get(stmdev_ctx_t *ctx, lps33hw_odr_t *val);
 
-int32_t lps33hw_one_shoot_trigger_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_one_shoot_trigger_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_pressure_ref_set(lps33hw_ctx_t *ctx, uint8_t *buff);
-int32_t lps33hw_pressure_ref_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps33hw_pressure_offset_set(lps33hw_ctx_t *ctx, uint8_t *buff);
-int32_t lps33hw_pressure_offset_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps33hw_press_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_press_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_temp_data_ready_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_press_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_press_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_temp_data_ovr_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_pressure_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps33hw_temperature_raw_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps33hw_low_pass_rst_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_low_pass_rst_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps33hw_device_id_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lps33hw_reset_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_reset_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_boot_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_boot_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_low_power_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_low_power_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_low_power_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_low_power_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_boot_status_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_boot_status_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct{
   lps33hw_fifo_status_t  fifo_status;
   lps33hw_status_t       status;
 } lps33hw_dev_stat_t;
-int32_t lps33hw_dev_status_get(lps33hw_ctx_t *ctx, lps33hw_dev_stat_t *val);
+int32_t lps33hw_dev_status_get(stmdev_ctx_t *ctx, lps33hw_dev_stat_t *val);
 
 typedef enum {
   LPS33HW_NO_THRESHOLD = 0,
@@ -381,25 +354,25 @@ typedef enum {
   LPS33HW_NEGATIVE     = 2,
   LPS33HW_BOTH         = 3,
 } lps33hw_pe_t;
-int32_t lps33hw_sign_of_int_threshold_set(lps33hw_ctx_t *ctx,
+int32_t lps33hw_sign_of_int_threshold_set(stmdev_ctx_t *ctx,
                                           lps33hw_pe_t val);
-int32_t lps33hw_sign_of_int_threshold_get(lps33hw_ctx_t *ctx,
+int32_t lps33hw_sign_of_int_threshold_get(stmdev_ctx_t *ctx,
                                           lps33hw_pe_t *val);
 
 typedef enum {
   LPS33HW_INT_PULSED  = 0,
   LPS33HW_INT_LATCHED = 1,
 } lps33hw_lir_t;
-int32_t lps33hw_int_notification_mode_set(lps33hw_ctx_t *ctx,
+int32_t lps33hw_int_notification_mode_set(stmdev_ctx_t *ctx,
                                           lps33hw_lir_t val);
-int32_t lps33hw_int_notification_mode_get(lps33hw_ctx_t *ctx,
+int32_t lps33hw_int_notification_mode_get(stmdev_ctx_t *ctx,
                                           lps33hw_lir_t *val);
 
-int32_t lps33hw_int_generation_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_int_generation_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_int_generation_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_int_threshold_set(lps33hw_ctx_t *ctx, uint8_t *buff);
-int32_t lps33hw_int_threshold_get(lps33hw_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps33hw_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LPS33HW_DRDY_OR_FIFO_FLAGS = 0,
@@ -407,51 +380,51 @@ typedef enum {
   LPS33HW_LOW_PRES_INT       = 2,
   LPS33HW_EVERY_PRES_INT     = 3,
 } lps33hw_int_s_t;
-int32_t lps33hw_int_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_int_s_t val);
-int32_t lps33hw_int_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_int_s_t *val);
+int32_t lps33hw_int_pin_mode_set(stmdev_ctx_t *ctx, lps33hw_int_s_t val);
+int32_t lps33hw_int_pin_mode_get(stmdev_ctx_t *ctx, lps33hw_int_s_t *val);
 
-int32_t lps33hw_drdy_on_int_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_drdy_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_fifo_ovr_on_int_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_fifo_ovr_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_fifo_threshold_on_int_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_fifo_threshold_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_fifo_full_on_int_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_fifo_full_on_int_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS33HW_PUSH_PULL  = 0,
   LPS33HW_OPEN_DRAIN = 1,
 } lps33hw_pp_od_t;
-int32_t lps33hw_pin_mode_set(lps33hw_ctx_t *ctx, lps33hw_pp_od_t val);
-int32_t lps33hw_pin_mode_get(lps33hw_ctx_t *ctx, lps33hw_pp_od_t *val);
+int32_t lps33hw_pin_mode_set(stmdev_ctx_t *ctx, lps33hw_pp_od_t val);
+int32_t lps33hw_pin_mode_get(stmdev_ctx_t *ctx, lps33hw_pp_od_t *val);
 
 typedef enum {
   LPS33HW_ACTIVE_HIGH = 0,
   LPS33HW_ACTIVE_LOW = 1,
 } lps33hw_int_h_l_t;
-int32_t lps33hw_int_polarity_set(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t val);
-int32_t lps33hw_int_polarity_get(lps33hw_ctx_t *ctx, lps33hw_int_h_l_t *val);
+int32_t lps33hw_int_polarity_set(stmdev_ctx_t *ctx, lps33hw_int_h_l_t val);
+int32_t lps33hw_int_polarity_get(stmdev_ctx_t *ctx, lps33hw_int_h_l_t *val);
 
-int32_t lps33hw_int_source_get(lps33hw_ctx_t *ctx, lps33hw_int_source_t *val);
+int32_t lps33hw_int_source_get(stmdev_ctx_t *ctx, lps33hw_int_source_t *val);
 
-int32_t lps33hw_int_on_press_high_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_int_on_press_high_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_int_on_press_low_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_int_on_press_low_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_interrupt_event_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_interrupt_event_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_stop_on_fifo_threshold_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_stop_on_fifo_threshold_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_stop_on_fifo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_stop_on_fifo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_fifo_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_fifo_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_fifo_watermark_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_fifo_watermark_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS33HW_BYPASS_MODE           = 0,
@@ -462,31 +435,31 @@ typedef enum {
   LPS33HW_DYNAMIC_STREAM_MODE   = 6,
   LPS33HW_BYPASS_TO_FIFO_MODE   = 7,
 } lps33hw_f_mode_t;
-int32_t lps33hw_fifo_mode_set(lps33hw_ctx_t *ctx, lps33hw_f_mode_t val);
-int32_t lps33hw_fifo_mode_get(lps33hw_ctx_t *ctx, lps33hw_f_mode_t *val);
+int32_t lps33hw_fifo_mode_set(stmdev_ctx_t *ctx, lps33hw_f_mode_t val);
+int32_t lps33hw_fifo_mode_get(stmdev_ctx_t *ctx, lps33hw_f_mode_t *val);
 
-int32_t lps33hw_fifo_data_level_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_fifo_ovr_flag_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lps33hw_fifo_fth_flag_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LPS33HW_SPI_4_WIRE = 0,
   LPS33HW_SPI_3_WIRE = 1,
 } lps33hw_sim_t;
-int32_t lps33hw_spi_mode_set(lps33hw_ctx_t *ctx, lps33hw_sim_t val);
-int32_t lps33hw_spi_mode_get(lps33hw_ctx_t *ctx, lps33hw_sim_t *val);
+int32_t lps33hw_spi_mode_set(stmdev_ctx_t *ctx, lps33hw_sim_t val);
+int32_t lps33hw_spi_mode_get(stmdev_ctx_t *ctx, lps33hw_sim_t *val);
 
 typedef enum {
   LPS33HW_I2C_ENABLE = 0,
   LPS33HW_I2C_DISABLE = 1,
 } lps33hw_i2c_dis_t;
-int32_t lps33hw_i2c_interface_set(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t val);
-int32_t lps33hw_i2c_interface_get(lps33hw_ctx_t *ctx, lps33hw_i2c_dis_t *val);
+int32_t lps33hw_i2c_interface_set(stmdev_ctx_t *ctx, lps33hw_i2c_dis_t val);
+int32_t lps33hw_i2c_interface_get(stmdev_ctx_t *ctx, lps33hw_i2c_dis_t *val);
 
-int32_t lps33hw_auto_add_inc_set(lps33hw_ctx_t *ctx, uint8_t val);
-int32_t lps33hw_auto_add_inc_get(lps33hw_ctx_t *ctx, uint8_t *val);
+int32_t lps33hw_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33hw_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   *@}

--- a/sensor/stmemsc/lps33w_STdC/driver/lps33w_reg.c
+++ b/sensor/stmemsc/lps33w_STdC/driver/lps33w_reg.c
@@ -1,0 +1,1841 @@
+/*
+ ******************************************************************************
+ * @file    lps33w_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LPS33W driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "lps33w_reg.h"
+
+/**
+  * @defgroup    LPS33W
+  * @brief       This file provides a set of functions needed to drive the
+  *              ultra-compact piezoresistive absolute pressure sensor.
+  * @{
+  *
+  */
+
+/** 
+  * @defgroup    LPS33W_Interfaces_functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps33w_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                        uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lps33w_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33W_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lps33w_from_lsb_to_hpa(uint32_t lsb)
+{
+  return ( (float_t)lsb / 4096.0f );
+}
+
+float_t lps33w_from_lsb_to_degc(int16_t lsb)
+{
+  return ( (float_t)lsb / 100.0f );
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33W_data_generation_c
+  * @brief       This section group all the functions concerning data
+  *              generation
+  * @{
+  *
+  */
+
+
+/**
+  * @brief  Reset Autozero function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_az in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.reset_az = val;
+    ret = lps33w_write_reg(ctx, LPS33W_INTERRUPT_CFG,
+                           (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Autozero function.[get] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_az in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.reset_az;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autozero in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_autozero_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG, 
+                        (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.autozero = val;
+    ret = lps33w_write_reg(ctx, LPS33W_INTERRUPT_CFG,
+                           (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Autozero function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autozero in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_autozero_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.autozero;
+
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[set] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.reset_arp = val;
+    ret = lps33w_write_reg(ctx, LPS33W_INTERRUPT_CFG,
+                           (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset AutoRifP function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of reset_arp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.reset_arp;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRifP function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autorifp in reg INTERRUPT_CFG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.autorifp = val;
+    ret = lps33w_write_reg(ctx, LPS33W_INTERRUPT_CFG,
+                           (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable AutoRifP function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of autorifp in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.autorifp;
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.bdu = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  *val = ctrl_reg1.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Low-pass bandwidth selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lpfp in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_low_pass_filter_mode_set(stmdev_ctx_t *ctx, lps33w_lpfp_t val)
+{
+  lps33w_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.lpfp = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Low-pass bandwidth selection.[get] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpfp in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_low_pass_filter_mode_get(stmdev_ctx_t *ctx, lps33w_lpfp_t *val)
+{
+  lps33w_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.lpfp){
+    case LPS33W_LPF_ODR_DIV_2:
+      *val = LPS33W_LPF_ODR_DIV_2;
+      break;
+    case LPS33W_LPF_ODR_DIV_9:
+      *val = LPS33W_LPF_ODR_DIV_9;
+      break;
+    case LPS33W_LPF_ODR_DIV_20:
+      *val = LPS33W_LPF_ODR_DIV_20;
+      break;
+    default:
+      *val = LPS33W_LPF_ODR_DIV_2;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_data_rate_set(stmdev_ctx_t *ctx, lps33w_odr_t val)
+{
+  lps33w_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.odr = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Output data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_data_rate_get(stmdev_ctx_t *ctx, lps33w_odr_t *val)
+{
+  lps33w_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.odr){
+    case LPS33W_POWER_DOWN:
+      *val = LPS33W_POWER_DOWN;
+      break;
+    case LPS33W_ODR_1_Hz:
+      *val = LPS33W_ODR_1_Hz;
+      break;
+    case LPS33W_ODR_10_Hz:
+      *val = LPS33W_ODR_10_Hz;
+      break;
+    case LPS33W_ODR_25_Hz:
+      *val = LPS33W_ODR_25_Hz;
+      break;
+    case LPS33W_ODR_50_Hz:
+      *val = LPS33W_ODR_50_Hz;
+      break;
+    case LPS33W_ODR_75_Hz:
+      *val = LPS33W_ODR_75_Hz;
+      break;
+    default:
+      *val = LPS33W_ODR_1_Hz;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[set] 
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of one_shot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.one_shot = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  One-shot mode. Device perform a single measure.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of one_shot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.one_shot;
+
+  return ret;
+}
+
+/**
+  * @brief  pressure_ref:   The Reference pressure value is a 24-bit data
+  *         expressed as 2’s complement. The value is used when AUTOZERO
+  *         or AUTORIFP function is enabled.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_write_reg(ctx, LPS33W_REF_P_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  pressure_ref:   The Reference pressure value is a 24-bit data
+  *         expressed as 2’s complement. The value is used when AUTOZERO
+  *         or AUTORIFP function is enabled.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_REF_P_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data that can be used to
+  *         implement one-point calibration (OPC) after soldering.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_write_reg(ctx, LPS33W_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  The pressure offset value is 16-bit data that can be used to
+  *         implement one-point calibration (OPC) after soldering.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_RPDS_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Pressure data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of p_da in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_press_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_status_t status;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_STATUS, (uint8_t*)&status, 1);
+  *val = status.p_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of t_da in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_status_t status;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_STATUS, (uint8_t*)&status, 1);
+  *val = status.t_da;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of p_or in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_press_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_status_t status;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_STATUS, (uint8_t*)&status, 1);
+  *val = status.p_or;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data overrun.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of t_or in reg STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_status_t status;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_STATUS, (uint8_t*)&status, 1);
+  *val = status.t_or;
+
+  return ret;
+}
+
+/**
+  * @brief  Pressure output value[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_PRESS_OUT_XL, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  temperature_raw:   Temperature output value[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_TEMP_OUT_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Low-pass filter reset register. If the LPFP is active, in
+  *         order to avoid the transitory phase, the filter can be
+  *         reset by reading this register before generating pressure
+  *         measurements.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_low_pass_rst_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_LPFP_RES, (uint8_t*) buff, 1);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33W_common
+  * @brief       This section group common usefull functions
+  * @{
+  *
+  */
+
+/**
+  * @brief  Device Who am I[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_WHO_AM_I, (uint8_t*) buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of swreset in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.swreset = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of swreset in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.swreset;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.boot = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Low current mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lc_en in reg RES_CONF
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_low_power_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_res_conf_t res_conf;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_RES_CONF, (uint8_t*)&res_conf, 1);
+  if(ret == 0){
+    res_conf.lc_en = val;
+    ret = lps33w_write_reg(ctx, LPS33W_RES_CONF, (uint8_t*)&res_conf, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low current mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lc_en in reg RES_CONF
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_low_power_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_res_conf_t res_conf;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_RES_CONF, (uint8_t*)&res_conf, 1);
+  *val = res_conf.lc_en;
+
+  return ret;
+}
+
+/**
+  * @brief  If ‘1’ indicates that the Boot (Reboot) phase is running.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot_status in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_boot_status_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.boot_status;
+
+  return ret;
+}
+
+/**
+  * @brief  All the status bit, FIFO and data generation[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from FIFO_STATUS to STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_dev_status_get(stmdev_ctx_t *ctx, lps33w_dev_stat_t *val)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_FIFO_STATUS, (uint8_t*) val, 2);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33W_interrupts
+  * @brief       This section group all the functions that manage interrupts
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pe in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_sign_of_int_threshold_set(stmdev_ctx_t *ctx, lps33w_pe_t val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.pe = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_INTERRUPT_CFG,
+                           (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation on pressure low/high event.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pe in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_sign_of_int_threshold_get(stmdev_ctx_t *ctx, lps33w_pe_t *val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  switch (interrupt_cfg.pe){
+    case LPS33W_NO_THRESHOLD:
+      *val = LPS33W_NO_THRESHOLD;
+      break;
+    case LPS33W_POSITIVE:
+      *val = LPS33W_POSITIVE;
+      break;
+    case LPS33W_NEGATIVE:
+      *val = LPS33W_NEGATIVE;
+      break;
+    case LPS33W_BOTH:
+      *val = LPS33W_BOTH;
+      break;
+    default:
+      *val = LPS33W_NO_THRESHOLD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt request to the INT_SOURCE (25h) register
+  *         mode (pulsed / latched) [set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lir in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_notification_mode_set(stmdev_ctx_t *ctx, lps33w_lir_t val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.lir = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_INTERRUPT_CFG,
+                           (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Interrupt request to the INT_SOURCE (25h) register
+  *          mode (pulsed / latched) [get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lir in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_notification_mode_get(stmdev_ctx_t *ctx, lps33w_lir_t *val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  switch (interrupt_cfg.lir){
+    case LPS33W_INT_PULSED:
+      *val = LPS33W_INT_PULSED;
+      break;
+    case LPS33W_INT_LATCHED:
+      *val = LPS33W_INT_LATCHED;
+      break;
+    default:
+      *val = LPS33W_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of diff_en in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_generation_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  if(ret == 0){
+    interrupt_cfg.diff_en = val;
+    ret = lps33w_write_reg(ctx, LPS33W_INTERRUPT_CFG,
+                           (uint8_t*)&interrupt_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable interrupt generation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of diff_en in reg INTERRUPT_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_interrupt_cfg_t interrupt_cfg;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INTERRUPT_CFG,
+                        (uint8_t*)&interrupt_cfg, 1);
+  *val = interrupt_cfg.diff_en;
+
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_write_reg(ctx, LPS33W_THS_P_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  User-defined threshold value for pressure interrupt event[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_THS_P_L, (uint8_t*) buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT_DRDY pin control bits.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int_s in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_pin_mode_set(stmdev_ctx_t *ctx, lps33w_int_s_t val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.int_s = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data signal on INT_DRDY pin control bits.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of int_s in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_pin_mode_get(stmdev_ctx_t *ctx, lps33w_int_s_t *val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.int_s){
+    case LPS33W_DRDY_OR_FIFO_FLAGS:
+      *val = LPS33W_DRDY_OR_FIFO_FLAGS;
+      break;
+    case LPS33W_HIGH_PRES_INT:
+      *val = LPS33W_HIGH_PRES_INT;
+      break;
+    case LPS33W_LOW_PRES_INT:
+      *val = LPS33W_LOW_PRES_INT;
+      break;
+    case LPS33W_EVERY_PRES_INT:
+      *val = LPS33W_EVERY_PRES_INT;
+      break;
+    default:
+      *val = LPS33W_DRDY_OR_FIFO_FLAGS;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.drdy = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.drdy;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_ovr in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_ovr = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun interrupt on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_ovr in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fth in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_fth = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   FIFO watermark status on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fth in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fss5 in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.f_fss5 = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO full flag on INT_DRDY pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_fss5 in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  *val = ctrl_reg3.f_fss5;
+
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pin_mode_set(stmdev_ctx_t *ctx, lps33w_pp_od_t val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.pp_od = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pp_od in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_pin_mode_get(stmdev_ctx_t *ctx, lps33w_pp_od_t *val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.pp_od){
+    case LPS33W_PUSH_PULL:
+      *val = LPS33W_PUSH_PULL;
+      break;
+    case LPS33W_OPEN_DRAIN:
+      *val = LPS33W_OPEN_DRAIN;
+      break;
+    default:
+      *val = LPS33W_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int_h_l in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_polarity_set(stmdev_ctx_t *ctx, lps33w_int_h_l_t val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  if(ret == 0){
+    ctrl_reg3.int_h_l = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of int_h_l in reg CTRL_REG3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_polarity_get(stmdev_ctx_t *ctx, lps33w_int_h_l_t *val)
+{
+  lps33w_ctrl_reg3_t ctrl_reg3;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG3, (uint8_t*)&ctrl_reg3, 1);
+  switch (ctrl_reg3.int_h_l){
+    case LPS33W_ACTIVE_HIGH:
+      *val = LPS33W_ACTIVE_HIGH;
+      break;
+    case LPS33W_ACTIVE_LOW:
+      *val = LPS33W_ACTIVE_LOW;
+      break;
+    default:
+      *val = LPS33W_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt source register[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Register INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_source_get(stmdev_ctx_t *ctx, lps33w_int_source_t *val)
+{
+  int32_t ret;
+  ret =  lps33w_read_reg(ctx, LPS33W_INT_SOURCE, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Differential pressure high interrupt flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ph in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_on_press_high_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.ph;
+
+  return ret;
+}
+
+/**
+  * @brief  Differential pressure low interrupt flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pl in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_int_on_press_low_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.pl;
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ia in reg INT_SOURCE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_interrupt_event_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_int_source_t int_source;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_INT_SOURCE, (uint8_t*)&int_source, 1);
+  *val = int_source.ia;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33W_fifo
+  * @brief       This section group all the functions concerning the
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief   Stop on FIFO watermark. Enable FIFO watermark level use.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_stop_on_fifo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.stop_on_fth = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Stop on FIFO watermark. Enable FIFO watermark level use.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_stop_on_fifo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_en in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.fifo_en = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_en in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wtm in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.wtm = val;
+    ret = lps33w_write_reg(ctx, LPS33W_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wtm in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  *val = fifo_ctrl.wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of f_mode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_mode_set(stmdev_ctx_t *ctx, lps33w_f_mode_t val)
+{
+  lps33w_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  if(ret == 0){
+    fifo_ctrl.f_mode = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of f_mode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_mode_get(stmdev_ctx_t *ctx, lps33w_f_mode_t *val)
+{
+  lps33w_fifo_ctrl_t fifo_ctrl;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_FIFO_CTRL, (uint8_t*)&fifo_ctrl, 1);
+  switch (fifo_ctrl.f_mode){
+    case LPS33W_BYPASS_MODE:
+      *val = LPS33W_BYPASS_MODE;
+      break;
+    case LPS33W_FIFO_MODE:
+      *val = LPS33W_FIFO_MODE;
+      break;
+    case LPS33W_STREAM_MODE:
+      *val = LPS33W_STREAM_MODE;
+      break;
+    case LPS33W_STREAM_TO_FIFO_MODE:
+      *val = LPS33W_STREAM_TO_FIFO_MODE;
+      break;
+    case LPS33W_BYPASS_TO_STREAM_MODE:
+      *val = LPS33W_BYPASS_TO_STREAM_MODE;
+      break;
+    case LPS33W_DYNAMIC_STREAM_MODE:
+      *val = LPS33W_DYNAMIC_STREAM_MODE;
+      break;
+    case LPS33W_BYPASS_TO_FIFO_MODE:
+      *val = LPS33W_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LPS33W_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO stored data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fss in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.fss;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ovr in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.ovr;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth_fifo in reg FIFO_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_fifo_status_t fifo_status;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_FIFO_STATUS, (uint8_t*)&fifo_status, 1);
+  *val = fifo_status.fth_fifo;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LPS33W_serial_interface
+  * @brief       This section group all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sim in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_spi_mode_set(stmdev_ctx_t *ctx, lps33w_sim_t val)
+{
+  lps33w_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  if(ret == 0){
+    ctrl_reg1.sim = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim in reg CTRL_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_spi_mode_get(stmdev_ctx_t *ctx, lps33w_sim_t *val)
+{
+  lps33w_ctrl_reg1_t ctrl_reg1;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG1, (uint8_t*)&ctrl_reg1, 1);
+  switch (ctrl_reg1.sim){
+    case LPS33W_SPI_4_WIRE:
+      *val = LPS33W_SPI_4_WIRE;
+      break;
+    case LPS33W_SPI_3_WIRE:
+      *val = LPS33W_SPI_3_WIRE;
+      break;
+    default:
+      *val = LPS33W_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of i2c_dis in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_i2c_interface_set(stmdev_ctx_t *ctx, lps33w_i2c_dis_t val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.i2c_dis = (uint8_t)val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of i2c_dis in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_i2c_interface_get(stmdev_ctx_t *ctx, lps33w_i2c_dis_t *val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  switch (ctrl_reg2.i2c_dis){
+    case LPS33W_I2C_ENABLE:
+      *val = LPS33W_I2C_ENABLE;
+      break;
+    case LPS33W_I2C_DISABLE:
+      *val = LPS33W_I2C_DISABLE;
+      break;
+    default:
+      *val = LPS33W_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a
+  *         multiple byte access with a serial interface (I2C or SPI).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_add_inc in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  if(ret == 0){
+    ctrl_reg2.if_add_inc = val;
+    ret = lps33w_write_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a
+  *         multiple byte access with a serial interface (I2C or SPI).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_add_inc in reg CTRL_REG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lps33w_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lps33w_ctrl_reg2_t ctrl_reg2;
+  int32_t ret;
+
+  ret = lps33w_read_reg(ctx, LPS33W_CTRL_REG2, (uint8_t*)&ctrl_reg2, 1);
+  *val = ctrl_reg2.if_add_inc;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lps33w_STdC/driver/lps33w_reg.h
+++ b/sensor/stmemsc/lps33w_STdC/driver/lps33w_reg.h
@@ -1,0 +1,469 @@
+/*
+ ******************************************************************************
+ * @file    lps33w_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lps33w_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LPS33W_REGS_H
+#define LPS33W_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LPS33W
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+
+/** @defgroup LSM9DS1_Infos
+  * @{
+  *
+  */
+
+  /** I2C Device Address 8 bit format: if SA0=0 -> 0xB9 if SA0=1 -> 0xBB **/
+#define LPS33W_I2C_ADD_H   0xBBU
+#define LPS33W_I2C_ADD_L   0xB9U
+
+/** Device Identification (Who am I) **/
+#define LPS33W_ID            0xB1U
+
+/**
+  * @}
+  *
+  */
+
+#define LPS33W_INTERRUPT_CFG  0x0BU
+typedef struct {
+  uint8_t pe               : 2; /* ple + phe -> pe */
+  uint8_t lir              : 1;
+  uint8_t diff_en          : 1;
+  uint8_t reset_az         : 1;
+  uint8_t autozero         : 1;
+  uint8_t reset_arp        : 1;
+  uint8_t autorifp         : 1;
+} lps33w_interrupt_cfg_t;
+
+#define LPS33W_THS_P_L        0x0CU
+#define LPS33W_THS_P_H        0x0DU
+#define LPS33W_WHO_AM_I       0x0FU
+#define LPS33W_CTRL_REG1      0x10U
+typedef struct {
+  uint8_t sim              : 1;
+  uint8_t bdu              : 1;
+  uint8_t lpfp             : 2; /* en_lpfp + lpfp_cfg -> lpfp */
+  uint8_t odr              : 3;
+  uint8_t not_used_01      : 1;
+} lps33w_ctrl_reg1_t;
+
+#define LPS33W_CTRL_REG2      0x11U
+typedef struct {
+  uint8_t one_shot         : 1;
+  uint8_t not_used_01      : 1;
+  uint8_t swreset          : 1;
+  uint8_t i2c_dis          : 1;
+  uint8_t if_add_inc       : 1;
+  uint8_t stop_on_fth      : 1;
+  uint8_t fifo_en          : 1;
+  uint8_t boot             : 1;
+} lps33w_ctrl_reg2_t;
+
+#define LPS33W_CTRL_REG3      0x12U
+typedef struct {
+  uint8_t int_s            : 2;
+  uint8_t drdy             : 1;
+  uint8_t f_ovr            : 1;
+  uint8_t f_fth            : 1;
+  uint8_t f_fss5           : 1;
+  uint8_t pp_od            : 1;
+  uint8_t int_h_l          : 1;
+} lps33w_ctrl_reg3_t;
+
+
+#define LPS33W_FIFO_CTRL      0x14U
+typedef struct {
+  uint8_t wtm              : 5;
+  uint8_t f_mode           : 3;
+} lps33w_fifo_ctrl_t;
+
+#define LPS33W_REF_P_XL       0x15U
+#define LPS33W_REF_P_L        0x16U
+#define LPS33W_REF_P_H        0x17U
+#define LPS33W_RPDS_L         0x18U
+#define LPS33W_RPDS_H         0x19U
+
+#define LPS33W_RES_CONF       0x1AU
+typedef struct {
+  uint8_t lc_en            : 1;
+  uint8_t not_used_01      : 7;
+} lps33w_res_conf_t;
+
+#define LPS33W_INT_SOURCE     0x25U
+typedef struct {
+  uint8_t ph               : 1;
+  uint8_t pl               : 1;
+  uint8_t ia               : 1;
+  uint8_t not_used_01      : 4;
+  uint8_t boot_status      : 1;
+} lps33w_int_source_t;
+
+#define LPS33W_FIFO_STATUS    0x26U
+typedef struct {
+  uint8_t fss              : 6;
+  uint8_t ovr              : 1;
+  uint8_t fth_fifo         : 1;
+} lps33w_fifo_status_t;
+
+#define LPS33W_STATUS         0x27U
+typedef struct {
+  uint8_t p_da             : 1;
+  uint8_t t_da             : 1;
+  uint8_t not_used_02      : 2;
+  uint8_t p_or             : 1;
+  uint8_t t_or             : 1;
+  uint8_t not_used_01      : 2;
+} lps33w_status_t;
+
+#define LPS33W_PRESS_OUT_XL   0x28U
+#define LPS33W_PRESS_OUT_L    0x29U
+#define LPS33W_PRESS_OUT_H    0x2AU
+#define LPS33W_TEMP_OUT_L     0x2BU
+#define LPS33W_TEMP_OUT_H     0x2CU
+#define LPS33W_LPFP_RES       0x33U
+
+/**
+  * @defgroup LPS33W_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+
+typedef union{
+  lps33w_interrupt_cfg_t      interrupt_cfg;
+  lps33w_ctrl_reg1_t          ctrl_reg1;
+  lps33w_ctrl_reg2_t          ctrl_reg2;
+  lps33w_ctrl_reg3_t          ctrl_reg3;
+  lps33w_fifo_ctrl_t          fifo_ctrl;
+  lps33w_res_conf_t           res_conf;
+  lps33w_int_source_t         int_source;
+  lps33w_fifo_status_t        fifo_status;
+  lps33w_status_t             status;
+  bitwise_t                    bitwise;
+  uint8_t                      byte;
+} lps33w_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lps33w_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lps33w_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lps33w_from_lsb_to_hpa(uint32_t lsb);
+extern float_t lps33w_from_lsb_to_degc(int16_t lsb);
+
+int32_t lps33w_autozero_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_autozero_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_autozero_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_autozero_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_pressure_snap_rst_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_pressure_snap_rst_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_pressure_snap_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_pressure_snap_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS33W_LPF_ODR_DIV_2  = 0,
+  LPS33W_LPF_ODR_DIV_9  = 2,
+  LPS33W_LPF_ODR_DIV_20 = 3,
+} lps33w_lpfp_t;
+int32_t lps33w_low_pass_filter_mode_set(stmdev_ctx_t *ctx, lps33w_lpfp_t val);
+int32_t lps33w_low_pass_filter_mode_get(stmdev_ctx_t *ctx, lps33w_lpfp_t *val);
+
+typedef enum {
+  LPS33W_POWER_DOWN  = 0,
+  LPS33W_ODR_1_Hz    = 1,
+  LPS33W_ODR_10_Hz   = 2,
+  LPS33W_ODR_25_Hz   = 3,
+  LPS33W_ODR_50_Hz   = 4,
+  LPS33W_ODR_75_Hz   = 5,
+} lps33w_odr_t;
+int32_t lps33w_data_rate_set(stmdev_ctx_t *ctx, lps33w_odr_t val);
+int32_t lps33w_data_rate_get(stmdev_ctx_t *ctx, lps33w_odr_t *val);
+
+int32_t lps33w_one_shoot_trigger_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_one_shoot_trigger_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_pressure_ref_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps33w_pressure_ref_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33w_pressure_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps33w_pressure_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33w_press_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_press_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_pressure_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33w_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33w_low_pass_rst_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33w_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lps33w_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_low_power_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_low_power_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_boot_status_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct{
+  lps33w_fifo_status_t  fifo_status;
+  lps33w_status_t       status;
+} lps33w_dev_stat_t;
+int32_t lps33w_dev_status_get(stmdev_ctx_t *ctx, lps33w_dev_stat_t *val);
+
+typedef enum {
+  LPS33W_NO_THRESHOLD = 0,
+  LPS33W_POSITIVE     = 1,
+  LPS33W_NEGATIVE     = 2,
+  LPS33W_BOTH         = 3,
+} lps33w_pe_t;
+int32_t lps33w_sign_of_int_threshold_set(stmdev_ctx_t *ctx, lps33w_pe_t val);
+int32_t lps33w_sign_of_int_threshold_get(stmdev_ctx_t *ctx, lps33w_pe_t *val);
+
+typedef enum {
+  LPS33W_INT_PULSED  = 0,
+  LPS33W_INT_LATCHED = 1,
+} lps33w_lir_t;
+int32_t lps33w_int_notification_mode_set(stmdev_ctx_t *ctx, lps33w_lir_t val);
+int32_t lps33w_int_notification_mode_get(stmdev_ctx_t *ctx, lps33w_lir_t *val);
+
+int32_t lps33w_int_generation_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_int_generation_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_int_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lps33w_int_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LPS33W_DRDY_OR_FIFO_FLAGS = 0,
+  LPS33W_HIGH_PRES_INT      = 1,
+  LPS33W_LOW_PRES_INT       = 2,
+  LPS33W_EVERY_PRES_INT     = 3,
+} lps33w_int_s_t;
+int32_t lps33w_int_pin_mode_set(stmdev_ctx_t *ctx, lps33w_int_s_t val);
+int32_t lps33w_int_pin_mode_get(stmdev_ctx_t *ctx, lps33w_int_s_t *val);
+
+int32_t lps33w_drdy_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_drdy_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_fifo_ovr_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_fifo_ovr_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_fifo_threshold_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_fifo_threshold_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_fifo_full_on_int_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_fifo_full_on_int_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS33W_PUSH_PULL  = 0,
+  LPS33W_OPEN_DRAIN = 1,
+} lps33w_pp_od_t;
+int32_t lps33w_pin_mode_set(stmdev_ctx_t *ctx, lps33w_pp_od_t val);
+int32_t lps33w_pin_mode_get(stmdev_ctx_t *ctx, lps33w_pp_od_t *val);
+
+typedef enum {
+  LPS33W_ACTIVE_HIGH = 0,
+  LPS33W_ACTIVE_LOW = 1,
+} lps33w_int_h_l_t;
+int32_t lps33w_int_polarity_set(stmdev_ctx_t *ctx, lps33w_int_h_l_t val);
+int32_t lps33w_int_polarity_get(stmdev_ctx_t *ctx, lps33w_int_h_l_t *val);
+
+int32_t lps33w_int_source_get(stmdev_ctx_t *ctx, lps33w_int_source_t *val);
+
+int32_t lps33w_int_on_press_high_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_int_on_press_low_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_interrupt_event_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_stop_on_fifo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_stop_on_fifo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS33W_BYPASS_MODE           = 0,
+  LPS33W_FIFO_MODE             = 1,
+  LPS33W_STREAM_MODE           = 2,
+  LPS33W_STREAM_TO_FIFO_MODE   = 3,
+  LPS33W_BYPASS_TO_STREAM_MODE = 4,
+  LPS33W_DYNAMIC_STREAM_MODE   = 6,
+  LPS33W_BYPASS_TO_FIFO_MODE   = 7,
+} lps33w_f_mode_t;
+int32_t lps33w_fifo_mode_set(stmdev_ctx_t *ctx, lps33w_f_mode_t val);
+int32_t lps33w_fifo_mode_get(stmdev_ctx_t *ctx, lps33w_f_mode_t *val);
+
+int32_t lps33w_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lps33w_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LPS33W_SPI_4_WIRE = 0,
+  LPS33W_SPI_3_WIRE = 1,
+} lps33w_sim_t;
+int32_t lps33w_spi_mode_set(stmdev_ctx_t *ctx, lps33w_sim_t val);
+int32_t lps33w_spi_mode_get(stmdev_ctx_t *ctx, lps33w_sim_t *val);
+
+typedef enum {
+  LPS33W_I2C_ENABLE = 0,
+  LPS33W_I2C_DISABLE = 1,
+} lps33w_i2c_dis_t;
+int32_t lps33w_i2c_interface_set(stmdev_ctx_t *ctx, lps33w_i2c_dis_t val);
+int32_t lps33w_i2c_interface_get(stmdev_ctx_t *ctx, lps33w_i2c_dis_t *val);
+
+int32_t lps33w_auto_add_inc_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lps33w_auto_add_inc_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPS33W_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm303agr_STdC/driver/lsm303agr_reg.c
+++ b/sensor/stmemsc/lsm303agr_STdC/driver/lsm303agr_reg.c
@@ -1,38 +1,21 @@
 /*
-  ******************************************************************************
-  * @file    lsm303agr_reg.c
-  * @author  Sensor Solutions Software Team
-  * @brief   LSM303AGR driver file
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without
-  * modification, are permitted provided that the following conditions
-  * are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright
-  *      notice, this list of conditions and the following disclaimer in the
-  *      documentation and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its
-  *      contributors may be used to endorse or promote products derived from
-  *      this software without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-  * POSSIBILITY OF SUCH DAMAGE.
-  *
-  */
+ ******************************************************************************
+ * @file    lsm303agr_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LSM303AGR driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
 
 #include "lsm303agr_reg.h"
 
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm303agr_read_reg(lsm303agr_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm303agr_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lsm303agr_read_reg(lsm303agr_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm303agr_write_reg(lsm303agr_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm303agr_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -201,7 +184,7 @@ float_t lsm303agr_from_lsb_to_mgauss(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_temp_status_reg_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303agr_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm303agr_read_reg(ctx, LSM303AGR_STATUS_REG_AUX_A, buff, 1);
@@ -216,7 +199,7 @@ int32_t lsm303agr_temp_status_reg_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_temp_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_status_reg_aux_a_t status_reg_aux_a;
   int32_t ret;
@@ -236,7 +219,7 @@ int32_t lsm303agr_temp_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_temp_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_status_reg_aux_a_t status_reg_aux_a;
   int32_t ret;
@@ -256,7 +239,7 @@ int32_t lsm303agr_temp_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_temperature_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303agr_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm303agr_read_reg(ctx, LSM303AGR_OUT_TEMP_L_A, buff, 2);
@@ -271,7 +254,7 @@ int32_t lsm303agr_temperature_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_temperature_meas_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_temperature_meas_set(stmdev_ctx_t *ctx,
                                        lsm303agr_temp_en_a_t val)
 {
   lsm303agr_temp_cfg_reg_a_t temp_cfg_reg_a;
@@ -296,7 +279,7 @@ int32_t lsm303agr_temperature_meas_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_temperature_meas_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_temperature_meas_get(stmdev_ctx_t *ctx,
                                       lsm303agr_temp_en_a_t *val)
 {
   lsm303agr_temp_cfg_reg_a_t temp_cfg_reg_a;
@@ -328,7 +311,7 @@ int32_t lsm303agr_temperature_meas_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_operating_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_operating_mode_set(stmdev_ctx_t *ctx,
                                         lsm303agr_op_md_a_t val)
 {
   lsm303agr_ctrl_reg1_a_t ctrl_reg1_a;
@@ -376,7 +359,7 @@ int32_t lsm303agr_xl_operating_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_operating_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_operating_mode_get(stmdev_ctx_t *ctx,
                                         lsm303agr_op_md_a_t *val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -409,7 +392,7 @@ int32_t lsm303agr_xl_operating_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_data_rate_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_data_rate_set(stmdev_ctx_t *ctx,
                                    lsm303agr_odr_a_t val)
 {
   lsm303agr_ctrl_reg1_a_t ctrl_reg1_a;
@@ -434,7 +417,7 @@ int32_t lsm303agr_xl_data_rate_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_data_rate_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_data_rate_get(stmdev_ctx_t *ctx,
                                    lsm303agr_odr_a_t *val)
 {
   lsm303agr_ctrl_reg1_a_t ctrl_reg1_a;
@@ -490,7 +473,7 @@ int32_t lsm303agr_xl_data_rate_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_high_pass_on_outputs_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_on_outputs_set(stmdev_ctx_t *ctx,
                                               uint8_t val)
 {
   lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
@@ -516,7 +499,7 @@ int32_t lsm303agr_xl_high_pass_on_outputs_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_high_pass_on_outputs_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_on_outputs_get(stmdev_ctx_t *ctx,
                                               uint8_t *val)
 {
   lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
@@ -544,7 +527,7 @@ int32_t lsm303agr_xl_high_pass_on_outputs_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_high_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                              lsm303agr_hpcf_a_t val)
 {
   lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
@@ -576,7 +559,7 @@ int32_t lsm303agr_xl_high_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_high_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                              lsm303agr_hpcf_a_t *val)
 {
   lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
@@ -613,7 +596,7 @@ int32_t lsm303agr_xl_high_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_high_pass_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_mode_set(stmdev_ctx_t *ctx,
                                         lsm303agr_hpm_a_t val)
 {
   lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
@@ -638,7 +621,7 @@ int32_t lsm303agr_xl_high_pass_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_high_pass_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_mode_get(stmdev_ctx_t *ctx,
                                         lsm303agr_hpm_a_t *val)
 {
   lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
@@ -675,7 +658,7 @@ int32_t lsm303agr_xl_high_pass_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_full_scale_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_full_scale_set(stmdev_ctx_t *ctx,
                                     lsm303agr_fs_a_t val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -700,7 +683,7 @@ int32_t lsm303agr_xl_full_scale_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_full_scale_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_full_scale_get(stmdev_ctx_t *ctx,
                                     lsm303agr_fs_a_t *val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -737,7 +720,7 @@ int32_t lsm303agr_xl_full_scale_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_block_data_update_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_block_data_update_set(stmdev_ctx_t *ctx,
                                            uint8_t val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -762,7 +745,7 @@ int32_t lsm303agr_xl_block_data_update_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_block_data_update_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_block_data_update_get(stmdev_ctx_t *ctx,
                                            uint8_t *val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -784,7 +767,7 @@ int32_t lsm303agr_xl_block_data_update_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_filter_reference_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_filter_reference_set(stmdev_ctx_t *ctx,
                                           uint8_t *buff)
 {
   int32_t ret;
@@ -801,7 +784,7 @@ int32_t lsm303agr_xl_filter_reference_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_filter_reference_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_filter_reference_get(stmdev_ctx_t *ctx,
                                           uint8_t *buff)
 {
   int32_t ret;
@@ -817,7 +800,7 @@ int32_t lsm303agr_xl_filter_reference_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_status_reg_a_t status_reg_a;
   int32_t ret;
@@ -837,7 +820,7 @@ int32_t lsm303agr_xl_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_status_reg_a_t status_reg_a;
   int32_t ret;
@@ -857,7 +840,7 @@ int32_t lsm303agr_xl_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_acceleration_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303agr_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm303agr_read_reg(ctx, LSM303AGR_OUT_X_L_A, buff, 6);
@@ -879,7 +862,7 @@ int32_t lsm303agr_acceleration_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_user_offset_set(lsm303agr_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303agr_mag_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm303agr_write_reg(ctx, LSM303AGR_OFFSET_X_REG_L_M, buff, 6);
@@ -901,7 +884,7 @@ int32_t lsm303agr_mag_user_offset_set(lsm303agr_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_user_offset_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303agr_mag_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm303agr_read_reg(ctx, LSM303AGR_OFFSET_X_REG_L_M, buff, 6);
@@ -916,7 +899,7 @@ int32_t lsm303agr_mag_user_offset_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_operating_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_operating_mode_set(stmdev_ctx_t *ctx,
                                          lsm303agr_md_m_t val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
@@ -941,7 +924,7 @@ int32_t lsm303agr_mag_operating_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_operating_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_operating_mode_get(stmdev_ctx_t *ctx,
                                          lsm303agr_md_m_t *val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
@@ -975,7 +958,7 @@ int32_t lsm303agr_mag_operating_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_data_rate_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_data_rate_set(stmdev_ctx_t *ctx,
                                     lsm303agr_mg_odr_m_t val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
@@ -1000,7 +983,7 @@ int32_t lsm303agr_mag_data_rate_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_data_rate_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm303agr_mg_odr_m_t *val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
@@ -1037,7 +1020,7 @@ int32_t lsm303agr_mag_data_rate_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_power_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_power_mode_set(stmdev_ctx_t *ctx,
                                      lsm303agr_lp_m_t val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
@@ -1062,7 +1045,7 @@ int32_t lsm303agr_mag_power_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_power_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_power_mode_get(stmdev_ctx_t *ctx,
                                      lsm303agr_lp_m_t *val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
@@ -1093,7 +1076,7 @@ int32_t lsm303agr_mag_power_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_offset_temp_comp_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_mag_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
   int32_t ret;
@@ -1117,7 +1100,7 @@ int32_t lsm303agr_mag_offset_temp_comp_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_offset_temp_comp_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_mag_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
   int32_t ret;
@@ -1137,7 +1120,7 @@ int32_t lsm303agr_mag_offset_temp_comp_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_low_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                              lsm303agr_lpf_m_t val)
 {
   lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
@@ -1162,7 +1145,7 @@ int32_t lsm303agr_mag_low_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_low_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                              lsm303agr_lpf_m_t *val)
 {
   lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
@@ -1193,7 +1176,7 @@ int32_t lsm303agr_mag_low_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_set_rst_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_set_rst_mode_set(stmdev_ctx_t *ctx,
                                        lsm303agr_set_rst_m_t val)
 {
   lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
@@ -1218,7 +1201,7 @@ int32_t lsm303agr_mag_set_rst_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_set_rst_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_set_rst_mode_get(stmdev_ctx_t *ctx,
                                        lsm303agr_set_rst_m_t *val)
 {
   lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
@@ -1258,7 +1241,7 @@ int32_t lsm303agr_mag_set_rst_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_set_rst_sensor_single_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_set_rst_sensor_single_set(stmdev_ctx_t *ctx,
                                                 uint8_t val)
 {
   lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
@@ -1290,7 +1273,7 @@ int32_t lsm303agr_mag_set_rst_sensor_single_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_set_rst_sensor_single_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_set_rst_sensor_single_get(stmdev_ctx_t *ctx,
                                                 uint8_t *val)
 {
   lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
@@ -1311,7 +1294,7 @@ int32_t lsm303agr_mag_set_rst_sensor_single_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_block_data_update_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_block_data_update_set(stmdev_ctx_t *ctx,
                                             uint8_t val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
@@ -1336,7 +1319,7 @@ int32_t lsm303agr_mag_block_data_update_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_block_data_update_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_block_data_update_get(stmdev_ctx_t *ctx,
                                             uint8_t *val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
@@ -1357,7 +1340,7 @@ int32_t lsm303agr_mag_block_data_update_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_mag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_status_reg_m_t status_reg_m;
   int32_t ret;
@@ -1377,7 +1360,7 @@ int32_t lsm303agr_mag_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_mag_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_status_reg_m_t status_reg_m;
   int32_t ret;
@@ -1397,7 +1380,7 @@ int32_t lsm303agr_mag_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_magnetic_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303agr_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm303agr_read_reg(ctx, LSM303AGR_OUTX_L_REG_M, buff, 6);
@@ -1424,7 +1407,7 @@ int32_t lsm303agr_magnetic_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303agr_xl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm303agr_read_reg(ctx, LSM303AGR_WHO_AM_I_A, buff, 1);
@@ -1439,7 +1422,7 @@ int32_t lsm303agr_xl_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_self_test_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_self_test_set(stmdev_ctx_t *ctx,
                                    lsm303agr_st_a_t val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -1464,7 +1447,7 @@ int32_t lsm303agr_xl_self_test_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_self_test_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_self_test_get(stmdev_ctx_t *ctx,
                                    lsm303agr_st_a_t *val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -1498,7 +1481,7 @@ int32_t lsm303agr_xl_self_test_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_data_format_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_data_format_set(stmdev_ctx_t *ctx,
                                      lsm303agr_ble_a_t val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -1523,7 +1506,7 @@ int32_t lsm303agr_xl_data_format_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_data_format_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_data_format_get(stmdev_ctx_t *ctx,
                                      lsm303agr_ble_a_t *val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -1554,7 +1537,7 @@ int32_t lsm303agr_xl_data_format_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_boot_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_xl_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
   int32_t ret;
@@ -1578,7 +1561,7 @@ int32_t lsm303agr_xl_boot_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
   int32_t ret;
@@ -1598,7 +1581,7 @@ int32_t lsm303agr_xl_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_status_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_status_get(stmdev_ctx_t *ctx,
                                 lsm303agr_status_reg_a_t *val)
 {
   int32_t ret;
@@ -1614,7 +1597,7 @@ int32_t lsm303agr_xl_status_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303agr_mag_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm303agr_read_reg(ctx, LSM303AGR_WHO_AM_I_M, buff, 1);
@@ -1629,7 +1612,7 @@ int32_t lsm303agr_mag_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_reset_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_mag_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
   int32_t ret;
@@ -1653,7 +1636,7 @@ int32_t lsm303agr_mag_reset_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_reset_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_mag_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
   int32_t ret;
@@ -1673,7 +1656,7 @@ int32_t lsm303agr_mag_reset_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_boot_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_mag_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
   int32_t ret;
@@ -1697,7 +1680,7 @@ int32_t lsm303agr_mag_boot_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_mag_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_cfg_reg_a_m_t cfg_reg_a_m;
   int32_t ret;
@@ -1717,7 +1700,7 @@ int32_t lsm303agr_mag_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_self_test_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_mag_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
   int32_t ret;
@@ -1741,7 +1724,7 @@ int32_t lsm303agr_mag_self_test_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_self_test_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_mag_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
   int32_t ret;
@@ -1761,7 +1744,7 @@ int32_t lsm303agr_mag_self_test_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_data_format_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_data_format_set(stmdev_ctx_t *ctx,
                                       lsm303agr_ble_m_t val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
@@ -1786,7 +1769,7 @@ int32_t lsm303agr_mag_data_format_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_data_format_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_data_format_get(stmdev_ctx_t *ctx,
                                       lsm303agr_ble_m_t *val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
@@ -1817,7 +1800,7 @@ int32_t lsm303agr_mag_data_format_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_status_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_status_get(stmdev_ctx_t *ctx,
                                  lsm303agr_status_reg_m_t *val)
 {
   int32_t ret;
@@ -1846,7 +1829,7 @@ int32_t lsm303agr_mag_status_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_gen_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                        lsm303agr_int1_cfg_a_t *val)
 {
   int32_t ret;
@@ -1862,7 +1845,7 @@ int32_t lsm303agr_xl_int1_gen_conf_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_gen_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                        lsm303agr_int1_cfg_a_t *val)
 {
   int32_t ret;
@@ -1878,7 +1861,7 @@ int32_t lsm303agr_xl_int1_gen_conf_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_gen_source_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_source_get(stmdev_ctx_t *ctx,
                                          lsm303agr_int1_src_a_t *val)
 {
   int32_t ret;
@@ -1896,7 +1879,7 @@ int32_t lsm303agr_xl_int1_gen_source_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_gen_threshold_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_threshold_set(stmdev_ctx_t *ctx,
                                             uint8_t val)
 {
   lsm303agr_int1_ths_a_t int1_ths_a;
@@ -1923,7 +1906,7 @@ int32_t lsm303agr_xl_int1_gen_threshold_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_gen_threshold_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_threshold_get(stmdev_ctx_t *ctx,
                                             uint8_t *val)
 {
   lsm303agr_int1_ths_a_t int1_ths_a;
@@ -1945,7 +1928,7 @@ int32_t lsm303agr_xl_int1_gen_threshold_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_gen_duration_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_xl_int1_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_int1_duration_a_t int1_duration_a;
   int32_t ret;
@@ -1970,7 +1953,7 @@ int32_t lsm303agr_xl_int1_gen_duration_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_gen_duration_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_int1_gen_duration_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_int1_duration_a_t int1_duration_a;
   int32_t ret;
@@ -2003,7 +1986,7 @@ int32_t lsm303agr_xl_int1_gen_duration_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_gen_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                        lsm303agr_int2_cfg_a_t *val)
 {
   int32_t ret;
@@ -2019,7 +2002,7 @@ int32_t lsm303agr_xl_int2_gen_conf_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_gen_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                        lsm303agr_int2_cfg_a_t *val)
 {
   int32_t ret;
@@ -2035,7 +2018,7 @@ int32_t lsm303agr_xl_int2_gen_conf_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_gen_source_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_source_get(stmdev_ctx_t *ctx,
                                          lsm303agr_int2_src_a_t *val)
 {
   int32_t ret;
@@ -2053,7 +2036,7 @@ int32_t lsm303agr_xl_int2_gen_source_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_gen_threshold_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_threshold_set(stmdev_ctx_t *ctx,
                                             uint8_t val)
 {
   lsm303agr_int2_ths_a_t int2_ths_a;
@@ -2080,7 +2063,7 @@ int32_t lsm303agr_xl_int2_gen_threshold_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_gen_threshold_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_threshold_get(stmdev_ctx_t *ctx,
                                             uint8_t *val)
 {
   lsm303agr_int2_ths_a_t int2_ths_a;
@@ -2102,7 +2085,7 @@ int32_t lsm303agr_xl_int2_gen_threshold_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_gen_duration_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_xl_int2_gen_duration_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_int2_duration_a_t int2_duration_a;
   int32_t ret;
@@ -2127,7 +2110,7 @@ int32_t lsm303agr_xl_int2_gen_duration_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_gen_duration_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_duration_get(stmdev_ctx_t *ctx,
                                            uint8_t *val)
 {
   lsm303agr_int2_duration_a_t int2_duration_a;
@@ -2161,7 +2144,7 @@ int32_t lsm303agr_xl_int2_gen_duration_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_high_pass_int_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                             lsm303agr_hp_a_t val)
 {
   lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
@@ -2186,7 +2169,7 @@ int32_t lsm303agr_xl_high_pass_int_conf_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_high_pass_int_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                             lsm303agr_hp_a_t *val)
 {
   lsm303agr_ctrl_reg2_a_t ctrl_reg2_a;
@@ -2235,7 +2218,7 @@ int32_t lsm303agr_xl_high_pass_int_conf_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_pin_int1_config_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_pin_int1_config_set(stmdev_ctx_t *ctx,
                                          lsm303agr_ctrl_reg3_a_t *val)
 {
   int32_t ret;
@@ -2251,7 +2234,7 @@ int32_t lsm303agr_xl_pin_int1_config_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_pin_int1_config_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_pin_int1_config_get(stmdev_ctx_t *ctx,
                                          lsm303agr_ctrl_reg3_a_t *val)
 {
   int32_t ret;
@@ -2268,7 +2251,7 @@ int32_t lsm303agr_xl_pin_int1_config_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_pin_detect_4d_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_pin_detect_4d_set(stmdev_ctx_t *ctx,
                                             uint8_t val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
@@ -2294,7 +2277,7 @@ int32_t lsm303agr_xl_int2_pin_detect_4d_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2_pin_detect_4d_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_pin_detect_4d_get(stmdev_ctx_t *ctx,
                                             uint8_t *val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
@@ -2317,7 +2300,7 @@ int32_t lsm303agr_xl_int2_pin_detect_4d_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2pin_notification_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                    lsm303agr_lir_int2_a_t val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
@@ -2344,7 +2327,7 @@ int32_t lsm303agr_xl_int2pin_notification_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int2pin_notification_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                 lsm303agr_lir_int2_a_t *val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
@@ -2376,7 +2359,7 @@ int32_t lsm303agr_xl_int2pin_notification_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_pin_detect_4d_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_xl_int1_pin_detect_4d_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
   int32_t ret;
@@ -2401,7 +2384,7 @@ int32_t lsm303agr_xl_int1_pin_detect_4d_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1_pin_detect_4d_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_int1_pin_detect_4d_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
   int32_t ret;
@@ -2423,7 +2406,7 @@ int32_t lsm303agr_xl_int1_pin_detect_4d_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1pin_notification_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                    lsm303agr_lir_int1_a_t val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
@@ -2450,7 +2433,7 @@ int32_t lsm303agr_xl_int1pin_notification_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_int1pin_notification_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                    lsm303agr_lir_int1_a_t *val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
@@ -2481,7 +2464,7 @@ int32_t lsm303agr_xl_int1pin_notification_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_pin_int2_config_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_pin_int2_config_set(stmdev_ctx_t *ctx,
                                          lsm303agr_ctrl_reg6_a_t *val)
 {
   int32_t ret;
@@ -2497,7 +2480,7 @@ int32_t lsm303agr_xl_pin_int2_config_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_pin_int2_config_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_pin_int2_config_get(stmdev_ctx_t *ctx,
                                          lsm303agr_ctrl_reg6_a_t *val)
 {
   int32_t ret;
@@ -2528,7 +2511,7 @@ int32_t lsm303agr_xl_pin_int2_config_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_offset_int_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_offset_int_conf_set(stmdev_ctx_t *ctx,
                                           lsm303agr_int_on_dataoff_m_t val)
 {
   lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
@@ -2555,7 +2538,7 @@ int32_t lsm303agr_mag_offset_int_conf_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_offset_int_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_offset_int_conf_get(stmdev_ctx_t *ctx,
                                           lsm303agr_int_on_dataoff_m_t *val)
 {
   lsm303agr_cfg_reg_b_m_t cfg_reg_b_m;
@@ -2586,7 +2569,7 @@ int32_t lsm303agr_mag_offset_int_conf_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_drdy_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_mag_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
   int32_t ret;
@@ -2610,7 +2593,7 @@ int32_t lsm303agr_mag_drdy_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_drdy_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_mag_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
   int32_t ret;
@@ -2630,7 +2613,7 @@ int32_t lsm303agr_mag_drdy_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_int_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_mag_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
   int32_t ret;
@@ -2654,7 +2637,7 @@ int32_t lsm303agr_mag_int_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_int_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_mag_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
   int32_t ret;
@@ -2674,7 +2657,7 @@ int32_t lsm303agr_mag_int_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_int_gen_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_conf_set(stmdev_ctx_t *ctx,
                                        lsm303agr_int_crtl_reg_m_t *val)
 {
   int32_t ret;
@@ -2690,7 +2673,7 @@ int32_t lsm303agr_mag_int_gen_conf_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_int_gen_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_conf_get(stmdev_ctx_t *ctx,
                                        lsm303agr_int_crtl_reg_m_t *val)
 {
   int32_t ret;
@@ -2707,7 +2690,7 @@ int32_t lsm303agr_mag_int_gen_conf_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_int_gen_source_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_source_get(stmdev_ctx_t *ctx,
                                          lsm303agr_int_source_reg_m_t *val)
 {
   int32_t ret;
@@ -2727,7 +2710,7 @@ int32_t lsm303agr_mag_int_gen_source_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_int_gen_treshold_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_treshold_set(stmdev_ctx_t *ctx,
                                            uint8_t *buff)
 {
   int32_t ret;
@@ -2746,7 +2729,7 @@ int32_t lsm303agr_mag_int_gen_treshold_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_int_gen_treshold_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_treshold_get(stmdev_ctx_t *ctx,
                                            uint8_t *buff)
 {
   int32_t ret;
@@ -2775,7 +2758,7 @@ int32_t lsm303agr_mag_int_gen_treshold_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_xl_fifo_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
   int32_t ret;
@@ -2799,7 +2782,7 @@ int32_t lsm303agr_xl_fifo_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_fifo_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_ctrl_reg5_a_t ctrl_reg5_a;
   int32_t ret;
@@ -2819,7 +2802,7 @@ int32_t lsm303agr_xl_fifo_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_watermark_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_xl_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
   int32_t ret;
@@ -2843,7 +2826,7 @@ int32_t lsm303agr_xl_fifo_watermark_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_watermark_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
   int32_t ret;
@@ -2863,7 +2846,7 @@ int32_t lsm303agr_xl_fifo_watermark_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_trigger_event_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                         lsm303agr_tr_a_t val)
 {
   lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
@@ -2888,7 +2871,7 @@ int32_t lsm303agr_xl_fifo_trigger_event_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_trigger_event_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                             lsm303agr_tr_a_t *val)
 {
   lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
@@ -2919,7 +2902,7 @@ int32_t lsm303agr_xl_fifo_trigger_event_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_mode_set(stmdev_ctx_t *ctx,
                                    lsm303agr_fm_a_t val)
 {
   lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
@@ -2944,7 +2927,7 @@ int32_t lsm303agr_xl_fifo_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_mode_get(stmdev_ctx_t *ctx,
                                    lsm303agr_fm_a_t *val)
 {
   lsm303agr_fifo_ctrl_reg_a_t fifo_ctrl_reg_a;
@@ -2981,7 +2964,7 @@ int32_t lsm303agr_xl_fifo_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_status_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_status_get(stmdev_ctx_t *ctx,
                                      lsm303agr_fifo_src_reg_a_t *val)
 {
   int32_t ret;
@@ -2997,7 +2980,7 @@ int32_t lsm303agr_xl_fifo_status_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_data_level_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_fifo_src_reg_a_t fifo_src_reg_a;
   int32_t ret;
@@ -3017,7 +3000,7 @@ int32_t lsm303agr_xl_fifo_data_level_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_empty_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_fifo_src_reg_a_t fifo_src_reg_a;
   int32_t ret;
@@ -3037,7 +3020,7 @@ int32_t lsm303agr_xl_fifo_empty_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_ovr_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_fifo_src_reg_a_t fifo_src_reg_a;
   int32_t ret;
@@ -3057,7 +3040,7 @@ int32_t lsm303agr_xl_fifo_ovr_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_fifo_fth_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_xl_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_fifo_src_reg_a_t fifo_src_reg_a;
   int32_t ret;
@@ -3090,7 +3073,7 @@ int32_t lsm303agr_xl_fifo_fth_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_tap_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_tap_conf_set(stmdev_ctx_t *ctx,
                                lsm303agr_click_cfg_a_t *val)
 {
   int32_t ret;
@@ -3106,7 +3089,7 @@ int32_t lsm303agr_tap_conf_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_tap_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_tap_conf_get(stmdev_ctx_t *ctx,
                                lsm303agr_click_cfg_a_t *val)
 {
   int32_t ret;
@@ -3122,7 +3105,7 @@ int32_t lsm303agr_tap_conf_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_tap_source_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_tap_source_get(stmdev_ctx_t *ctx,
                                  lsm303agr_click_src_a_t *val)
 {
   int32_t ret;
@@ -3139,7 +3122,7 @@ int32_t lsm303agr_tap_source_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_tap_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_click_ths_a_t click_ths_a;
   int32_t ret;
@@ -3164,7 +3147,7 @@ int32_t lsm303agr_tap_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_tap_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_click_ths_a_t click_ths_a;
   int32_t ret;
@@ -3186,7 +3169,7 @@ int32_t lsm303agr_tap_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_shock_dur_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_time_limit_a_t time_limit_a;
   int32_t ret;
@@ -3212,7 +3195,7 @@ int32_t lsm303agr_shock_dur_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_shock_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_time_limit_a_t time_limit_a;
   int32_t ret;
@@ -3235,7 +3218,7 @@ int32_t lsm303agr_shock_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_quiet_dur_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_time_latency_a_t time_latency_a;
   int32_t ret;
@@ -3261,7 +3244,7 @@ int32_t lsm303agr_quiet_dur_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_quiet_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_time_latency_a_t time_latency_a;
   int32_t ret;
@@ -3284,7 +3267,7 @@ int32_t lsm303agr_quiet_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_double_tap_timeout_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_double_tap_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_time_window_a_t time_window_a;
   int32_t ret;
@@ -3311,7 +3294,7 @@ int32_t lsm303agr_double_tap_timeout_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_double_tap_timeout_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_double_tap_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_time_window_a_t time_window_a;
   int32_t ret;
@@ -3346,7 +3329,7 @@ int32_t lsm303agr_double_tap_timeout_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_act_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_act_ths_a_t act_ths_a;
   int32_t ret;
@@ -3372,7 +3355,7 @@ int32_t lsm303agr_act_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_act_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_act_ths_a_t act_ths_a;
   int32_t ret;
@@ -3392,7 +3375,7 @@ int32_t lsm303agr_act_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_act_timeout_set(lsm303agr_ctx_t *ctx, uint8_t val)
+int32_t lsm303agr_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm303agr_act_dur_a_t act_dur_a;
   int32_t ret;
@@ -3416,7 +3399,7 @@ int32_t lsm303agr_act_timeout_set(lsm303agr_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_act_timeout_get(lsm303agr_ctx_t *ctx, uint8_t *val)
+int32_t lsm303agr_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm303agr_act_dur_a_t act_dur_a;
   int32_t ret;
@@ -3449,7 +3432,7 @@ int32_t lsm303agr_act_timeout_get(lsm303agr_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_spi_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_spi_mode_set(stmdev_ctx_t *ctx,
                                   lsm303agr_sim_a_t val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -3474,7 +3457,7 @@ int32_t lsm303agr_xl_spi_mode_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_xl_spi_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_spi_mode_get(stmdev_ctx_t *ctx,
                                   lsm303agr_sim_a_t *val)
 {
   lsm303agr_ctrl_reg4_a_t ctrl_reg4_a;
@@ -3505,7 +3488,7 @@ int32_t lsm303agr_xl_spi_mode_get(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_i2c_interface_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_i2c_interface_set(stmdev_ctx_t *ctx,
                                         lsm303agr_i2c_dis_m_t val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;
@@ -3530,7 +3513,7 @@ int32_t lsm303agr_mag_i2c_interface_set(lsm303agr_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303agr_mag_i2c_interface_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_i2c_interface_get(stmdev_ctx_t *ctx,
                                         lsm303agr_i2c_dis_m_t *val)
 {
   lsm303agr_cfg_reg_c_m_t cfg_reg_c_m;

--- a/sensor/stmemsc/lsm303agr_STdC/driver/lsm303agr_reg.h
+++ b/sensor/stmemsc/lsm303agr_STdC/driver/lsm303agr_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef LSM303AGR_REGS_H
 #define LSM303AGR_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup LSM303AGR_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-  /** @addtogroup  LSM303AGR_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -125,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lsm303agr_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lsm303agr_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lsm303agr_write_ptr  write_reg;
-  lsm303agr_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lsm303agr_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -540,9 +513,9 @@ typedef union{
   *
   */
 
-int32_t lsm303agr_read_reg(lsm303agr_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm303agr_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
-int32_t lsm303agr_write_reg(lsm303agr_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm303agr_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t lsm303agr_from_fs_2g_hr_to_mg(int16_t lsb);
@@ -565,21 +538,21 @@ extern float_t lsm303agr_from_lsb_lp_to_celsius(int16_t lsb);
 
 extern float_t lsm303agr_from_lsb_to_mgauss(int16_t lsb);
 
-int32_t lsm303agr_temp_status_reg_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303agr_temp_status_reg_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303agr_temp_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_temp_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_temp_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_temp_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_temperature_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303agr_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM303AGR_TEMP_DISABLE  = 0,
   LSM303AGR_TEMP_ENABLE   = 3,
 } lsm303agr_temp_en_a_t;
-int32_t lsm303agr_temperature_meas_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_temperature_meas_set(stmdev_ctx_t *ctx,
                                        lsm303agr_temp_en_a_t val);
-int32_t lsm303agr_temperature_meas_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_temperature_meas_get(stmdev_ctx_t *ctx,
                                        lsm303agr_temp_en_a_t *val);
 
 typedef enum {
@@ -587,9 +560,9 @@ typedef enum {
   LSM303AGR_NM_10bit   = 1,
   LSM303AGR_LP_8bit    = 2,
 } lsm303agr_op_md_a_t;
-int32_t lsm303agr_xl_operating_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_operating_mode_set(stmdev_ctx_t *ctx,
                                         lsm303agr_op_md_a_t val);
-int32_t lsm303agr_xl_operating_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_operating_mode_get(stmdev_ctx_t *ctx,
                                         lsm303agr_op_md_a_t *val);
 
 typedef enum {
@@ -604,14 +577,14 @@ typedef enum {
   LSM303AGR_XL_ODR_1kHz620_LP                  = 8,
   LSM303AGR_XL_ODR_1kHz344_NM_HP_5kHz376_LP    = 9,
 } lsm303agr_odr_a_t;
-int32_t lsm303agr_xl_data_rate_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_data_rate_set(stmdev_ctx_t *ctx,
                                    lsm303agr_odr_a_t val);
-int32_t lsm303agr_xl_data_rate_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_data_rate_get(stmdev_ctx_t *ctx,
                                    lsm303agr_odr_a_t *val);
 
-int32_t lsm303agr_xl_high_pass_on_outputs_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_on_outputs_set(stmdev_ctx_t *ctx,
                                               uint8_t val);
-int32_t lsm303agr_xl_high_pass_on_outputs_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_on_outputs_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
 typedef enum {
@@ -620,9 +593,9 @@ typedef enum {
   LSM303AGR_MEDIUM      = 2,
   LSM303AGR_LIGHT       = 3,
 } lsm303agr_hpcf_a_t;
-int32_t lsm303agr_xl_high_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                              lsm303agr_hpcf_a_t val);
-int32_t lsm303agr_xl_high_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                              lsm303agr_hpcf_a_t *val);
 
 typedef enum {
@@ -631,9 +604,9 @@ typedef enum {
   LSM303AGR_NORMAL           = 2,
   LSM303AGR_AUTORST_ON_INT   = 3,
 } lsm303agr_hpm_a_t;
-int32_t lsm303agr_xl_high_pass_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_mode_set(stmdev_ctx_t *ctx,
                                         lsm303agr_hpm_a_t val);
-int32_t lsm303agr_xl_high_pass_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_mode_get(stmdev_ctx_t *ctx,
                                         lsm303agr_hpm_a_t *val);
 
 typedef enum {
@@ -642,88 +615,88 @@ typedef enum {
   LSM303AGR_8g   = 2,
   LSM303AGR_16g  = 3,
 } lsm303agr_fs_a_t;
-int32_t lsm303agr_xl_full_scale_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_full_scale_set(stmdev_ctx_t *ctx,
                                     lsm303agr_fs_a_t val);
-int32_t lsm303agr_xl_full_scale_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_full_scale_get(stmdev_ctx_t *ctx,
                                     lsm303agr_fs_a_t *val);
 
-int32_t lsm303agr_xl_block_data_update_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_block_data_update_set(stmdev_ctx_t *ctx,
                                            uint8_t val);
-int32_t lsm303agr_xl_block_data_update_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_block_data_update_get(stmdev_ctx_t *ctx,
                                            uint8_t *val);
 
-int32_t lsm303agr_xl_filter_reference_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_filter_reference_set(stmdev_ctx_t *ctx,
                                           uint8_t *buff);
-int32_t lsm303agr_xl_filter_reference_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_filter_reference_get(stmdev_ctx_t *ctx,
                                           uint8_t *buff);
 
-int32_t lsm303agr_xl_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_xl_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_acceleration_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303agr_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303agr_xl_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303agr_xl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM303AGR_ST_DISABLE   = 0,
   LSM303AGR_ST_POSITIVE  = 1,
   LSM303AGR_ST_NEGATIVE  = 2,
 } lsm303agr_st_a_t;
-int32_t lsm303agr_xl_self_test_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_self_test_set(stmdev_ctx_t *ctx,
                                    lsm303agr_st_a_t val);
-int32_t lsm303agr_xl_self_test_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_self_test_get(stmdev_ctx_t *ctx,
                                    lsm303agr_st_a_t *val);
 
 typedef enum {
   LSM303AGR_XL_LSB_AT_LOW_ADD = 0,
   LSM303AGR_XL_MSB_AT_LOW_ADD = 1,
 } lsm303agr_ble_a_t;
-int32_t lsm303agr_xl_data_format_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_data_format_set(stmdev_ctx_t *ctx,
                                      lsm303agr_ble_a_t val);
-int32_t lsm303agr_xl_data_format_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_data_format_get(stmdev_ctx_t *ctx,
                                      lsm303agr_ble_a_t *val);
 
-int32_t lsm303agr_xl_boot_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_xl_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_xl_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_xl_status_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_status_get(stmdev_ctx_t *ctx,
                                 lsm303agr_status_reg_a_t *val);
 
-int32_t lsm303agr_xl_int1_gen_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_conf_set(stmdev_ctx_t *ctx,
                                        lsm303agr_int1_cfg_a_t *val);
-int32_t lsm303agr_xl_int1_gen_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_conf_get(stmdev_ctx_t *ctx,
                                        lsm303agr_int1_cfg_a_t *val);
 
-int32_t lsm303agr_xl_int1_gen_source_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_source_get(stmdev_ctx_t *ctx,
                                          lsm303agr_int1_src_a_t *val);
 
-int32_t lsm303agr_xl_int1_gen_threshold_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_threshold_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t lsm303agr_xl_int1_gen_threshold_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_threshold_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
-int32_t lsm303agr_xl_int1_gen_duration_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_duration_set(stmdev_ctx_t *ctx,
                                            uint8_t val);
-int32_t lsm303agr_xl_int1_gen_duration_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_gen_duration_get(stmdev_ctx_t *ctx,
                                            uint8_t *val);
 
-int32_t lsm303agr_xl_int2_gen_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_conf_set(stmdev_ctx_t *ctx,
                                        lsm303agr_int2_cfg_a_t *val);
-int32_t lsm303agr_xl_int2_gen_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_conf_get(stmdev_ctx_t *ctx,
                                        lsm303agr_int2_cfg_a_t *val);
 
-int32_t lsm303agr_xl_int2_gen_source_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_source_get(stmdev_ctx_t *ctx,
                                          lsm303agr_int2_src_a_t *val);
 
-int32_t lsm303agr_xl_int2_gen_threshold_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_threshold_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t lsm303agr_xl_int2_gen_threshold_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_threshold_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
-int32_t lsm303agr_xl_int2_gen_duration_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_duration_set(stmdev_ctx_t *ctx,
                                            uint8_t val);
-int32_t lsm303agr_xl_int2_gen_duration_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_gen_duration_get(stmdev_ctx_t *ctx,
                                            uint8_t *val);
 
 typedef enum {
@@ -736,62 +709,62 @@ typedef enum {
   LSM303AGR_ON_INT2_TAP_GEN          = 6,
   LSM303AGR_ON_INT1_INT2_TAP_GEN     = 7,
 } lsm303agr_hp_a_t;
-int32_t lsm303agr_xl_high_pass_int_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_int_conf_set(stmdev_ctx_t *ctx,
                                             lsm303agr_hp_a_t val);
-int32_t lsm303agr_xl_high_pass_int_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_high_pass_int_conf_get(stmdev_ctx_t *ctx,
                                             lsm303agr_hp_a_t *val);
 
-int32_t lsm303agr_xl_pin_int1_config_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_pin_int1_config_set(stmdev_ctx_t *ctx,
                                          lsm303agr_ctrl_reg3_a_t *val);
-int32_t lsm303agr_xl_pin_int1_config_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_pin_int1_config_get(stmdev_ctx_t *ctx,
                                          lsm303agr_ctrl_reg3_a_t *val);
 
-int32_t lsm303agr_xl_int2_pin_detect_4d_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_pin_detect_4d_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t lsm303agr_xl_int2_pin_detect_4d_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2_pin_detect_4d_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
 typedef enum {
   LSM303AGR_INT2_PULSED   = 0,
   LSM303AGR_INT2_LATCHED  = 1,
 } lsm303agr_lir_int2_a_t;
-int32_t lsm303agr_xl_int2pin_notification_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                    lsm303agr_lir_int2_a_t val);
-int32_t lsm303agr_xl_int2pin_notification_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int2pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                    lsm303agr_lir_int2_a_t *val);
 
-int32_t lsm303agr_xl_int1_pin_detect_4d_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_pin_detect_4d_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t lsm303agr_xl_int1_pin_detect_4d_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1_pin_detect_4d_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
 typedef enum {
   LSM303AGR_INT1_PULSED   = 0,
   LSM303AGR_INT1_LATCHED  = 1,
 } lsm303agr_lir_int1_a_t;
-int32_t lsm303agr_xl_int1pin_notification_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1pin_notification_mode_set(stmdev_ctx_t *ctx,
                                                    lsm303agr_lir_int1_a_t val);
-int32_t lsm303agr_xl_int1pin_notification_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_int1pin_notification_mode_get(stmdev_ctx_t *ctx,
                                                    lsm303agr_lir_int1_a_t *val);
 
-int32_t lsm303agr_xl_pin_int2_config_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_pin_int2_config_set(stmdev_ctx_t *ctx,
                                          lsm303agr_ctrl_reg6_a_t *val);
-int32_t lsm303agr_xl_pin_int2_config_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_pin_int2_config_get(stmdev_ctx_t *ctx,
                                          lsm303agr_ctrl_reg6_a_t *val);
 
-int32_t lsm303agr_xl_fifo_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_xl_fifo_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_fifo_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_xl_fifo_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_xl_fifo_watermark_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_xl_fifo_watermark_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_xl_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AGR_INT1_GEN = 0,
   LSM303AGR_INT2_GEN = 1,
 } lsm303agr_tr_a_t;
-int32_t lsm303agr_xl_fifo_trigger_event_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_trigger_event_set(stmdev_ctx_t *ctx,
                                             lsm303agr_tr_a_t val);
-int32_t lsm303agr_xl_fifo_trigger_event_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_trigger_event_get(stmdev_ctx_t *ctx,
                                             lsm303agr_tr_a_t *val);
 
 typedef enum {
@@ -800,62 +773,62 @@ typedef enum {
   LSM303AGR_DYNAMIC_STREAM_MODE   = 2,
   LSM303AGR_STREAM_TO_FIFO_MODE   = 3,
 } lsm303agr_fm_a_t;
-int32_t lsm303agr_xl_fifo_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_mode_set(stmdev_ctx_t *ctx,
                                    lsm303agr_fm_a_t val);
-int32_t lsm303agr_xl_fifo_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_mode_get(stmdev_ctx_t *ctx,
                                    lsm303agr_fm_a_t *val);
 
-int32_t lsm303agr_xl_fifo_status_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_fifo_status_get(stmdev_ctx_t *ctx,
                                      lsm303agr_fifo_src_reg_a_t *val);
 
-int32_t lsm303agr_xl_fifo_data_level_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_xl_fifo_empty_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_fifo_empty_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_xl_fifo_ovr_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_xl_fifo_fth_flag_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_xl_fifo_fth_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_tap_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_tap_conf_set(stmdev_ctx_t *ctx,
                                lsm303agr_click_cfg_a_t *val);
-int32_t lsm303agr_tap_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_tap_conf_get(stmdev_ctx_t *ctx,
                                lsm303agr_click_cfg_a_t *val);
 
-int32_t lsm303agr_tap_source_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_tap_source_get(stmdev_ctx_t *ctx,
                                 lsm303agr_click_src_a_t *val);
 
-int32_t lsm303agr_tap_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_tap_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_shock_dur_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_shock_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_shock_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_shock_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_quiet_dur_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_quiet_dur_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_quiet_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_quiet_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_double_tap_timeout_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_double_tap_timeout_set(stmdev_ctx_t *ctx,
                                          uint8_t val);
-int32_t lsm303agr_double_tap_timeout_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_double_tap_timeout_get(stmdev_ctx_t *ctx,
                                          uint8_t *val);
 
-int32_t lsm303agr_act_threshold_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_act_threshold_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_act_timeout_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_act_timeout_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_act_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_act_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AGR_SPI_4_WIRE = 0,
   LSM303AGR_SPI_3_WIRE = 1,
 } lsm303agr_sim_a_t;
-int32_t lsm303agr_xl_spi_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_spi_mode_set(stmdev_ctx_t *ctx,
                                   lsm303agr_sim_a_t val);
-int32_t lsm303agr_xl_spi_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_xl_spi_mode_get(stmdev_ctx_t *ctx,
                                   lsm303agr_sim_a_t *val);
 
-int32_t lsm303agr_mag_user_offset_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_user_offset_set(stmdev_ctx_t *ctx,
                                       uint8_t *buff);
-int32_t lsm303agr_mag_user_offset_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_user_offset_get(stmdev_ctx_t *ctx,
                                       uint8_t *buff);
 
 typedef enum {
@@ -863,9 +836,9 @@ typedef enum {
   LSM303AGR_SINGLE_TRIGGER   = 1,
   LSM303AGR_POWER_DOWN       = 2,
 } lsm303agr_md_m_t;
-int32_t lsm303agr_mag_operating_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_operating_mode_set(stmdev_ctx_t *ctx,
                                          lsm303agr_md_m_t val);
-int32_t lsm303agr_mag_operating_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_operating_mode_get(stmdev_ctx_t *ctx,
                                          lsm303agr_md_m_t *val);
 
 typedef enum {
@@ -874,32 +847,32 @@ typedef enum {
   LSM303AGR_MG_ODR_50Hz   = 2,
   LSM303AGR_MG_ODR_100Hz  = 3,
 } lsm303agr_mg_odr_m_t;
-int32_t lsm303agr_mag_data_rate_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_data_rate_set(stmdev_ctx_t *ctx,
                                     lsm303agr_mg_odr_m_t val);
-int32_t lsm303agr_mag_data_rate_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm303agr_mg_odr_m_t *val);
 
 typedef enum {
   LSM303AGR_HIGH_RESOLUTION  = 0,
   LSM303AGR_LOW_POWER        = 1,
 } lsm303agr_lp_m_t;
-int32_t lsm303agr_mag_power_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_power_mode_set(stmdev_ctx_t *ctx,
                                      lsm303agr_lp_m_t val);
-int32_t lsm303agr_mag_power_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_power_mode_get(stmdev_ctx_t *ctx,
                                      lsm303agr_lp_m_t *val);
 
-int32_t lsm303agr_mag_offset_temp_comp_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_offset_temp_comp_set(stmdev_ctx_t *ctx,
                                            uint8_t val);
-int32_t lsm303agr_mag_offset_temp_comp_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_offset_temp_comp_get(stmdev_ctx_t *ctx,
                                            uint8_t *val);
 
 typedef enum {
   LSM303AGR_ODR_DIV_2  = 0,
   LSM303AGR_ODR_DIV_4  = 1,
 } lsm303agr_lpf_m_t;
-int32_t lsm303agr_mag_low_pass_bandwidth_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                              lsm303agr_lpf_m_t val);
-int32_t lsm303agr_mag_low_pass_bandwidth_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                              lsm303agr_lpf_m_t *val);
 
 typedef enum {
@@ -907,86 +880,86 @@ typedef enum {
   LSM303AGR_SENS_OFF_CANC_EVERY_ODR    = 1,
   LSM303AGR_SET_SENS_ONLY_AT_POWER_ON  = 2,
 } lsm303agr_set_rst_m_t;
-int32_t lsm303agr_mag_set_rst_mode_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_set_rst_mode_set(stmdev_ctx_t *ctx,
                                        lsm303agr_set_rst_m_t val);
-int32_t lsm303agr_mag_set_rst_mode_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_set_rst_mode_get(stmdev_ctx_t *ctx,
                                        lsm303agr_set_rst_m_t *val);
 
-int32_t lsm303agr_mag_set_rst_sensor_single_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_set_rst_sensor_single_set(stmdev_ctx_t *ctx,
                                                 uint8_t val);
-int32_t lsm303agr_mag_set_rst_sensor_single_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_set_rst_sensor_single_get(stmdev_ctx_t *ctx,
                                                 uint8_t *val);
 
-int32_t lsm303agr_mag_block_data_update_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_block_data_update_set(stmdev_ctx_t *ctx,
                                             uint8_t val);
-int32_t lsm303agr_mag_block_data_update_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_block_data_update_get(stmdev_ctx_t *ctx,
                                             uint8_t *val);
 
-int32_t lsm303agr_mag_data_ready_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_mag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_mag_data_ovr_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_mag_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_magnetic_raw_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303agr_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303agr_mag_device_id_get(lsm303agr_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303agr_mag_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303agr_mag_reset_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_mag_reset_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_mag_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_mag_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_mag_boot_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_mag_boot_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_mag_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_mag_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_mag_self_test_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_self_test_set(stmdev_ctx_t *ctx,
                                     uint8_t val);
-int32_t lsm303agr_mag_self_test_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_self_test_get(stmdev_ctx_t *ctx,
                                     uint8_t *val);
 
 typedef enum {
   LSM303AGR_MG_LSB_AT_LOW_ADD  = 0,
   LSM303AGR_MG_MSB_AT_LOW_ADD  = 1,
 } lsm303agr_ble_m_t;
-int32_t lsm303agr_mag_data_format_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_data_format_set(stmdev_ctx_t *ctx,
                                       lsm303agr_ble_m_t val);
-int32_t lsm303agr_mag_data_format_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_data_format_get(stmdev_ctx_t *ctx,
                                       lsm303agr_ble_m_t *val);
 
-int32_t lsm303agr_mag_status_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_status_get(stmdev_ctx_t *ctx,
                                  lsm303agr_status_reg_m_t *val);
 
 typedef enum {
   LSM303AGR_CHECK_BEFORE  = 0,
   LSM303AGR_CHECK_AFTER   = 1,
 } lsm303agr_int_on_dataoff_m_t;
-int32_t lsm303agr_mag_offset_int_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_offset_int_conf_set(stmdev_ctx_t *ctx,
                                           lsm303agr_int_on_dataoff_m_t val);
-int32_t lsm303agr_mag_offset_int_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_offset_int_conf_get(stmdev_ctx_t *ctx,
                                           lsm303agr_int_on_dataoff_m_t *val);
 
-int32_t lsm303agr_mag_drdy_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_mag_drdy_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_mag_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_mag_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_mag_int_on_pin_set(lsm303agr_ctx_t *ctx, uint8_t val);
-int32_t lsm303agr_mag_int_on_pin_get(lsm303agr_ctx_t *ctx, uint8_t *val);
+int32_t lsm303agr_mag_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303agr_mag_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303agr_mag_int_gen_conf_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_conf_set(stmdev_ctx_t *ctx,
                                        lsm303agr_int_crtl_reg_m_t *val);
-int32_t lsm303agr_mag_int_gen_conf_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_conf_get(stmdev_ctx_t *ctx,
                                        lsm303agr_int_crtl_reg_m_t *val);
 
-int32_t lsm303agr_mag_int_gen_source_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_source_get(stmdev_ctx_t *ctx,
                                          lsm303agr_int_source_reg_m_t *val);
 
-int32_t lsm303agr_mag_int_gen_treshold_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_treshold_set(stmdev_ctx_t *ctx,
                                            uint8_t *buff);
-int32_t lsm303agr_mag_int_gen_treshold_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_int_gen_treshold_get(stmdev_ctx_t *ctx,
                                            uint8_t *buff);
 typedef enum {
   LSM303AGR_I2C_ENABLE   = 0,
   LSM303AGR_I2C_DISABLE  = 1,
 } lsm303agr_i2c_dis_m_t;
-int32_t lsm303agr_mag_i2c_interface_set(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_i2c_interface_set(stmdev_ctx_t *ctx,
                                         lsm303agr_i2c_dis_m_t val);
-int32_t lsm303agr_mag_i2c_interface_get(lsm303agr_ctx_t *ctx,
+int32_t lsm303agr_mag_i2c_interface_get(stmdev_ctx_t *ctx,
                                         lsm303agr_i2c_dis_m_t *val);
 
 /**

--- a/sensor/stmemsc/lsm303ah_STdC/driver/lsm303ah_reg.c
+++ b/sensor/stmemsc/lsm303ah_STdC/driver/lsm303ah_reg.c
@@ -1,3355 +1,4022 @@
 /*
  ******************************************************************************
  * @file    lsm303ah_reg.c
- * @author  MEMS Software Solution Team
- * @date    19-December-2017
+ * @author  Sensors Software Solution Team
  * @brief   LSM303AH driver file
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 #include "lsm303ah_reg.h"
 
 /**
-  * @addtogroup  lsm303ah
-  * @brief  This file provides a set of functions needed to drive the
-  *         lsm303ah enanced inertial module.
+  * @defgroup  LSM303AH
+  * @brief     This file provides a set of functions needed to drive the
+  *            lsm303ah enhanced inertial module.
   * @{
+  *
   */
 
 /**
-  * @addtogroup  interfaces_functions
-  * @brief  This section provide a set of functions used to read and write
-  *         a generic register of the device.
+  * @defgroup  LSM303AH_Interfaces_Functions
+  * @brief     This section provide a set of functions used to read and
+  *            write a generic register of the device.
+  *            MANDATORY: return 0 -> no Error.
   * @{
+  *
   */
 
 /**
   * @brief  Read generic device register
   *
-  * @param  lsm303ah_ctx_t* ctx: read / write interface definitions
-  * @param  uint8_t reg: register to read
-  * @param  uint8_t* data: pointer to buffer that store the data read
-  * @param  uint16_t len: number of consecutive register to read
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm303ah_read_reg(lsm303ah_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm303ah_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
-  return ctx->read_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @brief  Write generic device register
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t reg: register to write
-  * @param  uint8_t* data: pointer to data to write in register reg
-  * @param  uint16_t len: number of consecutive register to write
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
-*/
-int32_t lsm303ah_write_reg(lsm303ah_ctx_t* ctx, uint8_t reg, uint8_t* data,
-                           uint16_t len)
+  */
+int32_t lsm303ah_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
 {
-  return ctx->write_reg(ctx->handle, reg, data, len);
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  data_generation_c
-  * @brief   This section groups all the functions concerning data generation
+  * @defgroup    LSM303AH_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
   * @{
+  *
+  */
+
+float_t lsm303ah_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t lsm303ah_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t lsm303ah_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t lsm303ah_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t lsm303ah_from_lsb_to_mgauss(int16_t lsb)
+{
+  return ((float_t)lsb * 1.5f);
+}
+
+float_t lsm303ah_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
   */
 
 /**
-  * @brief  all_sources: [get] Read all the interrupt/status flag of
-  *                            the device.
-  *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_all_sources: FIFO_SRC, STATUS_DUP, WAKE_UP_SRC,
-  *                               TAP_SRC, 6D_SRC, FUNC_CK_GATE, FUNC_SRC.
+  * @defgroup  Data Generation
+  * @brief     This section groups all the functions concerning data generation.
+  * @{
   *
   */
-int32_t lsm303ah_xl_all_sources_get(lsm303ah_ctx_t *ctx,
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    get FIFO_SRC, STATUS_DUP, WAKE_UP_SRC,
+  *                TAP_SRC, 6D_SRC, FUNC_CK_GATE, FUNC_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm303ah_xl_all_sources_get(stmdev_ctx_t *ctx,
                                  lsm303ah_xl_all_sources_t *val)
 {
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A,
-                               &(val->byte[0]), 1);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STATUS_DUP_A,
-                               &(val->byte[1]), 4);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A,
-                               &(val->byte[5]), 2);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A,
+                          (uint8_t*)&(val->fifo_src_a), 1);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_STATUS_DUP_A,
+                            (uint8_t*)&(val->status_dup_a), 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_SRC_A,
+                            (uint8_t*)&(val->wake_up_src_a), 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_TAP_SRC_A,
+                            (uint8_t*)&(val->tap_src_a), 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_6D_SRC_A,
+                            (uint8_t*)&(val->_6d_src_a), 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A,
+                            (uint8_t*)&(val->func_ck_gate_a), 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_SRC_A,
+                            (uint8_t*)&(val->func_src_a), 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [set] Blockdataupdate.
+  * @brief  Block data update.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of bdu in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_block_data_update_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
-  reg.ctrl1_a.bdu = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  if(ret == 0){
+    ctrl1_a.bdu = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [get] Blockdataupdate.
+  * @brief  Block data update.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of bdu in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    get the values of bdu in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_block_data_update_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
-  *val = reg.ctrl1_a.bdu;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  *val = ctrl1_a.bdu;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [set] Blockdataupdate.
+  * @brief  Block data update.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of bdu in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param val     Change the values of bdu in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_block_data_update_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_mg_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.bdu = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.bdu = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  block_data_update: [get] Blockdataupdate.
+  * @brief  Block data update.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of bdu in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    get the values of bdu in reg CFG_REG_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_block_data_update_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  *val = reg.cfg_reg_c_m.bdu;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.bdu;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  data_format: [set]  Big/Little Endian data selection.
+  * @brief  Big/Little Endian data selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_ble_t: change the values of ble in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of ble in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_data_format_set(lsm303ah_ctx_t *ctx, lsm303ah_mg_ble_t val)
+int32_t lsm303ah_mg_data_format_set(stmdev_ctx_t *ctx, lsm303ah_mg_ble_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.ble = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.ble = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  data_format: [get]  Big/Little Endian data selection.
+  * @brief  Big/Little Endian data selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_ble_t: Get the values of ble in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of ble in reg CFG_REG_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_data_format_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_data_format_get(stmdev_ctx_t *ctx,
                                     lsm303ah_mg_ble_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  *val = (lsm303ah_mg_ble_t) reg.cfg_reg_c_m.ble;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  switch (cfg_reg_c_m.ble){
+    case LSM303AH_MG_LSB_AT_LOW_ADD:
+      *val = LSM303AH_MG_LSB_AT_LOW_ADD;
+      break;
+    case LSM303AH_MG_MSB_AT_LOW_ADD:
+      *val = LSM303AH_MG_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LSM303AH_MG_LSB_AT_LOW_ADD;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_full_scale: [set]   Accelerometer full-scale selection.
+  * @brief  Accelerometer full-scale selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_fs_t: change the values of fs in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_full_scale_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_fs_t val)
+int32_t lsm303ah_xl_full_scale_set(stmdev_ctx_t *ctx, lsm303ah_xl_fs_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
-  reg.ctrl1_a.fs = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  if(ret == 0){
+    ctrl1_a.fs = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  xl_full_scale: [get]   Accelerometer full-scale selection.
+  * @brief  Accelerometer full-scale selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_fs_t: Get the values of fs in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_full_scale_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_fs_t *val)
+int32_t lsm303ah_xl_full_scale_get(stmdev_ctx_t *ctx, lsm303ah_xl_fs_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_fs_t) reg.ctrl1_a.fs;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  switch (ctrl1_a.fs){
+    case LSM303AH_XL_2g:
+      *val = LSM303AH_XL_2g;
+      break;
+    case LSM303AH_XL_16g:
+      *val = LSM303AH_XL_16g;
+      break;
+    case LSM303AH_XL_4g:
+      *val = LSM303AH_XL_4g;
+      break;
+    case LSM303AH_XL_8g:
+      *val = LSM303AH_XL_8g;
+      break;
+    default:
+      *val = LSM303AH_XL_2g;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  xl_data_rate: [set]  Accelerometer data rate selection.
+  * @brief  Accelerometer data rate selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_odr_t: change the values of odr in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr in reg CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_data_rate_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_odr_t val)
+int32_t lsm303ah_xl_data_rate_set(stmdev_ctx_t *ctx, lsm303ah_xl_odr_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
-  reg.ctrl1_a.odr = val & 0x0F;
-  reg.ctrl1_a.hf_odr = (val & 0x10) >> 4;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  if(ret == 0){
+    ctrl1_a.odr = (uint8_t)val & 0x0FU;
+    ctrl1_a.hf_odr = ((uint8_t)val & 0x10U) >> 4;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  xl_data_rate: [get]  Accelerometer data rate selection.
+  * @brief  Accelerometer data rate selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_odr_t: Get the values of odr in reg CTRL1
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CTRL1.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_data_rate_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_odr_t *val)
+int32_t lsm303ah_xl_data_rate_get(stmdev_ctx_t *ctx, lsm303ah_xl_odr_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl1_a_t ctrl1_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_odr_t) ((reg.ctrl1_a.hf_odr << 4) + reg.ctrl1_a.odr);
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL1_A, (uint8_t*)&ctrl1_a, 1);
+  switch ((ctrl1_a.hf_odr << 4) + ctrl1_a.odr){
+    case LSM303AH_XL_ODR_OFF:
+      *val = LSM303AH_XL_ODR_OFF;
+      break;
+    case LSM303AH_XL_ODR_1Hz_LP:
+      *val = LSM303AH_XL_ODR_1Hz_LP;
+      break;
+    case LSM303AH_XL_ODR_12Hz5_LP:
+      *val = LSM303AH_XL_ODR_12Hz5_LP;
+      break;
+    case LSM303AH_XL_ODR_25Hz_LP:
+      *val = LSM303AH_XL_ODR_25Hz_LP;
+      break;
+    case LSM303AH_XL_ODR_50Hz_LP:
+      *val = LSM303AH_XL_ODR_50Hz_LP;
+      break;
+    case LSM303AH_XL_ODR_100Hz_LP:
+      *val = LSM303AH_XL_ODR_100Hz_LP;
+      break;
+    case LSM303AH_XL_ODR_200Hz_LP:
+      *val = LSM303AH_XL_ODR_200Hz_LP;
+      break;
+    case LSM303AH_XL_ODR_400Hz_LP:
+      *val = LSM303AH_XL_ODR_400Hz_LP;
+      break;
+    case LSM303AH_XL_ODR_800Hz_LP:
+      *val = LSM303AH_XL_ODR_800Hz_LP;
+      break;
+    case LSM303AH_XL_ODR_12Hz5_HR:
+      *val = LSM303AH_XL_ODR_12Hz5_HR;
+      break;
+    case LSM303AH_XL_ODR_25Hz_HR:
+      *val = LSM303AH_XL_ODR_25Hz_HR;
+      break;
+    case LSM303AH_XL_ODR_50Hz_HR:
+      *val = LSM303AH_XL_ODR_50Hz_HR;
+      break;
+    case LSM303AH_XL_ODR_100Hz_HR:
+      *val = LSM303AH_XL_ODR_100Hz_HR;
+      break;
+    case LSM303AH_XL_ODR_200Hz_HR:
+      *val = LSM303AH_XL_ODR_200Hz_HR;
+      break;
+    case LSM303AH_XL_ODR_400Hz_HR:
+      *val = LSM303AH_XL_ODR_400Hz_HR;
+      break;
+    case LSM303AH_XL_ODR_800Hz_HR:
+      *val = LSM303AH_XL_ODR_800Hz_HR;
+      break;
+    case LSM303AH_XL_ODR_1k6Hz_HF:
+      *val = LSM303AH_XL_ODR_1k6Hz_HF;
+      break;
+    case LSM303AH_XL_ODR_3k2Hz_HF:
+      *val = LSM303AH_XL_ODR_3k2Hz_HF;
+      break;
+    case LSM303AH_XL_ODR_6k4Hz_HF:
+      *val = LSM303AH_XL_ODR_6k4Hz_HF;
+      break;
+    default:
+      *val = LSM303AH_XL_ODR_OFF;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  status_reg: [get]  The STATUS_REG register.
+  * @brief  The STATUS_REG register.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_status_reg_t: registers STATUS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_status_reg_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_status_reg_get(stmdev_ctx_t *ctx,
                                    lsm303ah_status_a_t *val)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_STATUS_A, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STATUS_A, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  status: [get]  Info about device status.
+  * @brief  Info about device status.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_status_reg_t: registers STATUS_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_status_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_status_get(stmdev_ctx_t *ctx,
                                lsm303ah_status_reg_m_t *val)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  xl_flag_data_ready: [get]  Accelerometer new data available.
+  * @brief  Accelerometer new data available.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of drdy in reg STATUS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy in reg STATUS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_flag_data_ready_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_status_a_t status_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STATUS_A, &reg.byte, 1);
-  *val = reg.status_a.drdy;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STATUS_A, (uint8_t*)&status_a, 1);
+  *val = status_a.drdy;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  mag_data_ready: [get]  Magnetic set of data available.
+  * @brief  Magnetic set of data available.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of zyxda in reg STATUS_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxda in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_data_ready_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_status_reg_m_t status_reg_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, &reg.byte, 1);
-  *val = reg.status_reg_m.zyxda;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, (uint8_t*)&status_reg_m, 1);
+  *val = status_reg_m.zyxda;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  mag_data_ovr: [get]  Magnetic set of data overrun.
+  * @brief  Magnetic set of data overrun.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of zyxor in reg STATUS_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of zyxor in reg STATUS_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_data_ovr_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_status_reg_m_t status_reg_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, &reg.byte, 1);
-  *val = reg.status_reg_m.zyxor;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STATUS_REG_M, (uint8_t*)&status_reg_m, 1);
+  *val = status_reg_m.zyxor;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  mag_user_offset: [set]  These registers comprise a 3 group of
-  *                                 16-bit number and represent hard-iron
-  *                                 offset in order to compensate environmental
-  *                                 effects. Data format is the same of
-  *                                 output data raw: two’s complement with
-  *                                 1LSb = 1.5mG. These values act on the
-  *                                 magnetic output data value in order to
-  *                                 delete the environmental offset.
+  * @brief  These registers comprise a 3 group of 16-bit number and represent
+  *         hard-iron offset in order to compensate environmental effects. Data
+  *         format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG. These values act on the magnetic output data value in
+  *         order to delete the environmental offset.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that contains data to write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_user_offset_set(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_mg_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_write_reg(ctx, LSM303AH_OFFSET_X_REG_L_M, buff, 6);
+  int32_t ret;
+  ret = lsm303ah_write_reg(ctx, LSM303AH_OFFSET_X_REG_L_M, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  mag_user_offset: [get]  These registers comprise a 3 group of
-  *                                 16-bit number and represent hard-iron
-  *                                 offset in order to compensate environmental
-  *                                 effects. Data format is the same of
-  *                                 output data raw: two’s complement with
-  *                                 1LSb = 1.5mG. These values act on the
-  *                                 magnetic output data value in order to
-  *                                 delete the environmental offset.
+  * @brief  These registers comprise a 3 group of 16-bit number and represent
+  *         hard-iron offset in order to compensate environmental effects. Data
+  *         format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG. These values act on the magnetic output data value in
+  *         order to delete the environmental offset.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_user_offset_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_mg_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_OFFSET_X_REG_L_M, buff, 6);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_OFFSET_X_REG_L_M, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  operating_mode: [set]  Operating mode selection.
+  * @brief  Operating mode selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_md_t: change the values of md in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of md in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_operating_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_operating_mode_set(stmdev_ctx_t *ctx,
                                        lsm303ah_mg_md_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.md = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.md = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  operating_mode: [get]  Operating mode selection.
+  * @brief  Operating mode selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_md_t: Get the values of md in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of md in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_operating_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_operating_mode_get(stmdev_ctx_t *ctx,
                                        lsm303ah_mg_md_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  *val = (lsm303ah_mg_md_t) reg.cfg_reg_a_m.md;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  switch (cfg_reg_a_m.md){
+    case LSM303AH_MG_CONTINUOUS_MODE:
+      *val = LSM303AH_MG_CONTINUOUS_MODE;
+      break;
+    case LSM303AH_MG_SINGLE_TRIGGER:
+      *val = LSM303AH_MG_SINGLE_TRIGGER;
+      break;
+    case LSM303AH_MG_POWER_DOWN:
+      *val = LSM303AH_MG_POWER_DOWN;
+      break;
+    default:
+      *val = LSM303AH_MG_CONTINUOUS_MODE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  data_rate: [set]  Output data rate selection.
+  * @brief  Output data rate selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_odr_t: change the values of odr in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_data_rate_set(lsm303ah_ctx_t *ctx, lsm303ah_mg_odr_t val)
+int32_t lsm303ah_mg_data_rate_set(stmdev_ctx_t *ctx, lsm303ah_mg_odr_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.odr = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.odr = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  data_rate: [get]  Output data rate selection.
+  * @brief  Output data rate selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_odr_t: Get the values of odr in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_data_rate_get(lsm303ah_ctx_t *ctx, lsm303ah_mg_odr_t *val)
+int32_t lsm303ah_mg_data_rate_get(stmdev_ctx_t *ctx, lsm303ah_mg_odr_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  *val = (lsm303ah_mg_odr_t) reg.cfg_reg_a_m.odr;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  switch (cfg_reg_a_m.odr){
+    case LSM303AH_MG_ODR_10Hz:
+      *val = LSM303AH_MG_ODR_10Hz;
+      break;
+    case LSM303AH_MG_ODR_20Hz:
+      *val = LSM303AH_MG_ODR_20Hz;
+      break;
+    case LSM303AH_MG_ODR_50Hz:
+      *val = LSM303AH_MG_ODR_50Hz;
+      break;
+    case LSM303AH_MG_ODR_100Hz:
+      *val = LSM303AH_MG_ODR_100Hz;
+      break;
+    default:
+      *val = LSM303AH_MG_ODR_10Hz;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  power_mode: [set]  Enables high-resolution/low-power mode.
+  * @brief  Enables high-resolution/low-power mode.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_lp_t: change the values of lp in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of lp in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_power_mode_set(lsm303ah_ctx_t *ctx, lsm303ah_mg_lp_t val)
+int32_t lsm303ah_mg_power_mode_set(stmdev_ctx_t *ctx, lsm303ah_mg_lp_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.lp = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.lp = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  power_mode: [get]  Enables high-resolution/low-power mode.
+  * @brief  Enables high-resolution/low-power mode.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_lp_t: Get the values of lp in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lp in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_power_mode_get(lsm303ah_ctx_t *ctx, lsm303ah_mg_lp_t *val)
+int32_t lsm303ah_mg_power_mode_get(stmdev_ctx_t *ctx, lsm303ah_mg_lp_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  *val = (lsm303ah_mg_lp_t) reg.cfg_reg_a_m.lp;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  switch (cfg_reg_a_m.lp){
+    case LSM303AH_MG_HIGH_RESOLUTION:
+      *val = LSM303AH_MG_HIGH_RESOLUTION;
+      break;
+    case LSM303AH_MG_LOW_POWER:
+      *val = LSM303AH_MG_LOW_POWER;
+      break;
+    default:
+      *val = LSM303AH_MG_HIGH_RESOLUTION;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  offset_temp_comp: [set]  Enables the magnetometer temperature
-  *                                  compensation.
+  * @brief  Enables the magnetometer temperature compensation.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of comp_temp_en in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of comp_temp_en in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_offset_temp_comp_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_mg_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.comp_temp_en = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.comp_temp_en = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  offset_temp_comp: [get]  Enables the magnetometer temperature
-  *                                  compensation.
+  * @brief  Enables the magnetometer temperature compensation.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of comp_temp_en in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of comp_temp_en in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_offset_temp_comp_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  *val = reg.cfg_reg_a_m.comp_temp_en;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.comp_temp_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  set_rst_mode: [set]
+  * @brief  Set/Reset mode.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_set_rst_t: change the values of set_rst in
-  *                            reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of set_rst in reg CFG_REG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_set_rst_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_set_rst_mode_set(stmdev_ctx_t *ctx,
                                      lsm303ah_mg_set_rst_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
-  reg.cfg_reg_b_m.set_rst = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
+    cfg_reg_b_m.set_rst = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  set_rst_mode: [get]
+  * @brief  Set/Reset mode.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_set_rst_t: Get the values of set_rst in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of set_rst in reg CFG_REG_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_set_rst_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_set_rst_mode_get(stmdev_ctx_t *ctx,
                                      lsm303ah_mg_set_rst_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
-  *val = (lsm303ah_mg_set_rst_t) reg.cfg_reg_b_m.set_rst;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  switch (cfg_reg_b_m.set_rst){
+    case LSM303AH_MG_SET_SENS_ODR_DIV_63:
+      *val = LSM303AH_MG_SET_SENS_ODR_DIV_63;
+      break;
+    case LSM303AH_MG_SENS_OFF_CANC_EVERY_ODR:
+      *val = LSM303AH_MG_SENS_OFF_CANC_EVERY_ODR;
+      break;
+    case LSM303AH_MG_SET_SENS_ONLY_AT_POWER_ON:
+      *val = LSM303AH_MG_SET_SENS_ONLY_AT_POWER_ON;
+      break;
+    default:
+      *val = LSM303AH_MG_SET_SENS_ODR_DIV_63;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief   set_rst_sensor_single: [set] Enables offset cancellation
-  *                                       in single measurement mode.
-  *                                       The OFF_CANC bit must be set
-  *                                       to 1 when enabling offset
-  *                                       cancellation in single measurement
-  *                                       mode this means a call function:
-  *                                       set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
-  *                                       is need.
+  * @brief   Enables offset cancellation in single measurement mode. The
+  *          OFF_CANC bit must be set to 1 when enabling offset cancellation
+  *          in single measurement mode this means a call function:
+  *          set_rst_mode(SENS_OFF_CANC_EVERY_ODR) is need.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of off_canc_one_shot in
-  *                      reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of off_canc_one_shot in reg CFG_REG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_set_rst_sensor_single_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_set_rst_sensor_single_set(stmdev_ctx_t *ctx,
                                               uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
-  reg.cfg_reg_b_m.off_canc_one_shot = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
+    cfg_reg_b_m.off_canc_one_shot = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   set_rst_sensor_single: [get] Enables offset cancellation
-  *                                       in single measurement mode.
-  *                                       The OFF_CANC bit must be set to
-  *                                       1 when enabling offset cancellation
-  *                                       in single measurement mode this
-  *                                       means a call function:
-  *                                       set_rst_mode(SENS_OFF_CANC_EVERY_ODR)
-  *                                       is need.
+  * @brief   Enables offset cancellation in single measurement mode. The
+  *          OFF_CANC bit must be set to 1 when enabling offset cancellation
+  *          in single measurement mode this means a call function:
+  *          set_rst_mode(SENS_OFF_CANC_EVERY_ODR) is need.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of off_canc_one_shot in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of off_canc_one_shot in reg CFG_REG_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_set_rst_sensor_single_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_set_rst_sensor_single_get(stmdev_ctx_t *ctx,
                                               uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
-  *val = reg.cfg_reg_b_m.off_canc_one_shot;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  *val = cfg_reg_b_m.off_canc_one_shot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Dataoutput
+  * @defgroup  Dataoutput
   * @brief   This section groups all the data output functions.
   * @{
+  *
   */
 
 /**
-  * @brief   acceleration_module_raw: [get]   Module output value (8-bit).
+  * @brief  Module output value (8-bit).[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_acceleration_module_raw_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_acceleration_module_raw_get(stmdev_ctx_t *ctx,
                                              uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_MODULE_8BIT_A, buff, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_MODULE_8BIT_A, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  temperature_raw: [get] Temperature data output register (r).
-  *                                L and H registers together express a 16-bit
-  *                                word in two’s complement.
+  * @brief  Temperature data output register (r). L and H registers together
+  *         express a 16-bit word in two’s complement.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_temperature_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_xl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_OUT_T_A, buff, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_OUT_T_A, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  acceleration_raw: [get] Linear acceleration output register.
-  *                                 The value is expressed as a 16-bit word
-  *                                 in two’s complement.
+  * @brief  Linear acceleration output register.
+  *         The value is expressed as a 16-bit word in two’s complement.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_acceleration_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_OUT_X_L_A, buff, 6);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_OUT_X_L_A, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  magnetic_raw: [get]  Magnetic output value.
+  * @brief  Magnetic output value.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_magnetic_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_OUTX_L_REG_M, buff, 6);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_OUTX_L_REG_M, buff, 6);
+  return ret;
 }
 
 /**
-  * @brief  number_of_steps: [get] Number of steps detected by step
-  *                                counter routine.
+  * @brief  Number of steps detected by step counter routine.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_number_of_steps_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_L_A, buff, 2);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_L_A, buff, 2);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  common
+  * @defgroup  common
   * @brief   This section groups common usefull functions.
   * @{
+  *
   */
 
 /**
-  * @brief  device_id: [get] DeviceWhoamI.
+  * @brief  DeviceWhoamI.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_device_id_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_xl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_WHO_AM_I_A, buff, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WHO_AM_I_A, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  device_id: [get] DeviceWhoamI.
+  * @brief  DeviceWhoamI.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_device_id_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_mg_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_WHO_AM_I_M, buff, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WHO_AM_I_M, buff, 1);
+  return ret;
 }
 
 /**
-  * @brief  auto_increment: [set] Register address automatically
-  *                               incremented during a multiple byte
-  *                               access with a serial interface.
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of if_add_inc in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_add_inc in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_auto_increment_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.if_add_inc = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
+    ctrl2_a.if_add_inc = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  auto_increment: [get] Register address automatically incremented
-  *                               during a multiple byte access with a
-  *                               serial interface.
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of if_add_inc in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_add_inc in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_auto_increment_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  *val = reg.ctrl2_a.if_add_inc;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  *val = ctrl2_a.if_add_inc;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  mem_bank: [set] Enable access to the embedded functions/sensor
-  *                         hub configuration registers.
+  * @brief  Enable access to the embedded functions/sensor
+  *         hub configuration registers.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_func_cfg_en_t: change the values of func_cfg_en in
-  *                                 reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of func_cfg_en in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_mem_bank_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_mem_bank_set(stmdev_ctx_t *ctx,
                                  lsm303ah_xl_func_cfg_en_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  lsm303ah_ctrl2_adv_a_t ctrl2_adv_a;
+  int32_t ret;
 
   if (val == LSM303AH_XL_ADV_BANK){
-    mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-    reg.ctrl2_a.func_cfg_en = val;
-    mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+    ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+    if(ret == 0){
+      ctrl2_a.func_cfg_en = (uint8_t)val;
+      ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+    }
   }
   else {
-    mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_ADV_A, &reg.byte, 1);
-    reg.ctrl2_a.func_cfg_en = val;
-    mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_ADV_A, &reg.byte, 1);
+    ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_ADV_A, (uint8_t*)&ctrl2_adv_a, 1);
+    if(ret == 0){
+      ctrl2_adv_a.func_cfg_en = (uint8_t)val;
+      ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_ADV_A, (uint8_t*)&ctrl2_adv_a, 1);
+    }
   }
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  reset: [set] Software reset. Restore the default values in
-  *                      user registers.
+  * @brief  Software reset. Restore the default values in user registers.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of soft_reset in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of soft_reset in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_reset_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.soft_reset = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
+    ctrl2_a.soft_reset = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  reset: [get] Software reset. Restore the default values in
-  *                      user registers.
+  * @brief  Software reset. Restore the default values in user registers.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of soft_reset in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of soft_reset in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  *val = reg.ctrl2_a.soft_reset;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  *val = ctrl2_a.soft_reset;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  reset: [set]  Software reset. Restore the default values in
-  *                       user registers.
+  * @brief  Software reset. Restore the default values in user registers.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of soft_rst in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of soft_rst in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_reset_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_mg_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.soft_rst = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.soft_rst = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  reset: [get]  Software reset. Restore the default values
-  *                       in user registers.
+  * @brief  Software reset. Restore the default values in user registers.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of soft_rst in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of soft_rst in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  *val = reg.cfg_reg_a_m.soft_rst;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.soft_rst;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot: [set] Reboot memory content. Reload the calibration
-  *                     parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of boot in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_boot_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.boot = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
+    ctrl2_a.boot = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot: [get] Reboot memory content. Reload the calibration
-  *                     parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of boot in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of boot in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_boot_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  *val = reg.ctrl2_a.boot;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  *val = ctrl2_a.boot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot: [set]  Reboot memory content. Reload the calibration
-  *                      parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of reboot in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of reboot in reg CFG_REG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_boot_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_mg_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  reg.cfg_reg_a_m.reboot = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  if(ret == 0){
+    cfg_reg_a_m.reboot = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  boot: [get]  Reboot memory content. Reload the
-  *                      calibration parameters.
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of reboot in reg CFG_REG_A
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of reboot in reg CFG_REG_A.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_boot_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_a_m_t cfg_reg_a_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, &reg.byte, 1);
-  *val = reg.cfg_reg_a_m.reboot;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_A_M, (uint8_t*)&cfg_reg_a_m, 1);
+  *val = cfg_reg_a_m.reboot;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  xl_self_test: [set]
+  * @brief  Accelerometer Self-Test.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_st_t: change the values of st in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of st in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_self_test_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_st_t val)
+int32_t lsm303ah_xl_self_test_set(stmdev_ctx_t *ctx, lsm303ah_xl_st_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.st = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
+    ctrl3_a.st = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  xl_self_test: [get]
+  * @brief  Accelerometer Self-Test.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_st_t: Get the values of st in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of st in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_self_test_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_st_t *val)
+int32_t lsm303ah_xl_self_test_get(stmdev_ctx_t *ctx, lsm303ah_xl_st_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_st_t) reg.ctrl3_a.st;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  switch (ctrl3_a.st){
+    case LSM303AH_XL_ST_DISABLE:
+      *val = LSM303AH_XL_ST_DISABLE;
+      break;
+    case LSM303AH_XL_ST_POSITIVE:
+      *val = LSM303AH_XL_ST_POSITIVE;
+      break;
+    case LSM303AH_XL_ST_NEGATIVE:
+      *val = LSM303AH_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM303AH_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  self_test: [set] Selftest.
+  * @brief  Magnetometer self-test.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of self_test in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of self_test in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_self_test_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_mg_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.self_test = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.self_test = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  self_test: [get] Selftest.
+  * @brief  Magnetometer self-test.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of self_test in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of self_test in reg CFG_REG_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_self_test_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  *val = reg.cfg_reg_c_m.self_test;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.self_test;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  data_ready_mode: [set]
+  * @brief  Accelerometer data ready mode.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_drdy_pulsed_t: change the values of drdy_pulsed in
-  *                                 reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_pulsed in reg CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_data_ready_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_data_ready_mode_set(stmdev_ctx_t *ctx,
                                      lsm303ah_xl_drdy_pulsed_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
-  reg.ctrl5_a.drdy_pulsed = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  if(ret == 0){
+    ctrl5_a.drdy_pulsed = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  data_ready_mode: [get]
+  * @brief  Accelerometer data ready mode.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_drdy_pulsed_t: Get the values of drdy_pulsed in
-  *                                    reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_pulsed in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_data_ready_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_data_ready_mode_get(stmdev_ctx_t *ctx,
                                      lsm303ah_xl_drdy_pulsed_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_drdy_pulsed_t) reg.ctrl5_a.drdy_pulsed;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  switch (ctrl5_a.drdy_pulsed){
+    case LSM303AH_XL_DRDY_LATCHED:
+      *val = LSM303AH_XL_DRDY_LATCHED;
+      break;
+    case LSM303AH_XL_DRDY_PULSED:
+      *val = LSM303AH_XL_DRDY_PULSED;
+      break;
+    default:
+      *val = LSM303AH_XL_DRDY_LATCHED;
+      break;
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Filters
+  * @defgroup  Filters
   * @brief   This section group all the functions concerning the filters
   *          configuration.
   * @{
+  *
   */
 
 /**
-  * @brief  xl_hp_path: [set] High-pass filter data selection on output
-  *                           register and FIFO.
+  * @brief  High-pass filter data selection on output register and FIFO.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_fds_slope_t: change the values of fds_slope in
-  *                                  reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of fds_slope in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_hp_path_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_hp_path_set(stmdev_ctx_t *ctx,
                                 lsm303ah_xl_fds_slope_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.fds_slope = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
+    ctrl2_a.fds_slope = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  xl_hp_path: [get] High-pass filter data selection on output
-  *                           register and FIFO.
+  * @brief  High-pass filter data selection on output register and FIFO.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_fds_slope_t: Get the values of fds_slope in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fds_slope in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_hp_path_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_hp_path_get(stmdev_ctx_t *ctx,
                                 lsm303ah_xl_fds_slope_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_fds_slope_t) reg.ctrl2_a.fds_slope;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  switch (ctrl2_a.fds_slope){
+    case LSM303AH_XL_HP_INTERNAL_ONLY:
+      *val = LSM303AH_XL_HP_INTERNAL_ONLY;
+      break;
+    case LSM303AH_XL_HP_ON_OUTPUTS:
+      *val = LSM303AH_XL_HP_ON_OUTPUTS;
+      break;
+    default:
+      *val = LSM303AH_XL_HP_INTERNAL_ONLY;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  low_pass_bandwidth: [set]  Low-pass bandwidth selection.
+  * @brief  Low-pass bandwidth selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_lpf_t: change the values of lpf in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf in reg CFG_REG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_low_pass_bandwidth_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
                                        lsm303ah_mg_lpf_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
-  reg.cfg_reg_b_m.lpf = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
+    cfg_reg_b_m.lpf = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  low_pass_bandwidth: [get]  Low-pass bandwidth selection.
+  * @brief  Low-pass bandwidth selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_lpf_t: Get the values of lpf in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lpf in reg CFG_REG_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_low_pass_bandwidth_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
                                        lsm303ah_mg_lpf_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
-  *val = (lsm303ah_mg_lpf_t) reg.cfg_reg_b_m.lpf;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  switch (cfg_reg_b_m.lpf){
+    case LSM303AH_MG_ODR_DIV_2:
+      *val = LSM303AH_MG_ODR_DIV_2;
+      break;
+    case LSM303AH_MG_ODR_DIV_4:
+      *val = LSM303AH_MG_ODR_DIV_4;
+      break;
+    default:
+      *val = LSM303AH_MG_ODR_DIV_2;
+      break;
+  }
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   Auxiliary_interface
+  * @defgroup   Auxiliary_interface
   * @brief   This section groups all the functions concerning auxiliary
   *          interface.
   * @{
+  *
   */
 
 /**
-  * @brief  spi_mode: [set]  SPI Serial Interface Mode selection.
+  * @brief  SPI Serial Interface Mode selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_sim_t: change the values of sim in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_spi_mode_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_sim_t val)
+int32_t lsm303ah_xl_spi_mode_set(stmdev_ctx_t *ctx, lsm303ah_xl_sim_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.sim = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
+    ctrl2_a.sim = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  spi_mode: [get]  SPI Serial Interface Mode selection.
+  * @brief  SPI Serial Interface Mode selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_sim_t: Get the values of sim in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_spi_mode_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_sim_t *val)
+int32_t lsm303ah_xl_spi_mode_get(stmdev_ctx_t *ctx, lsm303ah_xl_sim_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_sim_t) reg.ctrl2_a.sim;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  switch (ctrl2_a.sim){
+    case LSM303AH_XL_SPI_4_WIRE:
+      *val = LSM303AH_XL_SPI_4_WIRE;
+      break;
+    case LSM303AH_XL_SPI_3_WIRE:
+      *val = LSM303AH_XL_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM303AH_XL_SPI_4_WIRE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [set]  Disable / Enable I2C interface.
+  * @brief  Disable / Enable I2C interface.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_i2c_disable_t: change the values of i2c_disable
-  *                                 in reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_disable in reg CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_i2c_interface_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_i2c_interface_set(stmdev_ctx_t *ctx,
                                    lsm303ah_xl_i2c_disable_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  reg.ctrl2_a.i2c_disable = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  if(ret == 0){
+    ctrl2_a.i2c_disable = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [get]  Disable / Enable I2C interface.
+  * @brief  Disable / Enable I2C interface.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_i2c_disable_t: Get the values of i2c_disable in
-  *                                 reg CTRL2
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_disable in reg CTRL2.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_i2c_interface_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_i2c_interface_get(stmdev_ctx_t *ctx,
                                    lsm303ah_xl_i2c_disable_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl2_a_t ctrl2_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_i2c_disable_t) reg.ctrl2_a.i2c_disable;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL2_A, (uint8_t*)&ctrl2_a, 1);
+  switch (ctrl2_a.i2c_disable){
+    case LSM303AH_XL_I2C_ENABLE:
+      *val = LSM303AH_XL_I2C_ENABLE;
+      break;
+    case LSM303AH_XL_I2C_DISABLE:
+      *val = LSM303AH_XL_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM303AH_XL_I2C_ENABLE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [set]  Enable/Disable I2C interface.
+  * @brief  Enable/Disable I2C interface.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_i2c_dis_t: change the values of i2c_dis in
-  *                                reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_dis in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_i2c_interface_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_i2c_interface_set(stmdev_ctx_t *ctx,
                                       lsm303ah_mg_i2c_dis_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.i2c_dis = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.i2c_dis = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  i2c_interface: [get]  Enable/Disable I2C interface.
+  * @brief  Enable/Disable I2C interface.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_i2c_dis_t: Get the values of i2c_dis in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c_dis in reg CFG_REG_C.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_i2c_interface_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_i2c_interface_get(stmdev_ctx_t *ctx,
                                       lsm303ah_mg_i2c_dis_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  *val = (lsm303ah_mg_i2c_dis_t) reg.cfg_reg_c_m.i2c_dis;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  switch (cfg_reg_c_m.i2c_dis){
+    case LSM303AH_MG_I2C_ENABLE:
+      *val = LSM303AH_MG_I2C_ENABLE;
+      break;
+    case LSM303AH_MG_I2C_DISABLE:
+      *val = LSM303AH_MG_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM303AH_MG_I2C_ENABLE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  cs_mode: [set]  Connect/Disconnects pull-up in if_cs pad.
+  * @brief  Connect/Disconnects pull-up in if_cs pad.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_if_cs_pu_dis_t: change the values of if_cs_pu_dis
-  *                                  in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_cs_pu_dis in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_cs_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_cs_mode_set(stmdev_ctx_t *ctx,
                              lsm303ah_xl_if_cs_pu_dis_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
-  reg.fifo_ctrl_a.if_cs_pu_dis = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  if(ret == 0){
+    fifo_ctrl_a.if_cs_pu_dis = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  cs_mode: [get]  Connect/Disconnects pull-up in if_cs pad.
+  * @brief  Connect/Disconnects pull-up in if_cs pad.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_if_cs_pu_dis_t: Get the values of if_cs_pu_dis in
-  *                                  reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of if_cs_pu_dis in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_cs_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_cs_mode_get(stmdev_ctx_t *ctx,
                              lsm303ah_xl_if_cs_pu_dis_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_if_cs_pu_dis_t) reg.fifo_ctrl_a.if_cs_pu_dis;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  switch (fifo_ctrl_a.if_cs_pu_dis){
+    case LSM303AH_XL_PULL_UP_CONNECTED:
+      *val = LSM303AH_XL_PULL_UP_CONNECTED;
+      break;
+    case LSM303AH_XL_PULL_UP_DISCONNECTED:
+      *val = LSM303AH_XL_PULL_UP_DISCONNECTED;
+      break;
+    default:
+      *val = LSM303AH_XL_PULL_UP_CONNECTED;
+      break;
+  }
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   main_serial_interface
+  * @defgroup   main_serial_interface
   * @brief   This section groups all the functions concerning main serial
   *          interface management (not auxiliary)
   * @{
+  *
   */
 
 /**
-  * @brief  pin_mode: [set]  Push-pull/open-drain selection on interrupt pad.
+  * @brief  Push-pull/open-drain selection on interrupt pad.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_pp_od_t: change the values of pp_od in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pin_mode_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_pp_od_t val)
+int32_t lsm303ah_xl_pin_mode_set(stmdev_ctx_t *ctx, lsm303ah_xl_pp_od_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.pp_od = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
+    ctrl3_a.pp_od = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_mode: [get]  Push-pull/open-drain selection on interrupt pad.
+  * @brief  Push-pull/open-drain selection on interrupt pad.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_pp_od_t: Get the values of pp_od in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pin_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_mode_get(stmdev_ctx_t *ctx,
                                  lsm303ah_xl_pp_od_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_pp_od_t) reg.ctrl3_a.pp_od;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  switch (ctrl3_a.pp_od){
+    case LSM303AH_XL_PUSH_PULL:
+      *val = LSM303AH_XL_PUSH_PULL;
+      break;
+    case LSM303AH_XL_OPEN_DRAIN:
+      *val = LSM303AH_XL_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM303AH_XL_PUSH_PULL;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_polarity: [set]  Interrupt active-high/low.
+  * @brief  Interrupt active-high/low.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_h_lactive_t: change the values of h_lactive in
-  *                                  reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of h_lactive in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pin_polarity_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_polarity_set(stmdev_ctx_t *ctx,
                                   lsm303ah_xl_h_lactive_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.h_lactive = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
+    ctrl3_a.h_lactive = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_polarity: [get]  Interrupt active-high/low.
+  * @brief  Interrupt active-high/low.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_h_lactive_t: Get the values of h_lactive in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pin_polarity_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_polarity_get(stmdev_ctx_t *ctx,
                                   lsm303ah_xl_h_lactive_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_h_lactive_t) reg.ctrl3_a.h_lactive;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  switch (ctrl3_a.h_lactive){
+    case LSM303AH_XL_ACTIVE_HIGH:
+      *val = LSM303AH_XL_ACTIVE_HIGH;
+      break;
+    case LSM303AH_XL_ACTIVE_LOW:
+      *val = LSM303AH_XL_ACTIVE_LOW;
+      break;
+    default:
+      *val = LSM303AH_XL_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  int_notification: [set]  Latched/pulsed interrupt.
+  * @brief  Latched/pulsed interrupt.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_lir_t: change the values of lir in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_int_notification_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_int_notification_set(stmdev_ctx_t *ctx,
                                       lsm303ah_xl_lir_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.lir = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
+    ctrl3_a.lir = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_notification: [get]  Latched/pulsed interrupt.
+  * @brief  Latched/pulsed interrupt.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_lir_t: Get the values of lir in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_int_notification_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_int_notification_get(stmdev_ctx_t *ctx,
                                       lsm303ah_xl_lir_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_lir_t) reg.ctrl3_a.lir;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  switch (ctrl3_a.lir){
+    case LSM303AH_XL_INT_PULSED:
+      *val = LSM303AH_XL_INT_PULSED;
+      break;
+    case LSM303AH_XL_INT_LATCHED:
+      *val = LSM303AH_XL_INT_LATCHED;
+      break;
+    default:
+      *val = LSM303AH_XL_INT_PULSED;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  pin_int1_route: [set] Select the signal that need to route
-  *                               on int1 pad.
+  * @brief  Select the signal that need to route on int1 pad.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_pin_int1_route_t: union of registers from CTRL4 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change union of registers from CTRL4 to
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pin_int1_route_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     lsm303ah_xl_pin_int1_route_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl4_a_t ctrl4_a;
+  lsm303ah_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL4_A, &reg.byte, 1);
-  reg.ctrl4_a.int1_drdy         = val.int1_drdy;
-  reg.ctrl4_a.int1_fth          = val.int1_fth;
-  reg.ctrl4_a.int1_6d           = val.int1_6d;
-  reg.ctrl4_a.int1_tap          = val.int1_tap;
-  reg.ctrl4_a.int1_ff           = val.int1_ff;
-  reg.ctrl4_a.int1_wu           = val.int1_wu;
-  reg.ctrl4_a.int1_s_tap        = val.int1_s_tap;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL4_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL4_A, (uint8_t*)&ctrl4_a, 1);
+  if(ret == 0){
+    ctrl4_a.int1_drdy         = val.int1_drdy;
+    ctrl4_a.int1_fth          = val.int1_fth;
+    ctrl4_a.int1_6d           = val.int1_6d;
+    ctrl4_a.int1_tap          = val.int1_tap;
+    ctrl4_a.int1_ff           = val.int1_ff;
+    ctrl4_a.int1_wu           = val.int1_wu;
+    ctrl4_a.int1_s_tap        = val.int1_s_tap;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL4_A, (uint8_t*)&ctrl4_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  }
+  if(ret == 0){
+  	wake_up_dur_a.int1_fss7   = val.int1_fss7;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  }
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_dur_a.int1_fss7   = val.int1_fss7;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_int1_route: [get] Select the signal that need to route on
-  *                               int1 pad.
+  * @brief  Select the signal that need to route on int1 pad.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_pin_int1_route_t: union of registers from CTRL4 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from CTRL4 to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pin_int1_route_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     lsm303ah_xl_pin_int1_route_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl4_a_t ctrl4_a;
+  lsm303ah_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL4_A, &reg.byte, 1);
-  val->int1_drdy          = reg.ctrl4_a.int1_drdy;
-  val->int1_fth           = reg.ctrl4_a.int1_fth;
-  val->int1_6d            = reg.ctrl4_a.int1_6d;
-  val->int1_tap           = reg.ctrl4_a.int1_tap;
-  val->int1_ff            = reg.ctrl4_a.int1_ff;
-  val->int1_wu            = reg.ctrl4_a.int1_wu;
-  val->int1_s_tap         = reg.ctrl4_a.int1_s_tap;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL4_A, (uint8_t*)&ctrl4_a, 1);
+  if(ret == 0){
+    val->int1_drdy          = ctrl4_a.int1_drdy;
+    val->int1_fth           = ctrl4_a.int1_fth;
+    val->int1_6d            = ctrl4_a.int1_6d;
+    val->int1_tap           = ctrl4_a.int1_tap;
+    val->int1_ff            = ctrl4_a.int1_ff;
+    val->int1_wu            = ctrl4_a.int1_wu;
+    val->int1_s_tap         = ctrl4_a.int1_s_tap;
+  }
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  }
+  val->int1_fss7 = wake_up_dur_a.int1_fss7;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  val->int1_fss7 = reg.wake_up_dur_a.int1_fss7;
-
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_int2_route: [set] Select the signal that need to route on
-  *                               int2 pad.
+  * @brief  Select the signal that need to route on int2 pad.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_pin_int2_route_t: union of registers from CTRL5 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change union of registers from CTRL5 to
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pin_int2_route_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     lsm303ah_xl_pin_int2_route_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
-  reg.ctrl5_a.int2_boot       = val.int2_boot;
-  reg.ctrl5_a.int2_tilt       = val.int2_tilt;
-  reg.ctrl5_a.int2_sig_mot    = val.int2_sig_mot;
-  reg.ctrl5_a.int2_step       = val.int2_step;
-  reg.ctrl5_a.int2_fth        = val.int2_fth;
-  reg.ctrl5_a.int2_drdy       = val.int2_drdy;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  if(ret == 0){
+    ctrl5_a.int2_boot       = val.int2_boot;
+    ctrl5_a.int2_tilt       = val.int2_tilt;
+    ctrl5_a.int2_sig_mot    = val.int2_sig_mot;
+    ctrl5_a.int2_step       = val.int2_step;
+    ctrl5_a.int2_fth        = val.int2_fth;
+    ctrl5_a.int2_drdy       = val.int2_drdy;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pin_int2_route: [get] Select the signal that need to route on
-  *                               int2 pad.
+  * @brief  Select the signal that need to route on int2 pad.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_pin_int2_route_t: union of registers from CTRL5 to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from CTRL5 to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pin_int2_route_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     lsm303ah_xl_pin_int2_route_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
-  val->int2_boot     = reg.ctrl5_a.int2_boot;
-  val->int2_tilt     = reg.ctrl5_a.int2_tilt;
-  val->int2_sig_mot  = reg.ctrl5_a.int2_sig_mot;
-  val->int2_step     = reg.ctrl5_a.int2_step;
-  val->int2_fth      = reg.ctrl5_a.int2_fth;
-  val->int2_drdy     = reg.ctrl5_a.int2_drdy;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  val->int2_boot     = ctrl5_a.int2_boot;
+  val->int2_tilt     = ctrl5_a.int2_tilt;
+  val->int2_sig_mot  = ctrl5_a.int2_sig_mot;
+  val->int2_step     = ctrl5_a.int2_step;
+  val->int2_fth      = ctrl5_a.int2_fth;
+  val->int2_drdy     = ctrl5_a.int2_drdy;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  all_on_int1: [set] All interrupt signals become available on
-  *                            INT1 pin.
+  * @brief  All interrupt signals become available on INT1 pin.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int2_on_int1 in reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_all_on_int1_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
-  reg.ctrl5_a.int2_on_int1 = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  if(ret == 0){
+    ctrl5_a.int2_on_int1 = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  all_on_int1: [get] All interrupt signals become available on
-  *                            INT1 pin.
+  * @brief  All interrupt signals become available on INT1 pin.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int2_on_int1 in reg CTRL5
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of int2_on_int1 in reg CTRL5.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_all_on_int1_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl5_a_t ctrl5_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, &reg.byte, 1);
-  *val = reg.ctrl5_a.int2_on_int1;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL5_A, (uint8_t*)&ctrl5_a, 1);
+  *val = ctrl5_a.int2_on_int1;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_pin: [set]  Data-ready signal on INT_DRDY pin.
+  * @brief  Data-ready signal on INT_DRDY pin.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of drdy_on_pin in reg CFG_REG_C
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_on_pin in reg CFG_REG_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_drdy_on_pin_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_mg_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.int_mag = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.int_mag = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  drdy_on_pin: [get]  Data-ready signal on INT_DRDY pin.
+  * @brief  Data-ready signal on INT_DRDY pin.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of drdy_on_pin in reg CFG_REG_C_M
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of drdy_on_pin in reg CFG_REG_C_M.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_drdy_on_pin_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  *val = reg.cfg_reg_c_m.int_mag;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.int_mag;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_on_pin: [set]  Interrupt signal on INT_DRDY pin.
+  * @brief  Interrupt signal on INT_DRDY pin.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of int_on_pin in reg CFG_REG_C_M
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of int_on_pin in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_int_on_pin_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_mg_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  reg.cfg_reg_c_m.int_mag_pin = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  if(ret == 0){
+    cfg_reg_c_m.int_mag_pin = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_on_pin: [get]  Interrupt signal on INT_DRDY pin.
+  * @brief  Interrupt signal on INT_DRDY pin.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of int_on_pin in reg CFG_REG_C_M
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_on_pin in reg CFG_REG_C_M
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_int_on_pin_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_mg_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_c_m_t cfg_reg_c_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, &reg.byte, 1);
-  *val = reg.cfg_reg_c_m.int_mag_pin;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_C_M, (uint8_t*)&cfg_reg_c_m, 1);
+  *val = cfg_reg_c_m.int_mag_pin;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  int_gen_conf: [set]  Interrupt generator configuration register
+  * @brief  Interrupt generator configuration register.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_int_crtl_reg_m_t: registers INT_CRTL_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change registers INT_CRTL_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_int_gen_conf_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_int_gen_conf_set(stmdev_ctx_t *ctx,
                                  lsm303ah_int_crtl_reg_m_t *val)
 {
-  return lsm303ah_write_reg(ctx, LSM303AH_INT_CRTL_REG_M, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lsm303ah_write_reg(ctx, LSM303AH_INT_CRTL_REG_M, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_gen_conf: [get]  Interrupt generator configuration register
+  * @brief  Interrupt generator configuration register.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_int_crtl_reg_m_t: registers INT_CRTL_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers INT_CRTL_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_int_gen_conf_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_int_gen_conf_get(stmdev_ctx_t *ctx,
                                  lsm303ah_int_crtl_reg_m_t *val)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_INT_CRTL_REG_M, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_CRTL_REG_M, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_gen_source: [get]  Interrupt generator source register
+  * @brief  Interrupt generator source register.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_int_source_reg_m_t: registers INT_SOURCE_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers INT_SOURCE_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_int_gen_source_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_int_gen_source_get(stmdev_ctx_t *ctx,
                                    lsm303ah_int_source_reg_m_t *val)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_INT_SOURCE_REG_M, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_SOURCE_REG_M, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
-  * @brief  int_gen_treshold: [set]  User-defined threshold value for xl
-  *                                  interrupt event on generator.
-  *                                  Data format is the same of output
-  *                                  data raw: two’s complement with
-  *                                  1LSb = 1.5mG.
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that contains data to write.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_int_gen_treshold_set(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_mg_int_gen_treshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_write_reg(ctx, LSM303AH_INT_THS_L_REG_M, buff, 2);
+  int32_t ret;
+  ret = lsm303ah_write_reg(ctx, LSM303AH_INT_THS_L_REG_M, buff, 2);
+  return ret;
 }
 
 /**
-  * @brief  int_gen_treshold: [get]  User-defined threshold value for
-  *                                  xl interrupt event on generator.
-  *                                  Data format is the same of output
-  *                                  data raw: two’s complement with
-  *                                  1LSb = 1.5mG.
+  * @brief  User-defined threshold value for xl interrupt event on generator.
+  *         Data format is the same of output data raw: two’s complement with
+  *         1LSb = 1.5mG.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_int_gen_treshold_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_mg_int_gen_treshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_INT_THS_L_REG_M, buff, 2);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_THS_L_REG_M, buff, 2);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  interrupt_pins
+  * @defgroup  interrupt_pins
   * @brief   This section groups all the functions that manage interrup pins
   * @{
+  *
   */
 
 
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Wake_Up_event
+  * @defgroup  Wake_Up_event
   * @brief   This section groups all the functions that manage the Wake Up
   *          event generation.
   * @{
+  *
   */
 
 /**
-  * @brief  offset_int_conf: [set]  The interrupt block recognition checks
-  *                                 data after/before the hard-iron correction
-  *                                 to discover the interrupt.
+  * @brief  The interrupt block recognition checks data after/before the
+  *         hard-iron correction to discover the interrupt.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_int_on_dataoff_t: change the values of int_on_dataoff
-  *                                       in reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of int_on_dataoff in reg CFG_REG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_offset_int_conf_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_offset_int_conf_set(stmdev_ctx_t *ctx,
                                     lsm303ah_mg_int_on_dataoff_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
-  reg.cfg_reg_b_m.int_on_dataoff = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  if(ret == 0){
+    cfg_reg_b_m.int_on_dataoff = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  offset_int_conf: [get]  The interrupt block recognition checks
-  *                                 data after/before the hard-iron correction
-  *                                 to discover the interrupt.
+  * @brief  The interrupt block recognition checks data after/before the
+  *         hard-iron correction to discover the interrupt.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_mg_int_on_dataoff_t: Get the values of int_on_dataoff in
-  *                                   reg CFG_REG_B
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of int_on_dataoff in reg CFG_REG_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_mg_offset_int_conf_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_offset_int_conf_get(stmdev_ctx_t *ctx,
                                     lsm303ah_mg_int_on_dataoff_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_cfg_reg_b_m_t cfg_reg_b_m;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, &reg.byte, 1);
-  *val = (lsm303ah_mg_int_on_dataoff_t) reg.cfg_reg_b_m.int_on_dataoff;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CFG_REG_B_M, (uint8_t*)&cfg_reg_b_m, 1);
+  switch (cfg_reg_b_m.int_on_dataoff){
+    case LSM303AH_MG_CHECK_BEFORE:
+      *val = LSM303AH_MG_CHECK_BEFORE;
+      break;
+    case LSM303AH_MG_CHECK_AFTER:
+      *val = LSM303AH_MG_CHECK_AFTER;
+      break;
+    default:
+      *val = LSM303AH_MG_CHECK_BEFORE;
+      break;
+  }
+  return ret;
 }
 
   /**
-  * @brief  wkup_threshold: [set]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  * @brief  Threshold for wakeup [1 LSb = FS_XL / 64].[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of wu_ths in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of wu_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_wkup_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_ths_a.wu_ths = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  if(ret == 0){
+    wake_up_ths_a.wu_ths = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  wkup_threshold: [get]  Threshold for wakeup [1 LSb = FS_XL / 64].
+  * @brief  Threshold for wakeup [1 LSb = FS_XL / 64].[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of wu_ths in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of wu_ths in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_wkup_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = reg.wake_up_ths_a.wu_ths;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  *val = wake_up_ths_a.wu_ths;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  wkup_dur: [set]  Wakeup duration [1 LSb = 1 / ODR].
+  * @brief  Wakeup duration [1 LSb = 1 / ODR].[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of wu_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of wu_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_wkup_dur_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_dur_a.wu_dur = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  if(ret == 0){
+    wake_up_dur_a.wu_dur = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  wkup_dur: [get]  Wakeup duration [1 LSb = 1 / ODR].
+  * @brief  Wakeup duration [1 LSb = 1 / ODR].[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of wu_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of wu_dur in reg WAKE_UP_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_wkup_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = reg.wake_up_dur_a.wu_dur;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  *val = wake_up_dur_a.wu_dur;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   Activity/Inactivity_detection
+  * @defgroup   Activity/Inactivity_detection
   * @brief   This section groups all the functions concerning
   *          activity/inactivity detection.
   * @{
+  *
   */
 /**
-  * @brief  sleep_mode: [set]  Enables gyroscope Sleep mode.
+  * @brief  Enables gyroscope Sleep mode.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sleep_on in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_on in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_sleep_mode_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_ths_a.sleep_on = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  if(ret == 0){
+    wake_up_ths_a.sleep_on = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  sleep_mode: [get]  Enables gyroscope Sleep mode.
+  * @brief  Enables gyroscope Sleep mode.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sleep_on in reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_on in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_sleep_mode_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = reg.wake_up_ths_a.sleep_on;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  *val = wake_up_ths_a.sleep_on;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  act_sleep_dur: [set] Duration to go in sleep mode
-  *                              [1 LSb = 512 / ODR].
+  * @brief  Duration to go in sleep mode [1 LSb = 512 / ODR].[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sleep_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_act_sleep_dur_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_dur_a.sleep_dur = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  if(ret == 0){
+    wake_up_dur_a.sleep_dur = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  act_sleep_dur: [get] Duration to go in sleep mode
-  *                              [1 LSb = 512 / ODR].
+  * @brief  Duration to go in sleep mode [1 LSb = 512 / ODR].[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sleep_dur in reg WAKE_UP_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_dur in reg WAKE_UP_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_act_sleep_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_dur_a_t wake_up_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = reg.wake_up_dur_a.sleep_dur;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  *val = wake_up_dur_a.sleep_dur;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  tap_generator
+  * @defgroup  tap_generator
   * @brief   This section groups all the functions that manage the tap and
   *          double tap event generation.
   * @{
+  *
   */
 
 /**
-  * @brief  tap_detection_on_z: [set]  Enable Z direction in tap recognition.
+  * @brief  Enable Z direction in tap recognition.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_z_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_z_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_detection_on_z_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.tap_z_en = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
+    ctrl3_a.tap_z_en = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_z: [get]  Enable Z direction in tap recognition.
+  * @brief  Enable Z direction in tap recognition.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_z_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_z_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_detection_on_z_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  *val = reg.ctrl3_a.tap_z_en;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  *val = ctrl3_a.tap_z_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_y: [set]  Enable Y direction in tap recognition.
+  * @brief  Enable Y direction in tap recognition.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_y_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_y_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_detection_on_y_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.tap_y_en = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
+    ctrl3_a.tap_y_en = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_y: [get]  Enable Y direction in tap recognition.
+  * @brief  Enable Y direction in tap recognition.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_y_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_y_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_detection_on_y_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  *val = reg.ctrl3_a.tap_y_en;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  *val = ctrl3_a.tap_y_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_x: [set]  Enable X direction in tap recognition.
+  * @brief  Enable X direction in tap recognition.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_x_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_x_en in reg CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_detection_on_x_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  reg.ctrl3_a.tap_x_en = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  if(ret == 0){
+    ctrl3_a.tap_x_en = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_detection_on_x: [get]  Enable X direction in tap recognition.
+  * @brief  Enable X direction in tap recognition.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_x_en in reg CTRL3
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_x_en in reg CTRL3.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_detection_on_x_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_ctrl3_a_t ctrl3_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, &reg.byte, 1);
-  *val = reg.ctrl3_a.tap_x_en;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_CTRL3_A, (uint8_t*)&ctrl3_a, 1);
+  *val = ctrl3_a.tap_x_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_threshold: [set] Threshold for tap recognition
-  *                              [1 LSb = FS/32].
+  * @brief  Threshold for tap recognition [1 LSb = FS/32].[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tap_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
-  reg.tap_6d_ths_a.tap_ths = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  if(ret == 0){
+    tap_6d_ths_a.tap_ths = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_threshold: [get] Threshold for tap recognition
-  *                              [1 LSb = FS/32].
+  * @brief  Threshold for tap recognition [1 LSb = FS/32].[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tap_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_ths in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
-  *val = reg.tap_6d_ths_a.tap_ths;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  *val = tap_6d_ths_a.tap_ths;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_shock: [set] Maximum duration is the maximum time of
-  *                          an overthreshold signal detection to be
-  *                          recognized as a tap event. The default value
-  *                          of these bits is 00b which corresponds to
-  *                          4*ODR_XL time. If the SHOCK[1:0] bits are set
-  *                          to a different value, 1LSB corresponds to
-  *                          8*ODR_XL time.
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value of
+  *         these bits is 00b which corresponds to 4*ODR_XL time. If the
+  *         SHOCK[1:0] bits are set to a different value, 1LSB corresponds to
+  *         8*ODR_XL time.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of shock in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of shock in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_shock_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
-  reg.int_dur_a.shock = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  if(ret == 0){
+    int_dur_a.shock = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_shock: [get] Maximum duration is the maximum time of an
-  *                          overthreshold signal detection to be recognized
-  *                          as a tap event. The default value of these bits
-  *                          is 00b which corresponds to 4*ODR_XL time.
-  *                          If the SHOCK[1:0] bits are set to a different
-                             value, 1LSB corresponds to 8*ODR_XL time.
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value of
+  *         these bits is 00b which corresponds to 4*ODR_XL time. If the
+  *         SHOCK[1:0] bits are set to a different value, 1LSB corresponds to
+  *         8*ODR_XL time.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of shock in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of shock in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_shock_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
-  *val = reg.int_dur_a.shock;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  *val = int_dur_a.shock;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_quiet: [set] Quiet time is the time after the first
-  *                          detected tap in which there must not be any
-  *                          overthreshold event. The default value of these
-  *                          bits is 00b which corresponds to 2*ODR_XL time.
-  *                          If the QUIET[1:0] bits are set to a different
-  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event. The default value of these
+  *         bits is 00b which corresponds to 2*ODR_XL time. If the QUIET[1:0]
+  *         bits are set to a different value, 1LSB corresponds to
+  *         4*ODR_XL time.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of quiet in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of quiet in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_quiet_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
-  reg.int_dur_a.quiet = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  if(ret == 0){
+    int_dur_a.quiet = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_quiet: [get] Quiet time is the time after the first detected
-  *                          tap in which there must not be any overthreshold
-  *                          event. The default value of these bits is 00b
-  *                          which corresponds to 2*ODR_XL time.
-  *                          If the QUIET[1:0] bits are set to a different
-  *                          value, 1LSB corresponds to 4*ODR_XL time.
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event. The default value of these
+  *         bits is 00b which corresponds to 2*ODR_XL time. If the QUIET[1:0]
+  *         bits are set to a different value, 1LSB corresponds to
+  *         4*ODR_XL time.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of quiet in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of quiet in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_quiet_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
-  *val = reg.int_dur_a.quiet;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  *val = int_dur_a.quiet;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_dur: [set] When double tap recognition is enabled, this
-  *                        register expresses the maximum time between two
-  *                        consecutive detected taps to determine a double
-  *                        tap event. The default value of these bits is
-  *                        0000b which corresponds to 16*ODR_XL time.
-  *                        If the DUR[3:0] bits are set to a different value,
-  *                        1LSB corresponds to 32*ODR_XL time.
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event. The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time. If the DUR[3:0] bits are set to a
+  *         different value, 1LSB corresponds to 32*ODR_XL time.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of lat in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of lat in reg INT_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_dur_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
-  reg.int_dur_a.lat = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  if(ret == 0){
+    int_dur_a.lat = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_dur: [get] When double tap recognition is enabled,
-  *                        this register expresses the maximum time
-  *                        between two consecutive detected taps to
-  *                        determine a double tap event. The default
-  *                        value of these bits is 0000b which corresponds
-  *                        to 16*ODR_XL time. If the DUR[3:0] bits are set
-  *                        to a different value, 1LSB corresponds to
-  *                        32*ODR_XL time.
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event. The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time. If the DUR[3:0] bits are set to a
+  *         different value, 1LSB corresponds to 32*ODR_XL time.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of lat in reg INT_DUR
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of lat in reg INT_DUR.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_int_dur_a_t int_dur_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, &reg.byte, 1);
-  *val = reg.int_dur_a.lat;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_INT_DUR_A, (uint8_t*)&int_dur_a, 1);
+  *val = int_dur_a.lat;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_mode: [set]  Single/double-tap event enable/disable.
+  * @brief  Single/double-tap event enable/disable.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_single_double_tap_t: change the values of
-  *                                       single_double_tap in regWAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of single_double_tap in regWAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_tap_mode_set(stmdev_ctx_t *ctx,
                               lsm303ah_xl_single_double_tap_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  reg.wake_up_ths_a.single_double_tap = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  if(ret == 0){
+    wake_up_ths_a.single_double_tap = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tap_mode: [get]  Single/double-tap event enable/disable.
+  * @brief  Single/double-tap event enable/disable.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_single_double_tap_t: Get the values of
-  *                                        single_double_tap in
-  *                                        reg WAKE_UP_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of single_double_tap in reg WAKE_UP_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_tap_mode_get(stmdev_ctx_t *ctx,
                               lsm303ah_xl_single_double_tap_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_wake_up_ths_a_t wake_up_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_single_double_tap_t)reg.wake_up_ths_a.single_double_tap;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, (uint8_t*)&wake_up_ths_a, 1);
+  switch (wake_up_ths_a.single_double_tap){
+    case LSM303AH_XL_ONLY_SINGLE:
+      *val = LSM303AH_XL_ONLY_SINGLE;
+      break;
+    case LSM303AH_XL_ONLY_DOUBLE:
+      *val = LSM303AH_XL_ONLY_DOUBLE;
+      break;
+    default:
+      *val = LSM303AH_XL_ONLY_SINGLE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  tap_src: [get]  TAP source register
+  * @brief  TAP source register[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_tap_src_t: registers TAP_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers TAP_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tap_src_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_tap_src_get(stmdev_ctx_t *ctx,
                                 lsm303ah_tap_src_a_t *val)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_TAP_SRC_A, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_TAP_SRC_A, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup   Six_position_detection(6D/4D)
+  * @defgroup   Six_position_detection(6D/4D)
   * @brief   This section groups all the functions concerning six
   *          position detection (6D).
   * @{
+  *
   */
 
 /**
-  * @brief  6d_threshold: [set]  Threshold for 4D/6D function.
+  * @brief  Threshold for 4D/6D function.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_6d_ths_t: change the values of 6d_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of 6d_ths in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_6d_threshold_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_6d_threshold_set(stmdev_ctx_t *ctx,
                                      lsm303ah_xl_6d_ths_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
-  reg.tap_6d_ths_a._6d_ths = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  if(ret == 0){
+    tap_6d_ths_a._6d_ths = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  6d_threshold: [get]  Threshold for 4D/6D function.
+  * @brief  Threshold for 4D/6D function.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_6d_ths_t: Get the values of 6d_ths in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of 6d_ths in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_6d_threshold_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_6d_threshold_get(stmdev_ctx_t *ctx,
                                      lsm303ah_xl_6d_ths_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_6d_ths_t) reg.tap_6d_ths_a._6d_ths;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  switch (tap_6d_ths_a._6d_ths){
+    case LSM303AH_XL_DEG_80:
+      *val = LSM303AH_XL_DEG_80;
+      break;
+    case LSM303AH_XL_DEG_70:
+      *val = LSM303AH_XL_DEG_70;
+      break;
+    case LSM303AH_XL_DEG_60:
+      *val = LSM303AH_XL_DEG_60;
+      break;
+    case LSM303AH_XL_DEG_50:
+      *val = LSM303AH_XL_DEG_50;
+      break;
+    default:
+      *val = LSM303AH_XL_DEG_80;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  4d_mode: [set]  4D orientation detection enable.
+  * @brief  4D orientation detection enable.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of 4d_en in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of 4d_en in reg TAP_6D_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_4d_mode_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
-  reg.tap_6d_ths_a._4d_en = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  if(ret == 0){
+    tap_6d_ths_a._4d_en = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  4d_mode: [get]  4D orientation detection enable.
+  * @brief  4D orientation detection enable.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of 4d_en in reg TAP_6D_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of 4d_en in reg TAP_6D_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_4d_mode_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_tap_6d_ths_a_t tap_6d_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, &reg.byte, 1);
-  *val = reg.tap_6d_ths_a._4d_en;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_TAP_6D_THS_A, (uint8_t*)&tap_6d_ths_a, 1);
+  *val = tap_6d_ths_a._4d_en;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  6d_src: [get]  6D source register.
+  * @brief  6D source register.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_6d_src_t: union of registers from 6D_SRC to
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get union of registers from 6D_SRC to.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_6d_src_get(lsm303ah_ctx_t *ctx, lsm303ah_6d_src_a_t *val)
+int32_t lsm303ah_xl_6d_src_get(stmdev_ctx_t *ctx, lsm303ah_6d_src_a_t *val)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_6D_SRC_A, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_6D_SRC_A, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  free_fall
+  * @defgroup  free_fall
   * @brief   This section group all the functions concerning the
   *          free fall detection.
   * @{
+  *
   */
 
 /**
-  * @brief  ff_dur: [set]  Free-fall duration [1 LSb = 1 / ODR].
+  * @brief  Free-fall duration [1 LSb = 1 / ODR].[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of ff_dur in reg
-  *                      WAKE_UP_DUR/FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_ff_dur_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg[2];
-  int32_t mm_error;
+  lsm303ah_wake_up_dur_a_t wake_up_dur_a;
+  lsm303ah_free_fall_a_t free_fall_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg[0].byte, 2);
-  reg[1].free_fall_a.ff_dur = 0x1F & val;
-  reg[0].wake_up_dur_a.ff_dur = (val & 0x20) >> 5;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg[0].byte, 2);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  if(ret == 0){
+    wake_up_dur_a.ff_dur = (val & 0x20U) >> 5;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_FREE_FALL_A, (uint8_t*)&free_fall_a, 1);
+  }
+  if(ret == 0){
+    free_fall_a.ff_dur = 0x1FU & val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FREE_FALL_A, (uint8_t*)&free_fall_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  ff_dur: [get]  Free-fall duration [1 LSb = 1 / ODR].
+  * @brief  Free-fall duration [1 LSb = 1 / ODR].[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_dur in reg WAKE_UP_DUR/FREE_FALL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_ff_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg[2];
-  int32_t mm_error;
+  lsm303ah_wake_up_dur_a_t wake_up_dur_a;
+  lsm303ah_free_fall_a_t free_fall_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_THS_A, &reg[0].byte, 2);
-  *val = (reg[0].wake_up_dur_a.ff_dur << 5) + reg[1].free_fall_a.ff_dur;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_WAKE_UP_DUR_A, (uint8_t*)&wake_up_dur_a, 1);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_FREE_FALL_A, (uint8_t*)&free_fall_a, 1);
+  }
+  *val = (wake_up_dur_a.ff_dur << 5) + free_fall_a.ff_dur;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  ff_threshold: [set]  Free-fall threshold [1 LSB = 31.25 mg].
+  * @brief  Free-fall threshold [1 LSB = 31.25 mg].[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of ff_ths in reg FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_ff_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_ff_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_free_fall_a_t free_fall_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FREE_FALL_A, &reg.byte, 1);
-  reg.free_fall_a.ff_ths = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FREE_FALL_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FREE_FALL_A, (uint8_t*)&free_fall_a, 1);
+  if(ret == 0){
+    free_fall_a.ff_ths = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FREE_FALL_A, (uint8_t*)&free_fall_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  ff_threshold: [get]  Free-fall threshold [1 LSB = 31.25 mg].
+  * @brief  Free-fall threshold [1 LSB = 31.25 mg].[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of ff_ths in reg FREE_FALL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_ths in reg FREE_FALL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_ff_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_ff_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_free_fall_a_t free_fall_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FREE_FALL_A, &reg.byte, 1);
-  *val = reg.free_fall_a.ff_ths;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FREE_FALL_A, (uint8_t*)&free_fall_a, 1);
+  *val = free_fall_a.ff_ths;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Fifo
+  * @defgroup  Fifo
   * @brief   This section group all the functions concerning the fifo usage
   * @{
+  *
   */
 
 /**
-  * @brief   fifo_xl_module_batch: [set]  Module routine result is send to
-  *          FIFO instead of X,Y,Z acceleration data
+  * @brief   Module routine result is send to
+  *          FIFO instead of X,Y,Z acceleration data.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of module_to_fifo in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of module_to_fifo in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_xl_module_batch_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_fifo_xl_module_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
-  reg.fifo_ctrl_a.module_to_fifo = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  if(ret == 0){
+    fifo_ctrl_a.module_to_fifo = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   fifo_xl_module_batch: [get]  Module routine result is send to
-  *                                       FIFO instead of X,Y,Z acceleration
-  *                                       data
+  * @brief   Module routine result is send to
+  *          FIFO instead of X,Y,Z acceleration data.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of module_to_fifo in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of module_to_fifo in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_xl_module_batch_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_xl_module_batch_get(stmdev_ctx_t *ctx,
                                              uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
-  *val = reg.fifo_ctrl_a.module_to_fifo;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  *val = fifo_ctrl_a.module_to_fifo;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [set]  FIFO mode selection.
+  * @brief  FIFO mode selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_fmode_t: change the values of fmode in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of fmode in reg FIFO_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_mode_set(stmdev_ctx_t *ctx,
                                   lsm303ah_xl_fmode_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
-  reg.fifo_ctrl_a.fmode = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  if(ret == 0){
+    fifo_ctrl_a.fmode = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_mode: [get]  FIFO mode selection.
+  * @brief  FIFO mode selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_fmode_t: Get the values of fmode in reg FIFO_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fmode in reg FIFO_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_mode_get(stmdev_ctx_t *ctx,
                                   lsm303ah_xl_fmode_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_ctrl_a_t fifo_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, &reg.byte, 1);
-  *val = (lsm303ah_xl_fmode_t) reg.fifo_ctrl_a.fmode;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_CTRL_A, (uint8_t*)&fifo_ctrl_a, 1);
+  switch (fifo_ctrl_a.fmode){
+    case LSM303AH_XL_BYPASS_MODE:
+      *val = LSM303AH_XL_BYPASS_MODE;
+      break;
+    case LSM303AH_XL_FIFO_MODE:
+      *val = LSM303AH_XL_FIFO_MODE;
+      break;
+    case LSM303AH_XL_STREAM_TO_FIFO_MODE:
+      *val = LSM303AH_XL_STREAM_TO_FIFO_MODE;
+      break;
+    case LSM303AH_XL_BYPASS_TO_STREAM_MODE:
+      *val = LSM303AH_XL_BYPASS_TO_STREAM_MODE;
+      break;
+    case LSM303AH_XL_STREAM_MODE:
+      *val = LSM303AH_XL_STREAM_MODE;
+      break;
+    default:
+      *val = LSM303AH_XL_BYPASS_MODE;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [set]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of fifo_watermark in reg FIFO_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_watermark in reg FIFO_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_watermark_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  int32_t mm_error;
-
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FIFO_THS_A, &val, 1);
-
-  return mm_error;
+  int32_t ret;
+  ret = lsm303ah_write_reg(ctx, LSM303AH_FIFO_THS_A, (uint8_t*)&val, 1);
+  return ret;
 }
 
 /**
-  * @brief  fifo_watermark: [get]  FIFO watermark level selection.
+  * @brief  FIFO watermark level selection.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_watermark in reg FIFO_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_watermark in reg FIFO_THS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_watermark_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  int32_t mm_error;
-
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_THS_A, val, 1);
-
-  return mm_error;
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_THS_A, val, 1);
+  return ret;
 }
 
 /**
-  * @brief  fifo_full_flag: [get]  FIFO full, 256 unread samples.
+  * @brief  FIFO full, 256 unread samples.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of diff in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of diff in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_full_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_src_a_t fifo_src_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &reg.byte, 1);
-  *val = reg.fifo_src_a.diff;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, (uint8_t*)&fifo_src_a, 1);
+  *val = fifo_src_a.diff;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_ovr_flag: [get]  FIFO overrun status.
+  * @brief  FIFO overrun status.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fifo_ovr in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_ovr in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_ovr_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_src_a_t fifo_src_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &reg.byte, 1);
-  *val = reg.fifo_src_a.fifo_ovr;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, (uint8_t*)&fifo_src_a, 1);
+  *val = fifo_src_a.fifo_ovr;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_wtm_flag: [get]  FIFO threshold status.
+  * @brief  FIFO threshold status.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of fth in reg FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of fth in reg FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_wtm_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_fifo_src_a_t fifo_src_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &reg.byte, 1);
-  *val = reg.fifo_src_a.fth;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, (uint8_t*)&fifo_src_a, 1);
+  *val = fifo_src_a.fth;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  fifo_data_level: [get] The number of unread samples
-  *                                stored in FIFO.
+  * @brief  The number of unread samples stored in FIFO.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint16_t: change the values of diff in reg FIFO_SAMPLES
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of diff in reg FIFO_SAMPLES.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_data_level_get(lsm303ah_ctx_t *ctx, uint16_t *val)
+int32_t lsm303ah_xl_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
-  lsm303ah_reg_t reg[2];
-  int32_t mm_error;
+  lsm303ah_fifo_src_a_t fifo_src_a;
+  uint8_t fifo_sample_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &reg[0].byte, 2);
-  *val = (reg[1].fifo_src_a.diff << 7) + reg[0].byte;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, (uint8_t*)&fifo_src_a, 1);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, &fifo_sample_a, 1);
+    *val = fifo_src_a.diff;
+    *val = *val << 7;
+    *val += fifo_sample_a;
+  }
+  return ret;
 }
 
 /**
-  * @brief  fifo_src: [get] FIFO_SRCregister.
+  * @brief  FIFO_SRCregister.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_fifo_src_t: registers FIFO_SRC
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get registers FIFO_SRC.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_fifo_src_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_src_get(stmdev_ctx_t *ctx,
                                  lsm303ah_fifo_src_a_t *val)
 {
-  return lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, (uint8_t*) val, 1);
+  int32_t ret;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FIFO_SRC_A, (uint8_t*) val, 1);
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  Pedometer
+  * @defgroup  Pedometer
   * @brief   This section groups all the functions that manage pedometer.
   * @{
+  *
   */
 
 /**
-  * @brief  pedo_threshold: [set] Minimum threshold value for step
-  *                               counter routine.
+  * @brief  Minimum threshold value for step counter routine.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sc_mths in
-  *                      reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sc_mths in reg STEP_COUNTER_MINTHS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_step_counter_minths_a_t step_counter_minths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                               &reg.byte, 1);
-  reg. step_counter_minths_a.sc_mths = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                                &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               (uint8_t*)&step_counter_minths_a, 1);
+  if(ret == 0){
+    step_counter_minths_a.sc_mths = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                                (uint8_t*)&step_counter_minths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_threshold: [get] Minimum threshold value for step
-  *                               counter routine.
+  * @brief  Minimum threshold value for step counter routine.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sc_mths in reg  STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sc_mths in reg  STEP_COUNTER_MINTHS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_step_counter_minths_a_t step_counter_minths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                               &reg.byte, 1);
-  *val = reg. step_counter_minths_a.sc_mths;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               (uint8_t*)&step_counter_minths_a, 1);
+  *val = step_counter_minths_a.sc_mths;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_full_scale: [set]  Pedometer data range.
+  * @brief  Pedometer data range.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_pedo4g_t: change the values of pedo4g in
-  *                            reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of pedo4g in reg STEP_COUNTER_MINTHS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_full_scale_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pedo_full_scale_set(stmdev_ctx_t *ctx,
                                      lsm303ah_xl_pedo4g_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_step_counter_minths_a_t step_counter_minths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                               &reg.byte, 1);
-  reg. step_counter_minths_a.pedo4g = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                                &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               (uint8_t*)&step_counter_minths_a, 1);
+  if(ret == 0){
+    step_counter_minths_a.pedo4g = (uint8_t)val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                                (uint8_t*)&step_counter_minths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_full_scale: [get]  Pedometer data range.
+  * @brief  Pedometer data range.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  lsm303ah_xl_pedo4g_t: Get the values of pedo4g in
-  *                            reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of pedo4g in reg STEP_COUNTER_MINTHS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_full_scale_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pedo_full_scale_get(stmdev_ctx_t *ctx,
                                      lsm303ah_xl_pedo4g_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_step_counter_minths_a_t step_counter_minths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                               &reg.byte, 1);
-  *val = (lsm303ah_xl_pedo4g_t) reg. step_counter_minths_a.pedo4g;
-
-  return mm_error;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A, (uint8_t*)&step_counter_minths_a, 1);
+  switch (step_counter_minths_a.pedo4g){
+    case LSM303AH_XL_PEDO_AT_2g:
+      *val = LSM303AH_XL_PEDO_AT_2g;
+      break;
+    case LSM303AH_XL_PEDO_AT_4g:
+      *val = LSM303AH_XL_PEDO_AT_4g;
+      break;
+    default:
+      *val = LSM303AH_XL_PEDO_AT_2g;
+      break;
+  }
+  return ret;
 }
 
 /**
-  * @brief  pedo_step_reset: [set]  Reset pedometer step counter.
+  * @brief  Reset pedometer step counter.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of rst_nstep in
-  *                      reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_nstep in reg STEP_COUNTER_MINTHS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_step_reset_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_step_counter_minths_a_t step_counter_minths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                               &reg.byte, 1);
-  reg. step_counter_minths_a.rst_nstep = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                                &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               (uint8_t*)&step_counter_minths_a, 1);
+  if(ret == 0){
+    step_counter_minths_a.rst_nstep = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                                (uint8_t*)&step_counter_minths_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_step_reset: [get]  Reset pedometer step counter.
+  * @brief  Reset pedometer step counter.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of rst_nstep in
-  *                  reg STEP_COUNTER_MINTHS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of rst_nstep in reg STEP_COUNTER_MINTHS.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_step_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_step_counter_minths_a_t step_counter_minths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
-                               &reg.byte, 1);
-  *val = reg. step_counter_minths_a.rst_nstep;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNTER_MINTHS_A,
+                               (uint8_t*)&step_counter_minths_a, 1);
+  *val = step_counter_minths_a.rst_nstep;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   pedo_step_detect_flag: [get]  Step detection flag.
+  * @brief  Step detection flag.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of step_detect in reg FUNC_CK_GATE
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of step_detect in reg FUNC_CK_GATE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_step_detect_flag_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pedo_step_detect_flag_get(stmdev_ctx_t *ctx,
                                               uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ck_gate_a_t func_ck_gate_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, &reg.byte, 1);
-  *val = reg.func_ck_gate_a.step_detect;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, (uint8_t*)&func_ck_gate_a, 1);
+  *val = func_ck_gate_a.step_detect;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_sens: [set]  Enable pedometer algorithm.
+  * @brief  Enable pedometer algorithm.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of step_cnt_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of step_cnt_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_sens_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
-  reg.func_ctrl_a.step_cnt_on = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  if(ret == 0){
+    func_ctrl_a.step_cnt_on = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_sens: [get]  Enable pedometer algorithm.
+  * @brief  Enable pedometer algorithm.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of step_cnt_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of step_cnt_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
-  *val = reg.func_ctrl_a.step_cnt_on;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  *val = func_ctrl_a.step_cnt_on;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   pedo_debounce_steps: [set] Minimum number of steps to start
-  *                                     the increment step counter.
+  * @brief  Minimum number of steps to start the increment step counter.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of deb_step in reg PEDO_DEB_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of deb_step in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_debounce_steps_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_pedo_deb_reg_a_t pedo_deb_reg_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
-  reg.pedo_deb_reg_a.deb_step = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, (uint8_t*)&pedo_deb_reg_a, 1);
+  }
+  if(ret == 0){
+    pedo_deb_reg_a.deb_step = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_PEDO_DEB_REG_A, (uint8_t*)&pedo_deb_reg_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief   pedo_debounce_steps: [get] Minimum number of steps to start
-  *                                     the increment step counter.
+  * @brief  Minimum number of steps to start the increment step counter.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of deb_step in reg PEDO_DEB_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of deb_step in reg PEDO_DEB_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_debounce_steps_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_pedo_deb_reg_a_t pedo_deb_reg_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
-  *val = reg.pedo_deb_reg_a.deb_step;
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, (uint8_t*)&pedo_deb_reg_a, 1);
+  }
+  if(ret == 0){
+    *val = pedo_deb_reg_a.deb_step;
+    ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_timeout: [set] Debounce time. If the time between two
-  *                             consecutive steps is greater than
-  *                             DEB_TIME*80ms, the debouncer is reactivated.
-  *                             Default value: 01101
+  * @brief  Debounce time. If the time between two consecutive steps is greater
+  *         than DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of deb_time in reg PEDO_DEB_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of deb_time in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_timeout_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_pedo_deb_reg_a_t pedo_deb_reg_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
-  reg.pedo_deb_reg_a.deb_time = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, (uint8_t*)&pedo_deb_reg_a, 1);
+  }
+  if(ret == 0){
+    pedo_deb_reg_a.deb_time = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_PEDO_DEB_REG_A, (uint8_t*)&pedo_deb_reg_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_timeout: [get] Debounce time. If the time between two
-  *                             consecutive steps is greater than
-  *                             DEB_TIME*80ms, the debouncer is reactivated.
-  *                             Default value: 01101
+  * @brief  Debounce time. If the time between two consecutive steps is greater
+  *         than DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of deb_time in reg PEDO_DEB_REG
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of deb_time in reg PEDO_DEB_REG.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_timeout_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_pedo_deb_reg_a_t pedo_deb_reg_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, &reg.byte, 1);
-  *val = reg.pedo_deb_reg_a.deb_time;
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_PEDO_DEB_REG_A, (uint8_t*)&pedo_deb_reg_a, 1);
+  }
+  if(ret == 0){
+    *val = pedo_deb_reg_a.deb_time;
+    ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_steps_period: [set] Period of time to detect at
-  *                                  least one step to generate step
-  *                                  recognition [1 LSb = 1.6384 s].
+  * @brief  Period of time to detect at least one step to generate step
+  *         recognition [1 LSb = 1.6384 s].[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that contains data to write
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_steps_period_set(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_xl_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNT_DELTA_A, buff, 1);
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  if(ret == 0){
+    ret = lsm303ah_write_reg(ctx, LSM303AH_STEP_COUNT_DELTA_A, buff, 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  pedo_steps_period: [get] Period of time to detect at least
-  *                                  one step to generate step recognition
-  *                                  [1 LSb = 1.6384 s].
+  * @brief  Period of time to detect at least one step to generate step
+  *         recognition [1 LSb = 1.6384 s].[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t * : buffer that stores data read
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  buff   buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_pedo_steps_period_get(lsm303ah_ctx_t *ctx, uint8_t *buff)
+int32_t lsm303ah_xl_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
-  int32_t mm_error;
+  int32_t ret;
 
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNT_DELTA_A, buff, 1);
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_STEP_COUNT_DELTA_A, buff, 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  significant_motion
+  * @defgroup  significant_motion
   * @brief   This section groups all the functions that manage the
   *          significant motion detection.
   * @{
+  *
   */
 
 /**
-  * @brief   motion_data_ready_flag: [get] Significant motion event
-  *                                        detection status.
+  * @brief   Significant motion event detection status.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sig_mot_detect in reg FUNC_CK_GATE
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sig_mot_detect in reg FUNC_CK_GATE.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_motion_data_ready_flag_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_motion_data_ready_flag_get(stmdev_ctx_t *ctx,
                                                uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ck_gate_a_t func_ck_gate_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, &reg.byte, 1);
-  *val = reg.func_ck_gate_a.sig_mot_detect;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, (uint8_t*)&func_ck_gate_a, 1);
+  *val = func_ck_gate_a.sig_mot_detect;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  motion_sens: [set]  Enable significant motion detection function.
+  * @brief  Enable significant motion detection function.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sign_mot_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sign_mot_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_motion_sens_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
-  reg.func_ctrl_a.sign_mot_on = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  if(ret == 0){
+    func_ctrl_a.sign_mot_on = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  motion_sens: [get]  Enable significant motion detection function.
+  * @brief  Enable significant motion detection function.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sign_mot_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sign_mot_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_motion_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
-  *val = reg.func_ctrl_a.sign_mot_on;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  *val = func_ctrl_a.sign_mot_on;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  motion_threshold: [set] These bits define the threshold value
-  *                                 which corresponds to the number of steps
-  *                                 to be performed by the user upon a change
-  *                                 of location before the significant motion
-  *                                 interrupt is generated. It is expressed
-  *                                 as an 8-bit unsigned value.
-  *                                 The default value of this field is equal
-  *                                 to 6 (= 00000110b).
+  * @brief  These bits define the threshold value which corresponds to the
+  *         number of steps to be performed by the user upon a change of
+  *         location before the significant motion interrupt is generated.
+  *         It is expressed as an 8-bit unsigned value.
+  *         The default value of this field is equal to 6 (= 00000110b).[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of sm_ths in reg SM_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of sm_ths in reg SM_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_motion_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_sm_ths_a_t sm_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_SM_THS_A, &reg.byte, 1);
-  reg.sm_ths_a.sm_ths = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_SM_THS_A, &reg.byte, 1);
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_SM_THS_A, (uint8_t*)&sm_ths_a, 1);
+  }
+  if(ret == 0){
+    sm_ths_a.sm_ths = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_SM_THS_A, (uint8_t*)&sm_ths_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  motion_threshold: [get] These bits define the threshold value
-  *                                 which corresponds to the number of steps
-  *                                 to be performed by the user upon a change
-  *                                 of location before the significant motion
-  *                                 interrupt is generated. It is expressed as
-  *                                 an 8-bit unsigned value. The default value
-  *                                 of this field is equal to 6 (= 00000110b).
+  * @brief  These bits define the threshold value which corresponds to the
+  *         number of steps to be performed by the user upon a change of
+  *         location before the significant motion interrupt is generated.
+  *         It is expressed as an 8-bit unsigned value.
+  *         The default value of this field is equal to 6 (= 00000110b).[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of sm_ths in reg SM_THS
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of sm_ths in reg SM_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_motion_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_sm_ths_a_t sm_ths_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_SM_THS_A, &reg.byte, 1);
-  *val = reg.sm_ths_a.sm_ths;
-  mm_error = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_ADV_BANK);
+  if(ret == 0){
+    ret = lsm303ah_read_reg(ctx, LSM303AH_SM_THS_A, (uint8_t*)&sm_ths_a, 1);
+  }
+  if(ret == 0){
+    *val = sm_ths_a.sm_ths;
+    ret = lsm303ah_xl_mem_bank_set(ctx, LSM303AH_XL_USER_BANK);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  tilt_detection
+  * @defgroup  tilt_detection
   * @brief   This section groups all the functions that manage the tilt
   *          event detection.
   * @{
+  *
   */
 
 /**
-  * @brief   tilt_data_ready_flag: [get]  Tilt event detection status.
+  * @brief  Tilt event detection status.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tilt_int in reg FUNC_CK_GATE
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tilt_int in reg FUNC_CK_GATE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tilt_data_ready_flag_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_tilt_data_ready_flag_get(stmdev_ctx_t *ctx,
                                              uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ck_gate_a_t func_ck_gate_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, &reg.byte, 1);
-  *val = reg.func_ck_gate_a.tilt_int;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CK_GATE_A, (uint8_t*)&func_ck_gate_a, 1);
+  *val = func_ck_gate_a.tilt_int;
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tilt_sens: [set]  Enable tilt calculation.
+  * @brief  Enable tilt calculation.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of tilt_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of tilt_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tilt_sens_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
-  reg.func_ctrl_a.tilt_on = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  if(ret == 0){
+    func_ctrl_a.tilt_on = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  tilt_sens: [get]  Enable tilt calculation.
+  * @brief  Enable tilt calculation.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of tilt_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of tilt_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_tilt_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
-  *val = reg.func_ctrl_a.tilt_on;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  *val = func_ctrl_a.tilt_on;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
-  * @addtogroup  module
+  * @defgroup  module
   * @brief   This section groups all the functions that manage
   *          module calculation
   * @{
+  *
   */
 
 /**
-  * @brief  module_sens: [set]  Module processing enable.
+  * @brief  Module processing enable.[set]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t val: change the values of module_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Change the values of module_on in reg FUNC_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_module_sens_set(lsm303ah_ctx_t *ctx, uint8_t val)
+int32_t lsm303ah_xl_module_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
-  reg.func_ctrl_a.module_on = val;
-  mm_error = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  if(ret == 0){
+    func_ctrl_a.module_on = val;
+    ret = lsm303ah_write_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  }
 
-  return mm_error;
+  return ret;
 }
 
 /**
-  * @brief  module_sens: [get]  Module processing enable.
+  * @brief  Module processing enable.[get]
   *
-  * @param  lsm303ah_ctx_t *ctx: read / write interface definitions
-  * @param  uint8_t: change the values of module_on in reg FUNC_CTRL
+  * @param  ctx    read / write interface definitions.(ptr)
+  * @param  val    Get the values of module_on in reg FUNC_CTRL.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm303ah_xl_module_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val)
+int32_t lsm303ah_xl_module_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
-  lsm303ah_reg_t reg;
-  int32_t mm_error;
+  lsm303ah_func_ctrl_a_t func_ctrl_a;
+  int32_t ret;
 
-  mm_error = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, &reg.byte, 1);
-  *val = reg.func_ctrl_a.module_on;
+  ret = lsm303ah_read_reg(ctx, LSM303AH_FUNC_CTRL_A, (uint8_t*)&func_ctrl_a, 1);
+  *val = func_ctrl_a.module_on;
 
-  return mm_error;
+  return ret;
 }
 
 /**
   * @}
+  *
   */
 
 /**
   * @}
+  *
   */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm303ah_STdC/driver/lsm303ah_reg.h
+++ b/sensor/stmemsc/lsm303ah_STdC/driver/lsm303ah_reg.h
@@ -1,42 +1,26 @@
 /*
  ******************************************************************************
  * @file    lsm303ah_reg.h
- * @author  MEMS Software Solution Team
- * @date    19-December-2017
+ * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
  *          lsm303ah_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __LSM303AH_DRIVER__H
-#define __LSM303AH_DRIVER__H
+#ifndef LSM303AH_REGS_H
+#define LSM303AH_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -51,33 +35,13 @@
   *
   */
 
-/** @defgroup LSM303AH_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -93,68 +57,84 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
 
 /**
   * @}
   *
   */
 
-/** @defgroup lsm303ah_interface
-  * @{
-  */
+#endif /* MEMS_SHARED_TYPES */
 
-typedef int32_t (*lsm303ah_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lsm303ah_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
 
 typedef struct {
-  /** Component mandatory fields **/
-  lsm303ah_write_ptr  write_reg;
-  lsm303ah_read_ptr   read_reg;
-  /** Customizable optional pointer **/
-  void *handle;
-} lsm303ah_ctx_t;
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
 
 /**
   * @}
+  *
   */
 
-/** @defgroup lsm303ah_Infos
-  * @{
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
   */
+
+/** @defgroup LSM303AH_Infos
+  * @{
+  *
+  */
+
   /** I2C Device Address 8 bit format **/
-#define LSM303AH_I2C_ADD_XL     0x3B
-#define LSM303AH_I2C_ADD_MG       0x3D
+#define LSM303AH_I2C_ADD_XL       0x3BU
+#define LSM303AH_I2C_ADD_MG       0x3DU
 
 /** Device Identification (Who am I) **/
-#define LSM303AH_ID_XL            0x43
-#define LSM303AH_ID_MG            0x40
+#define LSM303AH_ID_XL            0x43U
+#define LSM303AH_ID_MG            0x40U
 
 /**
   * @}
+  *
   */
 
-/**
-  * @defgroup lsm303ah_Sensitivity
-  * @{
-  */
-
-#define LSM303AH_FROM_FS_2g_TO_mg(lsb)    (float)(lsb *  61.0f) / 1000.0f
-#define LSM303AH_FROM_FS_4g_TO_mg(lsb)    (float)(lsb * 122.0f) / 1000.0f
-#define LSM303AH_FROM_FS_8g_TO_mg(lsb)    (float)(lsb * 244.0f) / 1000.0f
-#define LSM303AH_FROM_FS_16g_TO_mg(lsb)   (float)(lsb * 488.0f) / 1000.0f
-
-#define LSM303AH_FROM_LSB_TO_mG(lsb)      (float)(lsb * 1.5f)
-
-#define LSM303AH_FROM_LSB_TO_degC(lsb)  ((float)((int16_t)lsb>>8)*1.0f + 25.0f)
-
-/**
-  * @}
-  */
-
-#define LSM303AH_MODULE_8BIT_A           0x0C
-#define LSM303AH_WHO_AM_I_A              0x0F
-#define LSM303AH_CTRL1_A                 0x20
+#define LSM303AH_MODULE_8BIT_A           0x0CU
+#define LSM303AH_WHO_AM_I_A              0x0FU
+#define LSM303AH_CTRL1_A                 0x20U
 typedef struct {
   uint8_t bdu                 : 1;
   uint8_t hf_odr              : 1;
@@ -162,7 +142,7 @@ typedef struct {
   uint8_t odr                 : 4;
 } lsm303ah_ctrl1_a_t;
 
-#define LSM303AH_CTRL2_A                 0x21
+#define LSM303AH_CTRL2_A                 0x21U
 typedef struct {
   uint8_t sim                 : 1;
   uint8_t i2c_disable         : 1;
@@ -174,7 +154,7 @@ typedef struct {
   uint8_t boot                : 1;
 } lsm303ah_ctrl2_a_t;
 
-#define LSM303AH_CTRL3_A                 0x22
+#define LSM303AH_CTRL3_A                 0x22U
 typedef struct {
   uint8_t pp_od               : 1;
   uint8_t h_lactive           : 1;
@@ -185,7 +165,7 @@ typedef struct {
   uint8_t st                  : 2;
 } lsm303ah_ctrl3_a_t;
 
-#define LSM303AH_CTRL4_A                 0x23
+#define LSM303AH_CTRL4_A                 0x23U
 typedef struct {
   uint8_t int1_drdy           : 1;
   uint8_t int1_fth            : 1;
@@ -197,7 +177,7 @@ typedef struct {
   uint8_t not_used_01    : 1;
 } lsm303ah_ctrl4_a_t;
 
-#define LSM303AH_CTRL5_A                 0x24
+#define LSM303AH_CTRL5_A                 0x24U
 typedef struct {
   uint8_t int2_drdy           : 1;
   uint8_t int2_fth            : 1;
@@ -209,7 +189,7 @@ typedef struct {
   uint8_t drdy_pulsed         : 1;
 } lsm303ah_ctrl5_a_t;
 
-#define LSM303AH_FIFO_CTRL_A             0x25
+#define LSM303AH_FIFO_CTRL_A             0x25U
 typedef struct {
   uint8_t if_cs_pu_dis        : 1;
   uint8_t not_used_01         : 2;
@@ -218,8 +198,8 @@ typedef struct {
   uint8_t fmode               : 3;
 } lsm303ah_fifo_ctrl_a_t;
 
-#define LSM303AH_OUT_T_A                 0x26
-#define LSM303AH_STATUS_A                0x27
+#define LSM303AH_OUT_T_A                 0x26U
+#define LSM303AH_STATUS_A                0x27U
 typedef struct {
   uint8_t drdy                : 1;
   uint8_t ff_ia               : 1;
@@ -231,14 +211,14 @@ typedef struct {
   uint8_t fifo_ths            : 1;
 } lsm303ah_status_a_t;
 
-#define LSM303AH_OUT_X_L_A               0x28
-#define LSM303AH_OUT_X_H_A               0x29
-#define LSM303AH_OUT_Y_L_A               0x2A
-#define LSM303AH_OUT_Y_H_A               0x2B
-#define LSM303AH_OUT_Z_L_A               0x2C
-#define LSM303AH_OUT_Z_H_A               0x2D
-#define LSM303AH_FIFO_THS_A              0x2E
-#define LSM303AH_FIFO_SRC_A              0x2F
+#define LSM303AH_OUT_X_L_A               0x28U
+#define LSM303AH_OUT_X_H_A               0x29U
+#define LSM303AH_OUT_Y_L_A               0x2AU
+#define LSM303AH_OUT_Y_H_A               0x2BU
+#define LSM303AH_OUT_Z_L_A               0x2CU
+#define LSM303AH_OUT_Z_H_A               0x2DU
+#define LSM303AH_FIFO_THS_A              0x2EU
+#define LSM303AH_FIFO_SRC_A              0x2FU
 typedef struct {
   uint8_t not_used_01         : 5;
   uint8_t diff                : 1;
@@ -246,29 +226,29 @@ typedef struct {
   uint8_t fth                 : 1;
 } lsm303ah_fifo_src_a_t;
 
-#define LSM303AH_FIFO_SAMPLES_A          0x30
-#define LSM303AH_TAP_6D_THS_A            0x31
+#define LSM303AH_FIFO_SAMPLES_A          0x30U
+#define LSM303AH_TAP_6D_THS_A            0x31U
 typedef struct {
   uint8_t tap_ths             : 5;
   uint8_t _6d_ths             : 2;
   uint8_t _4d_en              : 1;
 } lsm303ah_tap_6d_ths_a_t;
 
-#define LSM303AH_INT_DUR_A               0x32
+#define LSM303AH_INT_DUR_A               0x32U
 typedef struct {
   uint8_t shock               : 2;
   uint8_t quiet               : 2;
   uint8_t lat                 : 4;
 } lsm303ah_int_dur_a_t;
 
-#define LSM303AH_WAKE_UP_THS_A           0x33
+#define LSM303AH_WAKE_UP_THS_A           0x33U
 typedef struct {
   uint8_t wu_ths              : 6;
   uint8_t sleep_on            : 1;
   uint8_t single_double_tap   : 1;
 } lsm303ah_wake_up_ths_a_t;
 
-#define LSM303AH_WAKE_UP_DUR_A           0x34
+#define LSM303AH_WAKE_UP_DUR_A           0x34U
 typedef struct {
   uint8_t sleep_dur           : 4;
   uint8_t int1_fss7           : 1;
@@ -276,13 +256,13 @@ typedef struct {
   uint8_t ff_dur              : 1;
 } lsm303ah_wake_up_dur_a_t;
 
-#define LSM303AH_FREE_FALL_A             0x35
+#define LSM303AH_FREE_FALL_A             0x35U
 typedef struct {
   uint8_t ff_ths              : 3;
   uint8_t ff_dur              : 5;
 } lsm303ah_free_fall_a_t;
 
-#define LSM303AH_STATUS_DUP_A            0x36
+#define LSM303AH_STATUS_DUP_A            0x36U
 typedef struct {
   uint8_t drdy                : 1;
   uint8_t ff_ia               : 1;
@@ -294,7 +274,7 @@ typedef struct {
   uint8_t ovr                 : 1;
 } lsm303ah_status_dup_a_t;
 
-#define LSM303AH_WAKE_UP_SRC_A           0x37
+#define LSM303AH_WAKE_UP_SRC_A           0x37U
 typedef struct {
   uint8_t z_wu                : 1;
   uint8_t y_wu                : 1;
@@ -305,7 +285,7 @@ typedef struct {
   uint8_t not_used_01         : 2;
 } lsm303ah_wake_up_src_a_t;
 
-#define LSM303AH_TAP_SRC_A               0x38
+#define LSM303AH_TAP_SRC_A               0x38U
 typedef struct {
   uint8_t z_tap               : 1;
   uint8_t y_tap               : 1;
@@ -317,7 +297,7 @@ typedef struct {
   uint8_t not_used_01         : 1;
 } lsm303ah_tap_src_a_t;
 
-#define LSM303AH_6D_SRC_A                0x39
+#define LSM303AH_6D_SRC_A                0x39U
 typedef struct {
   uint8_t xl                  : 1;
   uint8_t xh                  : 1;
@@ -329,16 +309,16 @@ typedef struct {
   uint8_t not_used_01         : 1;
 } lsm303ah_6d_src_a_t;
 
-#define LSM303AH_STEP_COUNTER_MINTHS_A   0x3A
+#define LSM303AH_STEP_COUNTER_MINTHS_A   0x3AU
 typedef struct {
   uint8_t sc_mths             : 6;
   uint8_t pedo4g              : 1;
   uint8_t rst_nstep           : 1;
 } lsm303ah_step_counter_minths_a_t;
 
-#define LSM303AH_STEP_COUNTER_L_A        0x3B
-#define LSM303AH_STEP_COUNTER_H_A        0x3C
-#define LSM303AH_FUNC_CK_GATE_A          0x3D
+#define LSM303AH_STEP_COUNTER_L_A        0x3BU
+#define LSM303AH_STEP_COUNTER_H_A        0x3CU
+#define LSM303AH_FUNC_CK_GATE_A          0x3DU
 typedef struct {
   uint8_t ck_gate_func        : 1;
   uint8_t step_detect         : 1;
@@ -349,7 +329,7 @@ typedef struct {
   uint8_t tilt_int            : 1;
 } lsm303ah_func_ck_gate_a_t;
 
-#define LSM303AH_FUNC_SRC_A              0x3E
+#define LSM303AH_FUNC_SRC_A              0x3EU
 typedef struct {
   uint8_t not_used_01         : 1;
   uint8_t module_ready        : 1;
@@ -357,7 +337,7 @@ typedef struct {
   uint8_t not_used_02         : 5;
 } lsm303ah_func_src_a_t;
 
-#define LSM303AH_FUNC_CTRL_A             0x3F
+#define LSM303AH_FUNC_CTRL_A             0x3FU
 typedef struct {
   uint8_t step_cnt_on         : 1;
   uint8_t sign_mot_on         : 1;
@@ -367,23 +347,23 @@ typedef struct {
   uint8_t not_used_02         : 2;
 } lsm303ah_func_ctrl_a_t;
 
-#define LSM303AH_PEDO_DEB_REG_A          0x2B
+#define LSM303AH_PEDO_DEB_REG_A          0x2BU
 typedef struct {
   uint8_t deb_step            : 3;
   uint8_t deb_time            : 5;
 } lsm303ah_pedo_deb_reg_a_t;
 
-#define LSM303AH_SM_THS_A                0x34
+#define LSM303AH_SM_THS_A                0x34U
 typedef struct {
   uint8_t sm_ths              : 8;
 } lsm303ah_sm_ths_a_t;
 
-#define LSM303AH_STEP_COUNT_DELTA_A      0x3A
+#define LSM303AH_STEP_COUNT_DELTA_A      0x3AU
 typedef struct {
   uint8_t step_count_d        : 8;
 } lsm303ah_step_count_delta_a_t;
 
-#define LSM303AH_CTRL2_ADV_A             0x3F
+#define LSM303AH_CTRL2_ADV_A             0x3FU
 typedef struct {
   uint8_t sim                 : 1;
   uint8_t i2c_disable         : 1;
@@ -395,14 +375,14 @@ typedef struct {
   uint8_t boot                : 1;
 } lsm303ah_ctrl2_adv_a_t;
 
-#define LSM303AH_OFFSET_X_REG_L_M          0x45
-#define LSM303AH_OFFSET_X_REG_H_M          0x46
-#define LSM303AH_OFFSET_Y_REG_L_M          0x47
-#define LSM303AH_OFFSET_Y_REG_H_M          0x48
-#define LSM303AH_OFFSET_Z_REG_L_M          0x49
-#define LSM303AH_OFFSET_Z_REG_H_M          0x4A
-#define LSM303AH_WHO_AM_I_M                0x4F
-#define LSM303AH_CFG_REG_A_M               0x60
+#define LSM303AH_OFFSET_X_REG_L_M          0x45U
+#define LSM303AH_OFFSET_X_REG_H_M          0x46U
+#define LSM303AH_OFFSET_Y_REG_L_M          0x47U
+#define LSM303AH_OFFSET_Y_REG_H_M          0x48U
+#define LSM303AH_OFFSET_Z_REG_L_M          0x49U
+#define LSM303AH_OFFSET_Z_REG_H_M          0x4AU
+#define LSM303AH_WHO_AM_I_M                0x4FU
+#define LSM303AH_CFG_REG_A_M               0x60U
 typedef struct {
   uint8_t md                     : 2;
   uint8_t odr                    : 2;
@@ -412,7 +392,7 @@ typedef struct {
   uint8_t comp_temp_en           : 1;
 } lsm303ah_cfg_reg_a_m_t;
 
-#define LSM303AH_CFG_REG_B_M               0x61
+#define LSM303AH_CFG_REG_B_M               0x61U
 typedef struct {
   uint8_t lpf                    : 1;
   uint8_t set_rst                : 2; /* off_canc + set_freq */
@@ -421,7 +401,7 @@ typedef struct {
   uint8_t not_used_01            : 3;
 } lsm303ah_cfg_reg_b_m_t;
 
-#define LSM303AH_CFG_REG_C_M               0x62
+#define LSM303AH_CFG_REG_C_M               0x62U
 typedef struct {
   uint8_t int_mag                : 1;
   uint8_t self_test              : 1;
@@ -433,7 +413,7 @@ typedef struct {
   uint8_t not_used_02            : 1;
 } lsm303ah_cfg_reg_c_m_t;
 
-#define LSM303AH_INT_CRTL_REG_M            0x63
+#define LSM303AH_INT_CRTL_REG_M            0x63U
 typedef struct {
   uint8_t ien                    : 1;
   uint8_t iel                    : 1;
@@ -444,7 +424,7 @@ typedef struct {
   uint8_t xien                   : 1;
 } lsm303ah_int_crtl_reg_m_t;
 
-#define LSM303AH_INT_SOURCE_REG_M          0x64
+#define LSM303AH_INT_SOURCE_REG_M          0x64U
 typedef struct {
   uint8_t _int                    : 1;
   uint8_t mroi                   : 1;
@@ -456,9 +436,9 @@ typedef struct {
   uint8_t p_th_s_x               : 1;
 } lsm303ah_int_source_reg_m_t;
 
-#define LSM303AH_INT_THS_L_REG_M           0x65
-#define LSM303AH_INT_THS_H_REG_M           0x66
-#define LSM303AH_STATUS_REG_M              0x67
+#define LSM303AH_INT_THS_L_REG_M           0x65U
+#define LSM303AH_INT_THS_H_REG_M           0x66U
+#define LSM303AH_STATUS_REG_M              0x67U
 typedef struct {
   uint8_t xda                    : 1;
   uint8_t yda                    : 1;
@@ -470,13 +450,25 @@ typedef struct {
   uint8_t zyxor                  : 1;
 } lsm303ah_status_reg_m_t;
 
-#define LSM303AH_OUTX_L_REG_M              0x68
-#define LSM303AH_OUTX_H_REG_M              0x69
-#define LSM303AH_OUTY_L_REG_M              0x6A
-#define LSM303AH_OUTY_H_REG_M              0x6B
-#define LSM303AH_OUTZ_L_REG_M              0x6C
-#define LSM303AH_OUTZ_H_REG_M              0x6D
+#define LSM303AH_OUTX_L_REG_M              0x68U
+#define LSM303AH_OUTX_H_REG_M              0x69U
+#define LSM303AH_OUTY_L_REG_M              0x6AU
+#define LSM303AH_OUTY_H_REG_M              0x6BU
+#define LSM303AH_OUTZ_L_REG_M              0x6CU
+#define LSM303AH_OUTZ_H_REG_M              0x6DU
 
+/**
+  * @defgroup LSM303AH_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
 typedef union{
   lsm303ah_ctrl1_a_t                      ctrl1_a;
   lsm303ah_ctrl2_a_t                      ctrl2_a;
@@ -512,13 +504,27 @@ typedef union{
   bitwise_t                               bitwise;
   uint8_t                                 byte;
 } lsm303ah_reg_t;
-int32_t lsm303ah_read_reg(lsm303ah_ctx_t *ctx, uint8_t reg, uint8_t* data,
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm303ah_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lsm303ah_write_reg(lsm303ah_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm303ah_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
-typedef union {
-  struct {
+extern float_t lsm303ah_from_fs2g_to_mg(int16_t lsb);
+extern float_t lsm303ah_from_fs4g_to_mg(int16_t lsb);
+extern float_t lsm303ah_from_fs8g_to_mg(int16_t lsb);
+extern float_t lsm303ah_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t lsm303ah_from_lsb_to_mgauss(int16_t lsb);
+
+extern float_t lsm303ah_from_lsb_to_celsius(int16_t lsb);
+
+typedef struct {
   lsm303ah_fifo_src_a_t       fifo_src_a;
   lsm303ah_status_dup_a_t     status_dup_a;
   lsm303ah_wake_up_src_a_t    wake_up_src_a;
@@ -526,37 +532,35 @@ typedef union {
   lsm303ah_6d_src_a_t         _6d_src_a;
   lsm303ah_func_ck_gate_a_t   func_ck_gate_a;
   lsm303ah_func_src_a_t       func_src_a;
-  } reg;
-  uint8_t byte[7];
 } lsm303ah_xl_all_sources_t;
-int32_t lsm303ah_xl_all_sources_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_all_sources_get(stmdev_ctx_t *ctx,
                                     lsm303ah_xl_all_sources_t *val);
 
 
-int32_t lsm303ah_xl_block_data_update_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_block_data_update_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_mg_block_data_update_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_mg_block_data_update_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AH_MG_LSB_AT_LOW_ADD  = 0,
   LSM303AH_MG_MSB_AT_LOW_ADD  = 1,
 } lsm303ah_mg_ble_t;
-int32_t lsm303ah_mg_data_format_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_data_format_set(stmdev_ctx_t *ctx,
                                     lsm303ah_mg_ble_t val);
-int32_t lsm303ah_mg_data_format_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_data_format_get(stmdev_ctx_t *ctx,
                                     lsm303ah_mg_ble_t *val);
 
 typedef enum {
-  LSM303AH_XL_2g = 0,
+  LSM303AH_XL_2g  = 0,
   LSM303AH_XL_16g = 1,
-  LSM303AH_XL_4g = 2,
-  LSM303AH_XL_8g = 3,
+  LSM303AH_XL_4g  = 2,
+  LSM303AH_XL_8g  = 3,
 } lsm303ah_xl_fs_t;
-int32_t lsm303ah_xl_full_scale_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_full_scale_set(stmdev_ctx_t *ctx,
                                    lsm303ah_xl_fs_t val);
-int32_t lsm303ah_xl_full_scale_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_full_scale_get(stmdev_ctx_t *ctx,
                                    lsm303ah_xl_fs_t *val);
 
 typedef enum {
@@ -580,31 +584,31 @@ typedef enum {
   LSM303AH_XL_ODR_3k2Hz_HF    = 0x16,
   LSM303AH_XL_ODR_6k4Hz_HF    = 0x17,
 } lsm303ah_xl_odr_t;
-int32_t lsm303ah_xl_data_rate_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_odr_t val);
-int32_t lsm303ah_xl_data_rate_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_odr_t *val);
+int32_t lsm303ah_xl_data_rate_set(stmdev_ctx_t *ctx, lsm303ah_xl_odr_t val);
+int32_t lsm303ah_xl_data_rate_get(stmdev_ctx_t *ctx, lsm303ah_xl_odr_t *val);
 
-int32_t lsm303ah_xl_status_reg_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_status_reg_get(stmdev_ctx_t *ctx,
                                    lsm303ah_status_a_t *val);
 
-int32_t lsm303ah_mg_status_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_status_get(stmdev_ctx_t *ctx,
                                lsm303ah_status_reg_m_t *val);
 
-int32_t lsm303ah_xl_flag_data_ready_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_mg_data_ready_get(lsm303ah_ctx_t *ctx, uint8_t *val);
-int32_t lsm303ah_mg_data_ovr_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_data_ovr_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_mg_user_offset_set(lsm303ah_ctx_t *ctx, uint8_t *buff);
-int32_t lsm303ah_mg_user_offset_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_mg_user_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_mg_user_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM303AH_MG_CONTINUOUS_MODE  = 0,
   LSM303AH_MG_SINGLE_TRIGGER   = 1,
   LSM303AH_MG_POWER_DOWN       = 2,
 } lsm303ah_mg_md_t;
-int32_t lsm303ah_mg_operating_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_operating_mode_set(stmdev_ctx_t *ctx,
                                        lsm303ah_mg_md_t val);
-int32_t lsm303ah_mg_operating_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_operating_mode_get(stmdev_ctx_t *ctx,
                                        lsm303ah_mg_md_t *val);
 
 typedef enum {
@@ -613,173 +617,173 @@ typedef enum {
   LSM303AH_MG_ODR_50Hz   = 2,
   LSM303AH_MG_ODR_100Hz  = 3,
 } lsm303ah_mg_odr_t;
-int32_t lsm303ah_mg_data_rate_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_data_rate_set(stmdev_ctx_t *ctx,
                                   lsm303ah_mg_odr_t val);
-int32_t lsm303ah_mg_data_rate_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_data_rate_get(stmdev_ctx_t *ctx,
                                   lsm303ah_mg_odr_t *val);
 
 typedef enum {
   LSM303AH_MG_HIGH_RESOLUTION  = 0,
   LSM303AH_MG_LOW_POWER        = 1,
 } lsm303ah_mg_lp_t;
-int32_t lsm303ah_mg_power_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_power_mode_set(stmdev_ctx_t *ctx,
                                    lsm303ah_mg_lp_t val);
-int32_t lsm303ah_mg_power_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_mg_power_mode_get(stmdev_ctx_t *ctx,
                                    lsm303ah_mg_lp_t *val);
 
-int32_t lsm303ah_mg_offset_temp_comp_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_mg_offset_temp_comp_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_offset_temp_comp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_offset_temp_comp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AH_MG_SET_SENS_ODR_DIV_63        = 0,
   LSM303AH_MG_SENS_OFF_CANC_EVERY_ODR    = 1,
   LSM303AH_MG_SET_SENS_ONLY_AT_POWER_ON  = 2,
 } lsm303ah_mg_set_rst_t;
-int32_t lsm303ah_mg_set_rst_mode_set(lsm303ah_ctx_t *ctx,
-                                 lsm303ah_mg_set_rst_t val);
-int32_t lsm303ah_mg_set_rst_mode_get(lsm303ah_ctx_t *ctx,
-                                 lsm303ah_mg_set_rst_t *val);
+int32_t lsm303ah_mg_set_rst_mode_set(stmdev_ctx_t *ctx,
+                                     lsm303ah_mg_set_rst_t val);
+int32_t lsm303ah_mg_set_rst_mode_get(stmdev_ctx_t *ctx,
+                                     lsm303ah_mg_set_rst_t *val);
 
-int32_t lsm303ah_mg_set_rst_sensor_single_set(lsm303ah_ctx_t *ctx,
-                                          uint8_t val);
-int32_t lsm303ah_mg_set_rst_sensor_single_get(lsm303ah_ctx_t *ctx,
-                                          uint8_t *val);
+int32_t lsm303ah_mg_set_rst_sensor_single_set(stmdev_ctx_t *ctx,
+                                              uint8_t val);
+int32_t lsm303ah_mg_set_rst_sensor_single_get(stmdev_ctx_t *ctx,
+                                              uint8_t *val);
 
-int32_t lsm303ah_acceleration_module_raw_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_acceleration_module_raw_get(stmdev_ctx_t *ctx,
                                              uint8_t *buff);
 
-int32_t lsm303ah_magnetic_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303ah_xl_temperature_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_xl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303ah_acceleration_raw_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303ah_number_of_steps_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303ah_xl_device_id_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_xl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303ah_mg_device_id_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_mg_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm303ah_xl_auto_increment_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_auto_increment_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AH_XL_USER_BANK   = 0,
   LSM303AH_XL_ADV_BANK    = 1,
 } lsm303ah_xl_func_cfg_en_t;
-int32_t lsm303ah_xl_mem_bank_set(lsm303ah_ctx_t *ctx,
-                              lsm303ah_xl_func_cfg_en_t val);
+int32_t lsm303ah_xl_mem_bank_set(stmdev_ctx_t *ctx,
+                                 lsm303ah_xl_func_cfg_en_t val);
 
-int32_t lsm303ah_xl_reset_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_mg_reset_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_mg_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_boot_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_boot_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_mg_boot_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_mg_boot_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AH_XL_ST_DISABLE     = 0,
   LSM303AH_XL_ST_POSITIVE    = 1,
   LSM303AH_XL_ST_NEGATIVE    = 2,
 } lsm303ah_xl_st_t;
-int32_t lsm303ah_xl_self_test_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_st_t val);
-int32_t lsm303ah_xl_self_test_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_st_t *val);
+int32_t lsm303ah_xl_self_test_set(stmdev_ctx_t *ctx, lsm303ah_xl_st_t val);
+int32_t lsm303ah_xl_self_test_get(stmdev_ctx_t *ctx, lsm303ah_xl_st_t *val);
 
-int32_t lsm303ah_mg_self_test_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_mg_self_test_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_self_test_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_self_test_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AH_XL_DRDY_LATCHED   = 0,
   LSM303AH_XL_DRDY_PULSED    = 1,
 } lsm303ah_xl_drdy_pulsed_t;
-int32_t lsm303ah_xl_data_ready_mode_set(lsm303ah_ctx_t *ctx,
-                                     lsm303ah_xl_drdy_pulsed_t val);
-int32_t lsm303ah_xl_data_ready_mode_get(lsm303ah_ctx_t *ctx,
-                                     lsm303ah_xl_drdy_pulsed_t *val);
+int32_t lsm303ah_xl_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                        lsm303ah_xl_drdy_pulsed_t val);
+int32_t lsm303ah_xl_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                        lsm303ah_xl_drdy_pulsed_t *val);
 
 typedef enum {
   LSM303AH_XL_HP_INTERNAL_ONLY  = 0,
   LSM303AH_XL_HP_ON_OUTPUTS     = 1,
 } lsm303ah_xl_fds_slope_t;
-int32_t lsm303ah_xl_hp_path_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_hp_path_set(stmdev_ctx_t *ctx,
                                 lsm303ah_xl_fds_slope_t val);
-int32_t lsm303ah_xl_hp_path_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_hp_path_get(stmdev_ctx_t *ctx,
                                 lsm303ah_xl_fds_slope_t *val);
 
 typedef enum {
   LSM303AH_MG_ODR_DIV_2  = 0,
   LSM303AH_MG_ODR_DIV_4  = 1,
 } lsm303ah_mg_lpf_t;
-int32_t lsm303ah_mg_low_pass_bandwidth_set(lsm303ah_ctx_t *ctx,
-                                       lsm303ah_mg_lpf_t val);
-int32_t lsm303ah_mg_low_pass_bandwidth_get(lsm303ah_ctx_t *ctx,
-                                       lsm303ah_mg_lpf_t *val);
+int32_t lsm303ah_mg_low_pass_bandwidth_set(stmdev_ctx_t *ctx,
+                                           lsm303ah_mg_lpf_t val);
+int32_t lsm303ah_mg_low_pass_bandwidth_get(stmdev_ctx_t *ctx,
+                                           lsm303ah_mg_lpf_t *val);
 
 typedef enum {
   LSM303AH_XL_SPI_4_WIRE   = 0,
   LSM303AH_XL_SPI_3_WIRE   = 1,
 } lsm303ah_xl_sim_t;
-int32_t lsm303ah_xl_spi_mode_set(lsm303ah_ctx_t *ctx, lsm303ah_xl_sim_t val);
-int32_t lsm303ah_xl_spi_mode_get(lsm303ah_ctx_t *ctx, lsm303ah_xl_sim_t *val);
+int32_t lsm303ah_xl_spi_mode_set(stmdev_ctx_t *ctx, lsm303ah_xl_sim_t val);
+int32_t lsm303ah_xl_spi_mode_get(stmdev_ctx_t *ctx, lsm303ah_xl_sim_t *val);
 
 typedef enum {
   LSM303AH_XL_I2C_ENABLE   = 0,
   LSM303AH_XL_I2C_DISABLE  = 1,
 } lsm303ah_xl_i2c_disable_t;
-int32_t lsm303ah_xl_i2c_interface_set(lsm303ah_ctx_t *ctx,
-                                   lsm303ah_xl_i2c_disable_t val);
-int32_t lsm303ah_xl_i2c_interface_get(lsm303ah_ctx_t *ctx,
-                                   lsm303ah_xl_i2c_disable_t *val);
+int32_t lsm303ah_xl_i2c_interface_set(stmdev_ctx_t *ctx,
+                                      lsm303ah_xl_i2c_disable_t val);
+int32_t lsm303ah_xl_i2c_interface_get(stmdev_ctx_t *ctx,
+                                      lsm303ah_xl_i2c_disable_t *val);
 
 typedef enum {
   LSM303AH_MG_I2C_ENABLE   = 0,
   LSM303AH_MG_I2C_DISABLE  = 1,
 } lsm303ah_mg_i2c_dis_t;
-int32_t lsm303ah_mg_i2c_interface_set(lsm303ah_ctx_t *ctx,
-                                  lsm303ah_mg_i2c_dis_t val);
-int32_t lsm303ah_mg_i2c_interface_get(lsm303ah_ctx_t *ctx,
-                                  lsm303ah_mg_i2c_dis_t *val);
+int32_t lsm303ah_mg_i2c_interface_set(stmdev_ctx_t *ctx,
+                                      lsm303ah_mg_i2c_dis_t val);
+int32_t lsm303ah_mg_i2c_interface_get(stmdev_ctx_t *ctx,
+                                      lsm303ah_mg_i2c_dis_t *val);
 
 typedef enum {
   LSM303AH_XL_PULL_UP_CONNECTED     = 0,
   LSM303AH_XL_PULL_UP_DISCONNECTED  = 1,
 } lsm303ah_xl_if_cs_pu_dis_t;
-int32_t lsm303ah_xl_cs_mode_set(lsm303ah_ctx_t *ctx,
-                             lsm303ah_xl_if_cs_pu_dis_t val);
-int32_t lsm303ah_xl_cs_mode_get(lsm303ah_ctx_t *ctx,
-                             lsm303ah_xl_if_cs_pu_dis_t *val);
+int32_t lsm303ah_xl_cs_mode_set(stmdev_ctx_t *ctx,
+                                lsm303ah_xl_if_cs_pu_dis_t val);
+int32_t lsm303ah_xl_cs_mode_get(stmdev_ctx_t *ctx,
+                                lsm303ah_xl_if_cs_pu_dis_t *val);
 
 typedef enum {
   LSM303AH_XL_PUSH_PULL   = 0,
   LSM303AH_XL_OPEN_DRAIN  = 1,
 } lsm303ah_xl_pp_od_t;
-int32_t lsm303ah_xl_pin_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_mode_set(stmdev_ctx_t *ctx,
                                  lsm303ah_xl_pp_od_t val);
-int32_t lsm303ah_xl_pin_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pin_mode_get(stmdev_ctx_t *ctx,
                                  lsm303ah_xl_pp_od_t *val);
 
 typedef enum {
   LSM303AH_XL_ACTIVE_HIGH  = 0,
   LSM303AH_XL_ACTIVE_LOW   = 1,
 } lsm303ah_xl_h_lactive_t;
-int32_t lsm303ah_xl_pin_polarity_set(lsm303ah_ctx_t *ctx,
-                                  lsm303ah_xl_h_lactive_t val);
-int32_t lsm303ah_xl_pin_polarity_get(lsm303ah_ctx_t *ctx,
-                                  lsm303ah_xl_h_lactive_t *val);
+int32_t lsm303ah_xl_pin_polarity_set(stmdev_ctx_t *ctx,
+                                     lsm303ah_xl_h_lactive_t val);
+int32_t lsm303ah_xl_pin_polarity_get(stmdev_ctx_t *ctx,
+                                     lsm303ah_xl_h_lactive_t *val);
 
 typedef enum {
   LSM303AH_XL_INT_PULSED   = 0,
   LSM303AH_XL_INT_LATCHED  = 1,
 } lsm303ah_xl_lir_t;
-int32_t lsm303ah_xl_int_notification_set(lsm303ah_ctx_t *ctx,
-                                      lsm303ah_xl_lir_t val);
-int32_t lsm303ah_xl_int_notification_get(lsm303ah_ctx_t *ctx,
-                                      lsm303ah_xl_lir_t *val);
+int32_t lsm303ah_xl_int_notification_set(stmdev_ctx_t *ctx,
+                                         lsm303ah_xl_lir_t val);
+int32_t lsm303ah_xl_int_notification_get(stmdev_ctx_t *ctx,
+                                         lsm303ah_xl_lir_t *val);
 
 typedef struct{
   uint8_t int1_drdy               : 1;
@@ -791,10 +795,10 @@ typedef struct{
   uint8_t int1_s_tap              : 1;
   uint8_t int1_fss7               : 1;
 } lsm303ah_xl_pin_int1_route_t;
-int32_t lsm303ah_xl_pin_int1_route_set(lsm303ah_ctx_t *ctx,
-                                    lsm303ah_xl_pin_int1_route_t val);
-int32_t lsm303ah_xl_pin_int1_route_get(lsm303ah_ctx_t *ctx,
-                                    lsm303ah_xl_pin_int1_route_t *val);
+int32_t lsm303ah_xl_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                       lsm303ah_xl_pin_int1_route_t val);
+int32_t lsm303ah_xl_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                       lsm303ah_xl_pin_int1_route_t *val);
 
 typedef struct{
   uint8_t int2_boot               : 1;
@@ -804,83 +808,83 @@ typedef struct{
   uint8_t int2_fth                : 1;
   uint8_t int2_drdy               : 1;
 } lsm303ah_xl_pin_int2_route_t;
-int32_t lsm303ah_xl_pin_int2_route_set(lsm303ah_ctx_t *ctx,
-                                    lsm303ah_xl_pin_int2_route_t val);
-int32_t lsm303ah_xl_pin_int2_route_get(lsm303ah_ctx_t *ctx,
-                                    lsm303ah_xl_pin_int2_route_t *val);
+int32_t lsm303ah_xl_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                       lsm303ah_xl_pin_int2_route_t val);
+int32_t lsm303ah_xl_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                       lsm303ah_xl_pin_int2_route_t *val);
 
-int32_t lsm303ah_xl_all_on_int1_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_all_on_int1_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_mg_drdy_on_pin_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_mg_drdy_on_pin_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_drdy_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_drdy_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_mg_int_on_pin_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_mg_int_on_pin_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_mg_int_on_pin_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_mg_int_on_pin_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_mg_int_gen_conf_set(lsm303ah_ctx_t *ctx,
-                                 lsm303ah_int_crtl_reg_m_t *val);
-int32_t lsm303ah_mg_int_gen_conf_get(lsm303ah_ctx_t *ctx,
-                                 lsm303ah_int_crtl_reg_m_t *val);
+int32_t lsm303ah_mg_int_gen_conf_set(stmdev_ctx_t *ctx,
+                                     lsm303ah_int_crtl_reg_m_t *val);
+int32_t lsm303ah_mg_int_gen_conf_get(stmdev_ctx_t *ctx,
+                                     lsm303ah_int_crtl_reg_m_t *val);
 
-int32_t lsm303ah_mg_int_gen_source_get(lsm303ah_ctx_t *ctx,
-                                   lsm303ah_int_source_reg_m_t *val);
+int32_t lsm303ah_mg_int_gen_source_get(stmdev_ctx_t *ctx,
+                                       lsm303ah_int_source_reg_m_t *val);
 
-int32_t lsm303ah_mg_int_gen_treshold_set(lsm303ah_ctx_t *ctx, uint8_t *buff);
-int32_t lsm303ah_mg_int_gen_treshold_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_mg_int_gen_treshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_mg_int_gen_treshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM303AH_MG_CHECK_BEFORE  = 0,
   LSM303AH_MG_CHECK_AFTER   = 1,
 } lsm303ah_mg_int_on_dataoff_t;
-int32_t lsm303ah_mg_offset_int_conf_set(lsm303ah_ctx_t *ctx,
-                                    lsm303ah_mg_int_on_dataoff_t val);
-int32_t lsm303ah_mg_offset_int_conf_get(lsm303ah_ctx_t *ctx,
-                                    lsm303ah_mg_int_on_dataoff_t *val);
+int32_t lsm303ah_mg_offset_int_conf_set(stmdev_ctx_t *ctx,
+                                        lsm303ah_mg_int_on_dataoff_t val);
+int32_t lsm303ah_mg_offset_int_conf_get(stmdev_ctx_t *ctx,
+                                        lsm303ah_mg_int_on_dataoff_t *val);
 
-int32_t lsm303ah_xl_wkup_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_wkup_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_wkup_dur_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_wkup_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_sleep_mode_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_sleep_mode_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_act_sleep_dur_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_act_sleep_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_tap_detection_on_z_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_tap_detection_on_z_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_tap_detection_on_y_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_tap_detection_on_y_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_tap_detection_on_x_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_tap_detection_on_x_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_tap_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_tap_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_tap_shock_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_tap_shock_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_tap_quiet_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_tap_quiet_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_tap_dur_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_tap_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AH_XL_ONLY_SINGLE  = 0,
   LSM303AH_XL_ONLY_DOUBLE  = 1,
 } lsm303ah_xl_single_double_tap_t;
-int32_t lsm303ah_xl_tap_mode_set(lsm303ah_ctx_t *ctx,
-                              lsm303ah_xl_single_double_tap_t val);
-int32_t lsm303ah_xl_tap_mode_get(lsm303ah_ctx_t *ctx,
-                              lsm303ah_xl_single_double_tap_t *val);
+int32_t lsm303ah_xl_tap_mode_set(stmdev_ctx_t *ctx,
+                                 lsm303ah_xl_single_double_tap_t val);
+int32_t lsm303ah_xl_tap_mode_get(stmdev_ctx_t *ctx,
+                                 lsm303ah_xl_single_double_tap_t *val);
 
-int32_t lsm303ah_xl_tap_src_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_tap_src_get(stmdev_ctx_t *ctx,
                                 lsm303ah_tap_src_a_t *val);
 
 typedef enum {
@@ -889,25 +893,25 @@ typedef enum {
   LSM303AH_XL_DEG_60   = 2,
   LSM303AH_XL_DEG_50   = 3,
 } lsm303ah_xl_6d_ths_t;
-int32_t lsm303ah_xl_6d_threshold_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_6d_threshold_set(stmdev_ctx_t *ctx,
                                      lsm303ah_xl_6d_ths_t val);
-int32_t lsm303ah_xl_6d_threshold_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_6d_threshold_get(stmdev_ctx_t *ctx,
                                      lsm303ah_xl_6d_ths_t *val);
 
-int32_t lsm303ah_xl_4d_mode_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_4d_mode_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_6d_src_get(lsm303ah_ctx_t *ctx, lsm303ah_6d_src_a_t *val);
+int32_t lsm303ah_xl_6d_src_get(stmdev_ctx_t *ctx, lsm303ah_6d_src_a_t *val);
 
-int32_t lsm303ah_xl_ff_dur_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_ff_dur_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_ff_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_ff_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_ff_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_ff_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_fifo_xl_module_batch_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_xl_module_batch_set(stmdev_ctx_t *ctx,
                                              uint8_t val);
-int32_t lsm303ah_xl_fifo_xl_module_batch_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_xl_module_batch_get(stmdev_ctx_t *ctx,
                                              uint8_t *val);
 
 typedef enum {
@@ -917,80 +921,81 @@ typedef enum {
   LSM303AH_XL_BYPASS_TO_STREAM_MODE  = 4,
   LSM303AH_XL_STREAM_MODE            = 6,
 } lsm303ah_xl_fmode_t;
-int32_t lsm303ah_xl_fifo_mode_set(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_mode_set(stmdev_ctx_t *ctx,
                                   lsm303ah_xl_fmode_t val);
-int32_t lsm303ah_xl_fifo_mode_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_mode_get(stmdev_ctx_t *ctx,
                                   lsm303ah_xl_fmode_t *val);
 
-int32_t lsm303ah_xl_fifo_watermark_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_fifo_watermark_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_fifo_full_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_fifo_ovr_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_fifo_wtm_flag_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_fifo_data_level_get(lsm303ah_ctx_t *ctx, uint16_t *val);
+int32_t lsm303ah_xl_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm303ah_xl_fifo_src_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_fifo_src_get(stmdev_ctx_t *ctx,
                                  lsm303ah_fifo_src_a_t *val);
 
-int32_t lsm303ah_xl_pedo_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_pedo_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM303AH_XL_PEDO_AT_2g  = 0,
   LSM303AH_XL_PEDO_AT_4g  = 1,
 } lsm303ah_xl_pedo4g_t;
-int32_t lsm303ah_xl_pedo_full_scale_set(lsm303ah_ctx_t *ctx,
-                                     lsm303ah_xl_pedo4g_t val);
-int32_t lsm303ah_xl_pedo_full_scale_get(lsm303ah_ctx_t *ctx,
-                                     lsm303ah_xl_pedo4g_t *val);
+int32_t lsm303ah_xl_pedo_full_scale_set(stmdev_ctx_t *ctx,
+                                        lsm303ah_xl_pedo4g_t val);
+int32_t lsm303ah_xl_pedo_full_scale_get(stmdev_ctx_t *ctx,
+                                        lsm303ah_xl_pedo4g_t *val);
 
-int32_t lsm303ah_xl_pedo_step_reset_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_pedo_step_reset_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_pedo_step_detect_flag_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pedo_step_detect_flag_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
-int32_t lsm303ah_xl_pedo_sens_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_pedo_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_pedo_debounce_steps_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_pedo_debounce_steps_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_pedo_timeout_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_pedo_timeout_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_pedo_steps_period_set(lsm303ah_ctx_t *ctx, uint8_t *buff);
-int32_t lsm303ah_xl_pedo_steps_period_get(lsm303ah_ctx_t *ctx, uint8_t *buff);
-int32_t lsm303ah_xl_motion_data_ready_flag_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_xl_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm303ah_xl_motion_data_ready_flag_get(stmdev_ctx_t *ctx,
                                                uint8_t *val);
 
-int32_t lsm303ah_xl_motion_sens_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_motion_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_motion_threshold_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_motion_threshold_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_tilt_data_ready_flag_get(lsm303ah_ctx_t *ctx,
+int32_t lsm303ah_xl_tilt_data_ready_flag_get(stmdev_ctx_t *ctx,
                                              uint8_t *val);
 
-int32_t lsm303ah_xl_tilt_sens_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_tilt_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm303ah_xl_module_sens_set(lsm303ah_ctx_t *ctx, uint8_t val);
-int32_t lsm303ah_xl_module_sens_get(lsm303ah_ctx_t *ctx, uint8_t *val);
+int32_t lsm303ah_xl_module_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm303ah_xl_module_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}
+  *
   */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /*__LSM303AH_DRIVER__H */
+#endif /*LSM303AH_REGS_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.c
+++ b/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.c
@@ -6,32 +6,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 #include "lsm6ds3_reg.h"
 
@@ -62,7 +45,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_read_reg(lsm6ds3_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6ds3_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -80,7 +63,7 @@ int32_t lsm6ds3_read_reg(lsm6ds3_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_write_reg(lsm6ds3_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6ds3_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -171,7 +154,7 @@ float_t lsm6ds3_from_lsb_to_celsius(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_data_orient_set(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_orient_t val)
+int32_t lsm6ds3_gy_data_orient_set(stmdev_ctx_t *ctx, lsm6ds3_gy_orient_t val)
 {
   lsm6ds3_orient_cfg_g_t orient_cfg_g;
   int32_t ret;
@@ -193,7 +176,7 @@ int32_t lsm6ds3_gy_data_orient_set(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_orient_t val)
   * @param  val         get the values of orient in reg ORIENT_CFG_G
   *
   */
-int32_t lsm6ds3_gy_data_orient_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_gy_data_orient_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_gy_orient_t *val)
 {
   lsm6ds3_orient_cfg_g_t orient_cfg_g;
@@ -237,7 +220,7 @@ int32_t lsm6ds3_gy_data_orient_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_data_sign_set(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t val)
+int32_t lsm6ds3_gy_data_sign_set(stmdev_ctx_t *ctx, lsm6ds3_gy_sgn_t val)
 {
   lsm6ds3_orient_cfg_g_t orient_cfg_g;
   int32_t ret;
@@ -259,7 +242,7 @@ int32_t lsm6ds3_gy_data_sign_set(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t val)
   * @param  val         get the values of sign_g in reg ORIENT_CFG_G
   *
   */
-int32_t lsm6ds3_gy_data_sign_get(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t *val)
+int32_t lsm6ds3_gy_data_sign_get(stmdev_ctx_t *ctx, lsm6ds3_gy_sgn_t *val)
 {
   lsm6ds3_orient_cfg_g_t orient_cfg_g;
   int32_t ret;
@@ -308,7 +291,7 @@ int32_t lsm6ds3_gy_data_sign_get(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t val)
+int32_t lsm6ds3_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3_xl_fs_t val)
 {
   lsm6ds3_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -328,7 +311,7 @@ int32_t lsm6ds3_xl_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t val)
   * @param  val         get the values of fs_xl in reg CTRL1_XL
   *
   */
-int32_t lsm6ds3_xl_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t *val)
+int32_t lsm6ds3_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3_xl_fs_t *val)
 {
   lsm6ds3_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -364,7 +347,7 @@ int32_t lsm6ds3_xl_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t val)
+int32_t lsm6ds3_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3_odr_xl_t val)
 {
   lsm6ds3_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -384,7 +367,7 @@ int32_t lsm6ds3_xl_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t val)
   * @param  val         get the values of odr_xl in reg CTRL1_XL
   *
   */
-int32_t lsm6ds3_xl_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t *val)
+int32_t lsm6ds3_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3_odr_xl_t *val)
 {
   lsm6ds3_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -441,7 +424,7 @@ int32_t lsm6ds3_xl_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t val)
+int32_t lsm6ds3_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3_fs_g_t val)
 {
   lsm6ds3_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -461,7 +444,7 @@ int32_t lsm6ds3_gy_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t val)
   * @param  val         get the values of fs_g in reg CTRL2_G
   *
   */
-int32_t lsm6ds3_gy_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t *val)
+int32_t lsm6ds3_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3_fs_g_t *val)
 {
   lsm6ds3_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -500,7 +483,7 @@ int32_t lsm6ds3_gy_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t val)
+int32_t lsm6ds3_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3_odr_g_t val)
 {
   lsm6ds3_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -520,7 +503,7 @@ int32_t lsm6ds3_gy_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t val)
   * @param  val         get the values of odr_g in reg CTRL2_G
   *
   */
-int32_t lsm6ds3_gy_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t *val)
+int32_t lsm6ds3_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3_odr_g_t *val)
 {
   lsm6ds3_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -571,7 +554,7 @@ int32_t lsm6ds3_gy_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_block_data_update_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -592,7 +575,7 @@ int32_t lsm6ds3_block_data_update_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_block_data_update_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -611,7 +594,7 @@ int32_t lsm6ds3_block_data_update_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_power_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_hm_mode_t val)
+int32_t lsm6ds3_xl_power_mode_set(stmdev_ctx_t *ctx, lsm6ds3_xl_hm_mode_t val)
 {
   lsm6ds3_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -631,7 +614,7 @@ int32_t lsm6ds3_xl_power_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_hm_mode_t val)
   * @param  val         get the values of xl_hm_mode in reg CTRL6_C
   *
   */
-int32_t lsm6ds3_xl_power_mode_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_xl_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6ds3_xl_hm_mode_t *val)
 {
   lsm6ds3_ctrl6_c_t ctrl6_c;
@@ -662,7 +645,7 @@ int32_t lsm6ds3_xl_power_mode_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_rounding_on_status_set(lsm6ds3_ctx_t *ctx, lsm6ds3_rnd_stat_t val)
+int32_t lsm6ds3_rounding_on_status_set(stmdev_ctx_t *ctx, lsm6ds3_rnd_stat_t val)
 {
   lsm6ds3_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -682,7 +665,7 @@ int32_t lsm6ds3_rounding_on_status_set(lsm6ds3_ctx_t *ctx, lsm6ds3_rnd_stat_t va
   * @param  val         get the values of rounding_status in reg CTRL7_G
   *
   */
-int32_t lsm6ds3_rounding_on_status_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_rounding_on_status_get(stmdev_ctx_t *ctx,
                                        lsm6ds3_rnd_stat_t *val)
 {
   lsm6ds3_ctrl7_g_t ctrl7_g;
@@ -713,7 +696,7 @@ int32_t lsm6ds3_rounding_on_status_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_power_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_g_hm_mode_t val)
+int32_t lsm6ds3_gy_power_mode_set(stmdev_ctx_t *ctx, lsm6ds3_g_hm_mode_t val)
 {
   lsm6ds3_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -733,7 +716,7 @@ int32_t lsm6ds3_gy_power_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_g_hm_mode_t val)
   * @param  val         get the values of g_hm_mode in reg CTRL7_G
   *
   */
-int32_t lsm6ds3_gy_power_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_g_hm_mode_t *val)
+int32_t lsm6ds3_gy_power_mode_get(stmdev_ctx_t *ctx, lsm6ds3_g_hm_mode_t *val)
 {
   lsm6ds3_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -763,7 +746,7 @@ int32_t lsm6ds3_gy_power_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_g_hm_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_xl_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -784,7 +767,7 @@ int32_t lsm6ds3_xl_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_xl_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -803,7 +786,7 @@ int32_t lsm6ds3_xl_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_xl_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -824,7 +807,7 @@ int32_t lsm6ds3_xl_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_xl_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -843,7 +826,7 @@ int32_t lsm6ds3_xl_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_xl_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -864,7 +847,7 @@ int32_t lsm6ds3_xl_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_xl_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -883,7 +866,7 @@ int32_t lsm6ds3_xl_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_gy_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -904,7 +887,7 @@ int32_t lsm6ds3_gy_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_gy_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -923,7 +906,7 @@ int32_t lsm6ds3_gy_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_gy_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -944,7 +927,7 @@ int32_t lsm6ds3_gy_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_gy_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -963,7 +946,7 @@ int32_t lsm6ds3_gy_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_gy_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -984,7 +967,7 @@ int32_t lsm6ds3_gy_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_gy_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -1003,7 +986,7 @@ int32_t lsm6ds3_gy_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   *                     WAKE_UP_SRC, TAP_SRC, D6D_SRC, FUNC_SRC.
   *
   */
-int32_t lsm6ds3_all_sources_get(lsm6ds3_ctx_t *ctx, lsm6ds3_all_src_t *val)
+int32_t lsm6ds3_all_sources_get(stmdev_ctx_t *ctx, lsm6ds3_all_src_t *val)
 {
   int32_t ret;
 
@@ -1031,7 +1014,7 @@ int32_t lsm6ds3_all_sources_get(lsm6ds3_ctx_t *ctx, lsm6ds3_all_src_t *val)
   * @param  val          The STATUS_REG register of the device.
   *
   */
-int32_t lsm6ds3_status_reg_get(lsm6ds3_ctx_t *ctx, lsm6ds3_status_reg_t *val)
+int32_t lsm6ds3_status_reg_get(stmdev_ctx_t *ctx, lsm6ds3_status_reg_t *val)
 {
   int32_t ret;
 
@@ -1048,7 +1031,7 @@ int32_t lsm6ds3_status_reg_get(lsm6ds3_ctx_t *ctx, lsm6ds3_status_reg_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_status_reg_t status_reg;
   int32_t ret;
@@ -1067,7 +1050,7 @@ int32_t lsm6ds3_xl_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_status_reg_t status_reg;
   int32_t ret;
@@ -1086,7 +1069,7 @@ int32_t lsm6ds3_gy_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_temp_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_status_reg_t status_reg;
   int32_t ret;
@@ -1119,7 +1102,7 @@ int32_t lsm6ds3_temp_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_TIMESTAMP0_REG, buff,
@@ -1134,7 +1117,7 @@ int32_t lsm6ds3_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data to be write
   *
   */
-int32_t lsm6ds3_timestamp_rst_set(lsm6ds3_ctx_t *ctx)
+int32_t lsm6ds3_timestamp_rst_set(stmdev_ctx_t *ctx)
 {
   int32_t ret;
   uint8_t rst_val = 0xAA;
@@ -1153,7 +1136,7 @@ int32_t lsm6ds3_timestamp_rst_set(lsm6ds3_ctx_t *ctx)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_timestamp_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -1176,7 +1159,7 @@ int32_t lsm6ds3_timestamp_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_timestamp_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -1195,7 +1178,7 @@ int32_t lsm6ds3_timestamp_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_timestamp_res_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t val)
+int32_t lsm6ds3_timestamp_res_set(stmdev_ctx_t *ctx, lsm6ds3_ts_res_t val)
 {
   lsm6ds3_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -1216,7 +1199,7 @@ int32_t lsm6ds3_timestamp_res_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t val)
   * @param  val         get the values of timer_hr in reg WAKE_UP_DUR
   *
   */
-int32_t lsm6ds3_timestamp_res_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t *val)
+int32_t lsm6ds3_timestamp_res_get(stmdev_ctx_t *ctx, lsm6ds3_ts_res_t *val)
 {
   lsm6ds3_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -1259,7 +1242,7 @@ int32_t lsm6ds3_timestamp_res_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_rounding_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_rounding_t val)
+int32_t lsm6ds3_rounding_mode_set(stmdev_ctx_t *ctx, lsm6ds3_rounding_t val)
 {
   lsm6ds3_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1280,7 +1263,7 @@ int32_t lsm6ds3_rounding_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_rounding_t val)
   * @param  val         get the values of rounding in reg CTRL5_C
   *
   */
-int32_t lsm6ds3_rounding_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_rounding_t *val)
+int32_t lsm6ds3_rounding_mode_get(stmdev_ctx_t *ctx, lsm6ds3_rounding_t *val)
 {
   lsm6ds3_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1328,7 +1311,7 @@ int32_t lsm6ds3_rounding_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_rounding_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_temperature_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_OUT_TEMP_L, buff, 2);
@@ -1343,7 +1326,7 @@ int32_t lsm6ds3_temperature_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_angular_rate_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_OUTX_L_G, buff, 6);
@@ -1358,7 +1341,7 @@ int32_t lsm6ds3_angular_rate_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_acceleration_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_OUTX_L_XL, buff, 6);
@@ -1368,12 +1351,12 @@ int32_t lsm6ds3_acceleration_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
 /**
   * @brief   fifo_raw_data: [get]  read data in FIFO.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  uint8_t *: data buffer to store FIFO data.
   * @param  uint8_t : number of data to read from FIFO.
   *
   */
-int32_t lsm6ds3_fifo_raw_data_get(lsm6ds3_ctx_t *ctx, uint8_t *buffer, uint8_t len)
+int32_t lsm6ds3_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer, uint8_t len)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_FIFO_DATA_OUT_L, buffer, len);
@@ -1387,7 +1370,7 @@ int32_t lsm6ds3_fifo_raw_data_get(lsm6ds3_ctx_t *ctx, uint8_t *buffer, uint8_t l
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_number_of_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_STEP_COUNTER_L, buff, 2);
@@ -1401,7 +1384,7 @@ int32_t lsm6ds3_number_of_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_mag_calibrated_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_OUT_MAG_RAW_X_L, buff, 6);
@@ -1428,7 +1411,7 @@ int32_t lsm6ds3_mag_calibrated_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_mem_bank_set(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t val)
+int32_t lsm6ds3_mem_bank_set(stmdev_ctx_t *ctx, lsm6ds3_func_cfg_en_t val)
 {
   lsm6ds3_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -1450,7 +1433,7 @@ int32_t lsm6ds3_mem_bank_set(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t val)
   * @param  val         get the values of func_cfg_en in reg FUNC_CFG_ACCESS
   *
   */
-int32_t lsm6ds3_mem_bank_get(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t *val)
+int32_t lsm6ds3_mem_bank_get(stmdev_ctx_t *ctx, lsm6ds3_func_cfg_en_t *val)
 {
   lsm6ds3_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -1480,7 +1463,7 @@ int32_t lsm6ds3_mem_bank_get(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_device_id_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_WHO_AM_I, buff, 1);
@@ -1495,7 +1478,7 @@ int32_t lsm6ds3_device_id_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1516,7 +1499,7 @@ int32_t lsm6ds3_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1535,7 +1518,7 @@ int32_t lsm6ds3_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_data_format_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t val)
+int32_t lsm6ds3_data_format_set(stmdev_ctx_t *ctx, lsm6ds3_ble_t val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1555,7 +1538,7 @@ int32_t lsm6ds3_data_format_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t val)
   * @param  val         get the values of ble in reg CTRL3_C
   *
   */
-int32_t lsm6ds3_data_format_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t *val)
+int32_t lsm6ds3_data_format_get(stmdev_ctx_t *ctx, lsm6ds3_ble_t *val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1586,7 +1569,7 @@ int32_t lsm6ds3_data_format_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_auto_increment_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1608,7 +1591,7 @@ int32_t lsm6ds3_auto_increment_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_auto_increment_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1627,7 +1610,7 @@ int32_t lsm6ds3_auto_increment_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_boot_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1648,7 +1631,7 @@ int32_t lsm6ds3_boot_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_boot_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1667,7 +1650,7 @@ int32_t lsm6ds3_boot_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t val)
+int32_t lsm6ds3_xl_self_test_set(stmdev_ctx_t *ctx, lsm6ds3_st_xl_t val)
 {
   lsm6ds3_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1687,7 +1670,7 @@ int32_t lsm6ds3_xl_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t val)
   * @param  val         get the values of st_xl in reg CTRL5_C
   *
   */
-int32_t lsm6ds3_xl_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t *val)
+int32_t lsm6ds3_xl_self_test_get(stmdev_ctx_t *ctx, lsm6ds3_st_xl_t *val)
 {
   lsm6ds3_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1720,7 +1703,7 @@ int32_t lsm6ds3_xl_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t val)
+int32_t lsm6ds3_gy_self_test_set(stmdev_ctx_t *ctx, lsm6ds3_st_g_t val)
 {
   lsm6ds3_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1740,7 +1723,7 @@ int32_t lsm6ds3_gy_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t val)
   * @param  val         get the values of st_g in reg CTRL5_C
   *
   */
-int32_t lsm6ds3_gy_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t *val)
+int32_t lsm6ds3_gy_self_test_get(stmdev_ctx_t *ctx, lsm6ds3_st_g_t *val)
 {
   lsm6ds3_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1787,7 +1770,7 @@ int32_t lsm6ds3_gy_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_filter_settling_mask_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_filter_settling_mask_set(stmdev_ctx_t *ctx,
                                          uint8_t val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
@@ -1810,7 +1793,7 @@ int32_t lsm6ds3_filter_settling_mask_set(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_filter_settling_mask_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1829,7 +1812,7 @@ int32_t lsm6ds3_filter_settling_mask_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t val)
+int32_t lsm6ds3_gy_hp_bandwidth_set(stmdev_ctx_t *ctx, lsm6ds3_hpcf_g_t val)
 {
   lsm6ds3_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -1849,7 +1832,7 @@ int32_t lsm6ds3_gy_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t val)
   * @param  val         get the values of hpcf_g in reg CTRL7_G
   *
   */
-int32_t lsm6ds3_gy_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t *val)
+int32_t lsm6ds3_gy_hp_bandwidth_get(stmdev_ctx_t *ctx, lsm6ds3_hpcf_g_t *val)
 {
   lsm6ds3_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -1885,7 +1868,7 @@ int32_t lsm6ds3_gy_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_hp_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_gy_hp_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -1906,7 +1889,7 @@ int32_t lsm6ds3_gy_hp_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_hp_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_gy_hp_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -1926,7 +1909,7 @@ int32_t lsm6ds3_gy_hp_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t val)
+int32_t lsm6ds3_xl_hp_bandwidth_set(stmdev_ctx_t *ctx, lsm6ds3_hp_bw_t val)
 {
   lsm6ds3_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1948,7 +1931,7 @@ int32_t lsm6ds3_xl_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t val)
   * @param  val         get the values of hp_slope_xl_en in reg CTRL8_XL
   *
   */
-int32_t lsm6ds3_xl_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t *val)
+int32_t lsm6ds3_xl_hp_bandwidth_get(stmdev_ctx_t *ctx, lsm6ds3_hp_bw_t *val)
 {
   lsm6ds3_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1985,7 +1968,7 @@ int32_t lsm6ds3_xl_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_lp2_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t val)
+int32_t lsm6ds3_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx, lsm6ds3_lp_bw_t val)
 {
   lsm6ds3_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -2007,7 +1990,7 @@ int32_t lsm6ds3_xl_lp2_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t val)
   * @param  val         get the values of lpf2_xl_en in reg CTRL8_XL
   *
   */
-int32_t lsm6ds3_xl_lp2_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t *val)
+int32_t lsm6ds3_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx, lsm6ds3_lp_bw_t *val)
 {
   lsm6ds3_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -2043,7 +2026,7 @@ int32_t lsm6ds3_xl_lp2_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_xl_filter_analog_set(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t val)
+int32_t lsm6ds3_xl_filter_analog_set(stmdev_ctx_t *ctx, lsm6ds3_bw_xl_t val)
 {
   lsm6ds3_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -2063,7 +2046,7 @@ int32_t lsm6ds3_xl_filter_analog_set(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t val)
   * @param  val         get the values of bw_xl in reg CTRL1_XL
   *
   */
-int32_t lsm6ds3_xl_filter_analog_get(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t *val)
+int32_t lsm6ds3_xl_filter_analog_get(stmdev_ctx_t *ctx, lsm6ds3_bw_xl_t *val)
 {
   lsm6ds3_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -2112,7 +2095,7 @@ int32_t lsm6ds3_xl_filter_analog_get(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_spi_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t val)
+int32_t lsm6ds3_spi_mode_set(stmdev_ctx_t *ctx, lsm6ds3_sim_t val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2132,7 +2115,7 @@ int32_t lsm6ds3_spi_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t val)
   * @param  val         get the values of sim in reg CTRL3_C
   *
   */
-int32_t lsm6ds3_spi_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t *val)
+int32_t lsm6ds3_spi_mode_get(stmdev_ctx_t *ctx, lsm6ds3_sim_t *val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2162,7 +2145,7 @@ int32_t lsm6ds3_spi_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_i2c_interface_set(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t val)
+int32_t lsm6ds3_i2c_interface_set(stmdev_ctx_t *ctx, lsm6ds3_i2c_dis_t val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2182,7 +2165,7 @@ int32_t lsm6ds3_i2c_interface_set(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t val)
   * @param  val         get the values of i2c_disable in reg CTRL4_C
   *
   */
-int32_t lsm6ds3_i2c_interface_get(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t *val)
+int32_t lsm6ds3_i2c_interface_get(stmdev_ctx_t *ctx, lsm6ds3_i2c_dis_t *val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2224,7 +2207,7 @@ int32_t lsm6ds3_i2c_interface_get(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t *val)
   * @param  val          Select the signal that need to route on int1 pad.
   *
   */
-int32_t lsm6ds3_pin_int1_route_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm6ds3_int1_route_t *val)
 {
   lsm6ds3_int1_ctrl_t int1_ctrl;
@@ -2273,7 +2256,7 @@ int32_t lsm6ds3_pin_int1_route_set(lsm6ds3_ctx_t *ctx,
   * @param  val          Select the signal that need to route on int1 pad.
   *
   */
-int32_t lsm6ds3_pin_int1_route_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_int1_route_t *val)
 {
   lsm6ds3_int1_ctrl_t int1_ctrl;
@@ -2318,7 +2301,7 @@ int32_t lsm6ds3_pin_int1_route_get(lsm6ds3_ctx_t *ctx,
   * @param  val         Select the signal that need to route on int1 pad.
   *
   */
-int32_t lsm6ds3_pin_int2_route_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    lsm6ds3_int2_route_t *val)
 {
   lsm6ds3_int2_ctrl_t int2_ctrl;
@@ -2367,7 +2350,7 @@ int32_t lsm6ds3_pin_int2_route_set(lsm6ds3_ctx_t *ctx,
   * @param  val         Select the signal that need to route on int1 pad.
   *
   */
-int32_t lsm6ds3_pin_int2_route_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_pin_int2_route_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_int2_route_t *val)
 {
   lsm6ds3_int2_ctrl_t int2_ctrl;
@@ -2413,7 +2396,7 @@ int32_t lsm6ds3_pin_int2_route_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t val)
+int32_t lsm6ds3_pin_mode_set(stmdev_ctx_t *ctx, lsm6ds3_pp_od_t val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2433,7 +2416,7 @@ int32_t lsm6ds3_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t val)
   * @param  val         get the values of pp_od in reg CTRL3_C
   *
   */
-int32_t lsm6ds3_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t *val)
+int32_t lsm6ds3_pin_mode_get(stmdev_ctx_t *ctx, lsm6ds3_pp_od_t *val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2463,7 +2446,7 @@ int32_t lsm6ds3_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pin_polarity_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pin_pol_t val)
+int32_t lsm6ds3_pin_polarity_set(stmdev_ctx_t *ctx, lsm6ds3_pin_pol_t val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2483,7 +2466,7 @@ int32_t lsm6ds3_pin_polarity_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pin_pol_t val)
   * @param  val         get the values of h_lactive in reg CTRL3_C
   *
   */
-int32_t lsm6ds3_pin_polarity_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pin_pol_t *val)
+int32_t lsm6ds3_pin_polarity_get(stmdev_ctx_t *ctx, lsm6ds3_pin_pol_t *val)
 {
   lsm6ds3_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2513,7 +2496,7 @@ int32_t lsm6ds3_pin_polarity_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pin_pol_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_all_on_int1_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2534,7 +2517,7 @@ int32_t lsm6ds3_all_on_int1_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_all_on_int1_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2553,7 +2536,7 @@ int32_t lsm6ds3_all_on_int1_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_int_notification_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t val)
+int32_t lsm6ds3_int_notification_set(stmdev_ctx_t *ctx, lsm6ds3_lir_t val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2573,7 +2556,7 @@ int32_t lsm6ds3_int_notification_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t val)
   * @param  val         get the values of lir in reg TAP_CFG
   *
   */
-int32_t lsm6ds3_int_notification_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t *val)
+int32_t lsm6ds3_int_notification_get(stmdev_ctx_t *ctx, lsm6ds3_lir_t *val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2615,7 +2598,7 @@ int32_t lsm6ds3_int_notification_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t *val)
   * @param  val          Read the wake_up_src status flag of the device.
   *
   */
-int32_t lsm6ds3_wkup_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_wake_up_src_t *val)
+int32_t lsm6ds3_wkup_src_get(stmdev_ctx_t *ctx, lsm6ds3_wake_up_src_t *val)
 {
   int32_t ret;
 
@@ -2632,7 +2615,7 @@ int32_t lsm6ds3_wkup_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_wake_up_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_wkup_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2654,7 +2637,7 @@ int32_t lsm6ds3_wkup_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_wkup_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2673,7 +2656,7 @@ int32_t lsm6ds3_wkup_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_wkup_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2695,7 +2678,7 @@ int32_t lsm6ds3_wkup_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_wkup_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2727,7 +2710,7 @@ int32_t lsm6ds3_wkup_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_sleep_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2748,7 +2731,7 @@ int32_t lsm6ds3_gy_sleep_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_gy_sleep_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2767,7 +2750,7 @@ int32_t lsm6ds3_gy_sleep_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_act_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_act_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2788,7 +2771,7 @@ int32_t lsm6ds3_act_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @param  val         get the values of inactivity in reg WAKE_UP_THS
   *
   */
-int32_t lsm6ds3_act_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_act_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2807,7 +2790,7 @@ int32_t lsm6ds3_act_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_act_sleep_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2829,7 +2812,7 @@ int32_t lsm6ds3_act_sleep_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_act_sleep_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2860,7 +2843,7 @@ int32_t lsm6ds3_act_sleep_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @param  val          Read the tap_src status flag of the device.
   *
   */
-int32_t lsm6ds3_tap_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_src_t *val)
+int32_t lsm6ds3_tap_src_get(stmdev_ctx_t *ctx, lsm6ds3_tap_src_t *val)
 {
   int32_t ret;
 
@@ -2877,7 +2860,7 @@ int32_t lsm6ds3_tap_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_detection_on_z_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2898,7 +2881,7 @@ int32_t lsm6ds3_tap_detection_on_z_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_detection_on_z_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2917,7 +2900,7 @@ int32_t lsm6ds3_tap_detection_on_z_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_detection_on_y_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2938,7 +2921,7 @@ int32_t lsm6ds3_tap_detection_on_y_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_detection_on_y_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2957,7 +2940,7 @@ int32_t lsm6ds3_tap_detection_on_y_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_detection_on_x_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2978,7 +2961,7 @@ int32_t lsm6ds3_tap_detection_on_x_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_detection_on_x_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2997,7 +2980,7 @@ int32_t lsm6ds3_tap_detection_on_x_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3018,7 +3001,7 @@ int32_t lsm6ds3_tap_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3041,7 +3024,7 @@ int32_t lsm6ds3_tap_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_shock_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_int_dur2_t int_dur2;
   int32_t ret;
@@ -3066,7 +3049,7 @@ int32_t lsm6ds3_tap_shock_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_shock_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_int_dur2_t int_dur2;
   int32_t ret;
@@ -3089,7 +3072,7 @@ int32_t lsm6ds3_tap_shock_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_quiet_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_int_dur2_t int_dur2;
   int32_t ret;
@@ -3114,7 +3097,7 @@ int32_t lsm6ds3_tap_quiet_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_quiet_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_int_dur2_t int_dur2;
   int32_t ret;
@@ -3138,7 +3121,7 @@ int32_t lsm6ds3_tap_quiet_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_int_dur2_t int_dur2;
   int32_t ret;
@@ -3164,7 +3147,7 @@ int32_t lsm6ds3_tap_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_int_dur2_t int_dur2;
   int32_t ret;
@@ -3183,7 +3166,7 @@ int32_t lsm6ds3_tap_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tap_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t val)
+int32_t lsm6ds3_tap_mode_set(stmdev_ctx_t *ctx, lsm6ds3_tap_md_t val)
 {
   lsm6ds3_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -3204,7 +3187,7 @@ int32_t lsm6ds3_tap_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t val)
   * @param  val         get the values of single_double_tap in reg WAKE_UP_THS
   *
   */
-int32_t lsm6ds3_tap_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t *val)
+int32_t lsm6ds3_tap_mode_get(stmdev_ctx_t *ctx, lsm6ds3_tap_md_t *val)
 {
   lsm6ds3_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -3247,7 +3230,7 @@ int32_t lsm6ds3_tap_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_6d_feed_data_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_6d_feed_data_set(stmdev_ctx_t *ctx,
                                  lsm6ds3_low_pass_on_6d_t val)
 {
   lsm6ds3_ctrl8_xl_t ctrl8_xl;
@@ -3268,7 +3251,7 @@ int32_t lsm6ds3_6d_feed_data_set(lsm6ds3_ctx_t *ctx,
   * @param  val         get the values of low_pass_on_6d in reg CTRL8_XL
   *
   */
-int32_t lsm6ds3_6d_feed_data_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_6d_feed_data_get(stmdev_ctx_t *ctx,
                                  lsm6ds3_low_pass_on_6d_t *val)
 {
   lsm6ds3_ctrl8_xl_t ctrl8_xl;
@@ -3298,7 +3281,7 @@ int32_t lsm6ds3_6d_feed_data_get(lsm6ds3_ctx_t *ctx,
   * @param  val          Read the d6d_src status flag of the device.
   *
   */
-int32_t lsm6ds3_6d_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_d6d_src_t *val)
+int32_t lsm6ds3_6d_src_get(stmdev_ctx_t *ctx, lsm6ds3_d6d_src_t *val)
 {
   int32_t ret;
 
@@ -3315,7 +3298,7 @@ int32_t lsm6ds3_6d_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_d6d_src_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_6d_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t val)
+int32_t lsm6ds3_6d_threshold_set(stmdev_ctx_t *ctx, lsm6ds3_sixd_ths_t val)
 {
   lsm6ds3_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3336,7 +3319,7 @@ int32_t lsm6ds3_6d_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t val)
   * @param  val         get the values of sixd_ths in reg TAP_THS_6D
   *
   */
-int32_t lsm6ds3_6d_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t *val)
+int32_t lsm6ds3_6d_threshold_get(stmdev_ctx_t *ctx, lsm6ds3_sixd_ths_t *val)
 {
   lsm6ds3_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3372,7 +3355,7 @@ int32_t lsm6ds3_6d_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_4d_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3394,7 +3377,7 @@ int32_t lsm6ds3_4d_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_4d_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3426,7 +3409,7 @@ int32_t lsm6ds3_4d_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_ff_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t val)
+int32_t lsm6ds3_ff_threshold_set(stmdev_ctx_t *ctx, lsm6ds3_ff_ths_t val)
 {
   lsm6ds3_free_fall_t free_fall;
   int32_t ret;
@@ -3446,7 +3429,7 @@ int32_t lsm6ds3_ff_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t val)
   * @param  val         get the values of ff_ths in reg FREE_FALL
   *
   */
-int32_t lsm6ds3_ff_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t *val)
+int32_t lsm6ds3_ff_threshold_get(stmdev_ctx_t *ctx, lsm6ds3_ff_ths_t *val)
 {
   lsm6ds3_free_fall_t free_fall;
   int32_t ret;
@@ -3494,7 +3477,7 @@ int32_t lsm6ds3_ff_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_ff_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_free_fall_t free_fall;
   int32_t ret;
@@ -3515,7 +3498,7 @@ int32_t lsm6ds3_ff_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_ff_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_free_fall_t free_fall;
   int32_t ret;
@@ -3547,7 +3530,7 @@ int32_t lsm6ds3_ff_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_watermark_set(lsm6ds3_ctx_t *ctx, uint16_t val)
+int32_t lsm6ds3_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   lsm6ds3_fifo_ctrl1_t fifo_ctrl1;
   lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
@@ -3576,7 +3559,7 @@ int32_t lsm6ds3_fifo_watermark_set(lsm6ds3_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_watermark_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
+int32_t lsm6ds3_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6ds3_fifo_ctrl1_t fifo_ctrl1;
   lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
@@ -3599,7 +3582,7 @@ int32_t lsm6ds3_fifo_watermark_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_write_trigger_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_write_trigger_set(stmdev_ctx_t *ctx,
                                lsm6ds3_tmr_ped_fifo_drdy_t val)
 {
   lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
@@ -3621,7 +3604,7 @@ int32_t lsm6ds3_fifo_write_trigger_set(lsm6ds3_ctx_t *ctx,
   *                     reg FIFO_CTRL2
   *
   */
-int32_t lsm6ds3_fifo_write_trigger_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_write_trigger_get(stmdev_ctx_t *ctx,
                                        lsm6ds3_tmr_ped_fifo_drdy_t *val)
 {
   lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
@@ -3652,7 +3635,7 @@ int32_t lsm6ds3_fifo_write_trigger_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_pedo_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3674,7 +3657,7 @@ int32_t lsm6ds3_fifo_pedo_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_pedo_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3694,7 +3677,7 @@ int32_t lsm6ds3_fifo_pedo_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_xl_batch_set(lsm6ds3_ctx_t *ctx, lsm6ds3_dec_fifo_xl_t val)
+int32_t lsm6ds3_fifo_xl_batch_set(stmdev_ctx_t *ctx, lsm6ds3_dec_fifo_xl_t val)
 {
   lsm6ds3_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
@@ -3716,7 +3699,7 @@ int32_t lsm6ds3_fifo_xl_batch_set(lsm6ds3_ctx_t *ctx, lsm6ds3_dec_fifo_xl_t val)
   * @param  val         get the values of dec_fifo_xl in reg FIFO_CTRL3
   *
   */
-int32_t lsm6ds3_fifo_xl_batch_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                   lsm6ds3_dec_fifo_xl_t *val)
 {
   lsm6ds3_fifo_ctrl3_t fifo_ctrl3;
@@ -3766,7 +3749,7 @@ int32_t lsm6ds3_fifo_xl_batch_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_gy_batch_set(lsm6ds3_ctx_t *ctx, lsm6ds3_dec_fifo_gyro_t val)
+int32_t lsm6ds3_fifo_gy_batch_set(stmdev_ctx_t *ctx, lsm6ds3_dec_fifo_gyro_t val)
 {
   lsm6ds3_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
@@ -3788,7 +3771,7 @@ int32_t lsm6ds3_fifo_gy_batch_set(lsm6ds3_ctx_t *ctx, lsm6ds3_dec_fifo_gyro_t va
   * @param  val         get the values of dec_fifo_gyro in reg FIFO_CTRL3
   *
   */
-int32_t lsm6ds3_fifo_gy_batch_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                   lsm6ds3_dec_fifo_gyro_t *val)
 {
   lsm6ds3_fifo_ctrl3_t fifo_ctrl3;
@@ -3838,7 +3821,7 @@ int32_t lsm6ds3_fifo_gy_batch_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_dataset_3_batch_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
                                          lsm6ds3_dec_ds3_fifo_t val)
 {
   lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
@@ -3861,7 +3844,7 @@ int32_t lsm6ds3_fifo_dataset_3_batch_set(lsm6ds3_ctx_t *ctx,
   * @param  val         get the values of dec_ds3_fifo in reg FIFO_CTRL4
   *
   */
-int32_t lsm6ds3_fifo_dataset_3_batch_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
                                           lsm6ds3_dec_ds3_fifo_t *val)
 {
   lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
@@ -3911,7 +3894,7 @@ int32_t lsm6ds3_fifo_dataset_3_batch_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_dataset_4_batch_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
                                          lsm6ds3_dec_ds4_fifo_t val)
 {
   lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
@@ -3934,7 +3917,7 @@ int32_t lsm6ds3_fifo_dataset_4_batch_set(lsm6ds3_ctx_t *ctx,
   * @param  val         get the values of dec_ds4_fifo in reg FIFO_CTRL4
   *
   */
-int32_t lsm6ds3_fifo_dataset_4_batch_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
                                          lsm6ds3_dec_ds4_fifo_t *val)
 {
   lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
@@ -3983,7 +3966,7 @@ int32_t lsm6ds3_fifo_dataset_4_batch_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_xl_gy_8bit_format_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -4005,7 +3988,7 @@ int32_t lsm6ds3_fifo_xl_gy_8bit_format_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_xl_gy_8bit_format_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -4024,7 +4007,7 @@ int32_t lsm6ds3_fifo_xl_gy_8bit_format_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t val)
+int32_t lsm6ds3_fifo_mode_set(stmdev_ctx_t *ctx, lsm6ds3_fifo_md_t val)
 {
   lsm6ds3_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -4045,7 +4028,7 @@ int32_t lsm6ds3_fifo_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t val)
   * @param  val         get the values of fifo_mode in reg FIFO_CTRL5
   *
   */
-int32_t lsm6ds3_fifo_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t *val)
+int32_t lsm6ds3_fifo_mode_get(stmdev_ctx_t *ctx, lsm6ds3_fifo_md_t *val)
 {
   lsm6ds3_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -4081,7 +4064,7 @@ int32_t lsm6ds3_fifo_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_fifo_t val)
+int32_t lsm6ds3_fifo_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3_odr_fifo_t val)
 {
   lsm6ds3_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -4102,7 +4085,7 @@ int32_t lsm6ds3_fifo_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_fifo_t val)
   * @param  val         get the values of odr_fifo in reg FIFO_CTRL5
   *
   */
-int32_t lsm6ds3_fifo_data_rate_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_data_rate_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_odr_fifo_t *val)
 {
   lsm6ds3_fifo_ctrl5_t fifo_ctrl5;
@@ -4161,7 +4144,7 @@ int32_t lsm6ds3_fifo_data_rate_get(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_stop_on_wtm_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -4183,7 +4166,7 @@ int32_t lsm6ds3_fifo_stop_on_wtm_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_stop_on_wtm_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -4202,7 +4185,7 @@ int32_t lsm6ds3_fifo_stop_on_wtm_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_temp_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -4223,7 +4206,7 @@ int32_t lsm6ds3_fifo_temp_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_temp_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -4242,7 +4225,7 @@ int32_t lsm6ds3_fifo_temp_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_data_level_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
+int32_t lsm6ds3_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6ds3_fifo_status1_t fifo_status1;
   lsm6ds3_fifo_status2_t fifo_status2;
@@ -4269,7 +4252,7 @@ int32_t lsm6ds3_fifo_data_level_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_full_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_fifo_status2_t fifo_status2;
   int32_t ret;
@@ -4289,7 +4272,7 @@ int32_t lsm6ds3_fifo_full_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_ovr_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_fifo_status2_t fifo_status2;
   int32_t ret;
@@ -4309,7 +4292,7 @@ int32_t lsm6ds3_fifo_ovr_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_wtm_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_fifo_status2_t fifo_status2;
   int32_t ret;
@@ -4329,7 +4312,7 @@ int32_t lsm6ds3_fifo_wtm_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_fifo_pattern_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
+int32_t lsm6ds3_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6ds3_fifo_status3_t fifo_status3;
   lsm6ds3_fifo_status4_t fifo_status4;
@@ -4369,7 +4352,7 @@ int32_t lsm6ds3_fifo_pattern_get(lsm6ds3_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_den_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t val)
+int32_t lsm6ds3_den_mode_set(stmdev_ctx_t *ctx, lsm6ds3_den_mode_t val)
 {
   lsm6ds3_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -4391,7 +4374,7 @@ int32_t lsm6ds3_den_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_den_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t *val)
+int32_t lsm6ds3_den_mode_get(stmdev_ctx_t *ctx, lsm6ds3_den_mode_t *val)
 {
   lsm6ds3_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -4442,7 +4425,7 @@ int32_t lsm6ds3_den_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_step_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -4463,7 +4446,7 @@ int32_t lsm6ds3_pedo_step_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_step_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -4483,7 +4466,7 @@ int32_t lsm6ds3_pedo_step_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_pedo_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_pedo_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_read_reg(ctx, LSM6DS3_STEP_TIMESTAMP_L, buff, 2);
@@ -4499,7 +4482,7 @@ int32_t lsm6ds3_pedo_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_step_detect_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_pedo_step_detect_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_func_src_t func_src;
   int32_t ret;
@@ -4518,7 +4501,7 @@ int32_t lsm6ds3_pedo_step_detect_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   lsm6ds3_tap_cfg_t tap_cfg;
@@ -4553,7 +4536,7 @@ int32_t lsm6ds3_pedo_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4573,7 +4556,7 @@ int32_t lsm6ds3_pedo_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_pedo_ths_reg_t pedo_ths_reg;
   int32_t ret;
@@ -4603,7 +4586,7 @@ int32_t lsm6ds3_pedo_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_pedo_ths_reg_t pedo_ths_reg;
   int32_t ret;
@@ -4629,7 +4612,7 @@ int32_t lsm6ds3_pedo_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pedo_fs_t val)
+int32_t lsm6ds3_pedo_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3_pedo_fs_t val)
 {
   lsm6ds3_pedo_ths_reg_t pedo_ths_reg;
   int32_t ret;
@@ -4658,7 +4641,7 @@ int32_t lsm6ds3_pedo_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pedo_fs_t val)
   * @param  val         get the values of pedo_4g in reg PEDO_THS_REG
   *
   */
-int32_t lsm6ds3_pedo_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pedo_fs_t *val)
+int32_t lsm6ds3_pedo_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3_pedo_fs_t *val)
 {
   lsm6ds3_pedo_ths_reg_t pedo_ths_reg;
   int32_t ret;
@@ -4694,7 +4677,7 @@ int32_t lsm6ds3_pedo_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pedo_fs_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_debounce_steps_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -4723,7 +4706,7 @@ int32_t lsm6ds3_pedo_debounce_steps_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_debounce_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -4749,7 +4732,7 @@ int32_t lsm6ds3_pedo_debounce_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_timeout_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -4779,7 +4762,7 @@ int32_t lsm6ds3_pedo_timeout_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_pedo_timeout_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -4817,7 +4800,7 @@ int32_t lsm6ds3_pedo_timeout_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_motion_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -4841,7 +4824,7 @@ int32_t lsm6ds3_motion_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_motion_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -4861,7 +4844,7 @@ int32_t lsm6ds3_motion_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_motion_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_motion_event_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_func_src_t func_src;
   int32_t ret;
@@ -4880,7 +4863,7 @@ int32_t lsm6ds3_motion_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_motion_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_sm_ths_t sm_ths;
   int32_t ret;
@@ -4907,7 +4890,7 @@ int32_t lsm6ds3_motion_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_motion_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_sm_ths_t sm_ths;
   int32_t ret;
@@ -4932,7 +4915,7 @@ int32_t lsm6ds3_motion_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sc_delta_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_sc_delta_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_step_count_delta_t  step_count_delta;
   int32_t ret;
@@ -4962,7 +4945,7 @@ int32_t lsm6ds3_sc_delta_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sc_delta_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_sc_delta_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_step_count_delta_t  step_count_delta;
   int32_t ret;
@@ -5000,7 +4983,7 @@ int32_t lsm6ds3_sc_delta_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tilt_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tilt_event_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_func_src_t func_src;
   int32_t ret;
@@ -5019,7 +5002,7 @@ int32_t lsm6ds3_tilt_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tilt_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   lsm6ds3_tap_cfg_t tap_cfg;
@@ -5051,7 +5034,7 @@ int32_t lsm6ds3_tilt_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_tilt_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -5083,7 +5066,7 @@ int32_t lsm6ds3_tilt_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_mag_soft_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   lsm6ds3_ctrl9_xl_t ctrl9_xl;
@@ -5115,7 +5098,7 @@ int32_t lsm6ds3_mag_soft_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_mag_soft_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5134,7 +5117,7 @@ int32_t lsm6ds3_mag_soft_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_mag_hard_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   lsm6ds3_master_config_t master_config;
@@ -5168,7 +5151,7 @@ int32_t lsm6ds3_mag_hard_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_mag_hard_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_master_config_t master_config;
   int32_t ret;
@@ -5188,7 +5171,7 @@ int32_t lsm6ds3_mag_hard_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_mag_soft_iron_end_op_flag_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_mag_soft_iron_end_op_flag_get(stmdev_ctx_t *ctx,
                                                uint8_t *val)
 {
   lsm6ds3_func_src_t func_src;
@@ -5207,7 +5190,7 @@ int32_t lsm6ds3_mag_soft_iron_end_op_flag_get(lsm6ds3_ctx_t *ctx,
   * @param  buff        buffer that stores data to be write
   *
   */
-int32_t lsm6ds3_mag_soft_iron_coeff_set(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_mag_soft_iron_coeff_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6ds3_mem_bank_set(ctx, LSM6DS3_EMBEDDED_FUNC_BANK);
@@ -5227,7 +5210,7 @@ int32_t lsm6ds3_mag_soft_iron_coeff_set(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_mag_soft_iron_coeff_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_mag_soft_iron_coeff_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5249,7 +5232,7 @@ int32_t lsm6ds3_mag_soft_iron_coeff_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data to be write
   *
   */
-int32_t lsm6ds3_mag_offset_set(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5271,7 +5254,7 @@ int32_t lsm6ds3_mag_offset_set(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_mag_offset_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6ds3_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5307,7 +5290,7 @@ int32_t lsm6ds3_mag_offset_get(lsm6ds3_ctx_t *ctx, uint8_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_sync_sens_frame_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_sensor_sync_time_frame_t  sensor_sync_time_frame;
   int32_t ret;
@@ -5331,7 +5314,7 @@ int32_t lsm6ds3_sh_sync_sens_frame_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_sync_sens_frame_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_sensor_sync_time_frame_t  sensor_sync_time_frame;
   int32_t ret;
@@ -5350,7 +5333,7 @@ int32_t lsm6ds3_sh_sync_sens_frame_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_master_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_ctrl10_c_t ctrl10_c;
   lsm6ds3_master_config_t master_config;
@@ -5384,7 +5367,7 @@ int32_t lsm6ds3_sh_master_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_master_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_master_config_t master_config;
   int32_t ret;
@@ -5404,7 +5387,7 @@ int32_t lsm6ds3_sh_master_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_pass_through_set(lsm6ds3_ctx_t *ctx, uint8_t val)
+int32_t lsm6ds3_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6ds3_master_config_t master_config;
   int32_t ret;
@@ -5427,7 +5410,7 @@ int32_t lsm6ds3_sh_pass_through_set(lsm6ds3_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_pass_through_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_master_config_t master_config;
   int32_t ret;
@@ -5446,7 +5429,7 @@ int32_t lsm6ds3_sh_pass_through_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t val)
+int32_t lsm6ds3_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6ds3_sh_pin_md_t val)
 {
   lsm6ds3_master_config_t master_config;
   int32_t ret;
@@ -5468,7 +5451,7 @@ int32_t lsm6ds3_sh_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t val)
   * @param  val         get the values of pull_up_en in reg MASTER_CONFIG
   *
   */
-int32_t lsm6ds3_sh_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t *val)
+int32_t lsm6ds3_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6ds3_sh_pin_md_t *val)
 {
   lsm6ds3_master_config_t master_config;
   int32_t ret;
@@ -5499,7 +5482,7 @@ int32_t lsm6ds3_sh_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_syncro_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_start_cfg_t val)
+int32_t lsm6ds3_sh_syncro_mode_set(stmdev_ctx_t *ctx, lsm6ds3_start_cfg_t val)
 {
   lsm6ds3_master_config_t master_config;
   int32_t ret;
@@ -5521,7 +5504,7 @@ int32_t lsm6ds3_sh_syncro_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_start_cfg_t val)
   * @param  val         get the values of start_config in reg MASTER_CONFIG
   *
   */
-int32_t lsm6ds3_sh_syncro_mode_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_start_cfg_t *val)
 {
   lsm6ds3_master_config_t master_config;
@@ -5552,7 +5535,7 @@ int32_t lsm6ds3_sh_syncro_mode_get(lsm6ds3_ctx_t *ctx,
   * @param  buff        buffer that stores data read
   *
   */
-int32_t lsm6ds3_sh_read_data_raw_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                      lsm6ds3_sh_read_t *buff)
 {
   int32_t ret;
@@ -5569,14 +5552,14 @@ int32_t lsm6ds3_sh_read_data_raw_get(lsm6ds3_ctx_t *ctx,
 /**
   * @brief  sh_cfg_write: Configure slave 0 for perform a write.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_sh_cfg_write_t: a structure that contain
   *                      - uint8_t slv1_add;    8 bit i2c device address
   *                      - uint8_t slv1_subadd; 8 bit register device address
   *                      - uint8_t slv1_data;   8 bit data to write
   *
   */
-int32_t lsm6ds3_sh_cfg_write(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_cfg_write_t *val)
+int32_t lsm6ds3_sh_cfg_write(stmdev_ctx_t *ctx, lsm6ds3_sh_cfg_write_t *val)
 {
   lsm6ds3_slv0_add_t slv0_add;
   int32_t ret;
@@ -5605,14 +5588,14 @@ int32_t lsm6ds3_sh_cfg_write(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_cfg_write_t *val)
 /**
   * @brief  sh_slv0_cfg_read: [get] Configure slave 0 for perform a write/read.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_sh_cfg_read_t: a structure that contain
   *                      - uint8_t slv1_add;    8 bit i2c device address
   *                      - uint8_t slv1_subadd; 8 bit register device address
   *                      - uint8_t slv1_len;    num of bit to read
   *
   */
-int32_t lsm6ds3_sh_slv0_cfg_read(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6ds3_sh_cfg_read_t *val)
 {
   lsm6ds3_slv0_add_t slv0_add;
@@ -5647,14 +5630,14 @@ int32_t lsm6ds3_sh_slv0_cfg_read(lsm6ds3_ctx_t *ctx,
 /**
   * @brief  sh_slv1_cfg_read: [get] Configure slave 0 for perform a write/read.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_sh_cfg_read_t: a structure that contain
   *                      - uint8_t slv1_add;    8 bit i2c device address
   *                      - uint8_t slv1_subadd; 8 bit register device address
   *                      - uint8_t slv1_len;    num of bit to read
   *
   */
-int32_t lsm6ds3_sh_slv1_cfg_read(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6ds3_sh_cfg_read_t *val)
 {
   lsm6ds3_slv1_add_t slv1_add;
@@ -5687,14 +5670,14 @@ int32_t lsm6ds3_sh_slv1_cfg_read(lsm6ds3_ctx_t *ctx,
 /**
   * @brief  sh_slv2_cfg_read: [get] Configure slave 0 for perform a write/read.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_sh_cfg_read_t: a structure that contain
   *                      - uint8_t slv2_add;    8 bit i2c device address
   *                      - uint8_t slv2_subadd; 8 bit register device address
   *                      - uint8_t slv2_len;    num of bit to read
   *
   */
-int32_t lsm6ds3_sh_slv2_cfg_read(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6ds3_sh_cfg_read_t *val)
 {
   lsm6ds3_slv2_add_t slv2_add;
@@ -5730,14 +5713,14 @@ int32_t lsm6ds3_sh_slv2_cfg_read(lsm6ds3_ctx_t *ctx,
 /**
   * @brief  sh_slv3_cfg_read: [get] Configure slave 0 for perform a write/read.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_sh_cfg_read_t: a structure that contain
   *                      - uint8_t slv3_add;    8 bit i2c device address
   *                      - uint8_t slv3_subadd; 8 bit register device address
   *                      - uint8_t slv3_len;    num of bit to read
   *
   */
-int32_t lsm6ds3_sh_slv3_cfg_read(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6ds3_sh_cfg_read_t *val)
 {
   lsm6ds3_slv3_add_t slv3_add;
@@ -5777,7 +5760,7 @@ int32_t lsm6ds3_sh_slv3_cfg_read(lsm6ds3_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6ds3_sh_end_op_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
+int32_t lsm6ds3_sh_end_op_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6ds3_func_src_t func_src;
   int32_t ret;
@@ -5793,11 +5776,11 @@ int32_t lsm6ds3_sh_end_op_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val)
   *                                     wake-up and Activity/Inactivity
   *                                     functions.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_slope_fds_t: change the values of slope_fds in reg TAP_CFG
   *
   */
-int32_t lsm6ds3_xl_hp_path_internal_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         lsm6ds3_slope_fds_t val)
 {
   lsm6ds3_tap_cfg_t tap_cfg;
@@ -5816,11 +5799,11 @@ int32_t lsm6ds3_xl_hp_path_internal_set(lsm6ds3_ctx_t *ctx,
   *                                     wake-up and Activity/Inactivity
   *                                     functions.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_slope_fds_t: Get the values of slope_fds in reg TAP_CFG
   *
   */
-int32_t lsm6ds3_xl_hp_path_internal_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         lsm6ds3_slope_fds_t *val)
 {
   lsm6ds3_tap_cfg_t reg;
@@ -5846,12 +5829,12 @@ int32_t lsm6ds3_xl_hp_path_internal_get(lsm6ds3_ctx_t *ctx,
   * @brief   sh_num_of_dev_connected: [set] Number of external sensors to
   *                                         be read by the sensor hub.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_aux_sens_on_t: change the values of aux_sens_on in
   *                                reg SLAVE0_CONFIG
   *
   */
-int32_t lsm6ds3_sh_num_of_dev_connected_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
                                             lsm6ds3_aux_sens_on_t val)
 {
   lsm6ds3_slave0_config_t reg;
@@ -5875,12 +5858,12 @@ int32_t lsm6ds3_sh_num_of_dev_connected_set(lsm6ds3_ctx_t *ctx,
   * @brief   sh_num_of_dev_connected: [get] Number of external sensors to
   *                                         be read by the sensor hub.
   *
-  * @param  lsm6ds3_ctx_t *ctx: read / write interface definitions
+  * @param  stmdev_ctx_t *ctx: read / write interface definitions
   * @param  lsm6ds3_aux_sens_on_t: Get the values of aux_sens_on in
   *                                reg SLAVE0_CONFIG
   *
   */
-int32_t lsm6ds3_sh_num_of_dev_connected_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
                                             lsm6ds3_aux_sens_on_t *val)
 {
   lsm6ds3_slave0_config_t reg;

--- a/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.h
+++ b/sensor/stmemsc/lsm6ds3_STdC/driver/lsm6ds3_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef LSM6DS3_REGS_H
 #define LSM6DS3_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup LSM6DS3_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LSM6DS3_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -125,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lsm6ds3_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lsm6ds3_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lsm6ds3_write_ptr  write_reg;
-  lsm6ds3_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lsm6ds3_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -950,9 +923,9 @@ typedef union{
   *
   */
 
-int32_t lsm6ds3_read_reg(lsm6ds3_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6ds3_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lsm6ds3_write_reg(lsm6ds3_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6ds3_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float_t lsm6ds3_from_fs2g_to_mg(int16_t lsb);
@@ -976,9 +949,9 @@ typedef enum {
   LSM6DS3_GY_ORIENT_ZXY = 4,
   LSM6DS3_GY_ORIENT_ZYX = 5,
 } lsm6ds3_gy_orient_t;
-int32_t lsm6ds3_gy_data_orient_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_gy_data_orient_set(stmdev_ctx_t *ctx,
                                    lsm6ds3_gy_orient_t val);
-int32_t lsm6ds3_gy_data_orient_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_gy_data_orient_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_gy_orient_t *val);
 
 typedef enum {
@@ -991,8 +964,8 @@ typedef enum {
   LSM6DS3_GY_SIGN_PNN = 3,
   LSM6DS3_GY_SIGN_NNN = 7,
 } lsm6ds3_gy_sgn_t;
-int32_t lsm6ds3_gy_data_sign_set(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t val);
-int32_t lsm6ds3_gy_data_sign_get(lsm6ds3_ctx_t *ctx, lsm6ds3_gy_sgn_t *val);
+int32_t lsm6ds3_gy_data_sign_set(stmdev_ctx_t *ctx, lsm6ds3_gy_sgn_t val);
+int32_t lsm6ds3_gy_data_sign_get(stmdev_ctx_t *ctx, lsm6ds3_gy_sgn_t *val);
 
 typedef enum {
   LSM6DS3_2g  = 0,
@@ -1000,8 +973,8 @@ typedef enum {
   LSM6DS3_4g  = 2,
   LSM6DS3_8g  = 3,
 } lsm6ds3_xl_fs_t;
-int32_t lsm6ds3_xl_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t val);
-int32_t lsm6ds3_xl_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_xl_fs_t *val);
+int32_t lsm6ds3_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3_xl_fs_t val);
+int32_t lsm6ds3_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3_xl_fs_t *val);
 
 typedef enum {
   LSM6DS3_XL_ODR_OFF    = 0,
@@ -1016,8 +989,8 @@ typedef enum {
   LSM6DS3_XL_ODR_3k33Hz = 9,
   LSM6DS3_XL_ODR_6k66Hz = 10,
 } lsm6ds3_odr_xl_t;
-int32_t lsm6ds3_xl_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t val);
-int32_t lsm6ds3_xl_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_xl_t *val);
+int32_t lsm6ds3_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3_odr_xl_t val);
+int32_t lsm6ds3_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3_odr_xl_t *val);
 
 typedef enum {
   LSM6DS3_250dps   = 0,
@@ -1026,8 +999,8 @@ typedef enum {
   LSM6DS3_1000dps  = 4,
   LSM6DS3_2000dps  = 6,
 } lsm6ds3_fs_g_t;
-int32_t lsm6ds3_gy_full_scale_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t val);
-int32_t lsm6ds3_gy_full_scale_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fs_g_t *val);
+int32_t lsm6ds3_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3_fs_g_t val);
+int32_t lsm6ds3_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3_fs_g_t *val);
 
 typedef enum {
   LSM6DS3_GY_ODR_OFF    = 0,
@@ -1040,56 +1013,56 @@ typedef enum {
   LSM6DS3_GY_ODR_833Hz  = 7,
   LSM6DS3_GY_ODR_1k66Hz = 8,
 } lsm6ds3_odr_g_t;
-int32_t lsm6ds3_gy_data_rate_set(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t val);
-int32_t lsm6ds3_gy_data_rate_get(lsm6ds3_ctx_t *ctx, lsm6ds3_odr_g_t *val);
+int32_t lsm6ds3_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3_odr_g_t val);
+int32_t lsm6ds3_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3_odr_g_t *val);
 
-int32_t lsm6ds3_block_data_update_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_block_data_update_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_XL_HIGH_PERFORMANCE = 0,
   LSM6DS3_XL_NORMAL           = 1,
 } lsm6ds3_xl_hm_mode_t;
-int32_t lsm6ds3_xl_power_mode_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_xl_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6ds3_xl_hm_mode_t val);
-int32_t lsm6ds3_xl_power_mode_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_xl_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6ds3_xl_hm_mode_t *val);
 
 typedef enum {
   LSM6DS3_STAT_RND_DISABLE = 0,
   LSM6DS3_STAT_RND_ENABLE  = 1,
 } lsm6ds3_rnd_stat_t;
-int32_t lsm6ds3_rounding_on_status_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_rounding_on_status_set(stmdev_ctx_t *ctx,
                                        lsm6ds3_rnd_stat_t val);
-int32_t lsm6ds3_rounding_on_status_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_rounding_on_status_get(stmdev_ctx_t *ctx,
                                        lsm6ds3_rnd_stat_t *val);
 
 typedef enum {
   LSM6DS3_GY_HIGH_PERFORMANCE = 0,
   LSM6DS3_GY_NORMAL           = 1,
 } lsm6ds3_g_hm_mode_t;
-int32_t lsm6ds3_gy_power_mode_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_gy_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6ds3_g_hm_mode_t val);
-int32_t lsm6ds3_gy_power_mode_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_gy_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6ds3_g_hm_mode_t *val);
 
-int32_t lsm6ds3_xl_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_xl_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_xl_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_xl_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_xl_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_xl_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_xl_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_xl_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_xl_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_xl_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_xl_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_xl_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_gy_axis_x_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_gy_axis_x_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_gy_axis_x_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_axis_x_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_gy_axis_y_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_gy_axis_y_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_gy_axis_y_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_axis_y_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_gy_axis_z_data_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_gy_axis_z_data_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_gy_axis_z_data_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_axis_z_data_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   lsm6ds3_wake_up_src_t  wake_up_src;
@@ -1097,28 +1070,28 @@ typedef struct {
   lsm6ds3_d6d_src_t      d6d_src;
   lsm6ds3_func_src_t     func_src;
 } lsm6ds3_all_src_t;
-int32_t lsm6ds3_all_sources_get(lsm6ds3_ctx_t *ctx, lsm6ds3_all_src_t *val);
+int32_t lsm6ds3_all_sources_get(stmdev_ctx_t *ctx, lsm6ds3_all_src_t *val);
 
-int32_t lsm6ds3_status_reg_get(lsm6ds3_ctx_t *ctx, lsm6ds3_status_reg_t *val);
+int32_t lsm6ds3_status_reg_get(stmdev_ctx_t *ctx, lsm6ds3_status_reg_t *val);
 
-int32_t lsm6ds3_xl_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_gy_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_temp_flag_data_ready_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_timestamp_rst_set(lsm6ds3_ctx_t *ctx);
+int32_t lsm6ds3_timestamp_rst_set(stmdev_ctx_t *ctx);
 
-int32_t lsm6ds3_timestamp_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_timestamp_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 typedef enum {
   LSM6DS3_LSB_6ms4 = 0,
   LSM6DS3_LSB_25us = 1,
 } lsm6ds3_ts_res_t;
-int32_t lsm6ds3_timestamp_res_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t val);
-int32_t lsm6ds3_timestamp_res_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ts_res_t *val);
+int32_t lsm6ds3_timestamp_res_set(stmdev_ctx_t *ctx, lsm6ds3_ts_res_t val);
+int32_t lsm6ds3_timestamp_res_get(stmdev_ctx_t *ctx, lsm6ds3_ts_res_t *val);
 
 typedef enum {
   LSM6DS3_ROUND_DISABLE             = 0,
@@ -1130,66 +1103,66 @@ typedef enum {
   LSM6DS3_ROUND_GY_XL_SH1_TO_SH12   = 6,
   LSM6DS3_ROUND_GY_XL_SH1_TO_SH6    = 7,
 } lsm6ds3_rounding_t;
-int32_t lsm6ds3_rounding_mode_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_rounding_mode_set(stmdev_ctx_t *ctx,
                                   lsm6ds3_rounding_t val);
-int32_t lsm6ds3_rounding_mode_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_rounding_mode_get(stmdev_ctx_t *ctx,
                                   lsm6ds3_rounding_t *val);
 
-int32_t lsm6ds3_temperature_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_angular_rate_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_acceleration_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_fifo_raw_data_get(lsm6ds3_ctx_t *ctx, uint8_t *buffer, uint8_t len);
+int32_t lsm6ds3_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer, uint8_t len);
 
-int32_t lsm6ds3_number_of_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_mag_calibrated_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM6DS3_USER_BANK                                = 0,
   LSM6DS3_EMBEDDED_FUNC_BANK                       = 1,
 } lsm6ds3_func_cfg_en_t;
-int32_t lsm6ds3_mem_bank_set(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t val);
-int32_t lsm6ds3_mem_bank_get(lsm6ds3_ctx_t *ctx, lsm6ds3_func_cfg_en_t *val);
+int32_t lsm6ds3_mem_bank_set(stmdev_ctx_t *ctx, lsm6ds3_func_cfg_en_t val);
+int32_t lsm6ds3_mem_bank_get(stmdev_ctx_t *ctx, lsm6ds3_func_cfg_en_t *val);
 
-int32_t lsm6ds3_device_id_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_LSB_AT_LOW_ADD = 0,
   LSM6DS3_MSB_AT_LOW_ADD = 1,
 } lsm6ds3_ble_t;
-int32_t lsm6ds3_data_format_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t val);
-int32_t lsm6ds3_data_format_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ble_t *val);
+int32_t lsm6ds3_data_format_set(stmdev_ctx_t *ctx, lsm6ds3_ble_t val);
+int32_t lsm6ds3_data_format_get(stmdev_ctx_t *ctx, lsm6ds3_ble_t *val);
 
-int32_t lsm6ds3_auto_increment_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_auto_increment_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_boot_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_boot_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_XL_ST_DISABLE  = 0,
   LSM6DS3_XL_ST_POSITIVE = 1,
   LSM6DS3_XL_ST_NEGATIVE = 2,
 } lsm6ds3_st_xl_t;
-int32_t lsm6ds3_xl_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t val);
-int32_t lsm6ds3_xl_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_xl_t *val);
+int32_t lsm6ds3_xl_self_test_set(stmdev_ctx_t *ctx, lsm6ds3_st_xl_t val);
+int32_t lsm6ds3_xl_self_test_get(stmdev_ctx_t *ctx, lsm6ds3_st_xl_t *val);
 
 typedef enum {
   LSM6DS3_GY_ST_DISABLE  = 0,
   LSM6DS3_GY_ST_POSITIVE = 1,
   LSM6DS3_GY_ST_NEGATIVE = 3,
 } lsm6ds3_st_g_t;
-int32_t lsm6ds3_gy_self_test_set(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t val);
-int32_t lsm6ds3_gy_self_test_get(lsm6ds3_ctx_t *ctx, lsm6ds3_st_g_t *val);
+int32_t lsm6ds3_gy_self_test_set(stmdev_ctx_t *ctx, lsm6ds3_st_g_t val);
+int32_t lsm6ds3_gy_self_test_get(stmdev_ctx_t *ctx, lsm6ds3_st_g_t *val);
 
-int32_t lsm6ds3_filter_settling_mask_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_filter_settling_mask_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_HP_CUT_OFF_8mHz1   = 0,
@@ -1197,11 +1170,11 @@ typedef enum {
   LSM6DS3_HP_CUT_OFF_2Hz07   = 2,
   LSM6DS3_HP_CUT_OFF_16Hz32  = 3,
 } lsm6ds3_hpcf_g_t;
-int32_t lsm6ds3_gy_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t val);
-int32_t lsm6ds3_gy_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hpcf_g_t *val);
+int32_t lsm6ds3_gy_hp_bandwidth_set(stmdev_ctx_t *ctx, lsm6ds3_hpcf_g_t val);
+int32_t lsm6ds3_gy_hp_bandwidth_get(stmdev_ctx_t *ctx, lsm6ds3_hpcf_g_t *val);
 
-int32_t lsm6ds3_gy_hp_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_gy_hp_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_gy_hp_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_hp_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_XL_HP_ODR_DIV_4   = 0,
@@ -1209,8 +1182,8 @@ typedef enum {
   LSM6DS3_XL_HP_ODR_DIV_9   = 2,
   LSM6DS3_XL_HP_ODR_DIV_400 = 3,
 } lsm6ds3_hp_bw_t;
-int32_t lsm6ds3_xl_hp_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t val);
-int32_t lsm6ds3_xl_hp_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_hp_bw_t *val);
+int32_t lsm6ds3_xl_hp_bandwidth_set(stmdev_ctx_t *ctx, lsm6ds3_hp_bw_t val);
+int32_t lsm6ds3_xl_hp_bandwidth_get(stmdev_ctx_t *ctx, lsm6ds3_hp_bw_t *val);
 
 typedef enum {
   LSM6DS3_XL_LP_ODR_DIV_50  = 0,
@@ -1218,8 +1191,8 @@ typedef enum {
   LSM6DS3_XL_LP_ODR_DIV_9   = 2,
   LSM6DS3_XL_LP_ODR_DIV_400 = 3,
 } lsm6ds3_lp_bw_t;
-int32_t lsm6ds3_xl_lp2_bandwidth_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t val);
-int32_t lsm6ds3_xl_lp2_bandwidth_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lp_bw_t *val);
+int32_t lsm6ds3_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx, lsm6ds3_lp_bw_t val);
+int32_t lsm6ds3_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx, lsm6ds3_lp_bw_t *val);
 
 typedef enum {
   LSM6DS3_ANTI_ALIASING_400Hz = 0,
@@ -1227,22 +1200,22 @@ typedef enum {
   LSM6DS3_ANTI_ALIASING_100Hz = 2,
   LSM6DS3_ANTI_ALIASING_50Hz  = 3,
 } lsm6ds3_bw_xl_t;
-int32_t lsm6ds3_xl_filter_analog_set(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t val);
-int32_t lsm6ds3_xl_filter_analog_get(lsm6ds3_ctx_t *ctx, lsm6ds3_bw_xl_t *val);
+int32_t lsm6ds3_xl_filter_analog_set(stmdev_ctx_t *ctx, lsm6ds3_bw_xl_t val);
+int32_t lsm6ds3_xl_filter_analog_get(stmdev_ctx_t *ctx, lsm6ds3_bw_xl_t *val);
 
 typedef enum {
   LSM6DS3_SPI_4_WIRE = 0,
   LSM6DS3_SPI_3_WIRE = 1,
 } lsm6ds3_sim_t;
-int32_t lsm6ds3_spi_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t val);
-int32_t lsm6ds3_spi_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sim_t *val);
+int32_t lsm6ds3_spi_mode_set(stmdev_ctx_t *ctx, lsm6ds3_sim_t val);
+int32_t lsm6ds3_spi_mode_get(stmdev_ctx_t *ctx, lsm6ds3_sim_t *val);
 
 typedef enum {
   LSM6DS3_I2C_ENABLE  = 0,
   LSM6DS3_I2C_DISABLE = 1,
 } lsm6ds3_i2c_dis_t;
-int32_t lsm6ds3_i2c_interface_set(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t val);
-int32_t lsm6ds3_i2c_interface_get(lsm6ds3_ctx_t *ctx, lsm6ds3_i2c_dis_t *val);
+int32_t lsm6ds3_i2c_interface_set(stmdev_ctx_t *ctx, lsm6ds3_i2c_dis_t val);
+int32_t lsm6ds3_i2c_interface_get(stmdev_ctx_t *ctx, lsm6ds3_i2c_dis_t *val);
 
 typedef struct {
   uint8_t  int1_drdy_xl         : 1;
@@ -1263,9 +1236,9 @@ typedef struct {
   uint8_t  int1_inact_state     : 1;
   uint8_t  drdy_on_int1         : 1;
 } lsm6ds3_int1_route_t;
-int32_t lsm6ds3_pin_int1_route_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm6ds3_int1_route_t *val);
-int32_t lsm6ds3_pin_int1_route_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_int1_route_t *val);
 
 typedef struct {
@@ -1287,90 +1260,90 @@ typedef struct {
   uint8_t int2_inact_state      : 1;
   uint8_t start_config          : 1;
 } lsm6ds3_int2_route_t;
-int32_t lsm6ds3_pin_int2_route_set(lsm6ds3_ctx_t *ctx, lsm6ds3_int2_route_t *val);
-int32_t lsm6ds3_pin_int2_route_get(lsm6ds3_ctx_t *ctx, lsm6ds3_int2_route_t *val);
+int32_t lsm6ds3_pin_int2_route_set(stmdev_ctx_t *ctx, lsm6ds3_int2_route_t *val);
+int32_t lsm6ds3_pin_int2_route_get(stmdev_ctx_t *ctx, lsm6ds3_int2_route_t *val);
 
 typedef enum {
   LSM6DS3_PUSH_PULL  = 0,
   LSM6DS3_OPEN_DRAIN = 1,
 } lsm6ds3_pp_od_t;
-int32_t lsm6ds3_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t val);
-int32_t lsm6ds3_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_pp_od_t *val);
+int32_t lsm6ds3_pin_mode_set(stmdev_ctx_t *ctx, lsm6ds3_pp_od_t val);
+int32_t lsm6ds3_pin_mode_get(stmdev_ctx_t *ctx, lsm6ds3_pp_od_t *val);
 
 typedef enum {
   LSM6DS3_ACTIVE_HIGH = 0,
   LSM6DS3_ACTIVE_LOW  = 1,
 } lsm6ds3_pin_pol_t;
-int32_t lsm6ds3_pin_polarity_set(lsm6ds3_ctx_t *ctx, lsm6ds3_pin_pol_t val);
-int32_t lsm6ds3_pin_polarity_get(lsm6ds3_ctx_t *ctx,  lsm6ds3_pin_pol_t *val);
+int32_t lsm6ds3_pin_polarity_set(stmdev_ctx_t *ctx, lsm6ds3_pin_pol_t val);
+int32_t lsm6ds3_pin_polarity_get(stmdev_ctx_t *ctx,  lsm6ds3_pin_pol_t *val);
 
-int32_t lsm6ds3_all_on_int1_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_all_on_int1_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_INT_PULSED  = 0,
   LSM6DS3_INT_LATCHED = 1,
 } lsm6ds3_lir_t;
-int32_t lsm6ds3_int_notification_set(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t val);
-int32_t lsm6ds3_int_notification_get(lsm6ds3_ctx_t *ctx, lsm6ds3_lir_t *val);
+int32_t lsm6ds3_int_notification_set(stmdev_ctx_t *ctx, lsm6ds3_lir_t val);
+int32_t lsm6ds3_int_notification_get(stmdev_ctx_t *ctx, lsm6ds3_lir_t *val);
 
-int32_t lsm6ds3_wkup_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_wake_up_src_t *val);
+int32_t lsm6ds3_wkup_src_get(stmdev_ctx_t *ctx, lsm6ds3_wake_up_src_t *val);
 
-int32_t lsm6ds3_wkup_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_wkup_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_wkup_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_wkup_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_gy_sleep_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_gy_sleep_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_act_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_act_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_act_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_act_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_act_sleep_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_act_sleep_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tap_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_src_t *val);
+int32_t lsm6ds3_tap_src_get(stmdev_ctx_t *ctx, lsm6ds3_tap_src_t *val);
 
-int32_t lsm6ds3_tap_detection_on_z_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_tap_detection_on_z_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tap_detection_on_y_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_tap_detection_on_y_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tap_detection_on_x_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_tap_detection_on_x_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tap_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_tap_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tap_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tap_shock_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_tap_shock_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tap_quiet_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_tap_quiet_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tap_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_tap_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_ONLY_DOUBLE = 1,
   LSM6DS3_SINGLE_DOUBLE = 0,
 } lsm6ds3_tap_md_t;
-int32_t lsm6ds3_tap_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t val);
-int32_t lsm6ds3_tap_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_tap_md_t *val);
+int32_t lsm6ds3_tap_mode_set(stmdev_ctx_t *ctx, lsm6ds3_tap_md_t val);
+int32_t lsm6ds3_tap_mode_get(stmdev_ctx_t *ctx, lsm6ds3_tap_md_t *val);
 
 typedef enum {
   LSM6DS3_ODR_DIV_2_FEED = 0,
   LSM6DS3_LPF2_FEED = 1,
 } lsm6ds3_low_pass_on_6d_t;
-int32_t lsm6ds3_6d_feed_data_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_6d_feed_data_set(stmdev_ctx_t *ctx,
                                  lsm6ds3_low_pass_on_6d_t val);
-int32_t lsm6ds3_6d_feed_data_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_6d_feed_data_get(stmdev_ctx_t *ctx,
                                  lsm6ds3_low_pass_on_6d_t *val);
 
-int32_t lsm6ds3_6d_src_get(lsm6ds3_ctx_t *ctx, lsm6ds3_d6d_src_t *val);
+int32_t lsm6ds3_6d_src_get(stmdev_ctx_t *ctx, lsm6ds3_d6d_src_t *val);
 
 typedef enum {
   LSM6DS3_DEG_80 = 0,
@@ -1378,11 +1351,11 @@ typedef enum {
   LSM6DS3_DEG_60 = 2,
   LSM6DS3_DEG_50 = 3,
 } lsm6ds3_sixd_ths_t;
-int32_t lsm6ds3_6d_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t val);
-int32_t lsm6ds3_6d_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sixd_ths_t *val);
+int32_t lsm6ds3_6d_threshold_set(stmdev_ctx_t *ctx, lsm6ds3_sixd_ths_t val);
+int32_t lsm6ds3_6d_threshold_get(stmdev_ctx_t *ctx, lsm6ds3_sixd_ths_t *val);
 
-int32_t lsm6ds3_4d_mode_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_4d_mode_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_156_mg = 0,
@@ -1394,26 +1367,26 @@ typedef enum {
   LSM6DS3_469_mg = 6,
   LSM6DS3_500_mg = 7,
 } lsm6ds3_ff_ths_t;
-int32_t lsm6ds3_ff_threshold_set(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t val);
-int32_t lsm6ds3_ff_threshold_get(lsm6ds3_ctx_t *ctx, lsm6ds3_ff_ths_t *val);
+int32_t lsm6ds3_ff_threshold_set(stmdev_ctx_t *ctx, lsm6ds3_ff_ths_t val);
+int32_t lsm6ds3_ff_threshold_get(stmdev_ctx_t *ctx, lsm6ds3_ff_ths_t *val);
 
-int32_t lsm6ds3_ff_dur_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_ff_dur_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_fifo_watermark_set(lsm6ds3_ctx_t *ctx, uint16_t val);
-int32_t lsm6ds3_fifo_watermark_get(lsm6ds3_ctx_t *ctx, uint16_t *val);
+int32_t lsm6ds3_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6ds3_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
 
 typedef enum {
   LSM6DS3_TRG_XL_GY_DRDY   = 0,
   LSM6DS3_TRG_STEP_DETECT  = 1,
 } lsm6ds3_tmr_ped_fifo_drdy_t;
-int32_t lsm6ds3_fifo_write_trigger_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_write_trigger_set(stmdev_ctx_t *ctx,
                                        lsm6ds3_tmr_ped_fifo_drdy_t val);
-int32_t lsm6ds3_fifo_write_trigger_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_write_trigger_get(stmdev_ctx_t *ctx,
                                        lsm6ds3_tmr_ped_fifo_drdy_t *val);
 
-int32_t lsm6ds3_fifo_pedo_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_fifo_pedo_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_FIFO_XL_DISABLE = 0,
@@ -1425,9 +1398,9 @@ typedef enum {
   LSM6DS3_FIFO_XL_DEC_16  = 6,
   LSM6DS3_FIFO_XL_DEC_32  = 7,
 } lsm6ds3_dec_fifo_xl_t;
-int32_t lsm6ds3_fifo_xl_batch_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                   lsm6ds3_dec_fifo_xl_t val);
-int32_t lsm6ds3_fifo_xl_batch_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                   lsm6ds3_dec_fifo_xl_t *val);
 
 typedef enum {
@@ -1440,9 +1413,9 @@ typedef enum {
   LSM6DS3_FIFO_GY_DEC_16  = 6,
   LSM6DS3_FIFO_GY_DEC_32  = 7,
 } lsm6ds3_dec_fifo_gyro_t;
-int32_t lsm6ds3_fifo_gy_batch_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                   lsm6ds3_dec_fifo_gyro_t val);
-int32_t lsm6ds3_fifo_gy_batch_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                   lsm6ds3_dec_fifo_gyro_t *val);
 
 typedef enum {
@@ -1455,9 +1428,9 @@ typedef enum {
   LSM6DS3_FIFO_DS3_DEC_16  = 6,
   LSM6DS3_FIFO_DS3_DEC_32  = 7,
 } lsm6ds3_dec_ds3_fifo_t;
-int32_t lsm6ds3_fifo_dataset_3_batch_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
                                          lsm6ds3_dec_ds3_fifo_t val);
-int32_t lsm6ds3_fifo_dataset_3_batch_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
                                          lsm6ds3_dec_ds3_fifo_t *val);
 
 typedef enum {
@@ -1470,13 +1443,13 @@ typedef enum {
   LSM6DS3_FIFO_DS4_DEC_16  = 6,
   LSM6DS3_FIFO_DS4_DEC_32  = 7,
 } lsm6ds3_dec_ds4_fifo_t;
-int32_t lsm6ds3_fifo_dataset_4_batch_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
                                          lsm6ds3_dec_ds4_fifo_t val);
-int32_t lsm6ds3_fifo_dataset_4_batch_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
                                          lsm6ds3_dec_ds4_fifo_t *val);
 
-int32_t lsm6ds3_fifo_xl_gy_8bit_format_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_fifo_xl_gy_8bit_format_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_BYPASS_MODE            = 0,
@@ -1485,8 +1458,8 @@ typedef enum {
   LSM6DS3_BYPASS_TO_STREAM_MODE  = 4,
   LSM6DS3_STREAM_MODE            = 6,
 } lsm6ds3_fifo_md_t;
-int32_t lsm6ds3_fifo_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t val);
-int32_t lsm6ds3_fifo_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_fifo_md_t *val);
+int32_t lsm6ds3_fifo_mode_set(stmdev_ctx_t *ctx, lsm6ds3_fifo_md_t val);
+int32_t lsm6ds3_fifo_mode_get(stmdev_ctx_t *ctx, lsm6ds3_fifo_md_t *val);
 
 typedef enum {
   LSM6DS3_FIFO_DISABLE = 0,
@@ -1501,26 +1474,26 @@ typedef enum {
   LSM6DS3_FIFO_3k33Hz  = 9,
   LSM6DS3_FIFO_6k66Hz  = 10,
 } lsm6ds3_odr_fifo_t;
-int32_t lsm6ds3_fifo_data_rate_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_data_rate_set(stmdev_ctx_t *ctx,
                                    lsm6ds3_odr_fifo_t val);
-int32_t lsm6ds3_fifo_data_rate_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_fifo_data_rate_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_odr_fifo_t *val);
 
-int32_t lsm6ds3_fifo_stop_on_wtm_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_fifo_stop_on_wtm_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_fifo_temp_batch_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_fifo_temp_batch_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_fifo_data_level_get(lsm6ds3_ctx_t *ctx, uint16_t *val);
+int32_t lsm6ds3_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6ds3_fifo_full_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_fifo_ovr_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_fifo_wtm_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_fifo_pattern_get(lsm6ds3_ctx_t *ctx, uint16_t *val);
+int32_t lsm6ds3_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val);
 
 typedef enum {
   LSM6DS3_DEN_DISABLE    = 0,
@@ -1529,91 +1502,91 @@ typedef enum {
   LSM6DS3_LEVEL_TRIGGER  = 2,
   LSM6DS3_EDGE_TRIGGER   = 4,
 } lsm6ds3_den_mode_t;
-int32_t lsm6ds3_den_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t val);
-int32_t lsm6ds3_den_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_den_mode_t *val);
+int32_t lsm6ds3_den_mode_set(stmdev_ctx_t *ctx, lsm6ds3_den_mode_t val);
+int32_t lsm6ds3_den_mode_get(stmdev_ctx_t *ctx, lsm6ds3_den_mode_t *val);
 
-int32_t lsm6ds3_pedo_step_reset_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_pedo_step_reset_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_pedo_timestamp_raw_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_pedo_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_pedo_step_detect_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_pedo_step_detect_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_pedo_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_pedo_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_pedo_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_pedo_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_PEDO_AT_2g = 0,
   LSM6DS3_PEDO_AT_4g = 1,
 } lsm6ds3_pedo_fs_t;
-int32_t lsm6ds3_pedo_full_scale_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_pedo_full_scale_set(stmdev_ctx_t *ctx,
                                     lsm6ds3_pedo_fs_t val);
-int32_t lsm6ds3_pedo_full_scale_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_pedo_full_scale_get(stmdev_ctx_t *ctx,
                                     lsm6ds3_pedo_fs_t *val);
 
-int32_t lsm6ds3_pedo_debounce_steps_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_pedo_debounce_steps_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_pedo_timeout_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_pedo_timeout_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_motion_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_motion_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_motion_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_motion_event_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_motion_threshold_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_motion_threshold_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_sc_delta_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_sc_delta_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_sc_delta_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_sc_delta_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tilt_event_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tilt_event_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_tilt_sens_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_tilt_sens_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_mag_soft_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_mag_soft_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_mag_hard_iron_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_mag_hard_iron_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_mag_soft_iron_end_op_flag_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_mag_soft_iron_end_op_flag_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
-int32_t lsm6ds3_mag_soft_iron_coeff_set(lsm6ds3_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6ds3_mag_soft_iron_coeff_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_mag_soft_iron_coeff_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_mag_soft_iron_coeff_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_mag_offset_set(lsm6ds3_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6ds3_mag_offset_get(lsm6ds3_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6ds3_sh_sync_sens_frame_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_sh_sync_sens_frame_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_sh_master_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_sh_master_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6ds3_sh_pass_through_set(lsm6ds3_ctx_t *ctx, uint8_t val);
-int32_t lsm6ds3_sh_pass_through_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_EXT_PULL_UP      = 0,
   LSM6DS3_INTERNAL_PULL_UP = 1,
 } lsm6ds3_sh_pin_md_t;
-int32_t lsm6ds3_sh_pin_mode_set(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t val);
-int32_t lsm6ds3_sh_pin_mode_get(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_pin_md_t *val);
+int32_t lsm6ds3_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6ds3_sh_pin_md_t val);
+int32_t lsm6ds3_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6ds3_sh_pin_md_t *val);
 
 typedef enum {
   LSM6DS3_XL_GY_DRDY      = 0,
   LSM6DS3_EXT_ON_INT2_PIN = 1,
 } lsm6ds3_start_cfg_t;
-int32_t lsm6ds3_sh_syncro_mode_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                    lsm6ds3_start_cfg_t val);
-int32_t lsm6ds3_sh_syncro_mode_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    lsm6ds3_start_cfg_t *val);
 
 typedef struct {
@@ -1636,7 +1609,7 @@ typedef struct {
     lsm6ds3_sensorhub17_reg_t  sh_byte_17;
     lsm6ds3_sensorhub18_reg_t  sh_byte_18;
 } lsm6ds3_sh_read_t;
-int32_t lsm6ds3_sh_read_data_raw_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                      lsm6ds3_sh_read_t *buff);
 
 typedef enum {
@@ -1645,9 +1618,9 @@ typedef enum {
   LSM6DS3_SLV_0_1_2    = 2,
   LSM6DS3_SLV_0_1_2_3  = 3,
 } lsm6ds3_aux_sens_on_t;
-int32_t lsm6ds3_sh_num_of_dev_connected_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
                                             lsm6ds3_aux_sens_on_t val);
-int32_t lsm6ds3_sh_num_of_dev_connected_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
                                             lsm6ds3_aux_sens_on_t *val);
 
 typedef struct{
@@ -1655,31 +1628,31 @@ typedef struct{
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } lsm6ds3_sh_cfg_write_t;
-int32_t lsm6ds3_sh_cfg_write(lsm6ds3_ctx_t *ctx, lsm6ds3_sh_cfg_write_t *val);
+int32_t lsm6ds3_sh_cfg_write(stmdev_ctx_t *ctx, lsm6ds3_sh_cfg_write_t *val);
 
 typedef struct{
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6ds3_sh_cfg_read_t;
-int32_t lsm6ds3_sh_slv0_cfg_read(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6ds3_sh_cfg_read_t *val);
-int32_t lsm6ds3_sh_slv1_cfg_read(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6ds3_sh_cfg_read_t *val);
-int32_t lsm6ds3_sh_slv2_cfg_read(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6ds3_sh_cfg_read_t *val);
-int32_t lsm6ds3_sh_slv3_cfg_read(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6ds3_sh_cfg_read_t *val);
 
-int32_t lsm6ds3_sh_end_op_flag_get(lsm6ds3_ctx_t *ctx, uint8_t *val);
+int32_t lsm6ds3_sh_end_op_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DS3_USE_SLOPE = 0,
   LSM6DS3_USE_HPF   = 1,
 } lsm6ds3_slope_fds_t;
-int32_t lsm6ds3_xl_hp_path_internal_set(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         lsm6ds3_slope_fds_t val);
-int32_t lsm6ds3_xl_hp_path_internal_get(lsm6ds3_ctx_t *ctx,
+int32_t lsm6ds3_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         lsm6ds3_slope_fds_t *val);
 
 /**

--- a/sensor/stmemsc/lsm6ds3tr_c_STdC/driver/lsm6ds3tr_c_reg.c
+++ b/sensor/stmemsc/lsm6ds3tr_c_STdC/driver/lsm6ds3tr_c_reg.c
@@ -1,0 +1,6795 @@
+/*
+ ******************************************************************************
+ * @file    lsm6ds3tr_c_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LSM6DS3TR_C driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "lsm6ds3tr_c_reg.h"
+
+/**
+  * @defgroup    LSM6DS3TR_C
+  * @brief       This file provides a set of functions needed to drive the
+  *              lsm6ds3tr_c enanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_interfaces_functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3tr_c_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6ds3tr_c_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lsm6ds3tr_c_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t lsm6ds3tr_c_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t lsm6ds3tr_c_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t lsm6ds3tr_c_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t lsm6ds3tr_c_from_fs125dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 4.375f);
+}
+
+float_t lsm6ds3tr_c_from_fs250dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 8.750f);
+}
+
+float_t lsm6ds3tr_c_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 17.50f);
+}
+
+float_t lsm6ds3tr_c_from_fs1000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 35.0f);
+}
+
+float_t lsm6ds3tr_c_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t lsm6ds3tr_c_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+
+/**
+  * @defgroup    LSM6DS3TR_C_data_generation
+  * @brief       This section groups all the functions concerning data
+  *              generation
+  * @{
+  *
+*/
+
+/**
+  * @brief  Accelerometer full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_fs_xl_t val)
+{
+  lsm6ds3tr_c_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_fs_xl_t *val)
+{
+  lsm6ds3tr_c_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.fs_xl) {
+    case LSM6DS3TR_C_2g:
+      *val = LSM6DS3TR_C_2g;
+      break;
+    case LSM6DS3TR_C_16g:
+      *val = LSM6DS3TR_C_16g;
+      break;
+    case LSM6DS3TR_C_4g:
+      *val = LSM6DS3TR_C_4g;
+      break;
+    case LSM6DS3TR_C_8g:
+      *val = LSM6DS3TR_C_8g;
+      break;
+    default:
+      *val = LSM6DS3TR_C_XL_FS_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_xl_t val)
+{
+  lsm6ds3tr_c_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.odr_xl = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_xl_t *val)
+{
+  lsm6ds3tr_c_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.odr_xl) {
+    case LSM6DS3TR_C_XL_ODR_OFF:
+      *val = LSM6DS3TR_C_XL_ODR_OFF;
+      break;
+    case LSM6DS3TR_C_XL_ODR_12Hz5:
+      *val = LSM6DS3TR_C_XL_ODR_12Hz5;
+      break;
+    case LSM6DS3TR_C_XL_ODR_26Hz:
+      *val = LSM6DS3TR_C_XL_ODR_26Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_52Hz:
+      *val = LSM6DS3TR_C_XL_ODR_52Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_104Hz:
+      *val = LSM6DS3TR_C_XL_ODR_104Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_208Hz:
+      *val = LSM6DS3TR_C_XL_ODR_208Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_416Hz:
+      *val = LSM6DS3TR_C_XL_ODR_416Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_833Hz:
+      *val = LSM6DS3TR_C_XL_ODR_833Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_1k66Hz:
+      *val = LSM6DS3TR_C_XL_ODR_1k66Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_3k33Hz:
+      *val = LSM6DS3TR_C_XL_ODR_3k33Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_6k66Hz:
+      *val = LSM6DS3TR_C_XL_ODR_6k66Hz;
+      break;
+    case LSM6DS3TR_C_XL_ODR_1Hz6:
+      *val = LSM6DS3TR_C_XL_ODR_1Hz6;
+      break;
+    default:
+      *val = LSM6DS3TR_C_XL_ODR_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope chain full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_fs_g_t val)
+{
+  lsm6ds3tr_c_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.fs_g = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_fs_g_t *val)
+{
+  lsm6ds3tr_c_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.fs_g) {
+    case LSM6DS3TR_C_250dps:
+      *val = LSM6DS3TR_C_250dps;
+      break;
+    case LSM6DS3TR_C_125dps:
+      *val = LSM6DS3TR_C_125dps;
+      break;
+    case LSM6DS3TR_C_500dps:
+      *val = LSM6DS3TR_C_500dps;
+      break;
+    case LSM6DS3TR_C_1000dps:
+      *val = LSM6DS3TR_C_1000dps;
+      break;
+    case LSM6DS3TR_C_2000dps:
+      *val = LSM6DS3TR_C_2000dps;
+      break;
+    default:
+      *val = LSM6DS3TR_C_GY_FS_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_g_t val)
+{
+  lsm6ds3tr_c_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.odr_g = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_g_t *val)
+{
+  lsm6ds3tr_c_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.odr_g) {
+    case LSM6DS3TR_C_GY_ODR_OFF:
+      *val = LSM6DS3TR_C_GY_ODR_OFF;
+      break;
+    case LSM6DS3TR_C_GY_ODR_12Hz5:
+      *val = LSM6DS3TR_C_GY_ODR_12Hz5;
+      break;
+    case LSM6DS3TR_C_GY_ODR_26Hz:
+      *val = LSM6DS3TR_C_GY_ODR_26Hz;
+      break;
+    case LSM6DS3TR_C_GY_ODR_52Hz:
+      *val = LSM6DS3TR_C_GY_ODR_52Hz;
+      break;
+    case LSM6DS3TR_C_GY_ODR_104Hz:
+      *val = LSM6DS3TR_C_GY_ODR_104Hz;
+      break;
+    case LSM6DS3TR_C_GY_ODR_208Hz:
+      *val = LSM6DS3TR_C_GY_ODR_208Hz;
+      break;
+    case LSM6DS3TR_C_GY_ODR_416Hz:
+      *val = LSM6DS3TR_C_GY_ODR_416Hz;
+      break;
+    case LSM6DS3TR_C_GY_ODR_833Hz:
+      *val = LSM6DS3TR_C_GY_ODR_833Hz;
+      break;
+    case LSM6DS3TR_C_GY_ODR_1k66Hz:
+      *val = LSM6DS3TR_C_GY_ODR_1k66Hz;
+      break;
+    case LSM6DS3TR_C_GY_ODR_3k33Hz:
+      *val = LSM6DS3TR_C_GY_ODR_3k33Hz;
+      break;
+    case LSM6DS3TR_C_GY_ODR_6k66Hz:
+      *val = LSM6DS3TR_C_GY_ODR_6k66Hz;
+      break;
+    default:
+      *val = LSM6DS3TR_C_GY_ODR_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers
+  *         X_OFS_USR(73h), Y_OFS_USR(74h), Z_OFS_USR(75h).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_offset_weight_set(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_usr_off_w_t val)
+{
+  lsm6ds3tr_c_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.usr_off_w = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers
+  *         X_OFS_USR(73h), Y_OFS_USR(74h), Z_OFS_USR(75h).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_offset_weight_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_usr_off_w_t *val)
+{
+  lsm6ds3tr_c_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.usr_off_w) {
+    case LSM6DS3TR_C_LSb_1mg:
+      *val = LSM6DS3TR_C_LSb_1mg;
+      break;
+    case LSM6DS3TR_C_LSb_16mg:
+      *val = LSM6DS3TR_C_LSb_16mg;
+      break;
+    default:
+      *val = LSM6DS3TR_C_WEIGHT_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode for accelerometer[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_power_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_xl_hm_mode_t val)
+{
+  lsm6ds3tr_c_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.xl_hm_mode = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode for accelerometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_power_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_xl_hm_mode_t *val)
+{
+  lsm6ds3tr_c_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.xl_hm_mode) {
+    case LSM6DS3TR_C_XL_HIGH_PERFORMANCE:
+      *val = LSM6DS3TR_C_XL_HIGH_PERFORMANCE;
+      break;
+    case LSM6DS3TR_C_XL_NORMAL:
+      *val = LSM6DS3TR_C_XL_NORMAL;
+      break;
+    default:
+      *val = LSM6DS3TR_C_XL_PW_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Source register rounding function on WAKE_UP_SRC (1Bh),
+  *         TAP_SRC (1Ch), D6D_SRC (1Dh), STATUS_REG (1Eh) and
+  *         FUNC_SRC1 (53h) registers in the primary interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rounding_status in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_rounding_on_status_set(stmdev_ctx_t *ctx,
+                                       lsm6ds3tr_c_rounding_status_t val)
+{
+  lsm6ds3tr_c_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.rounding_status = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Source register rounding function on WAKE_UP_SRC (1Bh),
+  *         TAP_SRC (1Ch), D6D_SRC (1Dh), STATUS_REG (1Eh) and
+  *         FUNC_SRC1 (53h) registers in the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rounding_status in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_rounding_on_status_get(stmdev_ctx_t *ctx,
+                                       lsm6ds3tr_c_rounding_status_t *val)
+{
+  lsm6ds3tr_c_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.rounding_status) {
+    case LSM6DS3TR_C_STAT_RND_DISABLE:
+      *val = LSM6DS3TR_C_STAT_RND_DISABLE;
+      break;
+    case LSM6DS3TR_C_STAT_RND_ENABLE:
+      *val = LSM6DS3TR_C_STAT_RND_ENABLE;
+      break;
+    default:
+      *val = LSM6DS3TR_C_STAT_RND_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode disable for gyroscope.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_power_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_g_hm_mode_t val)
+{
+  lsm6ds3tr_c_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.g_hm_mode = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High-performance operating mode disable for gyroscope.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_power_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_g_hm_mode_t *val)
+{
+  lsm6ds3tr_c_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.g_hm_mode) {
+    case LSM6DS3TR_C_GY_HIGH_PERFORMANCE:
+      *val = LSM6DS3TR_C_GY_HIGH_PERFORMANCE;
+      break;
+    case LSM6DS3TR_C_GY_NORMAL:
+      *val = LSM6DS3TR_C_GY_NORMAL;
+      break;
+    default:
+      *val = LSM6DS3TR_C_GY_PW_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt/status flag of the device.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    WAKE_UP_SRC, TAP_SRC, D6D_SRC, STATUS_REG,
+  *                FUNC_SRC1, FUNC_SRC2, WRIST_TILT_IA, A_WRIST_TILT_Mask
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_all_sources_get(stmdev_ctx_t *ctx,
+                                lsm6ds3tr_c_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_SRC,
+                         (uint8_t*)&(val->wake_up_src), 1);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_SRC,
+                           (uint8_t*)&(val->tap_src), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_D6D_SRC,
+                           (uint8_t*)&(val->d6d_src), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_STATUS_REG,
+                           (uint8_t*)&(val->status_reg), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FUNC_SRC1,
+                           (uint8_t*)&(val->func_src1), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FUNC_SRC2,
+                           (uint8_t*)&(val->func_src2), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WRIST_TILT_IA,
+                           (uint8_t*)&(val->wrist_tilt_ia), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_B);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_A_WRIST_TILT_MASK,
+                           (uint8_t*)&(val->a_wrist_tilt_mask), 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+  }
+
+  return ret;
+}
+/**
+  * @brief  The STATUS_REG register is read by the primary interface[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_status_reg_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of gda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_STATUS_REG, (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C.
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_X_OFS_USR, buff, 3);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer axis user offset correction xpressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C.
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_X_OFS_USR, buff, 3);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_Timestamp
+  * @brief       This section groups all the functions that manage the
+  *              timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable timestamp count. The count is saved in TIMESTAMP0_REG (40h),
+  *         TIMESTAMP1_REG (41h) and TIMESTAMP2_REG (42h).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.timer_en = val;
+    if ( val != 0x00U) {
+      ctrl10_c.func_en = val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable timestamp count. The count is saved in TIMESTAMP0_REG (40h),
+  *         TIMESTAMP1_REG (41h) and TIMESTAMP2_REG (42h).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.timer_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp register resolution setting.
+  *         Configuration of this bit affects
+  *         TIMESTAMP0_REG(40h), TIMESTAMP1_REG(41h),
+  *         TIMESTAMP2_REG(42h), STEP_TIMESTAMP_L(49h),
+  *         STEP_TIMESTAMP_H(4Ah) and
+  *         STEP_COUNT_DELTA(15h) registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_hr in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_timestamp_res_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_timer_hr_t val)
+{
+  lsm6ds3tr_c_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.timer_hr = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Timestamp register resolution setting.
+  *         Configuration of this bit affects
+  *         TIMESTAMP0_REG(40h), TIMESTAMP1_REG(41h),
+  *         TIMESTAMP2_REG(42h), STEP_TIMESTAMP_L(49h),
+  *         STEP_TIMESTAMP_H(4Ah) and
+  *         STEP_COUNT_DELTA(15h) registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of timer_hr in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_timestamp_res_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_timer_hr_t *val)
+{
+  lsm6ds3tr_c_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  switch (wake_up_dur.timer_hr) {
+    case LSM6DS3TR_C_LSB_6ms4:
+      *val = LSM6DS3TR_C_LSB_6ms4;
+      break;
+    case LSM6DS3TR_C_LSB_25us:
+      *val = LSM6DS3TR_C_LSB_25us;
+      break;
+    default:
+      *val = LSM6DS3TR_C_TS_RES_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_Dataoutput
+  * @brief       This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read from output registers
+  *         through the primary interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_rounding_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_rounding_t val)
+{
+  lsm6ds3tr_c_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Circular burst-mode (rounding) read from output registers
+  *         through the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_rounding_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_rounding_t *val)
+{
+  lsm6ds3tr_c_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.rounding) {
+    case LSM6DS3TR_C_ROUND_DISABLE:
+      *val = LSM6DS3TR_C_ROUND_DISABLE;
+      break;
+    case LSM6DS3TR_C_ROUND_XL:
+      *val = LSM6DS3TR_C_ROUND_XL;
+      break;
+    case LSM6DS3TR_C_ROUND_GY:
+      *val = LSM6DS3TR_C_ROUND_GY;
+      break;
+    case LSM6DS3TR_C_ROUND_GY_XL:
+      *val = LSM6DS3TR_C_ROUND_GY_XL;
+      break;
+    case LSM6DS3TR_C_ROUND_SH1_TO_SH6:
+      *val = LSM6DS3TR_C_ROUND_SH1_TO_SH6;
+      break;
+    case LSM6DS3TR_C_ROUND_XL_SH1_TO_SH6:
+      *val = LSM6DS3TR_C_ROUND_XL_SH1_TO_SH6;
+      break;
+    case LSM6DS3TR_C_ROUND_GY_XL_SH1_TO_SH12:
+      *val = LSM6DS3TR_C_ROUND_GY_XL_SH1_TO_SH12;
+      break;
+    case LSM6DS3TR_C_ROUND_GY_XL_SH1_TO_SH6:
+      *val = LSM6DS3TR_C_ROUND_GY_XL_SH1_TO_SH6;
+      break;
+    default:
+      *val = LSM6DS3TR_C_ROUND_OUT_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r). L and H registers together
+  *         express a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit word in
+  *         two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed
+  *         as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_OUTX_L_XL, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer raw data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_OUT_MAG_RAW_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Read data in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buffer Data buffer to store FIFO data.
+  * @param  len    Number of data to read from FIFO.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer,
+                                  uint8_t len)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_DATA_OUT_L, buffer, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_common
+  * @brief       This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub
+  *         configuration registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mem_bank_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_func_cfg_en_t val)
+{
+  lsm6ds3tr_c_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  if(ret == 0){
+    func_cfg_access.func_cfg_en = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FUNC_CFG_ACCESS,
+                            (uint8_t*)&func_cfg_access, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of func_cfg_en in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mem_bank_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_func_cfg_en_t *val)
+{
+  lsm6ds3tr_c_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FUNC_CFG_ACCESS,
+                         (uint8_t*)&func_cfg_access, 1);
+  switch (func_cfg_access.func_cfg_en) {
+    case LSM6DS3TR_C_USER_BANK:
+      *val = LSM6DS3TR_C_USER_BANK;
+      break;
+    case LSM6DS3TR_C_BANK_B:
+      *val = LSM6DS3TR_C_BANK_B;
+      break;
+    default:
+      *val = LSM6DS3TR_C_BANK_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_pulsed in reg DRDY_PULSE_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_drdy_pulsed_g_t val)
+{
+  lsm6ds3tr_c_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_DRDY_PULSE_CFG_G,
+                         (uint8_t*)&drdy_pulse_cfg_g, 1);
+  if(ret == 0){
+    drdy_pulse_cfg_g.drdy_pulsed = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_DRDY_PULSE_CFG_G,
+                            (uint8_t*)&drdy_pulse_cfg_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of drdy_pulsed in reg DRDY_PULSE_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_drdy_pulsed_g_t *val)
+{
+  lsm6ds3tr_c_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_DRDY_PULSE_CFG_G,
+                         (uint8_t*)&drdy_pulse_cfg_g, 1);
+  switch (drdy_pulse_cfg_g.drdy_pulsed) {
+    case LSM6DS3TR_C_DRDY_LATCHED:
+      *val = LSM6DS3TR_C_DRDY_LATCHED;
+      break;
+    case LSM6DS3TR_C_DRDY_PULSED:
+      *val = LSM6DS3TR_C_DRDY_PULSED;
+      break;
+    default:
+      *val = LSM6DS3TR_C_DRDY_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DeviceWhoamI.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ble in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_data_format_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_ble_t val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.ble = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Big/Little Endian Data selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ble in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_data_format_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_ble_t *val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.ble) {
+    case LSM6DS3TR_C_LSB_AT_LOW_ADD:
+      *val = LSM6DS3TR_C_LSB_AT_LOW_ADD;
+      break;
+    case LSM6DS3TR_C_MSB_AT_LOW_ADD:
+      *val = LSM6DS3TR_C_MSB_AT_LOW_ADD;
+      break;
+    default:
+      *val = LSM6DS3TR_C_DATA_FMT_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.boot;
+
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_self_test_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_st_xl_t val)
+{
+  lsm6ds3tr_c_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_self_test_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_st_xl_t *val)
+{
+  lsm6ds3tr_c_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.st_xl) {
+    case LSM6DS3TR_C_XL_ST_DISABLE:
+      *val = LSM6DS3TR_C_XL_ST_DISABLE;
+      break;
+    case LSM6DS3TR_C_XL_ST_POSITIVE:
+      *val = LSM6DS3TR_C_XL_ST_POSITIVE;
+      break;
+    case LSM6DS3TR_C_XL_ST_NEGATIVE:
+      *val = LSM6DS3TR_C_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DS3TR_C_XL_ST_ND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_self_test_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_st_g_t val)
+{
+  lsm6ds3tr_c_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_g = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_self_test_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_st_g_t *val)
+{
+  lsm6ds3tr_c_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.st_g) {
+    case LSM6DS3TR_C_GY_ST_DISABLE:
+      *val = LSM6DS3TR_C_GY_ST_DISABLE;
+      break;
+    case LSM6DS3TR_C_GY_ST_POSITIVE:
+      *val = LSM6DS3TR_C_GY_ST_POSITIVE;
+      break;
+    case LSM6DS3TR_C_GY_ST_NEGATIVE:
+      *val = LSM6DS3TR_C_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DS3TR_C_GY_ST_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact both accelerometer and gyro.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slope_fds in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                        lsm6ds3tr_c_slope_fds_t val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.slope_fds = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slope_fds in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                        lsm6ds3tr_c_slope_fds_t *val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.slope_fds) {
+    case LSM6DS3TR_C_USE_SLOPE:
+      *val = LSM6DS3TR_C_USE_SLOPE;
+      break;
+    case LSM6DS3TR_C_USE_HPF:
+      *val = LSM6DS3TR_C_USE_HPF;
+      break;
+    default:
+      *val = LSM6DS3TR_C_HP_PATH_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_accelerometer_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer in every mode.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer analog chain bandwidth selection (only for
+  *         accelerometer ODR ≥ 1.67 kHz).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of bw0_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_filter_analog_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_bw0_xl_t val)
+{
+  lsm6ds3tr_c_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.bw0_xl = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer analog chain bandwidth selection (only for
+  *         accelerometer ODR ≥ 1.67 kHz).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of bw0_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_filter_analog_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_bw0_xl_t *val)
+{
+  lsm6ds3tr_c_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.bw0_xl) {
+    case LSM6DS3TR_C_XL_ANA_BW_1k5Hz:
+      *val = LSM6DS3TR_C_XL_ANA_BW_1k5Hz;
+      break;
+    case LSM6DS3TR_C_XL_ANA_BW_400Hz:
+      *val = LSM6DS3TR_C_XL_ANA_BW_400Hz;
+      break;
+    default:
+      *val = LSM6DS3TR_C_XL_ANA_BW_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_accelerometer_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact accelerometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection LPF2 is
+  *         not used.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_lpf1_bw_sel_t val)
+{
+  lsm6ds3tr_c_ctrl1_xl_t ctrl1_xl;
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf1_bw_sel = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+      if(ret == 0){
+        ctrl8_xl.lpf2_xl_en = 0;
+        ctrl8_xl.hp_slope_xl_en = 0;
+        ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer digital LPF (LPF1) bandwidth selection LPF2
+  *         is not used.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lpf1_bw_sel in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_lpf1_bw_sel_t *val)
+{
+  lsm6ds3tr_c_ctrl1_xl_t ctrl1_xl;
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if ((ctrl8_xl.lpf2_xl_en != 0x00U) ||
+        (ctrl8_xl.hp_slope_xl_en != 0x00U)){
+      *val = LSM6DS3TR_C_XL_LP1_NA;
+    }
+    else{
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+      switch ( ctrl1_xl.lpf1_bw_sel) {
+        case LSM6DS3TR_C_XL_LP1_ODR_DIV_2:
+          *val = LSM6DS3TR_C_XL_LP1_ODR_DIV_2;
+          break;
+        case LSM6DS3TR_C_XL_LP1_ODR_DIV_4:
+          *val = LSM6DS3TR_C_XL_LP1_ODR_DIV_4;
+          break;
+        default:
+          *val = LSM6DS3TR_C_XL_LP1_NA;
+          break;
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 on outputs[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of input_composite in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_input_composite_t val)
+{
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.input_composite = ( (uint8_t) val & 0x10U ) >> 4;
+    ctrl8_xl.hpcf_xl = (uint8_t) val & 0x03U;
+    ctrl8_xl.lpf2_xl_en = 1;
+    ctrl8_xl.hp_slope_xl_en = 0;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 on outputs[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of input_composite in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_input_composite_t *val)
+{
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    if ((ctrl8_xl.lpf2_xl_en == 0x00U) ||
+        (ctrl8_xl.hp_slope_xl_en != 0x00U)){
+      *val = LSM6DS3TR_C_XL_LP_NA;
+    }
+    else{
+      switch ((ctrl8_xl.input_composite << 4) + ctrl8_xl.hpcf_xl) {
+        case LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_50:
+          *val = LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_50;
+          break;
+        case LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_100:
+          *val = LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_100;
+          break;
+        case LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_9:
+          *val = LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_9;
+          break;
+        case LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_400:
+          *val = LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_400;
+          break;
+        case LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_50:
+          *val = LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_50;
+          break;
+        case LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_100:
+          *val = LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_100;
+          break;
+        case LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_9:
+          *val = LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_9;
+          break;
+        case LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_400:
+          *val = LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_400;
+          break;
+        default:
+          *val = LSM6DS3TR_C_XL_LP_NA;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hp_ref_mode in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.hp_ref_mode = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable HP filter reference mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hp_ref_mode in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.hp_ref_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  High pass/Slope on outputs.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of hpcf_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_hp_bandwidth_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_hpcf_xl_t val)
+{
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.input_composite = 0;
+    ctrl8_xl.hpcf_xl = (uint8_t)val & 0x03U;
+    ctrl8_xl.hp_slope_xl_en = 1;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  High pass/Slope on outputs.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of hpcf_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_xl_hp_bandwidth_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_hpcf_xl_t *val)
+{
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if (ctrl8_xl.hp_slope_xl_en == 0x00U){
+    *val = LSM6DS3TR_C_XL_HP_NA;
+  }
+  switch (ctrl8_xl.hpcf_xl) {
+    case LSM6DS3TR_C_XL_HP_ODR_DIV_4:
+      *val = LSM6DS3TR_C_XL_HP_ODR_DIV_4;
+      break;
+    case LSM6DS3TR_C_XL_HP_ODR_DIV_100:
+      *val = LSM6DS3TR_C_XL_HP_ODR_DIV_100;
+      break;
+    case LSM6DS3TR_C_XL_HP_ODR_DIV_9:
+      *val = LSM6DS3TR_C_XL_HP_ODR_DIV_9;
+      break;
+    case LSM6DS3TR_C_XL_HP_ODR_DIV_400:
+      *val = LSM6DS3TR_C_XL_HP_ODR_DIV_400;
+      break;
+    default:
+      *val = LSM6DS3TR_C_XL_HP_NA;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_gyroscope_filters
+  * @brief       This section group all the functions concerning the filters
+  *              configuration that impact gyroscope.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Gyroscope low pass path bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope filtering chain configuration.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_band_pass_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_lpf1_sel_g_t val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  lsm6ds3tr_c_ctrl6_c_t ctrl6_c;
+  lsm6ds3tr_c_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hpm_g  =  ( (uint8_t)val & 0x30U ) >> 4;
+    ctrl7_g.hp_en_g = ( (uint8_t)val & 0x80U ) >> 7;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+      if(ret == 0){
+        ctrl6_c.ftype = (uint8_t)val & 0x03U;
+        ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+        if(ret == 0){
+          ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C,
+                                 (uint8_t*)&ctrl4_c, 1);
+          if(ret == 0){
+            ctrl4_c.lpf1_sel_g = ( (uint8_t)val & 0x08U ) >> 3;
+            ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL4_C,
+                                    (uint8_t*)&ctrl4_c, 1);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass path bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    gyroscope filtering chain
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_band_pass_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_lpf1_sel_g_t *val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  lsm6ds3tr_c_ctrl6_c_t ctrl6_c;
+  lsm6ds3tr_c_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+      switch ( ( ctrl7_g.hp_en_g << 7 ) + ( ctrl7_g.hpm_g << 4 ) +
+               ( ctrl4_c.lpf1_sel_g << 3) + ctrl6_c.ftype ) {
+        case LSM6DS3TR_C_HP_16mHz_LP2:
+          *val = LSM6DS3TR_C_HP_16mHz_LP2;
+          break;
+        case LSM6DS3TR_C_HP_65mHz_LP2:
+          *val = LSM6DS3TR_C_HP_65mHz_LP2;
+          break;
+        case LSM6DS3TR_C_HP_260mHz_LP2:
+          *val = LSM6DS3TR_C_HP_260mHz_LP2;
+          break;
+        case LSM6DS3TR_C_HP_1Hz04_LP2:
+          *val = LSM6DS3TR_C_HP_1Hz04_LP2;
+          break;
+        case LSM6DS3TR_C_HP_DISABLE_LP1_LIGHT:
+          *val = LSM6DS3TR_C_HP_DISABLE_LP1_LIGHT;
+          break;
+        case LSM6DS3TR_C_HP_DISABLE_LP1_NORMAL:
+          *val = LSM6DS3TR_C_HP_DISABLE_LP1_NORMAL;
+          break;
+        case LSM6DS3TR_C_HP_DISABLE_LP_STRONG:
+          *val = LSM6DS3TR_C_HP_DISABLE_LP_STRONG;
+          break;
+        case LSM6DS3TR_C_HP_DISABLE_LP1_AGGRESSIVE:
+          *val = LSM6DS3TR_C_HP_DISABLE_LP1_AGGRESSIVE;
+          break;
+        case LSM6DS3TR_C_HP_16mHz_LP1_LIGHT:
+          *val = LSM6DS3TR_C_HP_16mHz_LP1_LIGHT;
+          break;
+        case LSM6DS3TR_C_HP_65mHz_LP1_NORMAL:
+          *val = LSM6DS3TR_C_HP_65mHz_LP1_NORMAL;
+          break;
+        case LSM6DS3TR_C_HP_260mHz_LP1_STRONG:
+          *val = LSM6DS3TR_C_HP_260mHz_LP1_STRONG;
+          break;
+        case LSM6DS3TR_C_HP_1Hz04_LP1_AGGRESSIVE:
+          *val = LSM6DS3TR_C_HP_1Hz04_LP1_AGGRESSIVE;
+          break;
+        default:
+          *val = LSM6DS3TR_C_HP_GY_BAND_NA;
+          break;
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_serial_interface
+  * @brief       This section groups all the functions concerning serial
+  *              interface management
+  * @{
+  *
+  */
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_spi_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_sim_t val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_spi_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_sim_t *val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.sim) {
+    case LSM6DS3TR_C_SPI_4_WIRE:
+      *val = LSM6DS3TR_C_SPI_4_WIRE;
+      break;
+    case LSM6DS3TR_C_SPI_3_WIRE:
+      *val = LSM6DS3TR_C_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DS3TR_C_SPI_MODE_ND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_i2c_interface_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_i2c_disable_t val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_i2c_interface_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_i2c_disable_t *val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  switch (ctrl4_c.i2c_disable) {
+    case LSM6DS3TR_C_I2C_ENABLE:
+      *val = LSM6DS3TR_C_I2C_ENABLE;
+      break;
+    case LSM6DS3TR_C_I2C_DISABLE:
+      *val = LSM6DS3TR_C_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM6DS3TR_C_I2C_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_interrupt_pins
+  * @brief       This section groups all the functions that manage
+  *              interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief  Select the signal that need to route on int1 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    configure INT1_CTRL, MD1_CFG, CTRL4_C(den_drdy_int1),
+  *                MASTER_CONFIG(drdy_on_int1)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_int1_route_t val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  lsm6ds3tr_c_int1_ctrl_t int1_ctrl;
+  lsm6ds3tr_c_md1_cfg_t md1_cfg;
+  lsm6ds3tr_c_md2_cfg_t md2_cfg;
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    int1_ctrl.int1_drdy_xl        = val.int1_drdy_xl;
+    int1_ctrl.int1_drdy_g         = val.int1_drdy_g;
+    int1_ctrl.int1_boot           = val.int1_boot;
+    int1_ctrl.int1_fth            = val.int1_fth;
+    int1_ctrl.int1_fifo_ovr       = val.int1_fifo_ovr;
+    int1_ctrl.int1_full_flag      = val.int1_full_flag;
+    int1_ctrl.int1_sign_mot       = val.int1_sign_mot;
+    int1_ctrl.int1_step_detector  = val.int1_step_detector;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+        md1_cfg.int1_timer           = val.int1_timer;
+        md1_cfg.int1_tilt            = val.int1_tilt;
+        md1_cfg.int1_6d              = val.int1_6d;
+        md1_cfg.int1_double_tap      = val.int1_double_tap;
+        md1_cfg.int1_ff              = val.int1_ff;
+        md1_cfg.int1_wu              = val.int1_wu;
+        md1_cfg.int1_single_tap      = val.int1_single_tap;
+        md1_cfg.int1_inact_state     = val.int1_inact_state;
+        ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ctrl4_c.den_drdy_int1 = val.den_drdy_int1;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+     master_config.drdy_on_int1   = val.den_drdy_int1;
+     ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+    if ((val.int1_6d != 0x00U) ||
+        (val.int1_ff != 0x00U) ||
+        (val.int1_wu != 0x00U) ||
+        (val.int1_single_tap != 0x00U) ||
+        (val.int1_double_tap != 0x00U) ||
+        (val.int1_inact_state != 0x00U)||
+        (md2_cfg.int2_6d != 0x00U) ||
+        (md2_cfg.int2_ff != 0x00U) ||
+        (md2_cfg.int2_wu != 0x00U) ||
+        (md2_cfg.int2_single_tap != 0x00U) ||
+        (md2_cfg.int2_double_tap != 0x00U) ||
+        (md2_cfg.int2_inact_state!= 0x00U) ){
+      tap_cfg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){    
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    read INT1_CTRL, MD1_CFG, CTRL4_C(den_drdy_int1),
+  *                MASTER_CONFIG(drdy_on_int1)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_int1_route_t *val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  lsm6ds3tr_c_int1_ctrl_t int1_ctrl;
+  lsm6ds3tr_c_md1_cfg_t md1_cfg;
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT1_CTRL, (uint8_t*)&int1_ctrl, 1);
+  if(ret == 0){
+    val->int1_drdy_xl       = int1_ctrl.int1_drdy_xl;
+    val->int1_drdy_g        = int1_ctrl.int1_drdy_g;
+    val->int1_boot          = int1_ctrl.int1_boot;
+    val->int1_fth           = int1_ctrl.int1_fth;
+    val->int1_fifo_ovr      = int1_ctrl.int1_fifo_ovr;
+    val->int1_full_flag     = int1_ctrl.int1_full_flag;
+    val->int1_sign_mot      = int1_ctrl.int1_sign_mot;
+    val->int1_step_detector = int1_ctrl.int1_step_detector ;
+
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+    if(ret == 0){
+    val->int1_timer       = md1_cfg.int1_timer;
+    val->int1_tilt        = md1_cfg.int1_tilt;
+    val->int1_6d          = md1_cfg.int1_6d;
+    val->int1_double_tap  = md1_cfg.int1_double_tap;
+    val->int1_ff          = md1_cfg.int1_ff;
+    val->int1_wu          = md1_cfg.int1_wu;
+    val->int1_single_tap  = md1_cfg.int1_single_tap;
+    val->int1_inact_state = md1_cfg.int1_inact_state;
+
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      if(ret == 0){
+        val->den_drdy_int1 = ctrl4_c.den_drdy_int1;
+        ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                               (uint8_t*)&master_config, 1);
+        val->den_drdy_int1 = master_config.drdy_on_int1;
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    INT2_CTRL, DRDY_PULSE_CFG(int2_wrist_tilt), MD2_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_int2_route_t val)
+{
+  lsm6ds3tr_c_int2_ctrl_t int2_ctrl;
+  lsm6ds3tr_c_md1_cfg_t md1_cfg;
+  lsm6ds3tr_c_md2_cfg_t md2_cfg;
+  lsm6ds3tr_c_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    int2_ctrl.int2_drdy_xl        = val.int2_drdy_xl;
+    int2_ctrl.int2_drdy_g         = val.int2_drdy_g;
+    int2_ctrl.int2_drdy_temp      = val.int2_drdy_temp;
+    int2_ctrl.int2_fth            = val.int2_fth;
+    int2_ctrl.int2_fifo_ovr       = val.int2_fifo_ovr;
+    int2_ctrl.int2_full_flag      = val.int2_full_flag;
+    int2_ctrl.int2_step_count_ov  = val.int2_step_count_ov;
+    int2_ctrl.int2_step_delta     = val.int2_step_delta;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MD1_CFG, (uint8_t*)&md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+    md2_cfg.int2_iron              = val.int2_iron;
+    md2_cfg.int2_tilt              = val.int2_tilt;
+    md2_cfg.int2_6d                = val.int2_6d;
+    md2_cfg.int2_double_tap        = val.int2_double_tap;
+    md2_cfg.int2_ff                = val.int2_ff;
+    md2_cfg.int2_wu                = val.int2_wu;
+    md2_cfg.int2_single_tap        = val.int2_single_tap;
+    md2_cfg.int2_inact_state       = val.int2_inact_state;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_DRDY_PULSE_CFG_G,
+                           (uint8_t*)&drdy_pulse_cfg_g, 1);
+  }
+  if(ret == 0){
+    drdy_pulse_cfg_g.int2_wrist_tilt = val.int2_wrist_tilt;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_DRDY_PULSE_CFG_G,
+                            (uint8_t*)&drdy_pulse_cfg_g, 1);
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+    if ((md1_cfg.int1_6d != 0x00U) ||
+        (md1_cfg.int1_ff != 0x00U) ||
+        (md1_cfg.int1_wu != 0x00U) ||
+        (md1_cfg.int1_single_tap != 0x00U) ||
+        (md1_cfg.int1_double_tap != 0x00U) ||
+        (md1_cfg.int1_inact_state != 0x00U) ||
+        (val.int2_6d != 0x00U) ||
+        (val.int2_ff != 0x00U) ||
+        (val.int2_wu != 0x00U) ||
+        (val.int2_single_tap != 0x00U) ||
+        (val.int2_double_tap != 0x00U) ||
+        (val.int2_inact_state!= 0x00U) ){
+      tap_cfg.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    INT2_CTRL, DRDY_PULSE_CFG(int2_wrist_tilt), MD2_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pin_int2_route_get(stmdev_ctx_t *ctx,
+lsm6ds3tr_c_int2_route_t *val)
+{
+  lsm6ds3tr_c_int2_ctrl_t int2_ctrl;
+  lsm6ds3tr_c_md2_cfg_t md2_cfg;
+  lsm6ds3tr_c_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
+
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT2_CTRL, (uint8_t*)&int2_ctrl, 1);
+  if(ret == 0){
+    val->int2_drdy_xl         = int2_ctrl.int2_drdy_xl;
+    val->int2_drdy_g          = int2_ctrl.int2_drdy_g;
+    val->int2_drdy_temp       = int2_ctrl.int2_drdy_temp;
+    val->int2_fth             = int2_ctrl.int2_fth;
+    val->int2_fifo_ovr        = int2_ctrl.int2_fifo_ovr;
+    val->int2_full_flag       = int2_ctrl.int2_full_flag;
+    val->int2_step_count_ov   = int2_ctrl.int2_step_count_ov;
+    val->int2_step_delta      = int2_ctrl.int2_step_delta;
+
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MD2_CFG, (uint8_t*)&md2_cfg, 1);
+    if(ret == 0){
+      val->int2_iron           = md2_cfg.int2_iron;
+      val->int2_tilt           = md2_cfg.int2_tilt;
+      val->int2_6d             = md2_cfg.int2_6d;
+      val->int2_double_tap     = md2_cfg.int2_double_tap;
+      val->int2_ff             = md2_cfg.int2_ff;
+      val->int2_wu             = md2_cfg.int2_wu;
+      val->int2_single_tap     = md2_cfg.int2_single_tap;
+      val->int2_inact_state    = md2_cfg.int2_inact_state;
+
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_DRDY_PULSE_CFG_G,
+                             (uint8_t*)&drdy_pulse_cfg_g, 1);
+      val->int2_wrist_tilt = drdy_pulse_cfg_g.int2_wrist_tilt;
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pin_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_pp_od_t val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pin_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_pp_od_t *val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.pp_od) {
+    case LSM6DS3TR_C_PUSH_PULL:
+      *val = LSM6DS3TR_C_PUSH_PULL;
+      break;
+    case LSM6DS3TR_C_OPEN_DRAIN:
+      *val = LSM6DS3TR_C_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM6DS3TR_C_PIN_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pin_polarity_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_h_lactive_t val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pin_polarity_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_h_lactive_t *val)
+{
+  lsm6ds3tr_c_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  switch (ctrl3_c.h_lactive) {
+    case LSM6DS3TR_C_ACTIVE_HIGH:
+      *val = LSM6DS3TR_C_ACTIVE_HIGH;
+      break;
+    case LSM6DS3TR_C_ACTIVE_LOW:
+      *val = LSM6DS3TR_C_ACTIVE_LOW;
+      break;
+    default:
+      *val = LSM6DS3TR_C_POLARITY_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1 = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of lir in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_int_notification_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_lir_t val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.lir = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Latched/pulsed interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of lir in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_int_notification_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_lir_t *val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.lir) {
+    case LSM6DS3TR_C_INT_PULSED:
+      *val = LSM6DS3TR_C_INT_PULSED;
+      break;
+    case LSM6DS3TR_C_INT_LATCHED:
+      *val = LSM6DS3TR_C_INT_LATCHED;
+      break;
+    default:
+      *val = LSM6DS3TR_C_INT_MODE;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_Wake_Up_event
+  * @brief       This section groups all the functions that manage the
+  *              Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup.1 LSB = FS_XL / 64.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR,
+                            (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event.1LSb = 1 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_Activity/Inactivity_detection
+  * @brief       This section groups all the functions concerning
+  *              activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.sleep = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.sleep;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of inact_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_act_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_inact_en_t val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.inact_en = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of inact_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_act_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_inact_en_t *val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  switch (tap_cfg.inact_en) {
+    case LSM6DS3TR_C_PROPERTY_DISABLE:
+      *val = LSM6DS3TR_C_PROPERTY_DISABLE;
+      break;
+    case LSM6DS3TR_C_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = LSM6DS3TR_C_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case LSM6DS3TR_C_XL_12Hz5_GY_SLEEP:
+      *val = LSM6DS3TR_C_XL_12Hz5_GY_SLEEP;
+      break;
+    case LSM6DS3TR_C_XL_12Hz5_GY_PD:
+      *val = LSM6DS3TR_C_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = LSM6DS3TR_C_ACT_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.1 LSb = 512 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR,
+          (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode. 1 LSb = 512 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_tap_generator
+  * @brief       This section groups all the functions that manage the
+  *              tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read the tap / double tap source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from TAP_SRC
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_src_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_tap_src_t *val)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_SRC, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG
+  *
+  */
+int32_t lsm6ds3tr_c_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_z_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_y_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  if(ret == 0){
+    tap_cfg.tap_x_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_tap_cfg_t tap_cfg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_CFG, (uint8_t*)&tap_cfg, 1);
+  *val = tap_cfg.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.tap_ths = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tap_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.tap_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event.
+  *         The default value of these bits is 00b which corresponds to
+  *         4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.shock = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event.
+  *         The default value of these bits is 00b which corresponds to
+  *         4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.quiet = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which there
+  *         must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time.
+  *         If the QUIET[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,1LSB corresponds
+  *         to 32*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.dur = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine a
+  *         double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value,1LSB corresponds
+  *         to 32*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of
+  *                                      single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_mode_set(stmdev_ctx_t *ctx,
+                             lsm6ds3tr_c_single_double_tap_t val)
+{
+  lsm6ds3tr_c_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.single_double_tap = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_WAKE_UP_THS,
+                            (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable/disable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of single_double_tap
+  *                                      in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tap_mode_get(stmdev_ctx_t *ctx,
+                             lsm6ds3tr_c_single_double_tap_t *val)
+{
+  lsm6ds3tr_c_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_THS, (uint8_t*)&wake_up_ths, 1);
+  switch (wake_up_ths.single_double_tap) {
+    case LSM6DS3TR_C_ONLY_SINGLE:
+      *val = LSM6DS3TR_C_ONLY_SINGLE;
+      break;
+    case LSM6DS3TR_C_BOTH_SINGLE_DOUBLE:
+      *val = LSM6DS3TR_C_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LSM6DS3TR_C_TAP_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_ Six_position_detection(6D/4D)
+  * @brief       This section groups all the functions concerning six
+  *              position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  LPF2 feed 6D function selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of low_pass_on_6d in
+  *                                   reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_6d_feed_data_set(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_low_pass_on_6d_t val)
+{
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.low_pass_on_6d = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  LPF2 feed 6D function selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_6d_feed_data_get(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_low_pass_on_6d_t *val)
+{
+  lsm6ds3tr_c_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  switch (ctrl8_xl.low_pass_on_6d) {
+    case LSM6DS3TR_C_ODR_DIV_2_FEED:
+      *val = LSM6DS3TR_C_ODR_DIV_2_FEED;
+      break;
+    case LSM6DS3TR_C_LPF2_FEED:
+      *val = LSM6DS3TR_C_LPF2_FEED;
+      break;
+    default:
+      *val = LSM6DS3TR_C_6D_FEED_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_6d_threshold_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_sixd_ths_t val)
+{
+  lsm6ds3tr_c_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.sixd_ths = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_6d_threshold_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_sixd_ths_t *val)
+{
+  lsm6ds3tr_c_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  switch (tap_ths_6d.sixd_ths) {
+    case LSM6DS3TR_C_DEG_80:
+      *val = LSM6DS3TR_C_DEG_80;
+      break;
+    case LSM6DS3TR_C_DEG_70:
+      *val = LSM6DS3TR_C_DEG_70;
+      break;
+    case LSM6DS3TR_C_DEG_60:
+      *val = LSM6DS3TR_C_DEG_60;
+      break;
+    case LSM6DS3TR_C_DEG_50:
+      *val = LSM6DS3TR_C_DEG_50;
+      break;
+    default:
+      *val = LSM6DS3TR_C_6D_TH_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.d4d_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_TAP_THS_6D,
+                            (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_TAP_THS_6D, (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_free_fall
+  * @brief       This section group all the functions concerning the free
+  *              fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief Free-fall duration event. 1LSb = 1 / ODR[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_wake_up_dur_t wake_up_dur;
+  lsm6ds3tr_c_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_dur = (val & 0x1FU);
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FREE_FALL, (uint8_t*)&free_fall, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR,
+                             (uint8_t*)&wake_up_dur, 1);
+      if(ret == 0){
+        wake_up_dur.ff_dur = (val & 0x20U) >> 5;
+        ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR,
+                                (uint8_t*)&wake_up_dur, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event. 1LSb = 1 / ODR[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_wake_up_dur_t wake_up_dur;
+  lsm6ds3tr_c_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_WAKE_UP_DUR, (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_ff_threshold_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_ff_ths_t val)
+{
+  lsm6ds3tr_c_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FREE_FALL, (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_ff_threshold_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_ff_ths_t *val)
+{
+  lsm6ds3tr_c_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FREE_FALL, (uint8_t*)&free_fall, 1);
+  switch (free_fall.ff_ths) {
+    case LSM6DS3TR_C_FF_TSH_156mg:
+      *val = LSM6DS3TR_C_FF_TSH_156mg;
+      break;
+    case LSM6DS3TR_C_FF_TSH_219mg:
+      *val = LSM6DS3TR_C_FF_TSH_219mg;
+      break;
+    case LSM6DS3TR_C_FF_TSH_250mg:
+      *val = LSM6DS3TR_C_FF_TSH_250mg;
+      break;
+    case LSM6DS3TR_C_FF_TSH_312mg:
+      *val = LSM6DS3TR_C_FF_TSH_312mg;
+      break;
+    case LSM6DS3TR_C_FF_TSH_344mg:
+      *val = LSM6DS3TR_C_FF_TSH_344mg;
+      break;
+    case LSM6DS3TR_C_FF_TSH_406mg:
+      *val = LSM6DS3TR_C_FF_TSH_406mg;
+      break;
+    case LSM6DS3TR_C_FF_TSH_469mg:
+      *val = LSM6DS3TR_C_FF_TSH_469mg;
+      break;
+    case LSM6DS3TR_C_FF_TSH_500mg:
+      *val = LSM6DS3TR_C_FF_TSH_500mg;
+      break;
+    default:
+      *val = LSM6DS3TR_C_FF_TSH_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_fifo
+  * @brief       This section group all the functions concerning the
+  *              fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl1_t fifo_ctrl1;
+  lsm6ds3tr_c_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl1.fth = (uint8_t) (0x00FFU & val);
+    fifo_ctrl2.fth = (uint8_t) (( 0x0700U & val ) >> 8);
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fth in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl1_t fifo_ctrl1;
+  lsm6ds3tr_c_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL1, (uint8_t*)&fifo_ctrl1, 1);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  }
+  *val = ((uint16_t)fifo_ctrl2.fth << 8) + (uint16_t)fifo_ctrl1.fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO data level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of diff_fifo in reg  FIFO_STATUS1 and
+  *                FIFO_STATUS2(diff_fifo), it is recommended to set the
+  *                BDU bit.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  lsm6ds3tr_c_fifo_status1_t fifo_status1;
+  lsm6ds3tr_c_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_STATUS1,
+                         (uint8_t*)&fifo_status1, 1);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+    *val = ( (uint16_t) fifo_status2.diff_fifo << 8) +
+             (uint16_t) fifo_status1.diff_fifo;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of watermark in reg  FIFO_STATUS2 and
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_STATUS2, (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.waterm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO pattern.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the values of fifo_pattern in reg  FIFO_STATUS3 and
+  *                FIFO_STATUS4, it is recommended to set the BDU bit
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  lsm6ds3tr_c_fifo_status3_t fifo_status3;
+  lsm6ds3tr_c_fifo_status4_t fifo_status4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_STATUS3,
+                         (uint8_t*)&fifo_status3, 1);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_STATUS4,
+                           (uint8_t*)&fifo_status4, 1);
+    *val = ( (uint16_t)fifo_status4.fifo_pattern << 8) +
+             fifo_status3.fifo_pattern;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_temp_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.fifo_temp_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Batching of temperature data[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_temp_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.fifo_temp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger signal for FIFO write operation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    act on FIFO_CTRL2(timer_pedo_fifo_drdy)
+  *                and MASTER_CONFIG(data_valid_sel_fifo)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_write_trigger_set(stmdev_ctx_t *ctx,
+                                       lsm6ds3tr_c_trigger_fifo_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl2_t fifo_ctrl2;
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.timer_pedo_fifo_drdy = (uint8_t)val & 0x01U;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+      if(ret == 0){
+        master_config.data_valid_sel_fifo = (((uint8_t)val & 0x02U) >> 1);
+        ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                                (uint8_t*)&master_config, 1);
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Trigger signal for FIFO write operation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    act on FIFO_CTRL2(timer_pedo_fifo_drdy)
+  *                and MASTER_CONFIG(data_valid_sel_fifo)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_write_trigger_get(stmdev_ctx_t *ctx,
+                                       lsm6ds3tr_c_trigger_fifo_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl2_t fifo_ctrl2;
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                           (uint8_t*)&master_config, 1);
+
+    switch ( ( fifo_ctrl2.timer_pedo_fifo_drdy << 1 ) +
+             fifo_ctrl2. timer_pedo_fifo_drdy ) {
+      case LSM6DS3TR_C_TRG_XL_GY_DRDY:
+        *val = LSM6DS3TR_C_TRG_XL_GY_DRDY;
+        break;
+      case LSM6DS3TR_C_TRG_STEP_DETECT:
+        *val = LSM6DS3TR_C_TRG_STEP_DETECT;
+        break;
+      case LSM6DS3TR_C_TRG_SH_DRDY:
+        *val = LSM6DS3TR_C_TRG_SH_DRDY;
+        break;
+      default:
+        *val = LSM6DS3TR_C_TRG_SH_ND;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Enable pedometer step counter and timestamp as 4th
+  *          FIFO data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_pedo_fifo_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_pedo_and_timestamp_batch_set(stmdev_ctx_t *ctx,
+                                                  uint8_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.timer_pedo_fifo_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2,
+                            (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer step counter and timestamp as 4th
+  *         FIFO data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of timer_pedo_fifo_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_pedo_and_timestamp_batch_get(stmdev_ctx_t *ctx,
+                                                  uint8_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL2, (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.timer_pedo_fifo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO) for
+  *         accelerometer data.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_fifo_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_xl_batch_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_dec_fifo_xl_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_xl = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL3,
+                            (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO) for
+  *         accelerometer data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_fifo_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_xl_batch_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_dec_fifo_xl_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  switch (fifo_ctrl3.dec_fifo_xl) {
+    case LSM6DS3TR_C_FIFO_XL_DISABLE:
+      *val = LSM6DS3TR_C_FIFO_XL_DISABLE;
+      break;
+    case LSM6DS3TR_C_FIFO_XL_NO_DEC:
+      *val = LSM6DS3TR_C_FIFO_XL_NO_DEC;
+      break;
+    case LSM6DS3TR_C_FIFO_XL_DEC_2:
+      *val = LSM6DS3TR_C_FIFO_XL_DEC_2;
+      break;
+    case LSM6DS3TR_C_FIFO_XL_DEC_3:
+      *val = LSM6DS3TR_C_FIFO_XL_DEC_3;
+      break;
+    case LSM6DS3TR_C_FIFO_XL_DEC_4:
+      *val = LSM6DS3TR_C_FIFO_XL_DEC_4;
+      break;
+    case LSM6DS3TR_C_FIFO_XL_DEC_8:
+      *val = LSM6DS3TR_C_FIFO_XL_DEC_8;
+      break;
+    case LSM6DS3TR_C_FIFO_XL_DEC_16:
+      *val = LSM6DS3TR_C_FIFO_XL_DEC_16;
+      break;
+    case LSM6DS3TR_C_FIFO_XL_DEC_32:
+      *val = LSM6DS3TR_C_FIFO_XL_DEC_32;
+      break;
+    default:
+      *val = LSM6DS3TR_C_FIFO_XL_DEC_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_fifo_gyro in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_gy_batch_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_dec_fifo_gyro_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.dec_fifo_gyro = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_fifo_gyro in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_gy_batch_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_dec_fifo_gyro_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL3, (uint8_t*)&fifo_ctrl3, 1);
+  switch (fifo_ctrl3.dec_fifo_gyro) {
+    case LSM6DS3TR_C_FIFO_GY_DISABLE:
+      *val = LSM6DS3TR_C_FIFO_GY_DISABLE;
+      break;
+    case LSM6DS3TR_C_FIFO_GY_NO_DEC:
+      *val = LSM6DS3TR_C_FIFO_GY_NO_DEC;
+      break;
+    case LSM6DS3TR_C_FIFO_GY_DEC_2:
+      *val = LSM6DS3TR_C_FIFO_GY_DEC_2;
+      break;
+    case LSM6DS3TR_C_FIFO_GY_DEC_3:
+      *val = LSM6DS3TR_C_FIFO_GY_DEC_3;
+      break;
+    case LSM6DS3TR_C_FIFO_GY_DEC_4:
+      *val = LSM6DS3TR_C_FIFO_GY_DEC_4;
+      break;
+    case LSM6DS3TR_C_FIFO_GY_DEC_8:
+      *val = LSM6DS3TR_C_FIFO_GY_DEC_8;
+      break;
+    case LSM6DS3TR_C_FIFO_GY_DEC_16:
+      *val = LSM6DS3TR_C_FIFO_GY_DEC_16;
+      break;
+    case LSM6DS3TR_C_FIFO_GY_DEC_32:
+      *val = LSM6DS3TR_C_FIFO_GY_DEC_32;
+      break;
+    default:
+      *val = LSM6DS3TR_C_FIFO_GY_DEC_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_ds3_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
+                                         lsm6ds3tr_c_dec_ds3_fifo_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds3_fifo = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for third data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_ds3_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
+                                         lsm6ds3tr_c_dec_ds3_fifo_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  switch (fifo_ctrl4.dec_ds3_fifo) {
+    case LSM6DS3TR_C_FIFO_DS3_DISABLE:
+      *val = LSM6DS3TR_C_FIFO_DS3_DISABLE;
+      break;
+    case LSM6DS3TR_C_FIFO_DS3_NO_DEC:
+      *val = LSM6DS3TR_C_FIFO_DS3_NO_DEC;
+      break;
+    case LSM6DS3TR_C_FIFO_DS3_DEC_2:
+      *val = LSM6DS3TR_C_FIFO_DS3_DEC_2;
+      break;
+    case LSM6DS3TR_C_FIFO_DS3_DEC_3:
+      *val = LSM6DS3TR_C_FIFO_DS3_DEC_3;
+      break;
+    case LSM6DS3TR_C_FIFO_DS3_DEC_4:
+      *val = LSM6DS3TR_C_FIFO_DS3_DEC_4;
+      break;
+    case LSM6DS3TR_C_FIFO_DS3_DEC_8:
+      *val = LSM6DS3TR_C_FIFO_DS3_DEC_8;
+      break;
+    case LSM6DS3TR_C_FIFO_DS3_DEC_16:
+      *val = LSM6DS3TR_C_FIFO_DS3_DEC_16;
+      break;
+    case LSM6DS3TR_C_FIFO_DS3_DEC_32:
+      *val = LSM6DS3TR_C_FIFO_DS3_DEC_32;
+      break;
+    default:
+      *val = LSM6DS3TR_C_FIFO_DS3_DEC_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO)
+  *          for fourth data set.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of dec_ds4_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
+                                         lsm6ds3tr_c_dec_ds4_fifo_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.dec_ds4_fifo = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4,
+                            (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Selects Batching Data Rate (writing frequency in FIFO) for
+  *          fourth data set.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of dec_ds4_fifo in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
+                                         lsm6ds3tr_c_dec_ds4_fifo_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  switch (fifo_ctrl4.dec_ds4_fifo) {
+    case LSM6DS3TR_C_FIFO_DS4_DISABLE:
+      *val = LSM6DS3TR_C_FIFO_DS4_DISABLE;
+      break;
+    case LSM6DS3TR_C_FIFO_DS4_NO_DEC:
+      *val = LSM6DS3TR_C_FIFO_DS4_NO_DEC;
+      break;
+    case LSM6DS3TR_C_FIFO_DS4_DEC_2:
+      *val = LSM6DS3TR_C_FIFO_DS4_DEC_2;
+      break;
+    case LSM6DS3TR_C_FIFO_DS4_DEC_3:
+      *val = LSM6DS3TR_C_FIFO_DS4_DEC_3;
+      break;
+    case LSM6DS3TR_C_FIFO_DS4_DEC_4:
+      *val = LSM6DS3TR_C_FIFO_DS4_DEC_4;
+      break;
+    case LSM6DS3TR_C_FIFO_DS4_DEC_8:
+      *val = LSM6DS3TR_C_FIFO_DS4_DEC_8;
+      break;
+    case LSM6DS3TR_C_FIFO_DS4_DEC_16:
+      *val = LSM6DS3TR_C_FIFO_DS4_DEC_16;
+      break;
+    case LSM6DS3TR_C_FIFO_DS4_DEC_32:
+      *val = LSM6DS3TR_C_FIFO_DS4_DEC_32;
+      break;
+    default:
+      *val = LSM6DS3TR_C_FIFO_DS4_DEC_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief   8-bit data storage in FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of only_high_data in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.only_high_data = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  8-bit data storage in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of only_high_data in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.only_high_data;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.stop_on_fth = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of stop_on_fth in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL4, (uint8_t*)&fifo_ctrl4, 1);
+  *val = fifo_ctrl4.stop_on_fth;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of fifo_mode in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_fifo_mode_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.fifo_mode = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of fifo_mode in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_fifo_mode_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  switch (fifo_ctrl5.fifo_mode) {
+    case LSM6DS3TR_C_BYPASS_MODE:
+      *val = LSM6DS3TR_C_BYPASS_MODE;
+      break;
+    case LSM6DS3TR_C_FIFO_MODE:
+      *val = LSM6DS3TR_C_FIFO_MODE;
+      break;
+    case LSM6DS3TR_C_STREAM_TO_FIFO_MODE:
+      *val = LSM6DS3TR_C_STREAM_TO_FIFO_MODE;
+      break;
+    case LSM6DS3TR_C_BYPASS_TO_STREAM_MODE:
+      *val = LSM6DS3TR_C_BYPASS_TO_STREAM_MODE;
+      break;
+    case LSM6DS3TR_C_STREAM_MODE:
+      *val = LSM6DS3TR_C_STREAM_MODE;
+      break;
+    default:
+      *val = LSM6DS3TR_C_FIFO_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO ODR selection, setting FIFO_MODE also.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of odr_fifo in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_fifo_t val)
+{
+  lsm6ds3tr_c_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  if(ret == 0){
+    fifo_ctrl5.odr_fifo = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO ODR selection, setting FIFO_MODE also.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of odr_fifo in reg FIFO_CTRL5
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_fifo_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_fifo_t *val)
+{
+  lsm6ds3tr_c_fifo_ctrl5_t fifo_ctrl5;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_FIFO_CTRL5, (uint8_t*)&fifo_ctrl5, 1);
+  switch (fifo_ctrl5.odr_fifo) {
+    case LSM6DS3TR_C_FIFO_DISABLE:
+      *val = LSM6DS3TR_C_FIFO_DISABLE;
+      break;
+    case LSM6DS3TR_C_FIFO_12Hz5:
+      *val = LSM6DS3TR_C_FIFO_12Hz5;
+      break;
+    case LSM6DS3TR_C_FIFO_26Hz:
+      *val = LSM6DS3TR_C_FIFO_26Hz;
+      break;
+    case LSM6DS3TR_C_FIFO_52Hz:
+      *val = LSM6DS3TR_C_FIFO_52Hz;
+      break;
+    case LSM6DS3TR_C_FIFO_104Hz:
+      *val = LSM6DS3TR_C_FIFO_104Hz;
+      break;
+    case LSM6DS3TR_C_FIFO_208Hz:
+      *val = LSM6DS3TR_C_FIFO_208Hz;
+      break;
+    case LSM6DS3TR_C_FIFO_416Hz:
+      *val = LSM6DS3TR_C_FIFO_416Hz;
+      break;
+    case LSM6DS3TR_C_FIFO_833Hz:
+      *val = LSM6DS3TR_C_FIFO_833Hz;
+      break;
+    case LSM6DS3TR_C_FIFO_1k66Hz:
+      *val = LSM6DS3TR_C_FIFO_1k66Hz;
+      break;
+    case LSM6DS3TR_C_FIFO_3k33Hz:
+      *val = LSM6DS3TR_C_FIFO_3k33Hz;
+      break;
+    case LSM6DS3TR_C_FIFO_6k66Hz:
+      *val = LSM6DS3TR_C_FIFO_6k66Hz;
+      break;
+    default:
+      *val = LSM6DS3TR_C_FIFO_RATE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_DEN_functionality
+  * @brief       This section groups all the functions concerning DEN
+  *              functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_lh in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+ int32_t lsm6ds3tr_c_den_polarity_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_lh_t val)
+{
+  lsm6ds3tr_c_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.den_lh = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_lh in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_polarity_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_lh_t *val)
+{
+  lsm6ds3tr_c_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.den_lh) {
+    case LSM6DS3TR_C_DEN_ACT_LOW:
+      *val = LSM6DS3TR_C_DEN_ACT_LOW;
+      break;
+    case LSM6DS3TR_C_DEN_ACT_HIGH:
+      *val = LSM6DS3TR_C_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = LSM6DS3TR_C_DEN_POL_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_mode_t val)
+{
+  lsm6ds3tr_c_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.den_mode = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_mode_t *val)
+{
+  lsm6ds3tr_c_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.den_mode) {
+    case LSM6DS3TR_C_DEN_DISABLE:
+      *val = LSM6DS3TR_C_DEN_DISABLE;
+      break;
+    case LSM6DS3TR_C_LEVEL_LETCHED:
+      *val = LSM6DS3TR_C_LEVEL_LETCHED;
+      break;
+    case LSM6DS3TR_C_LEVEL_TRIGGER:
+      *val = LSM6DS3TR_C_LEVEL_TRIGGER;
+      break;
+    case LSM6DS3TR_C_EDGE_TRIGGER:
+      *val = LSM6DS3TR_C_EDGE_TRIGGER;
+      break;
+    default:
+      *val = LSM6DS3TR_C_DEN_MODE_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Extend DEN functionality to accelerometer sensor.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_xl_g in reg CTRL9_XL
+  *                             and den_xl_en in CTRL4_C.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_enable_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_xl_en_t val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_xl_g = (uint8_t)val & 0x01U;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      if(ret == 0){
+        ctrl4_c.den_xl_en = (uint8_t)val & 0x02U;
+        ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Extend DEN functionality to accelerometer sensor. [get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of den_xl_g in reg CTRL9_XL
+  *                             and den_xl_en in CTRL4_C.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_enable_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_xl_en_t *val)
+{
+  lsm6ds3tr_c_ctrl4_c_t ctrl4_c;
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+    switch ( ( ctrl4_c.den_xl_en << 1) + ctrl9_xl.den_xl_g ) {
+      case LSM6DS3TR_C_STAMP_IN_GY_DATA:
+        *val = LSM6DS3TR_C_STAMP_IN_GY_DATA;
+        break;
+      case LSM6DS3TR_C_STAMP_IN_XL_DATA:
+        *val = LSM6DS3TR_C_STAMP_IN_XL_DATA;
+        break;
+      case LSM6DS3TR_C_STAMP_IN_GY_XL_DATA:
+        *val = LSM6DS3TR_C_STAMP_IN_GY_XL_DATA;
+        break;
+      default:
+        *val = LSM6DS3TR_C_DEN_STAMP_ND;
+        break;
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_z = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_y = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_x = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_Pedometer
+  * @brief       This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Reset pedometer step counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_rst_step in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.pedo_rst_step = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset pedometer step counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_rst_step in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.pedo_rst_step;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer algorithm.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.pedo_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  pedo_sens:   Enable pedometer algorithm.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.pedo_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Minimum threshold to detect a peak. Default is 10h.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ths_min in reg
+  *                      CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+       config_pedo_ths_min.ths_min = val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CONFIG_PEDO_THS_MIN,
+                              (uint8_t*)&config_pedo_ths_min, 1);
+        if(ret == 0){
+          ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+        }
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  Minimum threshold to detect a peak. Default is 10h.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of ths_min in reg  CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+    ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CONFIG_PEDO_THS_MIN,
+                             (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+        *val =  config_pedo_ths_min.ths_min;
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  pedo_full_scale:   Pedometer data range.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pedo_fs in
+  *                            reg CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_pedo_fs_t val)
+{
+  lsm6ds3tr_c_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+    if(ret == 0){
+       config_pedo_ths_min.pedo_fs = (uint8_t) val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CONFIG_PEDO_THS_MIN,
+                              (uint8_t*)&config_pedo_ths_min, 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer data range.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pedo_fs in
+  *                            reg CONFIG_PEDO_THS_MIN
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_pedo_fs_t *val)
+{
+  lsm6ds3tr_c_config_pedo_ths_min_t config_pedo_ths_min;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CONFIG_PEDO_THS_MIN,
+                           (uint8_t*)&config_pedo_ths_min, 1);
+    if(ret == 0){
+      switch (config_pedo_ths_min.pedo_fs) {
+         case LSM6DS3TR_C_PEDO_AT_2g:
+          *val = LSM6DS3TR_C_PEDO_AT_2g;
+          break;
+        case LSM6DS3TR_C_PEDO_AT_4g:
+          *val = LSM6DS3TR_C_PEDO_AT_4g;
+          break;
+        default:
+          *val = LSM6DS3TR_C_PEDO_FS_ND;
+          break;
+      }
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_step in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      pedo_deb_reg.deb_step = val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_PEDO_DEB_REG,
+                              (uint8_t*)&pedo_deb_reg, 1);
+        if(ret == 0){
+          ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+        }
+      }
+    }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_step in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+      if(ret == 0){
+        *val = pedo_deb_reg.deb_step;
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+
+  return ret;
+}
+
+/**
+  * @brief  Debounce time. If the time between two consecutive steps is
+  *         greater than  DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_time in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      pedo_deb_reg.deb_time = val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_PEDO_DEB_REG,
+                              (uint8_t*)&pedo_deb_reg, 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Debounce time. If the time between two consecutive steps is
+  *         greater than  DEB_TIME*80ms, the debouncer is reactivated.
+  *         Default value: 01101[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of deb_time in reg PEDO_DEB_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_pedo_deb_reg_t pedo_deb_reg;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_PEDO_DEB_REG,
+                           (uint8_t*)&pedo_deb_reg, 1);
+    if(ret == 0){
+      *val = pedo_deb_reg.deb_time;
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_STEP_COUNT_DELTA, buff, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_STEP_COUNT_DELTA, buff, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_significant_motion
+  * @brief       This section groups all the functions that manage the
+  *              significant motion detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable significant motion detection function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sign_motion_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.sign_motion_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable significant motion detection function.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of sign_motion_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.sign_motion_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Significant motion threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that store significant motion threshold.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SM_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Significant motion threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that store significant motion threshold.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SM_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_tilt_detection
+  * @brief       This section groups all the functions that manage the tilt
+  *              event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.tilt_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.tilt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_wrist_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.wrist_tilt_en = val;
+    if (val != 0x00U) {
+      ctrl10_c.func_en = val;
+    }
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tilt_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_wrist_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.wrist_tilt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt latency register (r/w).
+  *         Absolute wrist tilt latency parameters.
+  *         1 LSB = 40 ms. Default value: 0Fh (600 ms).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tilt_latency_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_B);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_A_WRIST_TILT_LAT, buff, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt latency register (r/w).
+  *         Absolute wrist tilt latency parameters.
+  *         1 LSB = 40 ms. Default value: 0Fh (600 ms).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tilt_latency_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_B);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_A_WRIST_TILT_LAT, buff, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt threshold register(r/w).
+  *         Absolute wrist tilt threshold parameters.
+  *         1 LSB = 15.625 mg.Default value: 20h (500 mg).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tilt_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_B);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_A_WRIST_TILT_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt threshold register(r/w).
+  *         Absolute wrist tilt threshold parameters.
+  *         1 LSB = 15.625 mg.Default value: 20h (500 mg).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tilt_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_B);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_A_WRIST_TILT_THS, buff, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt mask register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers A_WRIST_TILT_MASK
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tilt_src_set(stmdev_ctx_t *ctx,
+                             lsm6ds3tr_c_a_wrist_tilt_mask_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_B);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_A_WRIST_TILT_MASK,
+                           (uint8_t*) val, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Absolute Wrist Tilt mask register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Registers A_WRIST_TILT_MASK
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_tilt_src_get(stmdev_ctx_t *ctx,
+                             lsm6ds3tr_c_a_wrist_tilt_mask_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_B);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_A_WRIST_TILT_MASK,
+                           (uint8_t*) val, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_ magnetometer_sensor
+  * @brief       This section groups all the functions that manage additional
+  *              magnetometer sensor.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable soft-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of soft_en in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.soft_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable soft-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of soft_en in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.soft_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable hard-iron correction algorithm for magnetometer.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of iron_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.iron_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+      if(ret == 0){
+        if (val != 0x00U) {
+          ctrl10_c.func_en = val;
+        }
+        ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL10_C,
+                                (uint8_t*)&ctrl10_c, 1);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable hard-iron correction algorithm for magnetometer.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of iron_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.iron_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Soft iron 3x3 matrix. Value are expressed in sign-module format.
+  *         (Es. SVVVVVVVb where S is the sign 0/+1/- and V is the value).[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_soft_iron_mat_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MAG_SI_XX, buff, 9);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft iron 3x3 matrix. Value are expressed in sign-module format.
+  *         (Es. SVVVVVVVb where S is the sign 0/+1/- and V is the value).[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_soft_iron_mat_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MAG_SI_XX, buff, 9);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w). The value is
+  *         expressed as a 16-bit word in two’s complement.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MAG_OFFX_L, buff, 6);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register(r/w).
+  *         The value is expressed as a 16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MAG_OFFX_L, buff, 6);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DS3TR_C_Sensor_hub
+  * @brief       This section groups all the functions that manage the sensor
+  *              hub functionality.
+  * @{
+  *
+  */
+
+  /**
+  * @brief  Enable function.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values func_en
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_func_en_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.func_en = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame with the step of 500 ms and
+  *         full range of 5s. Unsigned 8-bit.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tph in reg SENSOR_SYNC_TIME_FRAME
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_sensor_sync_time_frame_t sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SENSOR_SYNC_TIME_FRAME,
+                         (uint8_t*)&sensor_sync_time_frame, 1);
+  if(ret == 0){
+     sensor_sync_time_frame.tph = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SENSOR_SYNC_TIME_FRAME,
+                            (uint8_t*)&sensor_sync_time_frame, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame with the step of 500 ms and
+  *         full range of 5s. Unsigned 8-bit.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of tph in reg  SENSOR_SYNC_TIME_FRAME
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_sensor_sync_time_frame_t sensor_sync_time_frame;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SENSOR_SYNC_TIME_FRAME,
+                         (uint8_t*)&sensor_sync_time_frame, 1);
+  *val =  sensor_sync_time_frame.tph;
+
+  return ret;
+}
+
+/**
+  * @brief  Resolution ratio of error code for sensor synchronization.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of rr in reg  SENSOR_SYNC_RES_RATIO
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_sync_sens_ratio_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_rr_t val)
+{
+  lsm6ds3tr_c_sensor_sync_res_ratio_t sensor_sync_res_ratio;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SENSOR_SYNC_RES_RATIO,
+                              (uint8_t*)&sensor_sync_res_ratio, 1);
+  if(ret == 0){
+    sensor_sync_res_ratio.rr = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SENSOR_SYNC_RES_RATIO,
+                            (uint8_t*)&sensor_sync_res_ratio, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resolution ratio of error code for sensor synchronization.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of rr in reg  SENSOR_SYNC_RES_RATIO
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_sync_sens_ratio_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_rr_t *val)
+{
+  lsm6ds3tr_c_sensor_sync_res_ratio_t sensor_sync_res_ratio;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SENSOR_SYNC_RES_RATIO,
+                         (uint8_t*)&sensor_sync_res_ratio, 1);
+
+  switch ( sensor_sync_res_ratio.rr) {
+    case LSM6DS3TR_C_RES_RATIO_2_11:
+      *val = LSM6DS3TR_C_RES_RATIO_2_11;
+      break;
+    case LSM6DS3TR_C_RES_RATIO_2_12:
+      *val = LSM6DS3TR_C_RES_RATIO_2_12;
+      break;
+    case LSM6DS3TR_C_RES_RATIO_2_13:
+      *val = LSM6DS3TR_C_RES_RATIO_2_13;
+      break;
+    case LSM6DS3TR_C_RES_RATIO_2_14:
+      *val = LSM6DS3TR_C_RES_RATIO_2_14;
+      break;
+    default:
+      *val = LSM6DS3TR_C_RES_RATIO_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.master_on = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.master_on;
+
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pass_through_mode = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.pass_through_mode;
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable/disable.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of pull_up_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_pull_up_en_t val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.pull_up_en = (uint8_t) val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable/disable.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of pull_up_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_pull_up_en_t *val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  switch (master_config.pull_up_en) {
+    case LSM6DS3TR_C_EXT_PULL_UP:
+      *val = LSM6DS3TR_C_EXT_PULL_UP;
+      break;
+    case LSM6DS3TR_C_INTERNAL_PULL_UP:
+      *val = LSM6DS3TR_C_INTERNAL_PULL_UP;
+      break;
+    default:
+      *val = LSM6DS3TR_C_SH_PIN_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_syncro_mode_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_start_config_t val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.start_config = (uint8_t)val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_syncro_mode_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_start_config_t *val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  switch (master_config.start_config) {
+    case LSM6DS3TR_C_XL_GY_DRDY:
+      *val = LSM6DS3TR_C_XL_GY_DRDY;
+      break;
+    case LSM6DS3TR_C_EXT_ON_INT2_PIN:
+      *val = LSM6DS3TR_C_EXT_ON_INT2_PIN;
+      break;
+    default:
+      *val = LSM6DS3TR_C_SH_SYNCRO_ND;
+      break;
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Manage the Master DRDY signal on INT1 pad.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_on_int1 in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  if(ret == 0){
+    master_config.drdy_on_int1 = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                            (uint8_t*)&master_config, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Manage the Master DRDY signal on INT1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of drdy_on_int1 in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CONFIG,
+                         (uint8_t*)&master_config, 1);
+  *val = master_config.drdy_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure of registers from SENSORHUB1_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_read_data_raw_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_emb_sh_read_t *val)
+{
+  int32_t ret;
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SENSORHUB1_REG,
+                         (uint8_t*)&(val->sh_byte_1), 12);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SENSORHUB13_REG,
+                           (uint8_t*)&(val->sh_byte_13), 6);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master command code used for stamping for sensor sync.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_cmd_code in
+  *                reg MASTER_CMD_CODE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_cmd_sens_sync_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_master_cmd_code_t master_cmd_code;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CMD_CODE,
+                         (uint8_t*)&master_cmd_code, 1);
+  if(ret == 0){
+    master_cmd_code.master_cmd_code = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_MASTER_CMD_CODE,
+                            (uint8_t*)&master_cmd_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master command code used for stamping for sensor sync.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of master_cmd_code in
+  *                reg MASTER_CMD_CODE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_cmd_sens_sync_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_master_cmd_code_t master_cmd_code;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_MASTER_CMD_CODE,
+                         (uint8_t*)&master_cmd_code, 1);
+  *val = master_cmd_code.master_cmd_code;
+
+  return ret;
+}
+
+/**
+  * @brief  Error code used for sensor synchronization.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of error_code in
+  *                reg SENS_SYNC_SPI_ERROR_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_spi_sync_error_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6ds3tr_c_sens_sync_spi_error_code_t sens_sync_spi_error_code;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SENS_SYNC_SPI_ERROR_CODE,
+                         (uint8_t*)&sens_sync_spi_error_code, 1);
+  if(ret == 0){
+     sens_sync_spi_error_code.error_code = val;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SENS_SYNC_SPI_ERROR_CODE,
+                            (uint8_t*)&sens_sync_spi_error_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Error code used for sensor synchronization.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of error_code in
+  *                reg SENS_SYNC_SPI_ERROR_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_spi_sync_error_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6ds3tr_c_sens_sync_spi_error_code_t sens_sync_spi_error_code;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SENS_SYNC_SPI_ERROR_CODE,
+                         (uint8_t*)&sens_sync_spi_error_code, 1);
+  *val =  sens_sync_spi_error_code.error_code;
+
+  return ret;
+}
+
+/**
+  * @brief   Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of aux_sens_on in reg SLAVE0_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
+                                            lsm6ds3tr_c_aux_sens_on_t val)
+{
+  lsm6ds3tr_c_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      slave0_config.aux_sens_on = (uint8_t) val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE0_CONFIG,
+                              (uint8_t*)&slave0_config, 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief   Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of aux_sens_on in reg SLAVE0_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
+                                            lsm6ds3tr_c_aux_sens_on_t *val)
+{
+  lsm6ds3tr_c_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE0_CONFIG, 
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      switch (slave0_config.aux_sens_on) {
+        case LSM6DS3TR_C_SLV_0:
+          *val = LSM6DS3TR_C_SLV_0;
+          break;
+        case LSM6DS3TR_C_SLV_0_1:
+          *val = LSM6DS3TR_C_SLV_0_1;
+          break;
+        case LSM6DS3TR_C_SLV_0_1_2:
+          *val = LSM6DS3TR_C_SLV_0_1_2;
+          break;
+        case LSM6DS3TR_C_SLV_0_1_2_3:
+          *val = LSM6DS3TR_C_SLV_0_1_2_3;
+          break;
+        default:
+          *val = LSM6DS3TR_C_SLV_EN_ND;
+          break;
+      }
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_data;   8 bit data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_cfg_write(stmdev_ctx_t *ctx, lsm6ds3tr_c_sh_cfg_write_t *val)
+{
+  lsm6ds3tr_c_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv0_add;
+    slv0_add.rw_0 = 0;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV0_SUBADD,
+                              &(val->slv0_subadd), 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_DATAWRITE_SRC_MODE_SUB_SLV0,
+                                &(val->slv0_data), 1);
+        if(ret == 0){
+          ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_sh_cfg_read_t *val)
+{
+  lsm6ds3tr_c_slave0_config_t slave0_config;
+  lsm6ds3tr_c_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    slv0_add.slave0_add = val->slv_add;
+    slv0_add.rw_0 = 1;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV0_ADD, (uint8_t*)&slv0_add, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV0_SUBADD,
+                              &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE0_CONFIG,
+                               (uint8_t*)&slave0_config, 1);
+        slave0_config.slave0_numop = val->slv_len;
+        if(ret == 0){
+          ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE0_CONFIG,
+                                  (uint8_t*)&slave0_config, 1);
+          if(ret == 0){
+            ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 1 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_sh_cfg_read_t *val)
+{
+  lsm6ds3tr_c_slave1_config_t slave1_config;
+  lsm6ds3tr_c_slv1_add_t slv1_add;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    slv1_add.slave1_add  = val->slv_add;
+    slv1_add.r_1 = 1;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV1_ADD, (uint8_t*)&slv1_add, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV1_SUBADD,
+                                   &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE1_CONFIG,
+                               (uint8_t*)&slave1_config, 1);
+        slave1_config.slave1_numop = val->slv_len;
+        if(ret == 0){
+          ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE1_CONFIG,
+                                  (uint8_t*)&slave1_config, 1);
+          if(ret == 0){
+            ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 2 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_sh_cfg_read_t *val)
+{
+  lsm6ds3tr_c_slv2_add_t slv2_add;
+  lsm6ds3tr_c_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    slv2_add.slave2_add  = val->slv_add;
+    slv2_add.r_2 = 1;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV2_ADD, (uint8_t*)&slv2_add, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV2_SUBADD,
+                              &(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE2_CONFIG,
+                               (uint8_t*)&slave2_config, 1);
+        if(ret == 0){
+          slave2_config.slave2_numop = val->slv_len;
+          ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE2_CONFIG,
+                                  (uint8_t*)&slave2_config, 1);
+          if(ret == 0){
+            ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 3 for perform a read.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Structure that contain:
+  *                  - uint8_t slv_add;    8 bit i2c device address
+  *                  - uint8_t slv_subadd; 8 bit register device address
+  *                  - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_sh_cfg_read_t *val)
+{
+  lsm6ds3tr_c_slave3_config_t slave3_config;
+  lsm6ds3tr_c_slv3_add_t slv3_add;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    slv3_add.slave3_add  = val->slv_add;
+    slv3_add.r_3 = 1;
+    ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV3_ADD, (uint8_t*)&slv3_add, 1);
+    if(ret == 0){
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLV3_SUBADD,
+                              (uint8_t*)&(val->slv_subadd), 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE3_CONFIG,
+                               (uint8_t*)&slave3_config, 1);
+        if(ret == 0){
+          slave3_config.slave3_numop = val->slv_len;
+          ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE3_CONFIG,
+                                  (uint8_t*)&slave3_config, 1);
+          if(ret == 0){
+            ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+          }
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 0 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave0_rate in reg SLAVE0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slave_0_dec_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave0_rate_t val)
+{
+  lsm6ds3tr_c_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE0_CONFIG,
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      slave0_config.slave0_rate = (uint8_t) val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE0_CONFIG,
+                              (uint8_t*)&slave0_config, 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 0 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave0_rate in reg SLAVE0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slave_0_dec_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave0_rate_t *val)
+{
+  lsm6ds3tr_c_slave0_config_t slave0_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE0_CONFIG, 
+                           (uint8_t*)&slave0_config, 1);
+    if(ret == 0){
+      switch (slave0_config.slave0_rate) {
+        case LSM6DS3TR_C_SL0_NO_DEC:
+          *val = LSM6DS3TR_C_SL0_NO_DEC;
+          break;
+        case LSM6DS3TR_C_SL0_DEC_2:
+          *val = LSM6DS3TR_C_SL0_DEC_2;
+          break;
+        case LSM6DS3TR_C_SL0_DEC_4:
+          *val = LSM6DS3TR_C_SL0_DEC_4;
+          break;
+        case LSM6DS3TR_C_SL0_DEC_8:
+          *val = LSM6DS3TR_C_SL0_DEC_8;
+          break;
+        default:
+          *val = LSM6DS3TR_C_SL0_DEC_ND;
+          break;
+      }
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.
+  *         This is effective if the Aux_sens_on[1:0] field in
+  *         SLAVE0_CONFIG(04h) is set to a value other than 00.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of write_once in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_write_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_write_once_t val)
+{
+  lsm6ds3tr_c_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE1_CONFIG,
+                           (uint8_t*)&slave1_config, 1);
+    slave1_config.write_once = (uint8_t) val;
+    if(ret == 0){
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE1_CONFIG,
+                              (uint8_t*)&slave1_config, 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.
+  *         This is effective if the Aux_sens_on[1:0] field in
+  *         SLAVE0_CONFIG(04h) is set to a value other than 00.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of write_once in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_write_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_write_once_t *val)
+{
+  lsm6ds3tr_c_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE1_CONFIG, 
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      switch (slave1_config.write_once) {
+        case LSM6DS3TR_C_EACH_SH_CYCLE:
+          *val = LSM6DS3TR_C_EACH_SH_CYCLE;
+          break;
+        case LSM6DS3TR_C_ONLY_FIRST_CYCLE:
+          *val = LSM6DS3TR_C_ONLY_FIRST_CYCLE;
+          break;
+        default:
+          *val = LSM6DS3TR_C_SH_WR_MODE_ND;
+          break;
+      }
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 1 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave1_rate in reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slave_1_dec_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave1_rate_t val)
+{
+  lsm6ds3tr_c_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE1_CONFIG, 
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      slave1_config.slave1_rate = (uint8_t) val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE1_CONFIG, 
+                              (uint8_t*)&slave1_config, 1);
+      if(ret == 0){
+          ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 1 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions reg SLAVE1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slave_1_dec_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave1_rate_t *val)
+{
+  lsm6ds3tr_c_slave1_config_t slave1_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE1_CONFIG, 
+                           (uint8_t*)&slave1_config, 1);
+    if(ret == 0){
+      switch (slave1_config.slave1_rate) {
+        case LSM6DS3TR_C_SL1_NO_DEC:
+          *val = LSM6DS3TR_C_SL1_NO_DEC;
+          break;
+        case LSM6DS3TR_C_SL1_DEC_2:
+          *val = LSM6DS3TR_C_SL1_DEC_2;
+          break;
+        case LSM6DS3TR_C_SL1_DEC_4:
+          *val = LSM6DS3TR_C_SL1_DEC_4;
+          break;
+        case LSM6DS3TR_C_SL1_DEC_8:
+          *val = LSM6DS3TR_C_SL1_DEC_8;
+          break;
+        default:
+          *val = LSM6DS3TR_C_SL1_DEC_ND;
+          break;
+      }
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 2 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave2_rate in reg SLAVE2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slave_2_dec_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave2_rate_t val)
+{
+  lsm6ds3tr_c_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE2_CONFIG, 
+                           (uint8_t*)&slave2_config, 1);
+    if(ret == 0){
+      slave2_config.slave2_rate =(uint8_t) val;
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE2_CONFIG, 
+                              (uint8_t*)&slave2_config, 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 2 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave2_rate in reg SLAVE2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slave_2_dec_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave2_rate_t *val)
+{
+  lsm6ds3tr_c_slave2_config_t slave2_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE2_CONFIG, 
+                           (uint8_t*)&slave2_config, 1);
+    if(ret == 0){
+      switch (slave2_config.slave2_rate) {
+        case LSM6DS3TR_C_SL2_NO_DEC:
+          *val = LSM6DS3TR_C_SL2_NO_DEC;
+          break;
+        case LSM6DS3TR_C_SL2_DEC_2:
+          *val = LSM6DS3TR_C_SL2_DEC_2;
+          break;
+        case LSM6DS3TR_C_SL2_DEC_4:
+          *val = LSM6DS3TR_C_SL2_DEC_4;
+          break;
+        case LSM6DS3TR_C_SL2_DEC_8:
+          *val = LSM6DS3TR_C_SL2_DEC_8;
+          break;
+        default:
+          *val = LSM6DS3TR_C_SL2_DEC_ND;
+          break;
+      }
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 3 starting from the
+  *         sensor hub trigger.[set]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Change the values of slave3_rate in reg SLAVE3_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slave_3_dec_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave3_rate_t val)
+{
+  lsm6ds3tr_c_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE3_CONFIG, 
+                           (uint8_t*)&slave3_config, 1);
+    slave3_config.slave3_rate = (uint8_t)val;
+    if(ret == 0){
+      ret = lsm6ds3tr_c_write_reg(ctx, LSM6DS3TR_C_SLAVE3_CONFIG, 
+                              (uint8_t*)&slave3_config, 1);
+      if(ret == 0){
+        ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  Decimation of read operation on Slave 3 starting from the
+  *         sensor hub trigger.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    Get the values of slave3_rate in reg SLAVE3_CONFIG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6ds3tr_c_sh_slave_3_dec_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave3_rate_t *val)
+{
+  lsm6ds3tr_c_slave3_config_t slave3_config;
+  int32_t ret;
+
+  ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_BANK_A);
+  if(ret == 0){
+    ret = lsm6ds3tr_c_read_reg(ctx, LSM6DS3TR_C_SLAVE3_CONFIG, 
+                           (uint8_t*)&slave3_config, 1);
+    if(ret == 0){
+      switch (slave3_config.slave3_rate) {
+        case LSM6DS3TR_C_SL3_NO_DEC:
+          *val = LSM6DS3TR_C_SL3_NO_DEC;
+          break;
+        case LSM6DS3TR_C_SL3_DEC_2:
+          *val = LSM6DS3TR_C_SL3_DEC_2;
+          break;
+        case LSM6DS3TR_C_SL3_DEC_4:
+          *val = LSM6DS3TR_C_SL3_DEC_4;
+          break;
+        case LSM6DS3TR_C_SL3_DEC_8:
+          *val = LSM6DS3TR_C_SL3_DEC_8;
+          break;
+        default:
+          *val = LSM6DS3TR_C_SL3_DEC_ND;
+          break;
+      }
+      ret = lsm6ds3tr_c_mem_bank_set(ctx, LSM6DS3TR_C_USER_BANK);
+    }
+  }
+
+  return ret;
+}
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6ds3tr_c_STdC/driver/lsm6ds3tr_c_reg.h
+++ b/sensor/stmemsc/lsm6ds3tr_c_STdC/driver/lsm6ds3tr_c_reg.h
@@ -1,0 +1,1893 @@
+/*
+ ******************************************************************************
+ * @file    lsm6ds3tr_c_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm6ds3tr_c_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DS3TR_C_DRIVER_H
+#define LSM6DS3TR_C_DRIVER_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM6DS3TR_C
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+  *              You can create a sensor configuration by your own or using 
+  *              Unico / Unicleo tools available on STMicroelectronics
+  *              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DS3TR_C_Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define LSM6DS3TR_C_I2C_ADD_L     0xD5U
+#define LSM6DS3TR_C_I2C_ADD_H     0xD7U
+
+/** Device Identification (Who am I) **/
+#define LSM6DS3TR_C_ID            0x6AU
+
+/**
+  * @}
+  *
+  */
+
+#define LSM6DS3TR_C_FUNC_CFG_ACCESS              0x01U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t func_cfg_en              : 3;  /* func_cfg_en + func_cfg_en_b */
+} lsm6ds3tr_c_func_cfg_access_t;
+
+#define LSM6DS3TR_C_SENSOR_SYNC_TIME_FRAME       0x04U
+typedef struct {
+  uint8_t tph                      : 4;
+  uint8_t not_used_01              : 4;
+} lsm6ds3tr_c_sensor_sync_time_frame_t;
+
+#define LSM6DS3TR_C_SENSOR_SYNC_RES_RATIO        0x05U
+typedef struct {
+  uint8_t rr                       : 2;
+  uint8_t not_used_01              : 6;
+} lsm6ds3tr_c_sensor_sync_res_ratio_t;
+
+#define LSM6DS3TR_C_FIFO_CTRL1                   0x06U
+typedef struct {
+  uint8_t fth                      : 8;  /* + FIFO_CTRL2(fth) */
+} lsm6ds3tr_c_fifo_ctrl1_t;
+
+#define LSM6DS3TR_C_FIFO_CTRL2                   0x07U
+typedef struct {
+  uint8_t fth                      : 3;  /* + FIFO_CTRL1(fth) */
+  uint8_t fifo_temp_en             : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t timer_pedo_fifo_drdy     : 1;
+  uint8_t timer_pedo_fifo_en       : 1;
+} lsm6ds3tr_c_fifo_ctrl2_t;
+
+#define LSM6DS3TR_C_FIFO_CTRL3                   0x08U
+typedef struct {
+  uint8_t dec_fifo_xl              : 3;
+  uint8_t dec_fifo_gyro            : 3;
+  uint8_t not_used_01              : 2;
+} lsm6ds3tr_c_fifo_ctrl3_t;
+
+#define LSM6DS3TR_C_FIFO_CTRL4                   0x09U
+typedef struct {
+  uint8_t dec_ds3_fifo             : 3;
+  uint8_t dec_ds4_fifo             : 3;
+  uint8_t only_high_data           : 1;
+  uint8_t stop_on_fth              : 1;
+} lsm6ds3tr_c_fifo_ctrl4_t;
+
+#define LSM6DS3TR_C_FIFO_CTRL5                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t odr_fifo                 : 4;
+  uint8_t not_used_01              : 1;
+} lsm6ds3tr_c_fifo_ctrl5_t;
+
+#define LSM6DS3TR_C_DRDY_PULSE_CFG_G             0x0BU
+typedef struct {
+  uint8_t int2_wrist_tilt          : 1;
+  uint8_t not_used_01              : 6;
+  uint8_t drdy_pulsed              : 1;
+} lsm6ds3tr_c_drdy_pulse_cfg_g_t;
+
+#define LSM6DS3TR_C_INT1_CTRL                    0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_full_flag           : 1;
+  uint8_t int1_sign_mot            : 1;
+  uint8_t int1_step_detector       : 1;
+} lsm6ds3tr_c_int1_ctrl_t;
+
+#define LSM6DS3TR_C_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_full_flag           : 1;
+  uint8_t int2_step_count_ov       : 1;
+  uint8_t int2_step_delta          : 1;
+} lsm6ds3tr_c_int2_ctrl_t;
+
+#define LSM6DS3TR_C_WHO_AM_I                     0x0FU
+#define LSM6DS3TR_C_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t bw0_xl                   : 1;
+  uint8_t lpf1_bw_sel              : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} lsm6ds3tr_c_ctrl1_xl_t;
+
+#define LSM6DS3TR_C_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t fs_g                     : 3;  /* fs_g + fs_125 */
+  uint8_t odr_g                    : 4;
+} lsm6ds3tr_c_ctrl2_g_t;
+
+#define LSM6DS3TR_C_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t ble                      : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} lsm6ds3tr_c_ctrl3_c_t;
+
+#define LSM6DS3TR_C_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t den_drdy_int1            : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep                    : 1;
+  uint8_t den_xl_en                : 1;
+} lsm6ds3tr_c_ctrl4_c_t;
+
+#define LSM6DS3TR_C_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t den_lh                   : 1;
+  uint8_t rounding                 : 3;
+} lsm6ds3tr_c_ctrl5_c_t;
+
+#define LSM6DS3TR_C_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t ftype                    : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t usr_off_w                : 1;
+  uint8_t xl_hm_mode               : 1;
+  uint8_t den_mode                 : 3;  /* trig_en + lvl_en + lvl2_en */
+} lsm6ds3tr_c_ctrl6_c_t;
+
+#define LSM6DS3TR_C_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t rounding_status          : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t g_hm_mode                : 1;
+} lsm6ds3tr_c_ctrl7_g_t;
+
+#define LSM6DS3TR_C_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t input_composite          : 1;
+  uint8_t hp_ref_mode              : 1;
+  uint8_t hpcf_xl                  : 2;
+  uint8_t lpf2_xl_en               : 1;
+} lsm6ds3tr_c_ctrl8_xl_t;
+
+#define LSM6DS3TR_C_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t soft_en                  : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t den_xl_g                 : 1;
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} lsm6ds3tr_c_ctrl9_xl_t;
+
+#define LSM6DS3TR_C_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t sign_motion_en           : 1;
+  uint8_t pedo_rst_step            : 1;
+  uint8_t func_en                  : 1;
+  uint8_t tilt_en                  : 1;
+  uint8_t pedo_en                  : 1;
+  uint8_t timer_en                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t wrist_tilt_en            : 1;
+} lsm6ds3tr_c_ctrl10_c_t;
+
+#define LSM6DS3TR_C_MASTER_CONFIG                0x1AU
+typedef struct {
+  uint8_t master_on                : 1;
+  uint8_t iron_en                  : 1;
+  uint8_t pass_through_mode        : 1;
+  uint8_t pull_up_en               : 1;
+  uint8_t start_config             : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t data_valid_sel_fifo      : 1;
+  uint8_t drdy_on_int1             : 1;
+} lsm6ds3tr_c_master_config_t;
+
+#define LSM6DS3TR_C_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state_ia           : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t not_used_01              : 2;
+} lsm6ds3tr_c_wake_up_src_t;
+
+#define LSM6DS3TR_C_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_01              : 1;
+} lsm6ds3tr_c_tap_src_t;
+
+#define LSM6DS3TR_C_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} lsm6ds3tr_c_d6d_src_t;
+
+#define LSM6DS3TR_C_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} lsm6ds3tr_c_status_reg_t;
+
+#define LSM6DS3TR_C_OUT_TEMP_L                   0x20U
+#define LSM6DS3TR_C_OUT_TEMP_H                   0x21U
+#define LSM6DS3TR_C_OUTX_L_G                     0x22U
+#define LSM6DS3TR_C_OUTX_H_G                     0x23U
+#define LSM6DS3TR_C_OUTY_L_G                     0x24U
+#define LSM6DS3TR_C_OUTY_H_G                     0x25U
+#define LSM6DS3TR_C_OUTZ_L_G                     0x26U
+#define LSM6DS3TR_C_OUTZ_H_G                     0x27U
+#define LSM6DS3TR_C_OUTX_L_XL                    0x28U
+#define LSM6DS3TR_C_OUTX_H_XL                    0x29U
+#define LSM6DS3TR_C_OUTY_L_XL                    0x2AU
+#define LSM6DS3TR_C_OUTY_H_XL                    0x2BU
+#define LSM6DS3TR_C_OUTZ_L_XL                    0x2CU
+#define LSM6DS3TR_C_OUTZ_H_XL                    0x2DU
+#define LSM6DS3TR_C_SENSORHUB1_REG               0x2EU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub1_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB2_REG               0x2FU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub2_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB3_REG               0x30U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub3_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB4_REG               0x31U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub4_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB5_REG               0x32U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub5_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB6_REG               0x33U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub6_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB7_REG               0x34U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub7_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB8_REG               0x35U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub8_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB9_REG               0x36U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub9_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB10_REG              0x37U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub10_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB11_REG              0x38U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub11_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB12_REG              0x39U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub12_reg_t;
+
+#define LSM6DS3TR_C_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;  /* + FIFO_STATUS2(diff_fifo) */
+} lsm6ds3tr_c_fifo_status1_t;
+
+#define LSM6DS3TR_C_FIFO_STATUS2                 0x3BU
+typedef struct {
+  uint8_t diff_fifo                : 3;  /* + FIFO_STATUS1(diff_fifo) */
+  uint8_t not_used_01              : 1;
+  uint8_t fifo_empty               : 1;
+  uint8_t fifo_full_smart          : 1;
+  uint8_t over_run                 : 1;
+  uint8_t waterm                   : 1;
+} lsm6ds3tr_c_fifo_status2_t;
+
+#define LSM6DS3TR_C_FIFO_STATUS3                 0x3CU
+typedef struct {
+  uint8_t fifo_pattern             : 8;  /* + FIFO_STATUS4(fifo_pattern) */
+} lsm6ds3tr_c_fifo_status3_t;
+
+#define LSM6DS3TR_C_FIFO_STATUS4                 0x3DU
+typedef struct {
+  uint8_t fifo_pattern             : 2;  /* + FIFO_STATUS3(fifo_pattern) */
+  uint8_t not_used_01              : 6;
+} lsm6ds3tr_c_fifo_status4_t;
+
+#define LSM6DS3TR_C_FIFO_DATA_OUT_L              0x3EU
+#define LSM6DS3TR_C_FIFO_DATA_OUT_H              0x3FU
+#define LSM6DS3TR_C_TIMESTAMP0_REG               0x40U
+#define LSM6DS3TR_C_TIMESTAMP1_REG               0x41U
+#define LSM6DS3TR_C_TIMESTAMP2_REG               0x42U
+#define LSM6DS3TR_C_STEP_TIMESTAMP_L             0x49U
+#define LSM6DS3TR_C_STEP_TIMESTAMP_H             0x4AU
+#define LSM6DS3TR_C_STEP_COUNTER_L               0x4BU
+#define LSM6DS3TR_C_STEP_COUNTER_H               0x4CU
+
+#define LSM6DS3TR_C_SENSORHUB13_REG              0x4DU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub13_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB14_REG              0x4EU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub14_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB15_REG              0x4FU
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub15_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB16_REG              0x50U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub16_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB17_REG              0x51U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub17_reg_t;
+
+#define LSM6DS3TR_C_SENSORHUB18_REG              0x52U
+typedef struct {
+  uint8_t bit0                     : 1;
+  uint8_t bit1                     : 1;
+  uint8_t bit2                     : 1;
+  uint8_t bit3                     : 1;
+  uint8_t bit4                     : 1;
+  uint8_t bit5                     : 1;
+  uint8_t bit6                     : 1;
+  uint8_t bit7                     : 1;
+} lsm6ds3tr_c_sensorhub18_reg_t;
+
+#define LSM6DS3TR_C_FUNC_SRC1                    0x53U
+typedef struct {
+  uint8_t sensorhub_end_op         : 1;
+  uint8_t si_end_op                : 1;
+  uint8_t hi_fail                  : 1;
+  uint8_t step_overflow            : 1;
+  uint8_t step_detected            : 1;
+  uint8_t tilt_ia                  : 1;
+  uint8_t sign_motion_ia           : 1;
+  uint8_t step_count_delta_ia      : 1;
+} lsm6ds3tr_c_func_src1_t;
+
+#define LSM6DS3TR_C_FUNC_SRC2                    0x54U
+typedef struct {
+  uint8_t wrist_tilt_ia            : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t slave0_nack              : 1;
+  uint8_t slave1_nack              : 1;
+  uint8_t slave2_nack              : 1;
+  uint8_t slave3_nack              : 1;
+  uint8_t not_used_02              : 1;
+} lsm6ds3tr_c_func_src2_t;
+
+#define LSM6DS3TR_C_WRIST_TILT_IA                0x55U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t wrist_tilt_ia_zneg       : 1;
+  uint8_t wrist_tilt_ia_zpos       : 1;
+  uint8_t wrist_tilt_ia_yneg       : 1;
+  uint8_t wrist_tilt_ia_ypos       : 1;
+  uint8_t wrist_tilt_ia_xneg       : 1;
+  uint8_t wrist_tilt_ia_xpos       : 1;
+} lsm6ds3tr_c_wrist_tilt_ia_t;
+
+#define LSM6DS3TR_C_TAP_CFG                      0x58U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t tap_z_en                 : 1;
+  uint8_t tap_y_en                 : 1;
+  uint8_t tap_x_en                 : 1;
+  uint8_t slope_fds                : 1;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} lsm6ds3tr_c_tap_cfg_t;
+
+#define LSM6DS3TR_C_TAP_THS_6D                   0x59U
+typedef struct {
+  uint8_t tap_ths                  : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} lsm6ds3tr_c_tap_ths_6d_t;
+
+#define LSM6DS3TR_C_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} lsm6ds3tr_c_int_dur2_t;
+
+#define LSM6DS3TR_C_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t not_used_01              : 1;
+  uint8_t single_double_tap        : 1;
+} lsm6ds3tr_c_wake_up_ths_t;
+
+#define LSM6DS3TR_C_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t timer_hr                 : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} lsm6ds3tr_c_wake_up_dur_t;
+
+#define LSM6DS3TR_C_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} lsm6ds3tr_c_free_fall_t;
+
+#define LSM6DS3TR_C_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t int1_timer               : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_inact_state         : 1;
+} lsm6ds3tr_c_md1_cfg_t;
+
+#define LSM6DS3TR_C_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_iron                : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_inact_state         : 1;
+} lsm6ds3tr_c_md2_cfg_t;
+
+#define LSM6DS3TR_C_MASTER_CMD_CODE              0x60U
+typedef struct {
+  uint8_t master_cmd_code          : 8;
+} lsm6ds3tr_c_master_cmd_code_t;
+
+#define LSM6DS3TR_C_SENS_SYNC_SPI_ERROR_CODE     0x61U
+typedef struct {
+  uint8_t error_code               : 8;
+} lsm6ds3tr_c_sens_sync_spi_error_code_t;
+
+#define LSM6DS3TR_C_OUT_MAG_RAW_X_L              0x66U
+#define LSM6DS3TR_C_OUT_MAG_RAW_X_H              0x67U
+#define LSM6DS3TR_C_OUT_MAG_RAW_Y_L              0x68U
+#define LSM6DS3TR_C_OUT_MAG_RAW_Y_H              0x69U
+#define LSM6DS3TR_C_OUT_MAG_RAW_Z_L              0x6AU
+#define LSM6DS3TR_C_OUT_MAG_RAW_Z_H              0x6BU
+#define LSM6DS3TR_C_X_OFS_USR                    0x73U
+#define LSM6DS3TR_C_Y_OFS_USR                    0x74U
+#define LSM6DS3TR_C_Z_OFS_USR                    0x75U
+#define LSM6DS3TR_C_SLV0_ADD                     0x02U
+typedef struct {
+  uint8_t rw_0                     : 1;
+  uint8_t slave0_add               : 7;
+} lsm6ds3tr_c_slv0_add_t;
+
+#define LSM6DS3TR_C_SLV0_SUBADD                  0x03U
+typedef struct {
+  uint8_t slave0_reg               : 8;
+} lsm6ds3tr_c_slv0_subadd_t;
+
+#define LSM6DS3TR_C_SLAVE0_CONFIG                0x04U
+typedef struct {
+  uint8_t slave0_numop             : 3;
+  uint8_t src_mode                 : 1;
+  uint8_t aux_sens_on              : 2;
+  uint8_t slave0_rate              : 2;
+} lsm6ds3tr_c_slave0_config_t;
+
+#define LSM6DS3TR_C_SLV1_ADD                     0x05U
+typedef struct {
+  uint8_t r_1                      : 1;
+  uint8_t slave1_add               : 7;
+} lsm6ds3tr_c_slv1_add_t;
+
+#define LSM6DS3TR_C_SLV1_SUBADD                  0x06U
+typedef struct {
+  uint8_t slave1_reg               : 8;
+} lsm6ds3tr_c_slv1_subadd_t;
+
+#define LSM6DS3TR_C_SLAVE1_CONFIG                0x07U
+typedef struct {
+  uint8_t slave1_numop             : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t write_once               : 1;
+  uint8_t slave1_rate              : 2;
+} lsm6ds3tr_c_slave1_config_t;
+
+#define LSM6DS3TR_C_SLV2_ADD                     0x08U
+typedef struct {
+  uint8_t r_2                      : 1;
+  uint8_t slave2_add               : 7;
+} lsm6ds3tr_c_slv2_add_t;
+
+#define LSM6DS3TR_C_SLV2_SUBADD                  0x09U
+typedef struct {
+  uint8_t slave2_reg               : 8;
+} lsm6ds3tr_c_slv2_subadd_t;
+
+#define LSM6DS3TR_C_SLAVE2_CONFIG                0x0AU
+typedef struct {
+  uint8_t slave2_numop             : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t slave2_rate              : 2;
+} lsm6ds3tr_c_slave2_config_t;
+
+#define LSM6DS3TR_C_SLV3_ADD                     0x0BU
+typedef struct {
+  uint8_t r_3                      : 1;
+  uint8_t slave3_add               : 7;
+} lsm6ds3tr_c_slv3_add_t;
+
+#define LSM6DS3TR_C_SLV3_SUBADD                  0x0CU
+typedef struct {
+  uint8_t slave3_reg               : 8;
+} lsm6ds3tr_c_slv3_subadd_t;
+
+#define LSM6DS3TR_C_SLAVE3_CONFIG                0x0DU
+typedef struct {
+  uint8_t slave3_numop             : 3;
+  uint8_t not_used_01              : 3;
+  uint8_t slave3_rate              : 2;
+} lsm6ds3tr_c_slave3_config_t;
+
+#define LSM6DS3TR_C_DATAWRITE_SRC_MODE_SUB_SLV0  0x0EU
+typedef struct {
+  uint8_t slave_dataw              : 8;
+} lsm6ds3tr_c_datawrite_src_mode_sub_slv0_t;
+
+#define LSM6DS3TR_C_CONFIG_PEDO_THS_MIN          0x0FU
+typedef struct {
+  uint8_t ths_min                  : 5;
+  uint8_t not_used_01              : 2;
+  uint8_t pedo_fs                  : 1;
+} lsm6ds3tr_c_config_pedo_ths_min_t;
+
+#define LSM6DS3TR_C_SM_THS                       0x13U
+#define LSM6DS3TR_C_PEDO_DEB_REG                 0x14U
+typedef struct {
+  uint8_t deb_step      : 3;
+  uint8_t deb_time      : 5;
+} lsm6ds3tr_c_pedo_deb_reg_t;
+
+#define LSM6DS3TR_C_STEP_COUNT_DELTA             0x15U
+#define LSM6DS3TR_C_MAG_SI_XX                    0x24U
+#define LSM6DS3TR_C_MAG_SI_XY                    0x25U
+#define LSM6DS3TR_C_MAG_SI_XZ                    0x26U
+#define LSM6DS3TR_C_MAG_SI_YX                    0x27U
+#define LSM6DS3TR_C_MAG_SI_YY                    0x28U
+#define LSM6DS3TR_C_MAG_SI_YZ                    0x29U
+#define LSM6DS3TR_C_MAG_SI_ZX                    0x2AU
+#define LSM6DS3TR_C_MAG_SI_ZY                    0x2BU
+#define LSM6DS3TR_C_MAG_SI_ZZ                    0x2CU
+#define LSM6DS3TR_C_MAG_OFFX_L                   0x2DU
+#define LSM6DS3TR_C_MAG_OFFX_H                   0x2EU
+#define LSM6DS3TR_C_MAG_OFFY_L                   0x2FU
+#define LSM6DS3TR_C_MAG_OFFY_H                   0x30U
+#define LSM6DS3TR_C_MAG_OFFZ_L                   0x31U
+#define LSM6DS3TR_C_MAG_OFFZ_H                   0x32U
+#define LSM6DS3TR_C_A_WRIST_TILT_LAT             0x50U
+#define LSM6DS3TR_C_A_WRIST_TILT_THS             0x54U
+#define LSM6DS3TR_C_A_WRIST_TILT_MASK            0x59U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t  wrist_tilt_mask_zneg    : 1;
+  uint8_t  wrist_tilt_mask_zpos    : 1;
+  uint8_t  wrist_tilt_mask_yneg    : 1;
+  uint8_t  wrist_tilt_mask_ypos    : 1;
+  uint8_t  wrist_tilt_mask_xneg    : 1;
+  uint8_t  wrist_tilt_mask_xpos    : 1;
+} lsm6ds3tr_c_a_wrist_tilt_mask_t;
+
+/**
+  * @defgroup LSM6DS3TR_C_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lsm6ds3tr_c_func_cfg_access_t                  func_cfg_access;
+  lsm6ds3tr_c_sensor_sync_time_frame_t           sensor_sync_time_frame;
+  lsm6ds3tr_c_sensor_sync_res_ratio_t            sensor_sync_res_ratio;
+  lsm6ds3tr_c_fifo_ctrl1_t                       fifo_ctrl1;
+  lsm6ds3tr_c_fifo_ctrl2_t                       fifo_ctrl2;
+  lsm6ds3tr_c_fifo_ctrl3_t                       fifo_ctrl3;
+  lsm6ds3tr_c_fifo_ctrl4_t                       fifo_ctrl4;
+  lsm6ds3tr_c_fifo_ctrl5_t                       fifo_ctrl5;
+  lsm6ds3tr_c_drdy_pulse_cfg_g_t                 drdy_pulse_cfg_g;
+  lsm6ds3tr_c_int1_ctrl_t                        int1_ctrl;
+  lsm6ds3tr_c_int2_ctrl_t                        int2_ctrl;
+  lsm6ds3tr_c_ctrl1_xl_t                         ctrl1_xl;
+  lsm6ds3tr_c_ctrl2_g_t                          ctrl2_g;
+  lsm6ds3tr_c_ctrl3_c_t                          ctrl3_c;
+  lsm6ds3tr_c_ctrl4_c_t                          ctrl4_c;
+  lsm6ds3tr_c_ctrl5_c_t                          ctrl5_c;
+  lsm6ds3tr_c_ctrl6_c_t                          ctrl6_c;
+  lsm6ds3tr_c_ctrl7_g_t                          ctrl7_g;
+  lsm6ds3tr_c_ctrl8_xl_t                         ctrl8_xl;
+  lsm6ds3tr_c_ctrl9_xl_t                         ctrl9_xl;
+  lsm6ds3tr_c_ctrl10_c_t                         ctrl10_c;
+  lsm6ds3tr_c_master_config_t                    master_config;
+  lsm6ds3tr_c_wake_up_src_t                      wake_up_src;
+  lsm6ds3tr_c_tap_src_t                          tap_src;
+  lsm6ds3tr_c_d6d_src_t                          d6d_src;
+  lsm6ds3tr_c_status_reg_t                       status_reg;
+  lsm6ds3tr_c_sensorhub1_reg_t                   sensorhub1_reg;
+  lsm6ds3tr_c_sensorhub2_reg_t                   sensorhub2_reg;
+  lsm6ds3tr_c_sensorhub3_reg_t                   sensorhub3_reg;
+  lsm6ds3tr_c_sensorhub4_reg_t                   sensorhub4_reg;
+  lsm6ds3tr_c_sensorhub5_reg_t                   sensorhub5_reg;
+  lsm6ds3tr_c_sensorhub6_reg_t                   sensorhub6_reg;
+  lsm6ds3tr_c_sensorhub7_reg_t                   sensorhub7_reg;
+  lsm6ds3tr_c_sensorhub8_reg_t                   sensorhub8_reg;
+  lsm6ds3tr_c_sensorhub9_reg_t                   sensorhub9_reg;
+  lsm6ds3tr_c_sensorhub10_reg_t                  sensorhub10_reg;
+  lsm6ds3tr_c_sensorhub11_reg_t                  sensorhub11_reg;
+  lsm6ds3tr_c_sensorhub12_reg_t                  sensorhub12_reg;
+  lsm6ds3tr_c_fifo_status1_t                     fifo_status1;
+  lsm6ds3tr_c_fifo_status2_t                     fifo_status2;
+  lsm6ds3tr_c_fifo_status3_t                     fifo_status3;
+  lsm6ds3tr_c_fifo_status4_t                     fifo_status4;
+  lsm6ds3tr_c_sensorhub13_reg_t                  sensorhub13_reg;
+  lsm6ds3tr_c_sensorhub14_reg_t                  sensorhub14_reg;
+  lsm6ds3tr_c_sensorhub15_reg_t                  sensorhub15_reg;
+  lsm6ds3tr_c_sensorhub16_reg_t                  sensorhub16_reg;
+  lsm6ds3tr_c_sensorhub17_reg_t                  sensorhub17_reg;
+  lsm6ds3tr_c_sensorhub18_reg_t                  sensorhub18_reg;
+  lsm6ds3tr_c_func_src1_t                        func_src1;
+  lsm6ds3tr_c_func_src2_t                        func_src2;
+  lsm6ds3tr_c_wrist_tilt_ia_t                    wrist_tilt_ia;
+  lsm6ds3tr_c_tap_cfg_t                          tap_cfg;
+  lsm6ds3tr_c_tap_ths_6d_t                       tap_ths_6d;
+  lsm6ds3tr_c_int_dur2_t                         int_dur2;
+  lsm6ds3tr_c_wake_up_ths_t                      wake_up_ths;
+  lsm6ds3tr_c_wake_up_dur_t                      wake_up_dur;
+  lsm6ds3tr_c_free_fall_t                        free_fall;
+  lsm6ds3tr_c_md1_cfg_t                          md1_cfg;
+  lsm6ds3tr_c_md2_cfg_t                          md2_cfg;
+  lsm6ds3tr_c_master_cmd_code_t                  master_cmd_code;
+  lsm6ds3tr_c_sens_sync_spi_error_code_t         sens_sync_spi_error_code;
+  lsm6ds3tr_c_slv0_add_t                         slv0_add;
+  lsm6ds3tr_c_slv0_subadd_t                      slv0_subadd;
+  lsm6ds3tr_c_slave0_config_t                    slave0_config;
+  lsm6ds3tr_c_slv1_add_t                         slv1_add;
+  lsm6ds3tr_c_slv1_subadd_t                      slv1_subadd;
+  lsm6ds3tr_c_slave1_config_t                    slave1_config;
+  lsm6ds3tr_c_slv2_add_t                         slv2_add;
+  lsm6ds3tr_c_slv2_subadd_t                      slv2_subadd;
+  lsm6ds3tr_c_slave2_config_t                    slave2_config;
+  lsm6ds3tr_c_slv3_add_t                         slv3_add;
+  lsm6ds3tr_c_slv3_subadd_t                      slv3_subadd;
+  lsm6ds3tr_c_slave3_config_t                    slave3_config;
+  lsm6ds3tr_c_datawrite_src_mode_sub_slv0_t      datawrite_src_mode_sub_slv0;
+  lsm6ds3tr_c_config_pedo_ths_min_t              config_pedo_ths_min;
+  lsm6ds3tr_c_pedo_deb_reg_t                     pedo_deb_reg;
+  lsm6ds3tr_c_a_wrist_tilt_mask_t                a_wrist_tilt_mask;
+  bitwise_t                                  bitwise;
+  uint8_t                                    byte;
+} lsm6ds3tr_c_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm6ds3tr_c_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lsm6ds3tr_c_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lsm6ds3tr_c_from_fs2g_to_mg(int16_t lsb);
+extern float_t lsm6ds3tr_c_from_fs4g_to_mg(int16_t lsb);
+extern float_t lsm6ds3tr_c_from_fs8g_to_mg(int16_t lsb);
+extern float_t lsm6ds3tr_c_from_fs16g_to_mg(int16_t lsb);
+
+extern float_t lsm6ds3tr_c_from_fs125dps_to_mdps(int16_t lsb);
+extern float_t lsm6ds3tr_c_from_fs250dps_to_mdps(int16_t lsb);
+extern float_t lsm6ds3tr_c_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t lsm6ds3tr_c_from_fs1000dps_to_mdps(int16_t lsb);
+extern float_t lsm6ds3tr_c_from_fs2000dps_to_mdps(int16_t lsb);
+
+extern float_t lsm6ds3tr_c_from_lsb_to_celsius(int16_t lsb);
+
+typedef enum {
+  LSM6DS3TR_C_2g       = 0,
+  LSM6DS3TR_C_16g      = 1,
+  LSM6DS3TR_C_4g       = 2,
+  LSM6DS3TR_C_8g       = 3,
+  LSM6DS3TR_C_XL_FS_ND = 4,  /* ERROR CODE */
+} lsm6ds3tr_c_fs_xl_t;
+int32_t lsm6ds3tr_c_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_fs_xl_t val);
+int32_t lsm6ds3tr_c_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_fs_xl_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_XL_ODR_OFF      =  0,
+  LSM6DS3TR_C_XL_ODR_12Hz5    =  1,
+  LSM6DS3TR_C_XL_ODR_26Hz     =  2,
+  LSM6DS3TR_C_XL_ODR_52Hz     =  3,
+  LSM6DS3TR_C_XL_ODR_104Hz    =  4,
+  LSM6DS3TR_C_XL_ODR_208Hz    =  5,
+  LSM6DS3TR_C_XL_ODR_416Hz    =  6,
+  LSM6DS3TR_C_XL_ODR_833Hz    =  7,
+  LSM6DS3TR_C_XL_ODR_1k66Hz   =  8,
+  LSM6DS3TR_C_XL_ODR_3k33Hz   =  9,
+  LSM6DS3TR_C_XL_ODR_6k66Hz   = 10,
+  LSM6DS3TR_C_XL_ODR_1Hz6     = 11,
+  LSM6DS3TR_C_XL_ODR_ND       = 12,  /* ERROR CODE */
+} lsm6ds3tr_c_odr_xl_t;
+int32_t lsm6ds3tr_c_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_xl_t val);
+int32_t lsm6ds3tr_c_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_xl_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_250dps     = 0,
+  LSM6DS3TR_C_125dps     = 1,
+  LSM6DS3TR_C_500dps     = 2,
+  LSM6DS3TR_C_1000dps    = 4,
+  LSM6DS3TR_C_2000dps    = 6,
+  LSM6DS3TR_C_GY_FS_ND   = 7,    /* ERROR CODE */
+} lsm6ds3tr_c_fs_g_t;
+int32_t lsm6ds3tr_c_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_fs_g_t val);
+int32_t lsm6ds3tr_c_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_fs_g_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_GY_ODR_OFF    =  0,
+  LSM6DS3TR_C_GY_ODR_12Hz5  =  1,
+  LSM6DS3TR_C_GY_ODR_26Hz   =  2,
+  LSM6DS3TR_C_GY_ODR_52Hz   =  3,
+  LSM6DS3TR_C_GY_ODR_104Hz  =  4,
+  LSM6DS3TR_C_GY_ODR_208Hz  =  5,
+  LSM6DS3TR_C_GY_ODR_416Hz  =  6,
+  LSM6DS3TR_C_GY_ODR_833Hz  =  7,
+  LSM6DS3TR_C_GY_ODR_1k66Hz =  8,
+  LSM6DS3TR_C_GY_ODR_3k33Hz =  9,
+  LSM6DS3TR_C_GY_ODR_6k66Hz = 10,
+  LSM6DS3TR_C_GY_ODR_ND     = 11,    /* ERROR CODE */
+} lsm6ds3tr_c_odr_g_t;
+int32_t lsm6ds3tr_c_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_g_t val);
+int32_t lsm6ds3tr_c_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_odr_g_t *val);
+
+int32_t lsm6ds3tr_c_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_LSb_1mg   = 0,
+  LSM6DS3TR_C_LSb_16mg  = 1,
+  LSM6DS3TR_C_WEIGHT_ND = 2,
+} lsm6ds3tr_c_usr_off_w_t;
+int32_t lsm6ds3tr_c_xl_offset_weight_set(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_usr_off_w_t val);
+int32_t lsm6ds3tr_c_xl_offset_weight_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_usr_off_w_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_XL_HIGH_PERFORMANCE  = 0,
+  LSM6DS3TR_C_XL_NORMAL            = 1,
+  LSM6DS3TR_C_XL_PW_MODE_ND        = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_xl_hm_mode_t;
+int32_t lsm6ds3tr_c_xl_power_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_xl_hm_mode_t val);
+int32_t lsm6ds3tr_c_xl_power_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_xl_hm_mode_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_STAT_RND_DISABLE  = 0,
+  LSM6DS3TR_C_STAT_RND_ENABLE   = 1,
+  LSM6DS3TR_C_STAT_RND_ND       = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_rounding_status_t;
+int32_t lsm6ds3tr_c_rounding_on_status_set(stmdev_ctx_t *ctx,
+                                       lsm6ds3tr_c_rounding_status_t val);
+int32_t lsm6ds3tr_c_rounding_on_status_get(stmdev_ctx_t *ctx,
+                                       lsm6ds3tr_c_rounding_status_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_GY_HIGH_PERFORMANCE  = 0,
+  LSM6DS3TR_C_GY_NORMAL            = 1,
+  LSM6DS3TR_C_GY_PW_MODE_ND        = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_g_hm_mode_t;
+int32_t lsm6ds3tr_c_gy_power_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_g_hm_mode_t val);
+int32_t lsm6ds3tr_c_gy_power_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_g_hm_mode_t *val);
+
+typedef struct {
+  lsm6ds3tr_c_wake_up_src_t        wake_up_src;
+  lsm6ds3tr_c_tap_src_t            tap_src;
+  lsm6ds3tr_c_d6d_src_t            d6d_src;
+  lsm6ds3tr_c_status_reg_t         status_reg;
+  lsm6ds3tr_c_func_src1_t          func_src1;
+  lsm6ds3tr_c_func_src2_t          func_src2;
+  lsm6ds3tr_c_wrist_tilt_ia_t      wrist_tilt_ia;
+  lsm6ds3tr_c_a_wrist_tilt_mask_t  a_wrist_tilt_mask;
+} lsm6ds3tr_c_all_sources_t;
+int32_t lsm6ds3tr_c_all_sources_get(stmdev_ctx_t *ctx,
+                                lsm6ds3tr_c_all_sources_t *val);
+
+int32_t lsm6ds3tr_c_status_reg_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_status_reg_t *val);
+
+int32_t lsm6ds3tr_c_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_LSB_6ms4    = 0,
+  LSM6DS3TR_C_LSB_25us    = 1,
+  LSM6DS3TR_C_TS_RES_ND   = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_timer_hr_t;
+int32_t lsm6ds3tr_c_timestamp_res_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_timer_hr_t val);
+int32_t lsm6ds3tr_c_timestamp_res_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_timer_hr_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_ROUND_DISABLE            = 0,
+  LSM6DS3TR_C_ROUND_XL                 = 1,
+  LSM6DS3TR_C_ROUND_GY                 = 2,
+  LSM6DS3TR_C_ROUND_GY_XL              = 3,
+  LSM6DS3TR_C_ROUND_SH1_TO_SH6         = 4,
+  LSM6DS3TR_C_ROUND_XL_SH1_TO_SH6      = 5,
+  LSM6DS3TR_C_ROUND_GY_XL_SH1_TO_SH12  = 6,
+  LSM6DS3TR_C_ROUND_GY_XL_SH1_TO_SH6   = 7,
+  LSM6DS3TR_C_ROUND_OUT_ND             = 8,    /* ERROR CODE */
+} lsm6ds3tr_c_rounding_t;
+int32_t lsm6ds3tr_c_rounding_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_rounding_t val);
+int32_t lsm6ds3tr_c_rounding_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_rounding_t *val);
+
+int32_t lsm6ds3tr_c_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3tr_c_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3tr_c_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer,
+                                  uint8_t len);
+
+typedef enum {
+  LSM6DS3TR_C_USER_BANK   = 0,
+  LSM6DS3TR_C_BANK_A      = 4,
+  LSM6DS3TR_C_BANK_B      = 5,
+  LSM6DS3TR_C_BANK_ND     = 6,    /* ERROR CODE */
+} lsm6ds3tr_c_func_cfg_en_t;
+int32_t lsm6ds3tr_c_mem_bank_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_func_cfg_en_t val);
+int32_t lsm6ds3tr_c_mem_bank_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_func_cfg_en_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_DRDY_LATCHED    = 0,
+  LSM6DS3TR_C_DRDY_PULSED     = 1,
+  LSM6DS3TR_C_DRDY_ND         = 2,  /* ERROR CODE */
+} lsm6ds3tr_c_drdy_pulsed_g_t;
+int32_t lsm6ds3tr_c_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_drdy_pulsed_g_t val);
+int32_t lsm6ds3tr_c_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_drdy_pulsed_g_t *val);
+
+int32_t lsm6ds3tr_c_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_LSB_AT_LOW_ADD  = 0,
+  LSM6DS3TR_C_MSB_AT_LOW_ADD  = 1,
+  LSM6DS3TR_C_DATA_FMT_ND     = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_ble_t;
+int32_t lsm6ds3tr_c_data_format_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_ble_t val);
+int32_t lsm6ds3tr_c_data_format_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_ble_t *val);
+
+int32_t lsm6ds3tr_c_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_XL_ST_DISABLE    = 0,
+  LSM6DS3TR_C_XL_ST_POSITIVE   = 1,
+  LSM6DS3TR_C_XL_ST_NEGATIVE   = 2,
+  LSM6DS3TR_C_XL_ST_ND         = 3,    /* ERROR CODE */
+} lsm6ds3tr_c_st_xl_t;
+int32_t lsm6ds3tr_c_xl_self_test_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_st_xl_t val);
+int32_t lsm6ds3tr_c_xl_self_test_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_st_xl_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_GY_ST_DISABLE    = 0,
+  LSM6DS3TR_C_GY_ST_POSITIVE   = 1,
+  LSM6DS3TR_C_GY_ST_NEGATIVE   = 3,
+  LSM6DS3TR_C_GY_ST_ND         = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_st_g_t;
+int32_t lsm6ds3tr_c_gy_self_test_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_st_g_t val);
+int32_t lsm6ds3tr_c_gy_self_test_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_st_g_t *val);
+
+int32_t lsm6ds3tr_c_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_USE_SLOPE    = 0,
+  LSM6DS3TR_C_USE_HPF      = 1,
+  LSM6DS3TR_C_HP_PATH_ND   = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_slope_fds_t;
+int32_t lsm6ds3tr_c_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                        lsm6ds3tr_c_slope_fds_t val);
+int32_t lsm6ds3tr_c_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                        lsm6ds3tr_c_slope_fds_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_XL_ANA_BW_1k5Hz = 0,
+  LSM6DS3TR_C_XL_ANA_BW_400Hz = 1,
+  LSM6DS3TR_C_XL_ANA_BW_ND    = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_bw0_xl_t;
+int32_t lsm6ds3tr_c_xl_filter_analog_set(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_bw0_xl_t val);
+int32_t lsm6ds3tr_c_xl_filter_analog_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_bw0_xl_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_XL_LP1_ODR_DIV_2 = 0,
+  LSM6DS3TR_C_XL_LP1_ODR_DIV_4 = 1,
+  LSM6DS3TR_C_XL_LP1_NA        = 2,  /* ERROR CODE */
+} lsm6ds3tr_c_lpf1_bw_sel_t;
+int32_t lsm6ds3tr_c_xl_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_lpf1_bw_sel_t val);
+int32_t lsm6ds3tr_c_xl_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_lpf1_bw_sel_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_50     = 0x00,
+  LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_100    = 0x01,
+  LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_9      = 0x02,
+  LSM6DS3TR_C_XL_LOW_LAT_LP_ODR_DIV_400    = 0x03,
+  LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_50   = 0x10,
+  LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_100  = 0x11,
+  LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_9    = 0x12,
+  LSM6DS3TR_C_XL_LOW_NOISE_LP_ODR_DIV_400  = 0x13,
+  LSM6DS3TR_C_XL_LP_NA                     = 0x20, /* ERROR CODE */
+} lsm6ds3tr_c_input_composite_t;
+int32_t lsm6ds3tr_c_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_input_composite_t val);
+int32_t lsm6ds3tr_c_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_input_composite_t *val);
+
+int32_t lsm6ds3tr_c_xl_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_xl_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_XL_HP_ODR_DIV_4      = 0x00, /* Slope filter */
+  LSM6DS3TR_C_XL_HP_ODR_DIV_100    = 0x01,
+  LSM6DS3TR_C_XL_HP_ODR_DIV_9      = 0x02,
+  LSM6DS3TR_C_XL_HP_ODR_DIV_400    = 0x03,
+  LSM6DS3TR_C_XL_HP_NA             = 0x10, /* ERROR CODE */
+} lsm6ds3tr_c_hpcf_xl_t;
+int32_t lsm6ds3tr_c_xl_hp_bandwidth_set(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_hpcf_xl_t val);
+int32_t lsm6ds3tr_c_xl_hp_bandwidth_get(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_hpcf_xl_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_LP2_ONLY                    = 0x00,
+
+  LSM6DS3TR_C_HP_16mHz_LP2                = 0x80,
+  LSM6DS3TR_C_HP_65mHz_LP2                = 0x90,
+  LSM6DS3TR_C_HP_260mHz_LP2               = 0xA0,
+  LSM6DS3TR_C_HP_1Hz04_LP2                = 0xB0,
+
+  LSM6DS3TR_C_HP_DISABLE_LP1_LIGHT        = 0x0A,
+  LSM6DS3TR_C_HP_DISABLE_LP1_NORMAL       = 0x09,
+  LSM6DS3TR_C_HP_DISABLE_LP_STRONG        = 0x08,
+  LSM6DS3TR_C_HP_DISABLE_LP1_AGGRESSIVE   = 0x0B,
+
+  LSM6DS3TR_C_HP_16mHz_LP1_LIGHT          = 0x8A,
+  LSM6DS3TR_C_HP_65mHz_LP1_NORMAL         = 0x99,
+  LSM6DS3TR_C_HP_260mHz_LP1_STRONG        = 0xA8,
+  LSM6DS3TR_C_HP_1Hz04_LP1_AGGRESSIVE     = 0xBB,
+
+  LSM6DS3TR_C_HP_GY_BAND_NA               = 0xFF,    /* ERROR CODE */
+} lsm6ds3tr_c_lpf1_sel_g_t;
+int32_t lsm6ds3tr_c_gy_band_pass_set(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_lpf1_sel_g_t val);
+int32_t lsm6ds3tr_c_gy_band_pass_get(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_lpf1_sel_g_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_SPI_4_WIRE  = 0,
+  LSM6DS3TR_C_SPI_3_WIRE  = 1,
+  LSM6DS3TR_C_SPI_MODE_ND = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_sim_t;
+int32_t lsm6ds3tr_c_spi_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_sim_t val);
+int32_t lsm6ds3tr_c_spi_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_sim_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_I2C_ENABLE   = 0,
+  LSM6DS3TR_C_I2C_DISABLE  = 1,
+  LSM6DS3TR_C_I2C_MODE_ND  = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_i2c_disable_t;
+int32_t lsm6ds3tr_c_i2c_interface_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_i2c_disable_t val);
+int32_t lsm6ds3tr_c_i2c_interface_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_i2c_disable_t *val);
+
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fth                 : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_full_flag           : 1;
+  uint8_t int1_sign_mot            : 1;
+  uint8_t int1_step_detector       : 1;
+  uint8_t int1_timer               : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_inact_state         : 1;
+  uint8_t den_drdy_int1            : 1;
+  uint8_t drdy_on_int1             : 1;
+} lsm6ds3tr_c_int1_route_t;
+int32_t lsm6ds3tr_c_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_int1_route_t val);
+int32_t lsm6ds3tr_c_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_int1_route_t *val);
+
+typedef struct{
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fth                 : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_full_flag           : 1;
+  uint8_t int2_step_count_ov       : 1;
+  uint8_t int2_step_delta          : 1;
+  uint8_t int2_iron                : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_inact_state         : 1;
+  uint8_t int2_wrist_tilt          : 1;
+} lsm6ds3tr_c_int2_route_t;
+int32_t lsm6ds3tr_c_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_int2_route_t val);
+int32_t lsm6ds3tr_c_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_int2_route_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_PUSH_PULL   = 0,
+  LSM6DS3TR_C_OPEN_DRAIN  = 1,
+  LSM6DS3TR_C_PIN_MODE_ND = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_pp_od_t;
+int32_t lsm6ds3tr_c_pin_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_pp_od_t val);
+int32_t lsm6ds3tr_c_pin_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_pp_od_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_ACTIVE_HIGH   = 0,
+  LSM6DS3TR_C_ACTIVE_LOW    = 1,
+  LSM6DS3TR_C_POLARITY_ND   = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_h_lactive_t;
+int32_t lsm6ds3tr_c_pin_polarity_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_h_lactive_t val);
+int32_t lsm6ds3tr_c_pin_polarity_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_h_lactive_t *val);
+
+int32_t lsm6ds3tr_c_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_INT_PULSED   = 0,
+  LSM6DS3TR_C_INT_LATCHED  = 1,
+  LSM6DS3TR_C_INT_MODE     = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_lir_t;
+int32_t lsm6ds3tr_c_int_notification_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_lir_t val);
+int32_t lsm6ds3tr_c_int_notification_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_lir_t *val);
+
+int32_t lsm6ds3tr_c_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_PROPERTY_DISABLE          = 0,
+  LSM6DS3TR_C_XL_12Hz5_GY_NOT_AFFECTED  = 1,
+  LSM6DS3TR_C_XL_12Hz5_GY_SLEEP         = 2,
+  LSM6DS3TR_C_XL_12Hz5_GY_PD            = 3,
+  LSM6DS3TR_C_ACT_MODE_ND               = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_inact_en_t;
+int32_t lsm6ds3tr_c_act_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_inact_en_t val);
+int32_t lsm6ds3tr_c_act_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_inact_en_t *val);
+
+int32_t lsm6ds3tr_c_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_tap_src_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_tap_src_t *val);
+
+int32_t lsm6ds3tr_c_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_ONLY_SINGLE          = 0,
+  LSM6DS3TR_C_BOTH_SINGLE_DOUBLE   = 1,
+  LSM6DS3TR_C_TAP_MODE_ND          = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_single_double_tap_t;
+int32_t lsm6ds3tr_c_tap_mode_set(stmdev_ctx_t *ctx,
+                             lsm6ds3tr_c_single_double_tap_t val);
+int32_t lsm6ds3tr_c_tap_mode_get(stmdev_ctx_t *ctx,
+                             lsm6ds3tr_c_single_double_tap_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_ODR_DIV_2_FEED      = 0,
+  LSM6DS3TR_C_LPF2_FEED           = 1,
+  LSM6DS3TR_C_6D_FEED_ND          = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_low_pass_on_6d_t;
+int32_t lsm6ds3tr_c_6d_feed_data_set(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_low_pass_on_6d_t val);
+int32_t lsm6ds3tr_c_6d_feed_data_get(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_low_pass_on_6d_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_DEG_80      = 0,
+  LSM6DS3TR_C_DEG_70      = 1,
+  LSM6DS3TR_C_DEG_60      = 2,
+  LSM6DS3TR_C_DEG_50      = 3,
+  LSM6DS3TR_C_6D_TH_ND    = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_sixd_ths_t;
+int32_t lsm6ds3tr_c_6d_threshold_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_sixd_ths_t val);
+int32_t lsm6ds3tr_c_6d_threshold_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_sixd_ths_t *val);
+
+int32_t lsm6ds3tr_c_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_FF_TSH_156mg = 0,
+  LSM6DS3TR_C_FF_TSH_219mg = 1,
+  LSM6DS3TR_C_FF_TSH_250mg = 2,
+  LSM6DS3TR_C_FF_TSH_312mg = 3,
+  LSM6DS3TR_C_FF_TSH_344mg = 4,
+  LSM6DS3TR_C_FF_TSH_406mg = 5,
+  LSM6DS3TR_C_FF_TSH_469mg = 6,
+  LSM6DS3TR_C_FF_TSH_500mg = 7,
+  LSM6DS3TR_C_FF_TSH_ND    = 8,    /* ERROR CODE */
+} lsm6ds3tr_c_ff_ths_t;
+int32_t lsm6ds3tr_c_ff_threshold_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_ff_ths_t val);
+int32_t lsm6ds3tr_c_ff_threshold_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_ff_ths_t *val);
+
+int32_t lsm6ds3tr_c_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6ds3tr_c_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6ds3tr_c_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6ds3tr_c_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6ds3tr_c_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_TRG_XL_GY_DRDY     = 0,
+  LSM6DS3TR_C_TRG_STEP_DETECT    = 1,
+  LSM6DS3TR_C_TRG_SH_DRDY        = 2,
+  LSM6DS3TR_C_TRG_SH_ND          = 3,    /* ERROR CODE */
+} lsm6ds3tr_c_trigger_fifo_t;
+int32_t lsm6ds3tr_c_fifo_write_trigger_set(stmdev_ctx_t *ctx,
+                                       lsm6ds3tr_c_trigger_fifo_t val);
+int32_t lsm6ds3tr_c_fifo_write_trigger_get(stmdev_ctx_t *ctx,
+                                       lsm6ds3tr_c_trigger_fifo_t *val);
+
+int32_t lsm6ds3tr_c_fifo_pedo_and_timestamp_batch_set(stmdev_ctx_t *ctx,
+                                                  uint8_t val);
+int32_t lsm6ds3tr_c_fifo_pedo_and_timestamp_batch_get(stmdev_ctx_t *ctx,
+                                                  uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_FIFO_XL_DISABLE  = 0,
+  LSM6DS3TR_C_FIFO_XL_NO_DEC   = 1,
+  LSM6DS3TR_C_FIFO_XL_DEC_2    = 2,
+  LSM6DS3TR_C_FIFO_XL_DEC_3    = 3,
+  LSM6DS3TR_C_FIFO_XL_DEC_4    = 4,
+  LSM6DS3TR_C_FIFO_XL_DEC_8    = 5,
+  LSM6DS3TR_C_FIFO_XL_DEC_16   = 6,
+  LSM6DS3TR_C_FIFO_XL_DEC_32   = 7,
+  LSM6DS3TR_C_FIFO_XL_DEC_ND   = 8,    /* ERROR CODE */
+} lsm6ds3tr_c_dec_fifo_xl_t;
+int32_t lsm6ds3tr_c_fifo_xl_batch_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_dec_fifo_xl_t val);
+int32_t lsm6ds3tr_c_fifo_xl_batch_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_dec_fifo_xl_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_FIFO_GY_DISABLE = 0,
+  LSM6DS3TR_C_FIFO_GY_NO_DEC  = 1,
+  LSM6DS3TR_C_FIFO_GY_DEC_2   = 2,
+  LSM6DS3TR_C_FIFO_GY_DEC_3   = 3,
+  LSM6DS3TR_C_FIFO_GY_DEC_4   = 4,
+  LSM6DS3TR_C_FIFO_GY_DEC_8   = 5,
+  LSM6DS3TR_C_FIFO_GY_DEC_16  = 6,
+  LSM6DS3TR_C_FIFO_GY_DEC_32  = 7,
+  LSM6DS3TR_C_FIFO_GY_DEC_ND  = 8,    /* ERROR CODE */
+} lsm6ds3tr_c_dec_fifo_gyro_t;
+int32_t lsm6ds3tr_c_fifo_gy_batch_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_dec_fifo_gyro_t val);
+int32_t lsm6ds3tr_c_fifo_gy_batch_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_dec_fifo_gyro_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_FIFO_DS3_DISABLE   = 0,
+  LSM6DS3TR_C_FIFO_DS3_NO_DEC    = 1,
+  LSM6DS3TR_C_FIFO_DS3_DEC_2     = 2,
+  LSM6DS3TR_C_FIFO_DS3_DEC_3     = 3,
+  LSM6DS3TR_C_FIFO_DS3_DEC_4     = 4,
+  LSM6DS3TR_C_FIFO_DS3_DEC_8     = 5,
+  LSM6DS3TR_C_FIFO_DS3_DEC_16    = 6,
+  LSM6DS3TR_C_FIFO_DS3_DEC_32    = 7,
+  LSM6DS3TR_C_FIFO_DS3_DEC_ND    = 8,    /* ERROR CODE */
+} lsm6ds3tr_c_dec_ds3_fifo_t;
+int32_t lsm6ds3tr_c_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
+                                         lsm6ds3tr_c_dec_ds3_fifo_t val);
+int32_t lsm6ds3tr_c_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
+                                         lsm6ds3tr_c_dec_ds3_fifo_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_FIFO_DS4_DISABLE  = 0,
+  LSM6DS3TR_C_FIFO_DS4_NO_DEC   = 1,
+  LSM6DS3TR_C_FIFO_DS4_DEC_2    = 2,
+  LSM6DS3TR_C_FIFO_DS4_DEC_3    = 3,
+  LSM6DS3TR_C_FIFO_DS4_DEC_4    = 4,
+  LSM6DS3TR_C_FIFO_DS4_DEC_8    = 5,
+  LSM6DS3TR_C_FIFO_DS4_DEC_16   = 6,
+  LSM6DS3TR_C_FIFO_DS4_DEC_32   = 7,
+  LSM6DS3TR_C_FIFO_DS4_DEC_ND   = 8,    /* ERROR CODE */
+} lsm6ds3tr_c_dec_ds4_fifo_t;
+int32_t lsm6ds3tr_c_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
+                                         lsm6ds3tr_c_dec_ds4_fifo_t val);
+int32_t lsm6ds3tr_c_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
+                                         lsm6ds3tr_c_dec_ds4_fifo_t *val);
+
+int32_t lsm6ds3tr_c_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_BYPASS_MODE           = 0,
+  LSM6DS3TR_C_FIFO_MODE             = 1,
+  LSM6DS3TR_C_STREAM_TO_FIFO_MODE   = 3,
+  LSM6DS3TR_C_BYPASS_TO_STREAM_MODE = 4,
+  LSM6DS3TR_C_STREAM_MODE           = 6,
+  LSM6DS3TR_C_FIFO_MODE_ND          = 8,    /* ERROR CODE */
+} lsm6ds3tr_c_fifo_mode_t;
+int32_t lsm6ds3tr_c_fifo_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_fifo_mode_t val);
+int32_t lsm6ds3tr_c_fifo_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_fifo_mode_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_FIFO_DISABLE   =  0,
+  LSM6DS3TR_C_FIFO_12Hz5     =  1,
+  LSM6DS3TR_C_FIFO_26Hz      =  2,
+  LSM6DS3TR_C_FIFO_52Hz      =  3,
+  LSM6DS3TR_C_FIFO_104Hz     =  4,
+  LSM6DS3TR_C_FIFO_208Hz     =  5,
+  LSM6DS3TR_C_FIFO_416Hz     =  6,
+  LSM6DS3TR_C_FIFO_833Hz     =  7,
+  LSM6DS3TR_C_FIFO_1k66Hz    =  8,
+  LSM6DS3TR_C_FIFO_3k33Hz    =  9,
+  LSM6DS3TR_C_FIFO_6k66Hz    = 10,
+  LSM6DS3TR_C_FIFO_RATE_ND   = 11,    /* ERROR CODE */
+} lsm6ds3tr_c_odr_fifo_t;
+int32_t lsm6ds3tr_c_fifo_data_rate_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_odr_fifo_t val);
+int32_t lsm6ds3tr_c_fifo_data_rate_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_odr_fifo_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_DEN_ACT_LOW    = 0,
+  LSM6DS3TR_C_DEN_ACT_HIGH   = 1,
+  LSM6DS3TR_C_DEN_POL_ND     = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_den_lh_t;
+int32_t lsm6ds3tr_c_den_polarity_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_lh_t val);
+int32_t lsm6ds3tr_c_den_polarity_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_lh_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_DEN_DISABLE    = 0,
+  LSM6DS3TR_C_LEVEL_FIFO     = 6,
+  LSM6DS3TR_C_LEVEL_LETCHED  = 3,
+  LSM6DS3TR_C_LEVEL_TRIGGER  = 2,
+  LSM6DS3TR_C_EDGE_TRIGGER   = 4,
+  LSM6DS3TR_C_DEN_MODE_ND    = 5,    /* ERROR CODE */
+} lsm6ds3tr_c_den_mode_t;
+int32_t lsm6ds3tr_c_den_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_mode_t val);
+int32_t lsm6ds3tr_c_den_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_mode_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_STAMP_IN_GY_DATA     = 0,
+  LSM6DS3TR_C_STAMP_IN_XL_DATA     = 1,
+  LSM6DS3TR_C_STAMP_IN_GY_XL_DATA  = 2,
+  LSM6DS3TR_C_DEN_STAMP_ND         = 3,    /* ERROR CODE */
+} lsm6ds3tr_c_den_xl_en_t;
+int32_t lsm6ds3tr_c_den_enable_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_xl_en_t val);
+int32_t lsm6ds3tr_c_den_enable_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_den_xl_en_t *val);
+
+int32_t lsm6ds3tr_c_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_PEDO_AT_2g = 0,
+  LSM6DS3TR_C_PEDO_AT_4g = 1,
+  LSM6DS3TR_C_PEDO_FS_ND = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_pedo_fs_t;
+int32_t lsm6ds3tr_c_pedo_full_scale_set(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_pedo_fs_t val);
+int32_t lsm6ds3tr_c_pedo_full_scale_get(stmdev_ctx_t *ctx,
+                                    lsm6ds3tr_c_pedo_fs_t *val);
+
+int32_t lsm6ds3tr_c_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3tr_c_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3tr_c_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_wrist_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_wrist_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_tilt_latency_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_tilt_latency_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3tr_c_tilt_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_tilt_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3tr_c_tilt_src_set(stmdev_ctx_t *ctx,
+                             lsm6ds3tr_c_a_wrist_tilt_mask_t *val);
+int32_t lsm6ds3tr_c_tilt_src_get(stmdev_ctx_t *ctx,
+                             lsm6ds3tr_c_a_wrist_tilt_mask_t *val);
+
+int32_t lsm6ds3tr_c_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_mag_soft_iron_mat_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_mag_soft_iron_mat_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3tr_c_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6ds3tr_c_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6ds3tr_c_func_en_set(stmdev_ctx_t *ctx, uint8_t val);
+
+int32_t lsm6ds3tr_c_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_RES_RATIO_2_11  = 0,
+  LSM6DS3TR_C_RES_RATIO_2_12  = 1,
+  LSM6DS3TR_C_RES_RATIO_2_13  = 2,
+  LSM6DS3TR_C_RES_RATIO_2_14  = 3,
+  LSM6DS3TR_C_RES_RATIO_ND    = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_rr_t;
+int32_t lsm6ds3tr_c_sh_sync_sens_ratio_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_rr_t val);
+int32_t lsm6ds3tr_c_sh_sync_sens_ratio_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_rr_t *val);
+
+int32_t lsm6ds3tr_c_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_EXT_PULL_UP       = 0,
+  LSM6DS3TR_C_INTERNAL_PULL_UP  = 1,
+  LSM6DS3TR_C_SH_PIN_MODE       = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_pull_up_en_t;
+int32_t lsm6ds3tr_c_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6ds3tr_c_pull_up_en_t val);
+int32_t lsm6ds3tr_c_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6ds3tr_c_pull_up_en_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_XL_GY_DRDY        = 0,
+  LSM6DS3TR_C_EXT_ON_INT2_PIN   = 1,
+  LSM6DS3TR_C_SH_SYNCRO_ND      = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_start_config_t;
+int32_t lsm6ds3tr_c_sh_syncro_mode_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_start_config_t val);
+int32_t lsm6ds3tr_c_sh_syncro_mode_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_start_config_t *val);
+
+int32_t lsm6ds3tr_c_sh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_sh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+    lsm6ds3tr_c_sensorhub1_reg_t   sh_byte_1;
+    lsm6ds3tr_c_sensorhub2_reg_t   sh_byte_2;
+    lsm6ds3tr_c_sensorhub3_reg_t   sh_byte_3;
+    lsm6ds3tr_c_sensorhub4_reg_t   sh_byte_4;
+    lsm6ds3tr_c_sensorhub5_reg_t   sh_byte_5;
+    lsm6ds3tr_c_sensorhub6_reg_t   sh_byte_6;
+    lsm6ds3tr_c_sensorhub7_reg_t   sh_byte_7;
+    lsm6ds3tr_c_sensorhub8_reg_t   sh_byte_8;
+    lsm6ds3tr_c_sensorhub9_reg_t   sh_byte_9;
+    lsm6ds3tr_c_sensorhub10_reg_t  sh_byte_10;
+    lsm6ds3tr_c_sensorhub11_reg_t  sh_byte_11;
+    lsm6ds3tr_c_sensorhub12_reg_t  sh_byte_12;
+    lsm6ds3tr_c_sensorhub13_reg_t  sh_byte_13;
+    lsm6ds3tr_c_sensorhub14_reg_t  sh_byte_14;
+    lsm6ds3tr_c_sensorhub15_reg_t  sh_byte_15;
+    lsm6ds3tr_c_sensorhub16_reg_t  sh_byte_16;
+    lsm6ds3tr_c_sensorhub17_reg_t  sh_byte_17;
+    lsm6ds3tr_c_sensorhub18_reg_t  sh_byte_18;
+} lsm6ds3tr_c_emb_sh_read_t;
+int32_t lsm6ds3tr_c_sh_read_data_raw_get(stmdev_ctx_t *ctx,
+                                     lsm6ds3tr_c_emb_sh_read_t *val);
+
+int32_t lsm6ds3tr_c_sh_cmd_sens_sync_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_sh_cmd_sens_sync_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6ds3tr_c_sh_spi_sync_error_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6ds3tr_c_sh_spi_sync_error_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_SLV_0        = 0,
+  LSM6DS3TR_C_SLV_0_1      = 1,
+  LSM6DS3TR_C_SLV_0_1_2    = 2,
+  LSM6DS3TR_C_SLV_0_1_2_3  = 3,
+  LSM6DS3TR_C_SLV_EN_ND    = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_aux_sens_on_t;
+int32_t lsm6ds3tr_c_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
+                                            lsm6ds3tr_c_aux_sens_on_t val);
+int32_t lsm6ds3tr_c_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
+                                            lsm6ds3tr_c_aux_sens_on_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} lsm6ds3tr_c_sh_cfg_write_t;
+int32_t lsm6ds3tr_c_sh_cfg_write(stmdev_ctx_t *ctx, lsm6ds3tr_c_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} lsm6ds3tr_c_sh_cfg_read_t;
+int32_t lsm6ds3tr_c_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_sh_cfg_read_t *val);
+int32_t lsm6ds3tr_c_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_sh_cfg_read_t *val);
+int32_t lsm6ds3tr_c_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_sh_cfg_read_t *val);
+int32_t lsm6ds3tr_c_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6ds3tr_c_sh_cfg_read_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_SL0_NO_DEC   = 0,
+  LSM6DS3TR_C_SL0_DEC_2    = 1,
+  LSM6DS3TR_C_SL0_DEC_4    = 2,
+  LSM6DS3TR_C_SL0_DEC_8    = 3,
+  LSM6DS3TR_C_SL0_DEC_ND   = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_slave0_rate_t;
+int32_t lsm6ds3tr_c_sh_slave_0_dec_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave0_rate_t val);
+int32_t lsm6ds3tr_c_sh_slave_0_dec_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave0_rate_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_EACH_SH_CYCLE     = 0,
+  LSM6DS3TR_C_ONLY_FIRST_CYCLE  = 1,
+  LSM6DS3TR_C_SH_WR_MODE_ND     = 2,    /* ERROR CODE */
+} lsm6ds3tr_c_write_once_t;
+int32_t lsm6ds3tr_c_sh_write_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_write_once_t val);
+int32_t lsm6ds3tr_c_sh_write_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6ds3tr_c_write_once_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_SL1_NO_DEC   = 0,
+  LSM6DS3TR_C_SL1_DEC_2    = 1,
+  LSM6DS3TR_C_SL1_DEC_4    = 2,
+  LSM6DS3TR_C_SL1_DEC_8    = 3,
+  LSM6DS3TR_C_SL1_DEC_ND   = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_slave1_rate_t;
+int32_t lsm6ds3tr_c_sh_slave_1_dec_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave1_rate_t val);
+int32_t lsm6ds3tr_c_sh_slave_1_dec_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave1_rate_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_SL2_NO_DEC  = 0,
+  LSM6DS3TR_C_SL2_DEC_2   = 1,
+  LSM6DS3TR_C_SL2_DEC_4   = 2,
+  LSM6DS3TR_C_SL2_DEC_8   = 3,
+  LSM6DS3TR_C_SL2_DEC_ND  = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_slave2_rate_t;
+int32_t lsm6ds3tr_c_sh_slave_2_dec_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave2_rate_t val);
+int32_t lsm6ds3tr_c_sh_slave_2_dec_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave2_rate_t *val);
+
+typedef enum {
+  LSM6DS3TR_C_SL3_NO_DEC  = 0,
+  LSM6DS3TR_C_SL3_DEC_2   = 1,
+  LSM6DS3TR_C_SL3_DEC_4   = 2,
+  LSM6DS3TR_C_SL3_DEC_8   = 3,
+  LSM6DS3TR_C_SL3_DEC_ND  = 4,    /* ERROR CODE */
+} lsm6ds3tr_c_slave3_rate_t;
+int32_t lsm6ds3tr_c_sh_slave_3_dec_set(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave3_rate_t val);
+int32_t lsm6ds3tr_c_sh_slave_3_dec_get(stmdev_ctx_t *ctx,
+                                   lsm6ds3tr_c_slave3_rate_t *val);
+
+/**
+  * @}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSM6DS3TR_C_DRIVER_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsl_STdC/driver/lsm6dsl_reg.c
+++ b/sensor/stmemsc/lsm6dsl_STdC/driver/lsm6dsl_reg.c
@@ -6,33 +6,16 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 #include "lsm6dsl_reg.h"
 
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsl_read_reg(lsm6dsl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsl_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lsm6dsl_read_reg(lsm6dsl_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsl_write_reg(lsm6dsl_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsl_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -173,7 +156,7 @@ float_t lsm6dsl_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t val)
+int32_t lsm6dsl_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6dsl_fs_xl_t val)
 {
   lsm6dsl_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -194,7 +177,7 @@ int32_t lsm6dsl_xl_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t *val)
+int32_t lsm6dsl_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6dsl_fs_xl_t *val)
 {
   lsm6dsl_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -229,7 +212,7 @@ int32_t lsm6dsl_xl_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t val)
+int32_t lsm6dsl_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dsl_odr_xl_t val)
 {
   lsm6dsl_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -250,7 +233,7 @@ int32_t lsm6dsl_xl_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t *val)
+int32_t lsm6dsl_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dsl_odr_xl_t *val)
 {
   lsm6dsl_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -309,7 +292,7 @@ int32_t lsm6dsl_xl_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t val)
+int32_t lsm6dsl_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6dsl_fs_g_t val)
 {
   lsm6dsl_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -330,7 +313,7 @@ int32_t lsm6dsl_gy_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t *val)
+int32_t lsm6dsl_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6dsl_fs_g_t *val)
 {
   lsm6dsl_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -368,7 +351,7 @@ int32_t lsm6dsl_gy_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t val)
+int32_t lsm6dsl_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6dsl_odr_g_t val)
 {
   lsm6dsl_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -389,7 +372,7 @@ int32_t lsm6dsl_gy_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t *val)
+int32_t lsm6dsl_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6dsl_odr_g_t *val)
 {
   lsm6dsl_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -445,7 +428,7 @@ int32_t lsm6dsl_gy_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_block_data_update_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -466,7 +449,7 @@ int32_t lsm6dsl_block_data_update_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_block_data_update_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -486,7 +469,7 @@ int32_t lsm6dsl_block_data_update_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_offset_weight_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                      lsm6dsl_usr_off_w_t val)
 {
   lsm6dsl_ctrl6_c_t ctrl6_c;
@@ -509,7 +492,7 @@ int32_t lsm6dsl_xl_offset_weight_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_offset_weight_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_usr_off_w_t *val)
 {
   lsm6dsl_ctrl6_c_t ctrl6_c;
@@ -539,7 +522,7 @@ int32_t lsm6dsl_xl_offset_weight_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_power_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_xl_hm_mode_t val)
 {
   lsm6dsl_ctrl6_c_t ctrl6_c;
@@ -561,7 +544,7 @@ int32_t lsm6dsl_xl_power_mode_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_power_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_xl_hm_mode_t *val)
 {
   lsm6dsl_ctrl6_c_t ctrl6_c;
@@ -593,7 +576,7 @@ int32_t lsm6dsl_xl_power_mode_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_rounding_on_status_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_rounding_on_status_set(stmdev_ctx_t *ctx,
                                        lsm6dsl_rounding_status_t val)
 {
   lsm6dsl_ctrl7_g_t ctrl7_g;
@@ -617,7 +600,7 @@ int32_t lsm6dsl_rounding_on_status_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_rounding_on_status_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_rounding_on_status_get(stmdev_ctx_t *ctx,
                                        lsm6dsl_rounding_status_t *val)
 {
   lsm6dsl_ctrl7_g_t ctrl7_g;
@@ -647,7 +630,7 @@ int32_t lsm6dsl_rounding_on_status_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_power_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_g_hm_mode_t val)
+int32_t lsm6dsl_gy_power_mode_set(stmdev_ctx_t *ctx, lsm6dsl_g_hm_mode_t val)
 {
   lsm6dsl_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -668,7 +651,7 @@ int32_t lsm6dsl_gy_power_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_g_hm_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_power_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_g_hm_mode_t *val)
+int32_t lsm6dsl_gy_power_mode_get(stmdev_ctx_t *ctx, lsm6dsl_g_hm_mode_t *val)
 {
   lsm6dsl_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -698,7 +681,7 @@ int32_t lsm6dsl_gy_power_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_g_hm_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_all_sources_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_all_sources_get(stmdev_ctx_t *ctx,
                                 lsm6dsl_all_sources_t *val)
 {
   int32_t ret;
@@ -750,7 +733,7 @@ int32_t lsm6dsl_all_sources_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_status_reg_get(lsm6dsl_ctx_t *ctx, lsm6dsl_status_reg_t *val)
+int32_t lsm6dsl_status_reg_get(stmdev_ctx_t *ctx, lsm6dsl_status_reg_t *val)
 {
   int32_t ret;
   ret = lsm6dsl_read_reg(ctx, LSM6DSL_STATUS_REG, (uint8_t*) val, 1);
@@ -765,7 +748,7 @@ int32_t lsm6dsl_status_reg_get(lsm6dsl_ctx_t *ctx, lsm6dsl_status_reg_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_status_reg_t status_reg;
   int32_t ret;
@@ -784,7 +767,7 @@ int32_t lsm6dsl_xl_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_status_reg_t status_reg;
   int32_t ret;
@@ -803,7 +786,7 @@ int32_t lsm6dsl_gy_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_temp_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_status_reg_t status_reg;
   int32_t ret;
@@ -824,7 +807,7 @@ int32_t lsm6dsl_temp_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_usr_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsl_write_reg(ctx, LSM6DSL_X_OFS_USR, buff, 3);
@@ -841,7 +824,7 @@ int32_t lsm6dsl_xl_usr_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_usr_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsl_read_reg(ctx, LSM6DSL_X_OFS_USR, buff, 3);
@@ -870,7 +853,7 @@ int32_t lsm6dsl_xl_usr_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_timestamp_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -895,7 +878,7 @@ int32_t lsm6dsl_timestamp_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_timestamp_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -919,7 +902,7 @@ int32_t lsm6dsl_timestamp_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_timestamp_res_set(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t val)
+int32_t lsm6dsl_timestamp_res_set(stmdev_ctx_t *ctx, lsm6dsl_timer_hr_t val)
 {
   lsm6dsl_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -946,7 +929,7 @@ int32_t lsm6dsl_timestamp_res_set(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_timestamp_res_get(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t *val)
+int32_t lsm6dsl_timestamp_res_get(stmdev_ctx_t *ctx, lsm6dsl_timer_hr_t *val)
 {
   lsm6dsl_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -988,7 +971,7 @@ int32_t lsm6dsl_timestamp_res_get(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_rounding_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t val)
+int32_t lsm6dsl_rounding_mode_set(stmdev_ctx_t *ctx, lsm6dsl_rounding_t val)
 {
   lsm6dsl_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1010,7 +993,7 @@ int32_t lsm6dsl_rounding_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_rounding_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t *val)
+int32_t lsm6dsl_rounding_mode_get(stmdev_ctx_t *ctx, lsm6dsl_rounding_t *val)
 {
   lsm6dsl_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1058,7 +1041,7 @@ int32_t lsm6dsl_rounding_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_temperature_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsl_read_reg(ctx, LSM6DSL_OUT_TEMP_L, buff, 2);
@@ -1074,7 +1057,7 @@ int32_t lsm6dsl_temperature_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_angular_rate_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsl_read_reg(ctx, LSM6DSL_OUTX_L_G, buff, 6);
@@ -1090,7 +1073,7 @@ int32_t lsm6dsl_angular_rate_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_acceleration_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsl_read_reg(ctx, LSM6DSL_OUTX_L_XL, buff, 6);
@@ -1105,7 +1088,7 @@ int32_t lsm6dsl_acceleration_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_calibrated_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsl_read_reg(ctx, LSM6DSL_OUT_MAG_RAW_X_L, buff, 6);
@@ -1121,7 +1104,7 @@ int32_t lsm6dsl_mag_calibrated_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_raw_data_get(lsm6dsl_ctx_t *ctx, uint8_t *buffer,
+int32_t lsm6dsl_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer,
                                   uint8_t len)
 {
   int32_t ret;
@@ -1150,7 +1133,7 @@ int32_t lsm6dsl_fifo_raw_data_get(lsm6dsl_ctx_t *ctx, uint8_t *buffer,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mem_bank_set(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t val)
+int32_t lsm6dsl_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsl_func_cfg_en_t val)
 {
   lsm6dsl_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -1175,7 +1158,7 @@ int32_t lsm6dsl_mem_bank_set(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mem_bank_get(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t *val)
+int32_t lsm6dsl_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsl_func_cfg_en_t *val)
 {
   lsm6dsl_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -1205,7 +1188,7 @@ int32_t lsm6dsl_mem_bank_get(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_data_ready_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_data_ready_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dsl_drdy_pulsed_g_t val)
 {
   lsm6dsl_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
@@ -1229,7 +1212,7 @@ int32_t lsm6dsl_data_ready_mode_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_data_ready_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_data_ready_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dsl_drdy_pulsed_g_t *val)
 {
   lsm6dsl_drdy_pulse_cfg_g_t drdy_pulse_cfg_g;
@@ -1260,7 +1243,7 @@ int32_t lsm6dsl_data_ready_mode_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_device_id_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsl_read_reg(ctx, LSM6DSL_WHO_AM_I, buff, 1);
@@ -1275,7 +1258,7 @@ int32_t lsm6dsl_device_id_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1296,7 +1279,7 @@ int32_t lsm6dsl_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1315,7 +1298,7 @@ int32_t lsm6dsl_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_data_format_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t val)
+int32_t lsm6dsl_data_format_set(stmdev_ctx_t *ctx, lsm6dsl_ble_t val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1336,7 +1319,7 @@ int32_t lsm6dsl_data_format_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_data_format_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t *val)
+int32_t lsm6dsl_data_format_get(stmdev_ctx_t *ctx, lsm6dsl_ble_t *val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1366,7 +1349,7 @@ int32_t lsm6dsl_data_format_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_auto_increment_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1388,7 +1371,7 @@ int32_t lsm6dsl_auto_increment_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_auto_increment_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1407,7 +1390,7 @@ int32_t lsm6dsl_auto_increment_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_boot_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1428,7 +1411,7 @@ int32_t lsm6dsl_boot_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_boot_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1447,7 +1430,7 @@ int32_t lsm6dsl_boot_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t val)
+int32_t lsm6dsl_xl_self_test_set(stmdev_ctx_t *ctx, lsm6dsl_st_xl_t val)
 {
   lsm6dsl_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1468,7 +1451,7 @@ int32_t lsm6dsl_xl_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t *val)
+int32_t lsm6dsl_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dsl_st_xl_t *val)
 {
   lsm6dsl_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1499,7 +1482,7 @@ int32_t lsm6dsl_xl_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t val)
+int32_t lsm6dsl_gy_self_test_set(stmdev_ctx_t *ctx, lsm6dsl_st_g_t val)
 {
   lsm6dsl_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1520,7 +1503,7 @@ int32_t lsm6dsl_gy_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t *val)
+int32_t lsm6dsl_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dsl_st_g_t *val)
 {
   lsm6dsl_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1566,7 +1549,7 @@ int32_t lsm6dsl_gy_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_filter_settling_mask_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1588,7 +1571,7 @@ int32_t lsm6dsl_filter_settling_mask_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_filter_settling_mask_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1608,7 +1591,7 @@ int32_t lsm6dsl_filter_settling_mask_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_hp_path_internal_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         lsm6dsl_slope_fds_t val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
@@ -1631,7 +1614,7 @@ int32_t lsm6dsl_xl_hp_path_internal_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_hp_path_internal_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         lsm6dsl_slope_fds_t *val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
@@ -1675,7 +1658,7 @@ int32_t lsm6dsl_xl_hp_path_internal_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_filter_analog_set(lsm6dsl_ctx_t *ctx, lsm6dsl_bw0_xl_t val)
+int32_t lsm6dsl_xl_filter_analog_set(stmdev_ctx_t *ctx, lsm6dsl_bw0_xl_t val)
 {
   lsm6dsl_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -1697,7 +1680,7 @@ int32_t lsm6dsl_xl_filter_analog_set(lsm6dsl_ctx_t *ctx, lsm6dsl_bw0_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_filter_analog_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_filter_analog_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_bw0_xl_t *val)
 {
   lsm6dsl_ctrl1_xl_t ctrl1_xl;
@@ -1741,7 +1724,7 @@ int32_t lsm6dsl_xl_filter_analog_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_lp1_bandwidth_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsl_lpf1_bw_sel_t val)
 {
   lsm6dsl_ctrl1_xl_t ctrl1_xl;
@@ -1773,7 +1756,7 @@ int32_t lsm6dsl_xl_lp1_bandwidth_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_lp1_bandwidth_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_lpf1_bw_sel_t *val)
 {
   lsm6dsl_ctrl1_xl_t ctrl1_xl;
@@ -1812,7 +1795,7 @@ int32_t lsm6dsl_xl_lp1_bandwidth_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_lp2_bandwidth_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsl_input_composite_t val)
 {
   lsm6dsl_ctrl8_xl_t ctrl8_xl;
@@ -1837,7 +1820,7 @@ int32_t lsm6dsl_xl_lp2_bandwidth_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_lp2_bandwidth_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_input_composite_t *val)
 {
   lsm6dsl_ctrl8_xl_t ctrl8_xl;
@@ -1893,7 +1876,7 @@ int32_t lsm6dsl_xl_lp2_bandwidth_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_reference_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_xl_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1914,7 +1897,7 @@ int32_t lsm6dsl_xl_reference_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_reference_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_xl_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1933,7 +1916,7 @@ int32_t lsm6dsl_xl_reference_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_hp_bandwidth_set(lsm6dsl_ctx_t *ctx, lsm6dsl_hpcf_xl_t val)
+int32_t lsm6dsl_xl_hp_bandwidth_set(stmdev_ctx_t *ctx, lsm6dsl_hpcf_xl_t val)
 {
   lsm6dsl_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1956,7 +1939,7 @@ int32_t lsm6dsl_xl_hp_bandwidth_set(lsm6dsl_ctx_t *ctx, lsm6dsl_hpcf_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_xl_hp_bandwidth_get(lsm6dsl_ctx_t *ctx, lsm6dsl_hpcf_xl_t *val)
+int32_t lsm6dsl_xl_hp_bandwidth_get(stmdev_ctx_t *ctx, lsm6dsl_hpcf_xl_t *val)
 {
   lsm6dsl_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -2007,7 +1990,7 @@ int32_t lsm6dsl_xl_hp_bandwidth_get(lsm6dsl_ctx_t *ctx, lsm6dsl_hpcf_xl_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_band_pass_set(lsm6dsl_ctx_t *ctx, lsm6dsl_lpf1_sel_g_t val)
+int32_t lsm6dsl_gy_band_pass_set(stmdev_ctx_t *ctx, lsm6dsl_lpf1_sel_g_t val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   lsm6dsl_ctrl6_c_t ctrl6_c;
@@ -2047,7 +2030,7 @@ int32_t lsm6dsl_gy_band_pass_set(lsm6dsl_ctx_t *ctx, lsm6dsl_lpf1_sel_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_band_pass_get(lsm6dsl_ctx_t *ctx, lsm6dsl_lpf1_sel_g_t *val)
+int32_t lsm6dsl_gy_band_pass_get(stmdev_ctx_t *ctx, lsm6dsl_lpf1_sel_g_t *val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   lsm6dsl_ctrl6_c_t ctrl6_c;
@@ -2129,7 +2112,7 @@ int32_t lsm6dsl_gy_band_pass_get(lsm6dsl_ctx_t *ctx, lsm6dsl_lpf1_sel_g_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_spi_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t val)
+int32_t lsm6dsl_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsl_sim_t val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2150,7 +2133,7 @@ int32_t lsm6dsl_spi_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_spi_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t *val)
+int32_t lsm6dsl_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsl_sim_t *val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2178,7 +2161,7 @@ int32_t lsm6dsl_spi_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_i2c_interface_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_i2c_interface_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_i2c_disable_t val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
@@ -2200,7 +2183,7 @@ int32_t lsm6dsl_i2c_interface_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_i2c_interface_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_i2c_interface_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_i2c_disable_t *val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
@@ -2244,7 +2227,7 @@ int32_t lsm6dsl_i2c_interface_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pin_int1_route_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_int1_route_t val)
 {
   lsm6dsl_master_config_t master_config;
@@ -2335,7 +2318,7 @@ int32_t lsm6dsl_pin_int1_route_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pin_int1_route_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_int1_route_t *val)
 {
   lsm6dsl_master_config_t master_config;
@@ -2387,7 +2370,7 @@ int32_t lsm6dsl_pin_int1_route_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pin_int2_route_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_int2_route_t val)
 {
   lsm6dsl_int2_ctrl_t int2_ctrl;
@@ -2470,7 +2453,7 @@ int32_t lsm6dsl_pin_int2_route_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pin_int2_route_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pin_int2_route_get(stmdev_ctx_t *ctx,
 lsm6dsl_int2_route_t *val)
 {
   lsm6dsl_int2_ctrl_t int2_ctrl;
@@ -2517,7 +2500,7 @@ lsm6dsl_int2_route_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t val)
+int32_t lsm6dsl_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsl_pp_od_t val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2538,7 +2521,7 @@ int32_t lsm6dsl_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t *val)
+int32_t lsm6dsl_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsl_pp_od_t *val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2567,7 +2550,7 @@ int32_t lsm6dsl_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pin_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t val)
+int32_t lsm6dsl_pin_polarity_set(stmdev_ctx_t *ctx, lsm6dsl_h_lactive_t val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2588,7 +2571,7 @@ int32_t lsm6dsl_pin_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pin_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t *val)
+int32_t lsm6dsl_pin_polarity_get(stmdev_ctx_t *ctx, lsm6dsl_h_lactive_t *val)
 {
   lsm6dsl_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -2617,7 +2600,7 @@ int32_t lsm6dsl_pin_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_all_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2638,7 +2621,7 @@ int32_t lsm6dsl_all_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_all_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2657,7 +2640,7 @@ int32_t lsm6dsl_all_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_int_notification_set(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t val)
+int32_t lsm6dsl_int_notification_set(stmdev_ctx_t *ctx, lsm6dsl_lir_t val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2678,7 +2661,7 @@ int32_t lsm6dsl_int_notification_set(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_int_notification_get(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t *val)
+int32_t lsm6dsl_int_notification_get(stmdev_ctx_t *ctx, lsm6dsl_lir_t *val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2720,7 +2703,7 @@ int32_t lsm6dsl_int_notification_get(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_wkup_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2742,7 +2725,7 @@ int32_t lsm6dsl_wkup_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_wkup_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -2761,7 +2744,7 @@ int32_t lsm6dsl_wkup_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_wkup_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2783,7 +2766,7 @@ int32_t lsm6dsl_wkup_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_wkup_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2815,7 +2798,7 @@ int32_t lsm6dsl_wkup_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_sleep_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2836,7 +2819,7 @@ int32_t lsm6dsl_gy_sleep_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_gy_sleep_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -2855,7 +2838,7 @@ int32_t lsm6dsl_gy_sleep_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_act_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t val)
+int32_t lsm6dsl_act_mode_set(stmdev_ctx_t *ctx, lsm6dsl_inact_en_t val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2876,7 +2859,7 @@ int32_t lsm6dsl_act_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_act_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t *val)
+int32_t lsm6dsl_act_mode_get(stmdev_ctx_t *ctx, lsm6dsl_inact_en_t *val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -2911,7 +2894,7 @@ int32_t lsm6dsl_act_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_act_sleep_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2933,7 +2916,7 @@ int32_t lsm6dsl_act_sleep_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_act_sleep_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -2965,7 +2948,7 @@ int32_t lsm6dsl_act_sleep_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_src_get(lsm6dsl_ctx_t *ctx, lsm6dsl_tap_src_t *val)
+int32_t lsm6dsl_tap_src_get(stmdev_ctx_t *ctx, lsm6dsl_tap_src_t *val)
 {
   int32_t ret;
   ret = lsm6dsl_read_reg(ctx, LSM6DSL_TAP_SRC, (uint8_t*) val, 1);
@@ -2979,7 +2962,7 @@ int32_t lsm6dsl_tap_src_get(lsm6dsl_ctx_t *ctx, lsm6dsl_tap_src_t *val)
   * @param  val    Change the values of tap_z_en in reg TAP_CFG
   *
   */
-int32_t lsm6dsl_tap_detection_on_z_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3000,7 +2983,7 @@ int32_t lsm6dsl_tap_detection_on_z_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_detection_on_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3019,7 +3002,7 @@ int32_t lsm6dsl_tap_detection_on_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_detection_on_y_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3040,7 +3023,7 @@ int32_t lsm6dsl_tap_detection_on_y_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_detection_on_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3059,7 +3042,7 @@ int32_t lsm6dsl_tap_detection_on_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_detection_on_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3080,7 +3063,7 @@ int32_t lsm6dsl_tap_detection_on_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_detection_on_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3099,7 +3082,7 @@ int32_t lsm6dsl_tap_detection_on_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_threshold_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3121,7 +3104,7 @@ int32_t lsm6dsl_tap_threshold_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_threshold_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3145,7 +3128,7 @@ int32_t lsm6dsl_tap_threshold_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_shock_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_int_dur2_t int_dur2;
   int32_t ret;
@@ -3171,7 +3154,7 @@ int32_t lsm6dsl_tap_shock_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_shock_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_int_dur2_t int_dur2;
   int32_t ret;
@@ -3195,7 +3178,7 @@ int32_t lsm6dsl_tap_shock_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_quiet_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_int_dur2_t int_dur2;
   int32_t ret;
@@ -3221,7 +3204,7 @@ int32_t lsm6dsl_tap_quiet_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_quiet_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_int_dur2_t int_dur2;
   int32_t ret;
@@ -3246,7 +3229,7 @@ int32_t lsm6dsl_tap_quiet_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_int_dur2_t int_dur2;
   int32_t ret;
@@ -3273,7 +3256,7 @@ int32_t lsm6dsl_tap_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_int_dur2_t int_dur2;
   int32_t ret;
@@ -3293,7 +3276,7 @@ int32_t lsm6dsl_tap_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_tap_mode_set(stmdev_ctx_t *ctx,
                              lsm6dsl_single_double_tap_t val)
 {
   lsm6dsl_wake_up_ths_t wake_up_ths;
@@ -3317,7 +3300,7 @@ int32_t lsm6dsl_tap_mode_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tap_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_tap_mode_get(stmdev_ctx_t *ctx,
                              lsm6dsl_single_double_tap_t *val)
 {
   lsm6dsl_wake_up_ths_t wake_up_ths;
@@ -3361,7 +3344,7 @@ int32_t lsm6dsl_tap_mode_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_6d_feed_data_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_6d_feed_data_set(stmdev_ctx_t *ctx,
                                  lsm6dsl_low_pass_on_6d_t val)
 {
   lsm6dsl_ctrl8_xl_t ctrl8_xl;
@@ -3383,7 +3366,7 @@ int32_t lsm6dsl_6d_feed_data_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_6d_feed_data_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_6d_feed_data_get(stmdev_ctx_t *ctx,
                                  lsm6dsl_low_pass_on_6d_t *val)
 {
   lsm6dsl_ctrl8_xl_t ctrl8_xl;
@@ -3413,7 +3396,7 @@ int32_t lsm6dsl_6d_feed_data_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_6d_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t val)
+int32_t lsm6dsl_6d_threshold_set(stmdev_ctx_t *ctx, lsm6dsl_sixd_ths_t val)
 {
   lsm6dsl_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3434,7 +3417,7 @@ int32_t lsm6dsl_6d_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_6d_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t *val)
+int32_t lsm6dsl_6d_threshold_get(stmdev_ctx_t *ctx, lsm6dsl_sixd_ths_t *val)
 {
   lsm6dsl_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3469,7 +3452,7 @@ int32_t lsm6dsl_6d_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_4d_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3491,7 +3474,7 @@ int32_t lsm6dsl_4d_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_4d_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -3523,7 +3506,7 @@ int32_t lsm6dsl_4d_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_ff_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_wake_up_dur_t wake_up_dur;
   lsm6dsl_free_fall_t free_fall;
@@ -3554,7 +3537,7 @@ int32_t lsm6dsl_ff_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_ff_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_wake_up_dur_t wake_up_dur;
   lsm6dsl_free_fall_t free_fall;
@@ -3577,7 +3560,7 @@ int32_t lsm6dsl_ff_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_ff_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t val)
+int32_t lsm6dsl_ff_threshold_set(stmdev_ctx_t *ctx, lsm6dsl_ff_ths_t val)
 {
   lsm6dsl_free_fall_t free_fall;
   int32_t ret;
@@ -3598,7 +3581,7 @@ int32_t lsm6dsl_ff_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_ff_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t *val)
+int32_t lsm6dsl_ff_threshold_get(stmdev_ctx_t *ctx, lsm6dsl_ff_ths_t *val)
 {
   lsm6dsl_free_fall_t free_fall;
   int32_t ret;
@@ -3658,7 +3641,7 @@ int32_t lsm6dsl_ff_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_watermark_set(lsm6dsl_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsl_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   lsm6dsl_fifo_ctrl1_t fifo_ctrl1;
   lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
@@ -3685,7 +3668,7 @@ int32_t lsm6dsl_fifo_watermark_set(lsm6dsl_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_watermark_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsl_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6dsl_fifo_ctrl1_t fifo_ctrl1;
   lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
@@ -3710,7 +3693,7 @@ int32_t lsm6dsl_fifo_watermark_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_data_level_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsl_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6dsl_fifo_status1_t fifo_status1;
   lsm6dsl_fifo_status2_t fifo_status2;
@@ -3736,7 +3719,7 @@ int32_t lsm6dsl_fifo_data_level_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_wtm_flag_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_fifo_status2_t fifo_status2;
   int32_t ret;
@@ -3756,7 +3739,7 @@ int32_t lsm6dsl_fifo_wtm_flag_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_pattern_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsl_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6dsl_fifo_status3_t fifo_status3;
   lsm6dsl_fifo_status4_t fifo_status4;
@@ -3781,7 +3764,7 @@ int32_t lsm6dsl_fifo_pattern_get(lsm6dsl_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_temp_batch_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3804,7 +3787,7 @@ int32_t lsm6dsl_fifo_temp_batch_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_temp_batch_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3824,7 +3807,7 @@ int32_t lsm6dsl_fifo_temp_batch_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_write_trigger_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_write_trigger_set(stmdev_ctx_t *ctx,
                                        lsm6dsl_trigger_fifo_t val)
 {
   lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
@@ -3859,7 +3842,7 @@ int32_t lsm6dsl_fifo_write_trigger_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_write_trigger_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_write_trigger_get(stmdev_ctx_t *ctx,
                                        lsm6dsl_trigger_fifo_t *val)
 {
   lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
@@ -3900,7 +3883,7 @@ int32_t lsm6dsl_fifo_write_trigger_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_set(stmdev_ctx_t *ctx,
                                                   uint8_t val)
 {
   lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
@@ -3924,7 +3907,7 @@ int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_get(stmdev_ctx_t *ctx,
                                                   uint8_t *val)
 {
   lsm6dsl_fifo_ctrl2_t fifo_ctrl2;
@@ -3945,7 +3928,7 @@ int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_xl_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_dec_fifo_xl_t val)
 {
   lsm6dsl_fifo_ctrl3_t fifo_ctrl3;
@@ -3969,7 +3952,7 @@ int32_t lsm6dsl_fifo_xl_batch_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_xl_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_dec_fifo_xl_t *val)
 {
   lsm6dsl_fifo_ctrl3_t fifo_ctrl3;
@@ -4018,7 +4001,7 @@ int32_t lsm6dsl_fifo_xl_batch_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_gy_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_dec_fifo_gyro_t val)
 {
   lsm6dsl_fifo_ctrl3_t fifo_ctrl3;
@@ -4041,7 +4024,7 @@ int32_t lsm6dsl_fifo_gy_batch_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_gy_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_dec_fifo_gyro_t *val)
 {
   lsm6dsl_fifo_ctrl3_t fifo_ctrl3;
@@ -4090,7 +4073,7 @@ int32_t lsm6dsl_fifo_gy_batch_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_dataset_3_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
                                          lsm6dsl_dec_ds3_fifo_t val)
 {
   lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
@@ -4114,7 +4097,7 @@ int32_t lsm6dsl_fifo_dataset_3_batch_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_dataset_3_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
                                          lsm6dsl_dec_ds3_fifo_t *val)
 {
   lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
@@ -4163,7 +4146,7 @@ int32_t lsm6dsl_fifo_dataset_3_batch_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_dataset_4_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
                                          lsm6dsl_dec_ds4_fifo_t val)
 {
   lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
@@ -4187,7 +4170,7 @@ int32_t lsm6dsl_fifo_dataset_4_batch_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_dataset_4_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
                                          lsm6dsl_dec_ds4_fifo_t *val)
 {
   lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
@@ -4235,7 +4218,7 @@ int32_t lsm6dsl_fifo_dataset_4_batch_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_xl_gy_8bit_format_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -4256,7 +4239,7 @@ int32_t lsm6dsl_fifo_xl_gy_8bit_format_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_xl_gy_8bit_format_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -4276,7 +4259,7 @@ int32_t lsm6dsl_fifo_xl_gy_8bit_format_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_stop_on_wtm_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -4298,7 +4281,7 @@ int32_t lsm6dsl_fifo_stop_on_wtm_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_stop_on_wtm_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -4317,7 +4300,7 @@ int32_t lsm6dsl_fifo_stop_on_wtm_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t val)
+int32_t lsm6dsl_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsl_fifo_mode_t val)
 {
   lsm6dsl_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -4338,7 +4321,7 @@ int32_t lsm6dsl_fifo_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t *val)
+int32_t lsm6dsl_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsl_fifo_mode_t *val)
 {
   lsm6dsl_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -4376,7 +4359,7 @@ int32_t lsm6dsl_fifo_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_fifo_t val)
+int32_t lsm6dsl_fifo_data_rate_set(stmdev_ctx_t *ctx, lsm6dsl_odr_fifo_t val)
 {
   lsm6dsl_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -4397,7 +4380,7 @@ int32_t lsm6dsl_fifo_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_fifo_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_fifo_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_fifo_t *val)
+int32_t lsm6dsl_fifo_data_rate_get(stmdev_ctx_t *ctx, lsm6dsl_odr_fifo_t *val)
 {
   lsm6dsl_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -4466,7 +4449,7 @@ int32_t lsm6dsl_fifo_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_fifo_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
- int32_t lsm6dsl_den_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t val)
+ int32_t lsm6dsl_den_polarity_set(stmdev_ctx_t *ctx, lsm6dsl_den_lh_t val)
 {
   lsm6dsl_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -4487,7 +4470,7 @@ int32_t lsm6dsl_fifo_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_fifo_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t *val)
+int32_t lsm6dsl_den_polarity_get(stmdev_ctx_t *ctx, lsm6dsl_den_lh_t *val)
 {
   lsm6dsl_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -4516,7 +4499,7 @@ int32_t lsm6dsl_den_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t val)
+int32_t lsm6dsl_den_mode_set(stmdev_ctx_t *ctx, lsm6dsl_den_mode_t val)
 {
   lsm6dsl_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -4537,7 +4520,7 @@ int32_t lsm6dsl_den_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t *val)
+int32_t lsm6dsl_den_mode_get(stmdev_ctx_t *ctx, lsm6dsl_den_mode_t *val)
 {
   lsm6dsl_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -4573,7 +4556,7 @@ int32_t lsm6dsl_den_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_enable_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t val)
+int32_t lsm6dsl_den_enable_set(stmdev_ctx_t *ctx, lsm6dsl_den_xl_en_t val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
@@ -4603,7 +4586,7 @@ int32_t lsm6dsl_den_enable_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_enable_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t *val)
+int32_t lsm6dsl_den_enable_get(stmdev_ctx_t *ctx, lsm6dsl_den_xl_en_t *val)
 {
   lsm6dsl_ctrl4_c_t ctrl4_c;
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
@@ -4639,7 +4622,7 @@ int32_t lsm6dsl_den_enable_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_mark_axis_z_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4660,7 +4643,7 @@ int32_t lsm6dsl_den_mark_axis_z_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_mark_axis_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4679,7 +4662,7 @@ int32_t lsm6dsl_den_mark_axis_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_mark_axis_y_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4700,7 +4683,7 @@ int32_t lsm6dsl_den_mark_axis_y_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_mark_axis_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4719,7 +4702,7 @@ int32_t lsm6dsl_den_mark_axis_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_mark_axis_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4740,7 +4723,7 @@ int32_t lsm6dsl_den_mark_axis_x_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_den_mark_axis_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -4771,7 +4754,7 @@ int32_t lsm6dsl_den_mark_axis_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_step_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -4792,7 +4775,7 @@ int32_t lsm6dsl_pedo_step_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_step_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -4811,7 +4794,7 @@ int32_t lsm6dsl_pedo_step_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -4836,7 +4819,7 @@ int32_t lsm6dsl_pedo_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -4856,7 +4839,7 @@ int32_t lsm6dsl_pedo_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_config_pedo_ths_min_t config_pedo_ths_min;
   int32_t ret;
@@ -4885,7 +4868,7 @@ int32_t lsm6dsl_pedo_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_config_pedo_ths_min_t config_pedo_ths_min;
   int32_t ret;
@@ -4911,7 +4894,7 @@ int32_t lsm6dsl_pedo_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pedo_fs_t val)
+int32_t lsm6dsl_pedo_full_scale_set(stmdev_ctx_t *ctx, lsm6dsl_pedo_fs_t val)
 {
   lsm6dsl_config_pedo_ths_min_t config_pedo_ths_min;
   int32_t ret;
@@ -4941,7 +4924,7 @@ int32_t lsm6dsl_pedo_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pedo_fs_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pedo_fs_t *val)
+int32_t lsm6dsl_pedo_full_scale_get(stmdev_ctx_t *ctx, lsm6dsl_pedo_fs_t *val)
 {
   lsm6dsl_config_pedo_ths_min_t config_pedo_ths_min;
   int32_t ret;
@@ -4976,7 +4959,7 @@ int32_t lsm6dsl_pedo_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pedo_fs_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_debounce_steps_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -5005,7 +4988,7 @@ int32_t lsm6dsl_pedo_debounce_steps_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_debounce_steps_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -5033,7 +5016,7 @@ int32_t lsm6dsl_pedo_debounce_steps_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_timeout_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -5064,7 +5047,7 @@ int32_t lsm6dsl_pedo_timeout_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_timeout_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -5089,7 +5072,7 @@ int32_t lsm6dsl_pedo_timeout_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_steps_period_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5111,7 +5094,7 @@ int32_t lsm6dsl_pedo_steps_period_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_pedo_steps_period_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5146,7 +5129,7 @@ int32_t lsm6dsl_pedo_steps_period_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_motion_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5170,7 +5153,7 @@ int32_t lsm6dsl_motion_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_motion_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5189,7 +5172,7 @@ int32_t lsm6dsl_motion_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_motion_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5211,7 +5194,7 @@ int32_t lsm6dsl_motion_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_motion_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5246,7 +5229,7 @@ int32_t lsm6dsl_motion_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5270,7 +5253,7 @@ int32_t lsm6dsl_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5289,7 +5272,7 @@ int32_t lsm6dsl_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_wrist_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_wrist_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5313,7 +5296,7 @@ int32_t lsm6dsl_wrist_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_wrist_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_wrist_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5334,7 +5317,7 @@ int32_t lsm6dsl_wrist_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tilt_latency_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_tilt_latency_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5358,7 +5341,7 @@ int32_t lsm6dsl_tilt_latency_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tilt_latency_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_tilt_latency_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5382,7 +5365,7 @@ int32_t lsm6dsl_tilt_latency_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tilt_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_tilt_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5406,7 +5389,7 @@ int32_t lsm6dsl_tilt_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tilt_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_tilt_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5428,7 +5411,7 @@ int32_t lsm6dsl_tilt_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tilt_src_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_tilt_src_set(stmdev_ctx_t *ctx,
                              lsm6dsl_a_wrist_tilt_mask_t *val)
 {
   int32_t ret;
@@ -5452,7 +5435,7 @@ int32_t lsm6dsl_tilt_src_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_tilt_src_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_tilt_src_get(stmdev_ctx_t *ctx,
                              lsm6dsl_a_wrist_tilt_mask_t *val)
 {
   int32_t ret;
@@ -5490,7 +5473,7 @@ int32_t lsm6dsl_tilt_src_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_soft_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5511,7 +5494,7 @@ int32_t lsm6dsl_mag_soft_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_soft_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5530,7 +5513,7 @@ int32_t lsm6dsl_mag_soft_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_hard_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_master_config_t master_config;
   lsm6dsl_ctrl10_c_t ctrl10_c;
@@ -5564,7 +5547,7 @@ int32_t lsm6dsl_mag_hard_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_hard_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -5585,7 +5568,7 @@ int32_t lsm6dsl_mag_hard_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_soft_iron_mat_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_mag_soft_iron_mat_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5608,7 +5591,7 @@ int32_t lsm6dsl_mag_soft_iron_mat_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_soft_iron_mat_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_mag_soft_iron_mat_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5631,7 +5614,7 @@ int32_t lsm6dsl_mag_soft_iron_mat_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5654,7 +5637,7 @@ int32_t lsm6dsl_mag_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_mag_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsl_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -5689,7 +5672,7 @@ int32_t lsm6dsl_mag_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_func_en_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_func_en_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5712,7 +5695,7 @@ int32_t lsm6dsl_func_en_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_sync_sens_frame_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_sensor_sync_time_frame_t sensor_sync_time_frame;
   int32_t ret;
@@ -5736,7 +5719,7 @@ int32_t lsm6dsl_sh_sync_sens_frame_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_sync_sens_frame_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_sensor_sync_time_frame_t sensor_sync_time_frame;
   int32_t ret;
@@ -5756,7 +5739,7 @@ int32_t lsm6dsl_sh_sync_sens_frame_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_sync_sens_ratio_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t val)
+int32_t lsm6dsl_sh_sync_sens_ratio_set(stmdev_ctx_t *ctx, lsm6dsl_rr_t val)
 {
   lsm6dsl_sensor_sync_res_ratio_t sensor_sync_res_ratio;
   int32_t ret;
@@ -5779,7 +5762,7 @@ int32_t lsm6dsl_sh_sync_sens_ratio_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_sync_sens_ratio_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t *val)
+int32_t lsm6dsl_sh_sync_sens_ratio_get(stmdev_ctx_t *ctx, lsm6dsl_rr_t *val)
 {
   lsm6dsl_sensor_sync_res_ratio_t sensor_sync_res_ratio;
   int32_t ret;
@@ -5816,7 +5799,7 @@ int32_t lsm6dsl_sh_sync_sens_ratio_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_master_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -5839,7 +5822,7 @@ int32_t lsm6dsl_sh_master_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_master_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -5859,7 +5842,7 @@ int32_t lsm6dsl_sh_master_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_pass_through_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -5882,7 +5865,7 @@ int32_t lsm6dsl_sh_pass_through_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_pass_through_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -5902,7 +5885,7 @@ int32_t lsm6dsl_sh_pass_through_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t val)
+int32_t lsm6dsl_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsl_pull_up_en_t val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -5926,7 +5909,7 @@ int32_t lsm6dsl_sh_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t *val)
+int32_t lsm6dsl_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsl_pull_up_en_t *val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -5955,7 +5938,7 @@ int32_t lsm6dsl_sh_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_syncro_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_start_config_t val)
 {
   lsm6dsl_master_config_t master_config;
@@ -5979,7 +5962,7 @@ int32_t lsm6dsl_sh_syncro_mode_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_syncro_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_start_config_t *val)
 {
   lsm6dsl_master_config_t master_config;
@@ -6010,7 +5993,7 @@ int32_t lsm6dsl_sh_syncro_mode_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_drdy_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_sh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -6033,7 +6016,7 @@ int32_t lsm6dsl_sh_drdy_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_drdy_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_sh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_master_config_t master_config;
   int32_t ret;
@@ -6053,7 +6036,7 @@ int32_t lsm6dsl_sh_drdy_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_read_data_raw_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_emb_sh_read_t *val)
 {
   int32_t ret;
@@ -6075,7 +6058,7 @@ int32_t lsm6dsl_sh_read_data_raw_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_cmd_sens_sync_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_sh_cmd_sens_sync_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_master_cmd_code_t master_cmd_code;
   int32_t ret;
@@ -6099,7 +6082,7 @@ int32_t lsm6dsl_sh_cmd_sens_sync_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_cmd_sens_sync_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_sh_cmd_sens_sync_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_master_cmd_code_t master_cmd_code;
   int32_t ret;
@@ -6120,7 +6103,7 @@ int32_t lsm6dsl_sh_cmd_sens_sync_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_spi_sync_error_set(lsm6dsl_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsl_sh_spi_sync_error_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsl_sens_sync_spi_error_code_t sens_sync_spi_error_code;
   int32_t ret;
@@ -6144,7 +6127,7 @@ int32_t lsm6dsl_sh_spi_sync_error_set(lsm6dsl_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_spi_sync_error_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsl_sh_spi_sync_error_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsl_sens_sync_spi_error_code_t sens_sync_spi_error_code;
   int32_t ret;
@@ -6164,7 +6147,7 @@ int32_t lsm6dsl_sh_spi_sync_error_get(lsm6dsl_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_num_of_dev_connected_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
                                             lsm6dsl_aux_sens_on_t val)
 {
   lsm6dsl_slave0_config_t slave0_config;
@@ -6194,7 +6177,7 @@ int32_t lsm6dsl_sh_num_of_dev_connected_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_num_of_dev_connected_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
                                             lsm6dsl_aux_sens_on_t *val)
 {
   lsm6dsl_slave0_config_t slave0_config;
@@ -6240,7 +6223,7 @@ int32_t lsm6dsl_sh_num_of_dev_connected_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_cfg_write(lsm6dsl_ctx_t *ctx, lsm6dsl_sh_cfg_write_t *val)
+int32_t lsm6dsl_sh_cfg_write(stmdev_ctx_t *ctx, lsm6dsl_sh_cfg_write_t *val)
 {
   lsm6dsl_slv0_add_t slv0_add;
   int32_t ret;
@@ -6276,7 +6259,7 @@ int32_t lsm6dsl_sh_cfg_write(lsm6dsl_ctx_t *ctx, lsm6dsl_sh_cfg_write_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slv0_cfg_read(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsl_sh_cfg_read_t *val)
 {
   lsm6dsl_slave0_config_t slave0_config;
@@ -6319,7 +6302,7 @@ int32_t lsm6dsl_sh_slv0_cfg_read(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slv1_cfg_read(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsl_sh_cfg_read_t *val)
 {
   lsm6dsl_slave1_config_t slave1_config;
@@ -6362,7 +6345,7 @@ int32_t lsm6dsl_sh_slv1_cfg_read(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slv2_cfg_read(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsl_sh_cfg_read_t *val)
 {
   lsm6dsl_slv2_add_t slv2_add;
@@ -6406,7 +6389,7 @@ int32_t lsm6dsl_sh_slv2_cfg_read(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slv3_cfg_read(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsl_sh_cfg_read_t *val)
 {
   lsm6dsl_slave3_config_t slave3_config;
@@ -6447,7 +6430,7 @@ int32_t lsm6dsl_sh_slv3_cfg_read(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slave_0_dec_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_0_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave0_rate_t val)
 {
   lsm6dsl_slave0_config_t slave0_config;
@@ -6478,7 +6461,7 @@ int32_t lsm6dsl_sh_slave_0_dec_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slave_0_dec_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_0_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave0_rate_t *val)
 {
   lsm6dsl_slave0_config_t slave0_config;
@@ -6524,7 +6507,7 @@ int32_t lsm6dsl_sh_slave_0_dec_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_write_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_write_once_t val)
+int32_t lsm6dsl_sh_write_mode_set(stmdev_ctx_t *ctx, lsm6dsl_write_once_t val)
 {
   lsm6dsl_slave1_config_t slave1_config;
   int32_t ret;
@@ -6556,7 +6539,7 @@ int32_t lsm6dsl_sh_write_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_write_once_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_write_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_write_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_write_once_t *val)
 {
   lsm6dsl_slave1_config_t slave1_config;
@@ -6594,7 +6577,7 @@ int32_t lsm6dsl_sh_write_mode_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slave_1_dec_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_1_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave1_rate_t val)
 {
   lsm6dsl_slave1_config_t slave1_config;
@@ -6624,7 +6607,7 @@ int32_t lsm6dsl_sh_slave_1_dec_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slave_1_dec_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_1_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave1_rate_t *val)
 {
   lsm6dsl_slave1_config_t slave1_config;
@@ -6668,7 +6651,7 @@ int32_t lsm6dsl_sh_slave_1_dec_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slave_2_dec_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_2_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave2_rate_t val)
 {
   lsm6dsl_slave2_config_t slave2_config;
@@ -6699,7 +6682,7 @@ int32_t lsm6dsl_sh_slave_2_dec_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slave_2_dec_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_2_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave2_rate_t *val)
 {
   lsm6dsl_slave2_config_t slave2_config;
@@ -6743,7 +6726,7 @@ int32_t lsm6dsl_sh_slave_2_dec_get(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slave_3_dec_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_3_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave3_rate_t val)
 {
   lsm6dsl_slave3_config_t slave3_config;
@@ -6774,7 +6757,7 @@ int32_t lsm6dsl_sh_slave_3_dec_set(lsm6dsl_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsl_sh_slave_3_dec_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_3_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave3_rate_t *val)
 {
   lsm6dsl_slave3_config_t slave3_config;

--- a/sensor/stmemsc/lsm6dsl_STdC/driver/lsm6dsl_reg.h
+++ b/sensor/stmemsc/lsm6dsl_STdC/driver/lsm6dsl_reg.h
@@ -7,37 +7,20 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef LSM6DSL_DRIVER_H
-#define LSM6DSL_DRIVER_H
+#ifndef LSM6DSL_REGS_H
+#define LSM6DSL_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LSM6DSL_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LSM9DS1_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lsm6dsl_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lsm6dsl_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lsm6dsl_write_ptr  write_reg;
-  lsm6dsl_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lsm6dsl_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -1010,9 +982,9 @@ typedef union{
   *
   */
 
-int32_t lsm6dsl_read_reg(lsm6dsl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsl_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lsm6dsl_write_reg(lsm6dsl_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsl_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float_t lsm6dsl_from_fs2g_to_mg(int16_t lsb);
@@ -1035,8 +1007,8 @@ typedef enum {
   LSM6DSL_8g       = 3,
   LSM6DSL_XL_FS_ND = 4,  /* ERROR CODE */
 } lsm6dsl_fs_xl_t;
-int32_t lsm6dsl_xl_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t val);
-int32_t lsm6dsl_xl_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_xl_t *val);
+int32_t lsm6dsl_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6dsl_fs_xl_t val);
+int32_t lsm6dsl_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6dsl_fs_xl_t *val);
 
 typedef enum {
   LSM6DSL_XL_ODR_OFF      =  0,
@@ -1053,8 +1025,8 @@ typedef enum {
   LSM6DSL_XL_ODR_1Hz6     = 11,
   LSM6DSL_XL_ODR_ND       = 12,  /* ERROR CODE */
 } lsm6dsl_odr_xl_t;
-int32_t lsm6dsl_xl_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t val);
-int32_t lsm6dsl_xl_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_xl_t *val);
+int32_t lsm6dsl_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dsl_odr_xl_t val);
+int32_t lsm6dsl_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dsl_odr_xl_t *val);
 
 typedef enum {
   LSM6DSL_250dps     = 0,
@@ -1064,8 +1036,8 @@ typedef enum {
   LSM6DSL_2000dps    = 6,
   LSM6DSL_GY_FS_ND   = 7,    /* ERROR CODE */
 } lsm6dsl_fs_g_t;
-int32_t lsm6dsl_gy_full_scale_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t val);
-int32_t lsm6dsl_gy_full_scale_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fs_g_t *val);
+int32_t lsm6dsl_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6dsl_fs_g_t val);
+int32_t lsm6dsl_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6dsl_fs_g_t *val);
 
 typedef enum {
   LSM6DSL_GY_ODR_OFF    =  0,
@@ -1081,20 +1053,20 @@ typedef enum {
   LSM6DSL_GY_ODR_6k66Hz = 10,
   LSM6DSL_GY_ODR_ND     = 11,    /* ERROR CODE */
 } lsm6dsl_odr_g_t;
-int32_t lsm6dsl_gy_data_rate_set(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t val);
-int32_t lsm6dsl_gy_data_rate_get(lsm6dsl_ctx_t *ctx, lsm6dsl_odr_g_t *val);
+int32_t lsm6dsl_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6dsl_odr_g_t val);
+int32_t lsm6dsl_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6dsl_odr_g_t *val);
 
-int32_t lsm6dsl_block_data_update_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_block_data_update_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_LSb_1mg   = 0,
   LSM6DSL_LSb_16mg  = 1,
   LSM6DSL_WEIGHT_ND = 2,
 } lsm6dsl_usr_off_w_t;
-int32_t lsm6dsl_xl_offset_weight_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                      lsm6dsl_usr_off_w_t val);
-int32_t lsm6dsl_xl_offset_weight_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_usr_off_w_t *val);
 
 typedef enum {
@@ -1102,9 +1074,9 @@ typedef enum {
   LSM6DSL_XL_NORMAL            = 1,
   LSM6DSL_XL_PW_MODE_ND        = 2,    /* ERROR CODE */
 } lsm6dsl_xl_hm_mode_t;
-int32_t lsm6dsl_xl_power_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_xl_hm_mode_t val);
-int32_t lsm6dsl_xl_power_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_xl_hm_mode_t *val);
 
 typedef enum {
@@ -1112,9 +1084,9 @@ typedef enum {
   LSM6DSL_STAT_RND_ENABLE   = 1,
   LSM6DSL_STAT_RND_ND       = 2,    /* ERROR CODE */
 } lsm6dsl_rounding_status_t;
-int32_t lsm6dsl_rounding_on_status_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_rounding_on_status_set(stmdev_ctx_t *ctx,
                                        lsm6dsl_rounding_status_t val);
-int32_t lsm6dsl_rounding_on_status_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_rounding_on_status_get(stmdev_ctx_t *ctx,
                                        lsm6dsl_rounding_status_t *val);
 
 typedef enum {
@@ -1122,9 +1094,9 @@ typedef enum {
   LSM6DSL_GY_NORMAL            = 1,
   LSM6DSL_GY_PW_MODE_ND        = 2,    /* ERROR CODE */
 } lsm6dsl_g_hm_mode_t;
-int32_t lsm6dsl_gy_power_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_gy_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_g_hm_mode_t val);
-int32_t lsm6dsl_gy_power_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_gy_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_g_hm_mode_t *val);
 
 typedef struct {
@@ -1137,29 +1109,29 @@ typedef struct {
   lsm6dsl_wrist_tilt_ia_t      wrist_tilt_ia;
   lsm6dsl_a_wrist_tilt_mask_t  a_wrist_tilt_mask;
 } lsm6dsl_all_sources_t;
-int32_t lsm6dsl_all_sources_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_all_sources_get(stmdev_ctx_t *ctx,
                                 lsm6dsl_all_sources_t *val);
 
-int32_t lsm6dsl_status_reg_get(lsm6dsl_ctx_t *ctx, lsm6dsl_status_reg_t *val);
+int32_t lsm6dsl_status_reg_get(stmdev_ctx_t *ctx, lsm6dsl_status_reg_t *val);
 
-int32_t lsm6dsl_xl_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_gy_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_temp_flag_data_ready_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_xl_usr_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_xl_usr_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_timestamp_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_timestamp_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_LSB_6ms4    = 0,
   LSM6DSL_LSB_25us    = 1,
   LSM6DSL_TS_RES_ND   = 2,    /* ERROR CODE */
 } lsm6dsl_timer_hr_t;
-int32_t lsm6dsl_timestamp_res_set(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t val);
-int32_t lsm6dsl_timestamp_res_get(lsm6dsl_ctx_t *ctx, lsm6dsl_timer_hr_t *val);
+int32_t lsm6dsl_timestamp_res_set(stmdev_ctx_t *ctx, lsm6dsl_timer_hr_t val);
+int32_t lsm6dsl_timestamp_res_get(stmdev_ctx_t *ctx, lsm6dsl_timer_hr_t *val);
 
 typedef enum {
   LSM6DSL_ROUND_DISABLE            = 0,
@@ -1172,16 +1144,16 @@ typedef enum {
   LSM6DSL_ROUND_GY_XL_SH1_TO_SH6   = 7,
   LSM6DSL_ROUND_OUT_ND             = 8,    /* ERROR CODE */
 } lsm6dsl_rounding_t;
-int32_t lsm6dsl_rounding_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t val);
-int32_t lsm6dsl_rounding_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rounding_t *val);
+int32_t lsm6dsl_rounding_mode_set(stmdev_ctx_t *ctx, lsm6dsl_rounding_t val);
+int32_t lsm6dsl_rounding_mode_get(stmdev_ctx_t *ctx, lsm6dsl_rounding_t *val);
 
-int32_t lsm6dsl_temperature_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_angular_rate_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_acceleration_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsl_mag_calibrated_raw_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsl_fifo_raw_data_get(lsm6dsl_ctx_t *ctx, uint8_t *buffer,
+int32_t lsm6dsl_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer,
                                   uint8_t len);
 
 typedef enum {
@@ -1190,36 +1162,36 @@ typedef enum {
   LSM6DSL_BANK_B      = 5,
   LSM6DSL_BANK_ND     = 6,    /* ERROR CODE */
 } lsm6dsl_func_cfg_en_t;
-int32_t lsm6dsl_mem_bank_set(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t val);
-int32_t lsm6dsl_mem_bank_get(lsm6dsl_ctx_t *ctx, lsm6dsl_func_cfg_en_t *val);
+int32_t lsm6dsl_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsl_func_cfg_en_t val);
+int32_t lsm6dsl_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsl_func_cfg_en_t *val);
 
 typedef enum {
   LSM6DSL_DRDY_LATCHED    = 0,
   LSM6DSL_DRDY_PULSED     = 1,
   LSM6DSL_DRDY_ND         = 2,  /* ERROR CODE */
 } lsm6dsl_drdy_pulsed_g_t;
-int32_t lsm6dsl_data_ready_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_data_ready_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dsl_drdy_pulsed_g_t val);
-int32_t lsm6dsl_data_ready_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_data_ready_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dsl_drdy_pulsed_g_t *val);
 
-int32_t lsm6dsl_device_id_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_LSB_AT_LOW_ADD  = 0,
   LSM6DSL_MSB_AT_LOW_ADD  = 1,
   LSM6DSL_DATA_FMT_ND     = 2,    /* ERROR CODE */
 } lsm6dsl_ble_t;
-int32_t lsm6dsl_data_format_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t val);
-int32_t lsm6dsl_data_format_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ble_t *val);
+int32_t lsm6dsl_data_format_set(stmdev_ctx_t *ctx, lsm6dsl_ble_t val);
+int32_t lsm6dsl_data_format_get(stmdev_ctx_t *ctx, lsm6dsl_ble_t *val);
 
-int32_t lsm6dsl_auto_increment_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_auto_increment_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_boot_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_boot_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_XL_ST_DISABLE    = 0,
@@ -1227,8 +1199,8 @@ typedef enum {
   LSM6DSL_XL_ST_NEGATIVE   = 2,
   LSM6DSL_XL_ST_ND         = 3,    /* ERROR CODE */
 } lsm6dsl_st_xl_t;
-int32_t lsm6dsl_xl_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t val);
-int32_t lsm6dsl_xl_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_xl_t *val);
+int32_t lsm6dsl_xl_self_test_set(stmdev_ctx_t *ctx, lsm6dsl_st_xl_t val);
+int32_t lsm6dsl_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dsl_st_xl_t *val);
 
 typedef enum {
   LSM6DSL_GY_ST_DISABLE    = 0,
@@ -1236,20 +1208,20 @@ typedef enum {
   LSM6DSL_GY_ST_NEGATIVE   = 3,
   LSM6DSL_GY_ST_ND         = 4,    /* ERROR CODE */
 } lsm6dsl_st_g_t;
-int32_t lsm6dsl_gy_self_test_set(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t val);
-int32_t lsm6dsl_gy_self_test_get(lsm6dsl_ctx_t *ctx, lsm6dsl_st_g_t *val);
+int32_t lsm6dsl_gy_self_test_set(stmdev_ctx_t *ctx, lsm6dsl_st_g_t val);
+int32_t lsm6dsl_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dsl_st_g_t *val);
 
-int32_t lsm6dsl_filter_settling_mask_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_filter_settling_mask_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_USE_SLOPE    = 0,
   LSM6DSL_USE_HPF      = 1,
   LSM6DSL_HP_PATH_ND   = 2,    /* ERROR CODE */
 } lsm6dsl_slope_fds_t;
-int32_t lsm6dsl_xl_hp_path_internal_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         lsm6dsl_slope_fds_t val);
-int32_t lsm6dsl_xl_hp_path_internal_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         lsm6dsl_slope_fds_t *val);
 
 typedef enum {
@@ -1257,9 +1229,9 @@ typedef enum {
   LSM6DSL_XL_ANA_BW_400Hz = 1,
   LSM6DSL_XL_ANA_BW_ND    = 2,    /* ERROR CODE */
 } lsm6dsl_bw0_xl_t;
-int32_t lsm6dsl_xl_filter_analog_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_filter_analog_set(stmdev_ctx_t *ctx,
                                      lsm6dsl_bw0_xl_t val);
-int32_t lsm6dsl_xl_filter_analog_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_filter_analog_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_bw0_xl_t *val);
 
 typedef enum {
@@ -1267,9 +1239,9 @@ typedef enum {
   LSM6DSL_XL_LP1_ODR_DIV_4 = 1,
   LSM6DSL_XL_LP1_NA        = 2,  /* ERROR CODE */
 } lsm6dsl_lpf1_bw_sel_t;
-int32_t lsm6dsl_xl_lp1_bandwidth_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsl_lpf1_bw_sel_t val);
-int32_t lsm6dsl_xl_lp1_bandwidth_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_lpf1_bw_sel_t *val);
 
 typedef enum {
@@ -1283,13 +1255,13 @@ typedef enum {
   LSM6DSL_XL_LOW_NOISE_LP_ODR_DIV_400  = 0x13,
   LSM6DSL_XL_LP_NA                     = 0x20, /* ERROR CODE */
 } lsm6dsl_input_composite_t;
-int32_t lsm6dsl_xl_lp2_bandwidth_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsl_input_composite_t val);
-int32_t lsm6dsl_xl_lp2_bandwidth_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_input_composite_t *val);
 
-int32_t lsm6dsl_xl_reference_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_xl_reference_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_xl_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_xl_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_XL_HP_ODR_DIV_4      = 0x00, /* Slope filter */
@@ -1298,9 +1270,9 @@ typedef enum {
   LSM6DSL_XL_HP_ODR_DIV_400    = 0x03,
   LSM6DSL_XL_HP_NA             = 0x10, /* ERROR CODE */
 } lsm6dsl_hpcf_xl_t;
-int32_t lsm6dsl_xl_hp_bandwidth_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                     lsm6dsl_hpcf_xl_t val);
-int32_t lsm6dsl_xl_hp_bandwidth_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_xl_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                     lsm6dsl_hpcf_xl_t *val);
 
 typedef enum {
@@ -1323,9 +1295,9 @@ typedef enum {
 
   LSM6DSL_HP_GY_BAND_NA               = 0xFF,    /* ERROR CODE */
 } lsm6dsl_lpf1_sel_g_t;
-int32_t lsm6dsl_gy_band_pass_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_gy_band_pass_set(stmdev_ctx_t *ctx,
                                     lsm6dsl_lpf1_sel_g_t val);
-int32_t lsm6dsl_gy_band_pass_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_gy_band_pass_get(stmdev_ctx_t *ctx,
                                     lsm6dsl_lpf1_sel_g_t *val);
 
 typedef enum {
@@ -1333,17 +1305,17 @@ typedef enum {
   LSM6DSL_SPI_3_WIRE  = 1,
   LSM6DSL_SPI_MODE_ND = 2,    /* ERROR CODE */
 } lsm6dsl_sim_t;
-int32_t lsm6dsl_spi_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t val);
-int32_t lsm6dsl_spi_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sim_t *val);
+int32_t lsm6dsl_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsl_sim_t val);
+int32_t lsm6dsl_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsl_sim_t *val);
 
 typedef enum {
   LSM6DSL_I2C_ENABLE   = 0,
   LSM6DSL_I2C_DISABLE  = 1,
   LSM6DSL_I2C_MODE_ND  = 2,    /* ERROR CODE */
 } lsm6dsl_i2c_disable_t;
-int32_t lsm6dsl_i2c_interface_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_i2c_interface_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_i2c_disable_t val);
-int32_t lsm6dsl_i2c_interface_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_i2c_interface_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_i2c_disable_t *val);
 
 typedef struct {
@@ -1366,9 +1338,9 @@ typedef struct {
   uint8_t den_drdy_int1            : 1;
   uint8_t drdy_on_int1             : 1;
 } lsm6dsl_int1_route_t;
-int32_t lsm6dsl_pin_int1_route_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_int1_route_t val);
-int32_t lsm6dsl_pin_int1_route_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_int1_route_t *val);
 
 typedef struct{
@@ -1390,9 +1362,9 @@ typedef struct{
   uint8_t int2_inact_state         : 1;
   uint8_t int2_wrist_tilt          : 1;
 } lsm6dsl_int2_route_t;
-int32_t lsm6dsl_pin_int2_route_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_int2_route_t val);
-int32_t lsm6dsl_pin_int2_route_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pin_int2_route_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_int2_route_t *val);
 
 typedef enum {
@@ -1400,36 +1372,36 @@ typedef enum {
   LSM6DSL_OPEN_DRAIN  = 1,
   LSM6DSL_PIN_MODE_ND = 2,    /* ERROR CODE */
 } lsm6dsl_pp_od_t;
-int32_t lsm6dsl_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t val);
-int32_t lsm6dsl_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pp_od_t *val);
+int32_t lsm6dsl_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsl_pp_od_t val);
+int32_t lsm6dsl_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsl_pp_od_t *val);
 
 typedef enum {
   LSM6DSL_ACTIVE_HIGH   = 0,
   LSM6DSL_ACTIVE_LOW    = 1,
   LSM6DSL_POLARITY_ND   = 2,    /* ERROR CODE */
 } lsm6dsl_h_lactive_t;
-int32_t lsm6dsl_pin_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t val);
-int32_t lsm6dsl_pin_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_h_lactive_t *val);
+int32_t lsm6dsl_pin_polarity_set(stmdev_ctx_t *ctx, lsm6dsl_h_lactive_t val);
+int32_t lsm6dsl_pin_polarity_get(stmdev_ctx_t *ctx, lsm6dsl_h_lactive_t *val);
 
-int32_t lsm6dsl_all_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_all_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_INT_PULSED   = 0,
   LSM6DSL_INT_LATCHED  = 1,
   LSM6DSL_INT_MODE     = 2,    /* ERROR CODE */
 } lsm6dsl_lir_t;
-int32_t lsm6dsl_int_notification_set(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t val);
-int32_t lsm6dsl_int_notification_get(lsm6dsl_ctx_t *ctx, lsm6dsl_lir_t *val);
+int32_t lsm6dsl_int_notification_set(stmdev_ctx_t *ctx, lsm6dsl_lir_t val);
+int32_t lsm6dsl_int_notification_get(stmdev_ctx_t *ctx, lsm6dsl_lir_t *val);
 
-int32_t lsm6dsl_wkup_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_wkup_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_wkup_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_wkup_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_gy_sleep_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_gy_sleep_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_PROPERTY_DISABLE          = 0,
@@ -1438,43 +1410,43 @@ typedef enum {
   LSM6DSL_XL_12Hz5_GY_PD            = 3,
   LSM6DSL_ACT_MODE_ND               = 4,    /* ERROR CODE */
 } lsm6dsl_inact_en_t;
-int32_t lsm6dsl_act_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t val);
-int32_t lsm6dsl_act_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_inact_en_t *val);
+int32_t lsm6dsl_act_mode_set(stmdev_ctx_t *ctx, lsm6dsl_inact_en_t val);
+int32_t lsm6dsl_act_mode_get(stmdev_ctx_t *ctx, lsm6dsl_inact_en_t *val);
 
-int32_t lsm6dsl_act_sleep_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_act_sleep_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_tap_src_get(lsm6dsl_ctx_t *ctx, lsm6dsl_tap_src_t *val);
+int32_t lsm6dsl_tap_src_get(stmdev_ctx_t *ctx, lsm6dsl_tap_src_t *val);
 
-int32_t lsm6dsl_tap_detection_on_z_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_tap_detection_on_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_tap_detection_on_y_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_tap_detection_on_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_tap_detection_on_x_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_tap_detection_on_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_tap_threshold_x_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_tap_threshold_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_tap_shock_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_tap_shock_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_tap_quiet_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_tap_quiet_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_tap_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_tap_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_ONLY_SINGLE          = 0,
   LSM6DSL_BOTH_SINGLE_DOUBLE   = 1,
   LSM6DSL_TAP_MODE_ND          = 2,    /* ERROR CODE */
 } lsm6dsl_single_double_tap_t;
-int32_t lsm6dsl_tap_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_tap_mode_set(stmdev_ctx_t *ctx,
                              lsm6dsl_single_double_tap_t val);
-int32_t lsm6dsl_tap_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_tap_mode_get(stmdev_ctx_t *ctx,
                              lsm6dsl_single_double_tap_t *val);
 
 typedef enum {
@@ -1482,9 +1454,9 @@ typedef enum {
   LSM6DSL_LPF2_FEED           = 1,
   LSM6DSL_6D_FEED_ND          = 2,    /* ERROR CODE */
 } lsm6dsl_low_pass_on_6d_t;
-int32_t lsm6dsl_6d_feed_data_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_6d_feed_data_set(stmdev_ctx_t *ctx,
                                  lsm6dsl_low_pass_on_6d_t val);
-int32_t lsm6dsl_6d_feed_data_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_6d_feed_data_get(stmdev_ctx_t *ctx,
                                  lsm6dsl_low_pass_on_6d_t *val);
 
 typedef enum {
@@ -1494,14 +1466,14 @@ typedef enum {
   LSM6DSL_DEG_50      = 3,
   LSM6DSL_6D_TH_ND    = 4,    /* ERROR CODE */
 } lsm6dsl_sixd_ths_t;
-int32_t lsm6dsl_6d_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t val);
-int32_t lsm6dsl_6d_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_sixd_ths_t *val);
+int32_t lsm6dsl_6d_threshold_set(stmdev_ctx_t *ctx, lsm6dsl_sixd_ths_t val);
+int32_t lsm6dsl_6d_threshold_get(stmdev_ctx_t *ctx, lsm6dsl_sixd_ths_t *val);
 
-int32_t lsm6dsl_4d_mode_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_4d_mode_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_ff_dur_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_ff_dur_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_FF_TSH_156mg = 0,
@@ -1514,20 +1486,20 @@ typedef enum {
   LSM6DSL_FF_TSH_500mg = 7,
   LSM6DSL_FF_TSH_ND    = 8,    /* ERROR CODE */
 } lsm6dsl_ff_ths_t;
-int32_t lsm6dsl_ff_threshold_set(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t val);
-int32_t lsm6dsl_ff_threshold_get(lsm6dsl_ctx_t *ctx, lsm6dsl_ff_ths_t *val);
+int32_t lsm6dsl_ff_threshold_set(stmdev_ctx_t *ctx, lsm6dsl_ff_ths_t val);
+int32_t lsm6dsl_ff_threshold_get(stmdev_ctx_t *ctx, lsm6dsl_ff_ths_t *val);
 
-int32_t lsm6dsl_fifo_watermark_set(lsm6dsl_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsl_fifo_watermark_get(lsm6dsl_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsl_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsl_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsl_fifo_data_level_get(lsm6dsl_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsl_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsl_fifo_wtm_flag_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_fifo_pattern_get(lsm6dsl_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsl_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsl_fifo_temp_batch_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_fifo_temp_batch_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_TRG_XL_GY_DRDY     = 0,
@@ -1535,14 +1507,14 @@ typedef enum {
   LSM6DSL_TRG_SH_DRDY        = 2,
   LSM6DSL_TRG_SH_ND          = 3,    /* ERROR CODE */
 } lsm6dsl_trigger_fifo_t;
-int32_t lsm6dsl_fifo_write_trigger_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_write_trigger_set(stmdev_ctx_t *ctx,
                                        lsm6dsl_trigger_fifo_t val);
-int32_t lsm6dsl_fifo_write_trigger_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_write_trigger_get(stmdev_ctx_t *ctx,
                                        lsm6dsl_trigger_fifo_t *val);
 
-int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_set(stmdev_ctx_t *ctx,
                                                   uint8_t val);
-int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_pedo_and_timestamp_batch_get(stmdev_ctx_t *ctx,
                                                   uint8_t *val);
 
 typedef enum {
@@ -1556,9 +1528,9 @@ typedef enum {
   LSM6DSL_FIFO_XL_DEC_32   = 7,
   LSM6DSL_FIFO_XL_DEC_ND   = 8,    /* ERROR CODE */
 } lsm6dsl_dec_fifo_xl_t;
-int32_t lsm6dsl_fifo_xl_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_dec_fifo_xl_t val);
-int32_t lsm6dsl_fifo_xl_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_dec_fifo_xl_t *val);
 
 typedef enum {
@@ -1572,9 +1544,9 @@ typedef enum {
   LSM6DSL_FIFO_GY_DEC_32  = 7,
   LSM6DSL_FIFO_GY_DEC_ND  = 8,    /* ERROR CODE */
 } lsm6dsl_dec_fifo_gyro_t;
-int32_t lsm6dsl_fifo_gy_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_dec_fifo_gyro_t val);
-int32_t lsm6dsl_fifo_gy_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_dec_fifo_gyro_t *val);
 
 typedef enum {
@@ -1588,9 +1560,9 @@ typedef enum {
   LSM6DSL_FIFO_DS3_DEC_32    = 7,
   LSM6DSL_FIFO_DS3_DEC_ND    = 8,    /* ERROR CODE */
 } lsm6dsl_dec_ds3_fifo_t;
-int32_t lsm6dsl_fifo_dataset_3_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
                                          lsm6dsl_dec_ds3_fifo_t val);
-int32_t lsm6dsl_fifo_dataset_3_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
                                          lsm6dsl_dec_ds3_fifo_t *val);
 
 typedef enum {
@@ -1604,16 +1576,16 @@ typedef enum {
   LSM6DSL_FIFO_DS4_DEC_32   = 7,
   LSM6DSL_FIFO_DS4_DEC_ND   = 8,    /* ERROR CODE */
 } lsm6dsl_dec_ds4_fifo_t;
-int32_t lsm6dsl_fifo_dataset_4_batch_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
                                          lsm6dsl_dec_ds4_fifo_t val);
-int32_t lsm6dsl_fifo_dataset_4_batch_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
                                          lsm6dsl_dec_ds4_fifo_t *val);
 
-int32_t lsm6dsl_fifo_xl_gy_8bit_format_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_fifo_xl_gy_8bit_format_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_fifo_stop_on_wtm_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_fifo_stop_on_wtm_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_BYPASS_MODE           = 0,
@@ -1623,8 +1595,8 @@ typedef enum {
   LSM6DSL_STREAM_MODE           = 6,
   LSM6DSL_FIFO_MODE_ND          = 8,    /* ERROR CODE */
 } lsm6dsl_fifo_mode_t;
-int32_t lsm6dsl_fifo_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t val);
-int32_t lsm6dsl_fifo_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_fifo_mode_t *val);
+int32_t lsm6dsl_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsl_fifo_mode_t val);
+int32_t lsm6dsl_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsl_fifo_mode_t *val);
 
 typedef enum {
   LSM6DSL_FIFO_DISABLE   =  0,
@@ -1640,9 +1612,9 @@ typedef enum {
   LSM6DSL_FIFO_6k66Hz    = 10,
   LSM6DSL_FIFO_RATE_ND   = 11,    /* ERROR CODE */
 } lsm6dsl_odr_fifo_t;
-int32_t lsm6dsl_fifo_data_rate_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_data_rate_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_odr_fifo_t val);
-int32_t lsm6dsl_fifo_data_rate_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_fifo_data_rate_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_odr_fifo_t *val);
 
 typedef enum {
@@ -1650,8 +1622,8 @@ typedef enum {
   LSM6DSL_DEN_ACT_HIGH   = 1,
   LSM6DSL_DEN_POL_ND     = 2,    /* ERROR CODE */
 } lsm6dsl_den_lh_t;
-int32_t lsm6dsl_den_polarity_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t val);
-int32_t lsm6dsl_den_polarity_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_lh_t *val);
+int32_t lsm6dsl_den_polarity_set(stmdev_ctx_t *ctx, lsm6dsl_den_lh_t val);
+int32_t lsm6dsl_den_polarity_get(stmdev_ctx_t *ctx, lsm6dsl_den_lh_t *val);
 
 typedef enum {
   LSM6DSL_DEN_DISABLE    = 0,
@@ -1661,8 +1633,8 @@ typedef enum {
   LSM6DSL_EDGE_TRIGGER   = 4,
   LSM6DSL_DEN_MODE_ND    = 5,    /* ERROR CODE */
 } lsm6dsl_den_mode_t;
-int32_t lsm6dsl_den_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t val);
-int32_t lsm6dsl_den_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_mode_t *val);
+int32_t lsm6dsl_den_mode_set(stmdev_ctx_t *ctx, lsm6dsl_den_mode_t val);
+int32_t lsm6dsl_den_mode_get(stmdev_ctx_t *ctx, lsm6dsl_den_mode_t *val);
 
 typedef enum {
   LSM6DSL_STAMP_IN_GY_DATA     = 0,
@@ -1670,85 +1642,85 @@ typedef enum {
   LSM6DSL_STAMP_IN_GY_XL_DATA  = 2,
   LSM6DSL_DEN_STAMP_ND         = 3,    /* ERROR CODE */
 } lsm6dsl_den_xl_en_t;
-int32_t lsm6dsl_den_enable_set(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t val);
-int32_t lsm6dsl_den_enable_get(lsm6dsl_ctx_t *ctx, lsm6dsl_den_xl_en_t *val);
+int32_t lsm6dsl_den_enable_set(stmdev_ctx_t *ctx, lsm6dsl_den_xl_en_t val);
+int32_t lsm6dsl_den_enable_get(stmdev_ctx_t *ctx, lsm6dsl_den_xl_en_t *val);
 
-int32_t lsm6dsl_den_mark_axis_z_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_den_mark_axis_z_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_den_mark_axis_y_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_den_mark_axis_y_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_den_mark_axis_x_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_den_mark_axis_x_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_pedo_step_reset_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_pedo_step_reset_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_pedo_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_pedo_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_pedo_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_pedo_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_PEDO_AT_2g = 0,
   LSM6DSL_PEDO_AT_4g = 1,
   LSM6DSL_PEDO_FS_ND = 2,    /* ERROR CODE */
 } lsm6dsl_pedo_fs_t;
-int32_t lsm6dsl_pedo_full_scale_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pedo_full_scale_set(stmdev_ctx_t *ctx,
                                     lsm6dsl_pedo_fs_t val);
-int32_t lsm6dsl_pedo_full_scale_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_pedo_full_scale_get(stmdev_ctx_t *ctx,
                                     lsm6dsl_pedo_fs_t *val);
 
-int32_t lsm6dsl_pedo_debounce_steps_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_pedo_debounce_steps_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_pedo_timeout_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_pedo_timeout_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_pedo_steps_period_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_pedo_steps_period_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsl_motion_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_motion_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_motion_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_motion_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsl_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_wrist_tilt_sens_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_wrist_tilt_sens_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_wrist_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_wrist_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_tilt_latency_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_tilt_latency_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_tilt_latency_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_tilt_latency_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsl_tilt_threshold_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_tilt_threshold_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_tilt_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_tilt_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsl_tilt_src_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_tilt_src_set(stmdev_ctx_t *ctx,
                              lsm6dsl_a_wrist_tilt_mask_t *val);
-int32_t lsm6dsl_tilt_src_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_tilt_src_get(stmdev_ctx_t *ctx,
                              lsm6dsl_a_wrist_tilt_mask_t *val);
 
-int32_t lsm6dsl_mag_soft_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_mag_soft_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_mag_hard_iron_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_mag_hard_iron_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_mag_soft_iron_mat_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_mag_soft_iron_mat_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_mag_soft_iron_mat_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_mag_soft_iron_mat_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsl_mag_offset_set(lsm6dsl_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsl_mag_offset_get(lsm6dsl_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsl_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsl_func_en_set(lsm6dsl_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_func_en_set(stmdev_ctx_t *ctx, uint8_t val);
 
-int32_t lsm6dsl_sh_sync_sens_frame_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_sh_sync_sens_frame_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_RES_RATIO_2_11  = 0,
@@ -1757,35 +1729,35 @@ typedef enum {
   LSM6DSL_RES_RATIO_2_14  = 3,
   LSM6DSL_RES_RATIO_ND    = 4,    /* ERROR CODE */
 } lsm6dsl_rr_t;
-int32_t lsm6dsl_sh_sync_sens_ratio_set(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t val);
-int32_t lsm6dsl_sh_sync_sens_ratio_get(lsm6dsl_ctx_t *ctx, lsm6dsl_rr_t *val);
+int32_t lsm6dsl_sh_sync_sens_ratio_set(stmdev_ctx_t *ctx, lsm6dsl_rr_t val);
+int32_t lsm6dsl_sh_sync_sens_ratio_get(stmdev_ctx_t *ctx, lsm6dsl_rr_t *val);
 
-int32_t lsm6dsl_sh_master_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_sh_master_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_sh_pass_through_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_sh_pass_through_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_EXT_PULL_UP       = 0,
   LSM6DSL_INTERNAL_PULL_UP  = 1,
   LSM6DSL_SH_PIN_MODE       = 2,    /* ERROR CODE */
 } lsm6dsl_pull_up_en_t;
-int32_t lsm6dsl_sh_pin_mode_set(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t val);
-int32_t lsm6dsl_sh_pin_mode_get(lsm6dsl_ctx_t *ctx, lsm6dsl_pull_up_en_t *val);
+int32_t lsm6dsl_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsl_pull_up_en_t val);
+int32_t lsm6dsl_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsl_pull_up_en_t *val);
 
 typedef enum {
   LSM6DSL_XL_GY_DRDY        = 0,
   LSM6DSL_EXT_ON_INT2_PIN   = 1,
   LSM6DSL_SH_SYNCRO_ND      = 2,    /* ERROR CODE */
 } lsm6dsl_start_config_t;
-int32_t lsm6dsl_sh_syncro_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_start_config_t val);
-int32_t lsm6dsl_sh_syncro_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_start_config_t *val);
 
-int32_t lsm6dsl_sh_drdy_on_int1_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_sh_drdy_on_int1_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_sh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
     lsm6dsl_sensorhub1_reg_t   sh_byte_1;
@@ -1807,14 +1779,14 @@ typedef struct {
     lsm6dsl_sensorhub17_reg_t  sh_byte_17;
     lsm6dsl_sensorhub18_reg_t  sh_byte_18;
 } lsm6dsl_emb_sh_read_t;
-int32_t lsm6dsl_sh_read_data_raw_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                      lsm6dsl_emb_sh_read_t *val);
 
-int32_t lsm6dsl_sh_cmd_sens_sync_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_sh_cmd_sens_sync_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_sh_cmd_sens_sync_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_cmd_sens_sync_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsl_sh_spi_sync_error_set(lsm6dsl_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsl_sh_spi_sync_error_get(lsm6dsl_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsl_sh_spi_sync_error_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsl_sh_spi_sync_error_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSL_SLV_0        = 0,
@@ -1823,9 +1795,9 @@ typedef enum {
   LSM6DSL_SLV_0_1_2_3  = 3,
   LSM6DSL_SLV_EN_ND    = 4,    /* ERROR CODE */
 } lsm6dsl_aux_sens_on_t;
-int32_t lsm6dsl_sh_num_of_dev_connected_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
                                             lsm6dsl_aux_sens_on_t val);
-int32_t lsm6dsl_sh_num_of_dev_connected_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
                                             lsm6dsl_aux_sens_on_t *val);
 
 typedef struct{
@@ -1833,20 +1805,20 @@ typedef struct{
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } lsm6dsl_sh_cfg_write_t;
-int32_t lsm6dsl_sh_cfg_write(lsm6dsl_ctx_t *ctx, lsm6dsl_sh_cfg_write_t *val);
+int32_t lsm6dsl_sh_cfg_write(stmdev_ctx_t *ctx, lsm6dsl_sh_cfg_write_t *val);
 
 typedef struct{
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dsl_sh_cfg_read_t;
-int32_t lsm6dsl_sh_slv0_cfg_read(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsl_sh_cfg_read_t *val);
-int32_t lsm6dsl_sh_slv1_cfg_read(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsl_sh_cfg_read_t *val);
-int32_t lsm6dsl_sh_slv2_cfg_read(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsl_sh_cfg_read_t *val);
-int32_t lsm6dsl_sh_slv3_cfg_read(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsl_sh_cfg_read_t *val);
 
 typedef enum {
@@ -1856,9 +1828,9 @@ typedef enum {
   LSM6DSL_SL0_DEC_8    = 3,
   LSM6DSL_SL0_DEC_ND   = 4,    /* ERROR CODE */
 } lsm6dsl_slave0_rate_t;
-int32_t lsm6dsl_sh_slave_0_dec_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_0_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave0_rate_t val);
-int32_t lsm6dsl_sh_slave_0_dec_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_0_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave0_rate_t *val);
 
 typedef enum {
@@ -1866,9 +1838,9 @@ typedef enum {
   LSM6DSL_ONLY_FIRST_CYCLE  = 1,
   LSM6DSL_SH_WR_MODE_ND     = 2,    /* ERROR CODE */
 } lsm6dsl_write_once_t;
-int32_t lsm6dsl_sh_write_mode_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_write_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsl_write_once_t val);
-int32_t lsm6dsl_sh_write_mode_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_write_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsl_write_once_t *val);
 
 typedef enum {
@@ -1878,9 +1850,9 @@ typedef enum {
   LSM6DSL_SL1_DEC_8    = 3,
   LSM6DSL_SL1_DEC_ND   = 4,    /* ERROR CODE */
 } lsm6dsl_slave1_rate_t;
-int32_t lsm6dsl_sh_slave_1_dec_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_1_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave1_rate_t val);
-int32_t lsm6dsl_sh_slave_1_dec_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_1_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave1_rate_t *val);
 
 typedef enum {
@@ -1890,9 +1862,9 @@ typedef enum {
   LSM6DSL_SL2_DEC_8   = 3,
   LSM6DSL_SL2_DEC_ND  = 4,    /* ERROR CODE */
 } lsm6dsl_slave2_rate_t;
-int32_t lsm6dsl_sh_slave_2_dec_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_2_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave2_rate_t val);
-int32_t lsm6dsl_sh_slave_2_dec_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_2_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave2_rate_t *val);
 
 typedef enum {
@@ -1902,9 +1874,9 @@ typedef enum {
   LSM6DSL_SL3_DEC_8   = 3,
   LSM6DSL_SL3_DEC_ND  = 4,    /* ERROR CODE */
 } lsm6dsl_slave3_rate_t;
-int32_t lsm6dsl_sh_slave_3_dec_set(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_3_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave3_rate_t val);
-int32_t lsm6dsl_sh_slave_3_dec_get(lsm6dsl_ctx_t *ctx,
+int32_t lsm6dsl_sh_slave_3_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsl_slave3_rate_t *val);
 
 /**

--- a/sensor/stmemsc/lsm6dsm_STdC/driver/lsm6dsm_reg.c
+++ b/sensor/stmemsc/lsm6dsm_STdC/driver/lsm6dsm_reg.c
@@ -6,33 +6,16 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 #include "lsm6dsm_reg.h"
 
@@ -63,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsm_read_reg(lsm6dsm_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsm_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t lsm6dsm_read_reg(lsm6dsm_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsm_write_reg(lsm6dsm_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsm_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -173,7 +156,7 @@ float_t lsm6dsm_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t val)
+int32_t lsm6dsm_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6dsm_fs_xl_t val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -194,7 +177,7 @@ int32_t lsm6dsm_xl_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t *val)
+int32_t lsm6dsm_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6dsm_fs_xl_t *val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -229,7 +212,7 @@ int32_t lsm6dsm_xl_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t val)
+int32_t lsm6dsm_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dsm_odr_xl_t val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -250,7 +233,7 @@ int32_t lsm6dsm_xl_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t *val)
+int32_t lsm6dsm_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dsm_odr_xl_t *val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -309,7 +292,7 @@ int32_t lsm6dsm_xl_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t val)
+int32_t lsm6dsm_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6dsm_fs_g_t val)
 {
   lsm6dsm_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -330,7 +313,7 @@ int32_t lsm6dsm_gy_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t *val)
+int32_t lsm6dsm_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6dsm_fs_g_t *val)
 {
   lsm6dsm_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -368,7 +351,7 @@ int32_t lsm6dsm_gy_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t val)
+int32_t lsm6dsm_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6dsm_odr_g_t val)
 {
   lsm6dsm_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -389,7 +372,7 @@ int32_t lsm6dsm_gy_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t *val)
+int32_t lsm6dsm_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6dsm_odr_g_t *val)
 {
   lsm6dsm_ctrl2_g_t ctrl2_g;
   int32_t ret;
@@ -445,7 +428,7 @@ int32_t lsm6dsm_gy_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_block_data_update_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -466,7 +449,7 @@ int32_t lsm6dsm_block_data_update_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_block_data_update_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -486,7 +469,7 @@ int32_t lsm6dsm_block_data_update_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_offset_weight_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_usr_off_w_t val)
 {
   lsm6dsm_ctrl6_c_t ctrl6_c;
@@ -509,7 +492,7 @@ int32_t lsm6dsm_xl_offset_weight_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_offset_weight_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_usr_off_w_t *val)
 {
   lsm6dsm_ctrl6_c_t ctrl6_c;
@@ -539,7 +522,7 @@ int32_t lsm6dsm_xl_offset_weight_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_power_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_xl_hm_mode_t val)
 {
   lsm6dsm_ctrl6_c_t ctrl6_c;
@@ -561,7 +544,7 @@ int32_t lsm6dsm_xl_power_mode_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_power_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_xl_hm_mode_t *val)
 {
   lsm6dsm_ctrl6_c_t ctrl6_c;
@@ -593,7 +576,7 @@ int32_t lsm6dsm_xl_power_mode_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_rounding_on_status_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_rounding_on_status_set(stmdev_ctx_t *ctx,
                                        lsm6dsm_rounding_status_t val)
 {
   lsm6dsm_ctrl7_g_t ctrl7_g;
@@ -617,7 +600,7 @@ int32_t lsm6dsm_rounding_on_status_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_rounding_on_status_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_rounding_on_status_get(stmdev_ctx_t *ctx,
                                        lsm6dsm_rounding_status_t *val)
 {
   lsm6dsm_ctrl7_g_t ctrl7_g;
@@ -647,7 +630,7 @@ int32_t lsm6dsm_rounding_on_status_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_power_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_g_hm_mode_t val)
+int32_t lsm6dsm_gy_power_mode_set(stmdev_ctx_t *ctx, lsm6dsm_g_hm_mode_t val)
 {
   lsm6dsm_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -668,7 +651,7 @@ int32_t lsm6dsm_gy_power_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_g_hm_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_power_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_g_hm_mode_t *val)
+int32_t lsm6dsm_gy_power_mode_get(stmdev_ctx_t *ctx, lsm6dsm_g_hm_mode_t *val)
 {
   lsm6dsm_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -698,7 +681,7 @@ int32_t lsm6dsm_gy_power_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_g_hm_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_all_sources_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_all_sources_get(stmdev_ctx_t *ctx,
                                 lsm6dsm_all_sources_t *val)
 {
   int32_t ret;
@@ -750,7 +733,7 @@ int32_t lsm6dsm_all_sources_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_status_reg_get(lsm6dsm_ctx_t *ctx, lsm6dsm_status_reg_t *val)
+int32_t lsm6dsm_status_reg_get(stmdev_ctx_t *ctx, lsm6dsm_status_reg_t *val)
 {
   int32_t ret;
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_STATUS_REG, (uint8_t*) val, 1);
@@ -765,7 +748,7 @@ int32_t lsm6dsm_status_reg_get(lsm6dsm_ctx_t *ctx, lsm6dsm_status_reg_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_status_reg_t status_reg;
   int32_t ret;
@@ -784,7 +767,7 @@ int32_t lsm6dsm_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_status_reg_t status_reg;
   int32_t ret;
@@ -803,7 +786,7 @@ int32_t lsm6dsm_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_temp_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_status_reg_t status_reg;
   int32_t ret;
@@ -824,7 +807,7 @@ int32_t lsm6dsm_temp_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_usr_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsm_write_reg(ctx, LSM6DSM_X_OFS_USR, buff, 3);
@@ -841,7 +824,7 @@ int32_t lsm6dsm_xl_usr_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_usr_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_X_OFS_USR, buff, 3);
@@ -870,7 +853,7 @@ int32_t lsm6dsm_xl_usr_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_timestamp_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -895,7 +878,7 @@ int32_t lsm6dsm_timestamp_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_timestamp_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -919,7 +902,7 @@ int32_t lsm6dsm_timestamp_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_timestamp_res_set(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t val)
+int32_t lsm6dsm_timestamp_res_set(stmdev_ctx_t *ctx, lsm6dsm_timer_hr_t val)
 {
   lsm6dsm_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -946,7 +929,7 @@ int32_t lsm6dsm_timestamp_res_set(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_timestamp_res_get(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t *val)
+int32_t lsm6dsm_timestamp_res_get(stmdev_ctx_t *ctx, lsm6dsm_timer_hr_t *val)
 {
   lsm6dsm_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -988,7 +971,7 @@ int32_t lsm6dsm_timestamp_res_get(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_rounding_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t val)
+int32_t lsm6dsm_rounding_mode_set(stmdev_ctx_t *ctx, lsm6dsm_rounding_t val)
 {
   lsm6dsm_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1010,7 +993,7 @@ int32_t lsm6dsm_rounding_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_rounding_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t *val)
+int32_t lsm6dsm_rounding_mode_get(stmdev_ctx_t *ctx, lsm6dsm_rounding_t *val)
 {
   lsm6dsm_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1058,7 +1041,7 @@ int32_t lsm6dsm_rounding_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_temperature_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_OUT_TEMP_L, buff, 2);
@@ -1074,7 +1057,7 @@ int32_t lsm6dsm_temperature_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_angular_rate_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_OUTX_L_G, buff, 6);
@@ -1090,7 +1073,7 @@ int32_t lsm6dsm_angular_rate_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_acceleration_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_OUTX_L_XL, buff, 6);
@@ -1105,7 +1088,7 @@ int32_t lsm6dsm_acceleration_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_calibrated_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_OUT_MAG_RAW_X_L, buff, 6);
@@ -1121,7 +1104,7 @@ int32_t lsm6dsm_mag_calibrated_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_raw_data_get(lsm6dsm_ctx_t *ctx, uint8_t *buffer,
+int32_t lsm6dsm_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer,
                                   uint8_t len)
 {
   int32_t ret;
@@ -1150,7 +1133,7 @@ int32_t lsm6dsm_fifo_raw_data_get(lsm6dsm_ctx_t *ctx, uint8_t *buffer,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mem_bank_set(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t val)
+int32_t lsm6dsm_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsm_func_cfg_en_t val)
 {
   lsm6dsm_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -1175,7 +1158,7 @@ int32_t lsm6dsm_mem_bank_set(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mem_bank_get(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t *val)
+int32_t lsm6dsm_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsm_func_cfg_en_t *val)
 {
   lsm6dsm_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -1205,7 +1188,7 @@ int32_t lsm6dsm_mem_bank_get(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_data_ready_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_data_ready_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dsm_drdy_pulsed_g_t val)
 {
   lsm6dsm_drdy_pulse_cfg_t drdy_pulse_cfg;
@@ -1229,7 +1212,7 @@ int32_t lsm6dsm_data_ready_mode_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_data_ready_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_data_ready_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dsm_drdy_pulsed_g_t *val)
 {
   lsm6dsm_drdy_pulse_cfg_t drdy_pulse_cfg;
@@ -1260,7 +1243,7 @@ int32_t lsm6dsm_data_ready_mode_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_device_id_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_WHO_AM_I, buff, 1);
@@ -1275,7 +1258,7 @@ int32_t lsm6dsm_device_id_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1296,7 +1279,7 @@ int32_t lsm6dsm_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1315,7 +1298,7 @@ int32_t lsm6dsm_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_data_format_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t val)
+int32_t lsm6dsm_data_format_set(stmdev_ctx_t *ctx, lsm6dsm_ble_t val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1336,7 +1319,7 @@ int32_t lsm6dsm_data_format_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_data_format_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t *val)
+int32_t lsm6dsm_data_format_get(stmdev_ctx_t *ctx, lsm6dsm_ble_t *val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1366,7 +1349,7 @@ int32_t lsm6dsm_data_format_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_auto_increment_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1388,7 +1371,7 @@ int32_t lsm6dsm_auto_increment_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_auto_increment_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1407,7 +1390,7 @@ int32_t lsm6dsm_auto_increment_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_boot_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_boot_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1428,7 +1411,7 @@ int32_t lsm6dsm_boot_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_boot_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -1447,7 +1430,7 @@ int32_t lsm6dsm_boot_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t val)
+int32_t lsm6dsm_xl_self_test_set(stmdev_ctx_t *ctx, lsm6dsm_st_xl_t val)
 {
   lsm6dsm_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1468,7 +1451,7 @@ int32_t lsm6dsm_xl_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t *val)
+int32_t lsm6dsm_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dsm_st_xl_t *val)
 {
   lsm6dsm_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1499,7 +1482,7 @@ int32_t lsm6dsm_xl_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t val)
+int32_t lsm6dsm_gy_self_test_set(stmdev_ctx_t *ctx, lsm6dsm_st_g_t val)
 {
   lsm6dsm_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1520,7 +1503,7 @@ int32_t lsm6dsm_gy_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t *val)
+int32_t lsm6dsm_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dsm_st_g_t *val)
 {
   lsm6dsm_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -1566,7 +1549,7 @@ int32_t lsm6dsm_gy_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_filter_settling_mask_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1588,7 +1571,7 @@ int32_t lsm6dsm_filter_settling_mask_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_filter_settling_mask_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -1608,7 +1591,7 @@ int32_t lsm6dsm_filter_settling_mask_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_hp_path_internal_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         lsm6dsm_slope_fds_t val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
@@ -1631,7 +1614,7 @@ int32_t lsm6dsm_xl_hp_path_internal_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_hp_path_internal_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         lsm6dsm_slope_fds_t *val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
@@ -1675,7 +1658,7 @@ int32_t lsm6dsm_xl_hp_path_internal_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_filter_analog_set(lsm6dsm_ctx_t *ctx, lsm6dsm_bw0_xl_t val)
+int32_t lsm6dsm_xl_filter_analog_set(stmdev_ctx_t *ctx, lsm6dsm_bw0_xl_t val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
   int32_t ret;
@@ -1697,7 +1680,7 @@ int32_t lsm6dsm_xl_filter_analog_set(lsm6dsm_ctx_t *ctx, lsm6dsm_bw0_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_filter_analog_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_filter_analog_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_bw0_xl_t *val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
@@ -1742,7 +1725,7 @@ int32_t lsm6dsm_xl_filter_analog_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_lpf1_bw_sel_t val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
@@ -1774,7 +1757,7 @@ int32_t lsm6dsm_xl_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_lpf1_bw_sel_t *val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
@@ -1813,7 +1796,7 @@ int32_t lsm6dsm_xl_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_lp2_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_input_composite_t val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
@@ -1838,7 +1821,7 @@ int32_t lsm6dsm_xl_lp2_bandwidth_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_lp2_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_input_composite_t *val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
@@ -1894,7 +1877,7 @@ int32_t lsm6dsm_xl_lp2_bandwidth_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_reference_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_xl_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1915,7 +1898,7 @@ int32_t lsm6dsm_xl_reference_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_reference_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_xl_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1934,7 +1917,7 @@ int32_t lsm6dsm_xl_reference_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_hp_bandwidth_set(lsm6dsm_ctx_t *ctx, lsm6dsm_hpcf_xl_t val)
+int32_t lsm6dsm_xl_hp_bandwidth_set(stmdev_ctx_t *ctx, lsm6dsm_hpcf_xl_t val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -1957,7 +1940,7 @@ int32_t lsm6dsm_xl_hp_bandwidth_set(lsm6dsm_ctx_t *ctx, lsm6dsm_hpcf_xl_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_hp_bandwidth_get(lsm6dsm_ctx_t *ctx, lsm6dsm_hpcf_xl_t *val)
+int32_t lsm6dsm_xl_hp_bandwidth_get(stmdev_ctx_t *ctx, lsm6dsm_hpcf_xl_t *val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -2010,7 +1993,7 @@ int32_t lsm6dsm_xl_hp_bandwidth_get(lsm6dsm_ctx_t *ctx, lsm6dsm_hpcf_xl_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_ui_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_ui_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                         lsm6dsm_ui_lpf1_bw_sel_t val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
@@ -2041,7 +2024,7 @@ int32_t lsm6dsm_xl_ui_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
 */
-int32_t lsm6dsm_xl_ui_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_ui_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                         lsm6dsm_ui_lpf1_bw_sel_t *val)
 {
   lsm6dsm_ctrl1_xl_t ctrl1_xl;
@@ -2080,7 +2063,7 @@ int32_t lsm6dsm_xl_ui_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
 */
-int32_t lsm6dsm_xl_ui_slope_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_xl_ui_slope_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -2101,7 +2084,7 @@ int32_t lsm6dsm_xl_ui_slope_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
 */
-int32_t lsm6dsm_xl_ui_slope_get(lsm6dsm_ctx_t *ctx,  uint8_t *val)
+int32_t lsm6dsm_xl_ui_slope_get(stmdev_ctx_t *ctx,  uint8_t *val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
   int32_t ret;
@@ -2133,7 +2116,7 @@ int32_t lsm6dsm_xl_ui_slope_get(lsm6dsm_ctx_t *ctx,  uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_aux_lp_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_aux_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                         lsm6dsm_filter_xl_conf_ois_t val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -2168,7 +2151,7 @@ int32_t lsm6dsm_xl_aux_lp_bandwidth_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_xl_aux_lp_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_aux_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                         lsm6dsm_filter_xl_conf_ois_t *val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -2217,7 +2200,7 @@ int32_t lsm6dsm_xl_aux_lp_bandwidth_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_band_pass_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lpf1_sel_g_t val)
+int32_t lsm6dsm_gy_band_pass_set(stmdev_ctx_t *ctx, lsm6dsm_lpf1_sel_g_t val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   lsm6dsm_ctrl6_c_t ctrl6_c;
@@ -2257,7 +2240,7 @@ int32_t lsm6dsm_gy_band_pass_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lpf1_sel_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_band_pass_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_band_pass_get(stmdev_ctx_t *ctx,
                                  lsm6dsm_lpf1_sel_g_t *val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
@@ -2342,7 +2325,7 @@ int32_t lsm6dsm_gy_band_pass_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_ui_high_pass_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_gy_ui_high_pass_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -2364,7 +2347,7 @@ int32_t lsm6dsm_gy_ui_high_pass_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_ui_high_pass_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_gy_ui_high_pass_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl7_g_t ctrl7_g;
   int32_t ret;
@@ -2387,7 +2370,7 @@ int32_t lsm6dsm_gy_ui_high_pass_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_aux_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_aux_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_hp_en_ois_t val)
 {
   lsm6dsm_ctrl7_g_t ctrl7_g;
@@ -2421,7 +2404,7 @@ int32_t lsm6dsm_gy_aux_bandwidth_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_aux_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_aux_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_hp_en_ois_t *val)
 {
   lsm6dsm_ctrl2_ois_t ctrl2_ois;
@@ -2485,7 +2468,7 @@ int32_t lsm6dsm_gy_aux_bandwidth_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_status_reg_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_status_reg_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_status_spiaux_t *val)
 {
   int32_t ret;
@@ -2501,7 +2484,7 @@ int32_t lsm6dsm_aux_status_reg_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_status_spiaux_t status_spiaux;
   int32_t ret;
@@ -2520,7 +2503,7 @@ int32_t lsm6dsm_aux_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_status_spiaux_t status_spiaux;
   int32_t ret;
@@ -2539,7 +2522,7 @@ int32_t lsm6dsm_aux_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_gy_flag_settling_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_aux_gy_flag_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_status_spiaux_t status_spiaux;
   int32_t ret;
@@ -2558,7 +2541,7 @@ int32_t lsm6dsm_aux_gy_flag_settling_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_den_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lvl_ois_t val)
+int32_t lsm6dsm_aux_den_mode_set(stmdev_ctx_t *ctx, lsm6dsm_lvl_ois_t val)
 {
   lsm6dsm_int_ois_t int_ois;
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
@@ -2588,25 +2571,29 @@ int32_t lsm6dsm_aux_den_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lvl_ois_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_den_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_lvl_ois_t *val)
+int32_t lsm6dsm_aux_den_mode_get(stmdev_ctx_t *ctx, lsm6dsm_lvl_ois_t *val)
 {
   lsm6dsm_int_ois_t int_ois;
+  lsm6dsm_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
 
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_INT_OIS, (uint8_t*)&int_ois, 1);
-  switch ( int_ois.lvl2_ois ) {
-    case LSM6DSM_AUX_DEN_DISABLE:
-      *val = LSM6DSM_AUX_DEN_DISABLE;
-      break;
-    case LSM6DSM_AUX_DEN_LEVEL_LATCH:
-      *val = LSM6DSM_AUX_DEN_LEVEL_LATCH;
-      break;
-    case LSM6DSM_AUX_DEN_LEVEL_TRIG:
-      *val = LSM6DSM_AUX_DEN_LEVEL_TRIG;
-      break;
-    default:
-      *val = LSM6DSM_AUX_DEN_DISABLE;
-      break;
+  if(ret == 0){
+    ret = lsm6dsm_read_reg(ctx, LSM6DSM_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+    switch ( ( ctrl1_ois.lvl1_ois << 1) + int_ois.lvl2_ois ) {
+      case LSM6DSM_AUX_DEN_DISABLE:
+        *val = LSM6DSM_AUX_DEN_DISABLE;
+        break;
+      case LSM6DSM_AUX_DEN_LEVEL_LATCH:
+        *val = LSM6DSM_AUX_DEN_LEVEL_LATCH;
+        break;
+      case LSM6DSM_AUX_DEN_LEVEL_TRIG:
+        *val = LSM6DSM_AUX_DEN_LEVEL_TRIG;
+        break;
+      default:
+        *val = LSM6DSM_AUX_DEN_DISABLE;
+        break;
+    }
   }
   return ret;
 }
@@ -2620,7 +2607,7 @@ int32_t lsm6dsm_aux_den_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_lvl_ois_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_drdy_on_int2_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_int_ois_t int_ois;
   int32_t ret;
@@ -2642,7 +2629,7 @@ int32_t lsm6dsm_aux_drdy_on_int2_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_drdy_on_int2_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_int_ois_t int_ois;
   int32_t ret;
@@ -2668,7 +2655,7 @@ int32_t lsm6dsm_aux_drdy_on_int2_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t val)
+int32_t lsm6dsm_aux_mode_set(stmdev_ctx_t *ctx, lsm6dsm_ois_en_spi2_t val)
 {
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -2697,7 +2684,7 @@ int32_t lsm6dsm_aux_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t *val)
+int32_t lsm6dsm_aux_mode_get(stmdev_ctx_t *ctx, lsm6dsm_ois_en_spi2_t *val)
 {
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -2728,7 +2715,7 @@ int32_t lsm6dsm_aux_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_gy_full_scale_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
                                       lsm6dsm_fs_g_ois_t val)
 {
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
@@ -2750,7 +2737,7 @@ int32_t lsm6dsm_aux_gy_full_scale_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_gy_full_scale_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
                                       lsm6dsm_fs_g_ois_t *val)
 {
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
@@ -2788,7 +2775,7 @@ int32_t lsm6dsm_aux_gy_full_scale_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t val)
+int32_t lsm6dsm_aux_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsm_sim_ois_t val)
 {
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -2809,7 +2796,7 @@ int32_t lsm6dsm_aux_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t *val)
+int32_t lsm6dsm_aux_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsm_sim_ois_t *val)
 {
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -2837,7 +2824,7 @@ int32_t lsm6dsm_aux_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_data_format_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_ois_t val)
+int32_t lsm6dsm_aux_data_format_set(stmdev_ctx_t *ctx, lsm6dsm_ble_ois_t val)
 {
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -2858,7 +2845,7 @@ int32_t lsm6dsm_aux_data_format_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_ois_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_data_format_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_ois_t *val)
+int32_t lsm6dsm_aux_data_format_get(stmdev_ctx_t *ctx, lsm6dsm_ble_ois_t *val)
 {
   lsm6dsm_ctrl1_ois_t ctrl1_ois;
   int32_t ret;
@@ -2890,7 +2877,7 @@ int32_t lsm6dsm_aux_data_format_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_ois_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_gy_clamp_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_clamp_set(stmdev_ctx_t *ctx,
                                  lsm6dsm_st_ois_clampdis_t val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -2916,7 +2903,7 @@ int32_t lsm6dsm_aux_gy_clamp_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_gy_clamp_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_clamp_get(stmdev_ctx_t *ctx,
                                  lsm6dsm_st_ois_clampdis_t *val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -2945,7 +2932,7 @@ int32_t lsm6dsm_aux_gy_clamp_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_gy_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_ois_t val)
+int32_t lsm6dsm_aux_gy_self_test_set(stmdev_ctx_t *ctx, lsm6dsm_st_ois_t val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
   int32_t ret;
@@ -2966,7 +2953,7 @@ int32_t lsm6dsm_aux_gy_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_ois_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_gy_self_test_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_self_test_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_st_ois_t *val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -2998,7 +2985,7 @@ int32_t lsm6dsm_aux_gy_self_test_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_xl_full_scale_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
                                       lsm6dsm_fs_xl_ois_t val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -3020,7 +3007,7 @@ int32_t lsm6dsm_aux_xl_full_scale_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_xl_full_scale_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
                                       lsm6dsm_fs_xl_ois_t *val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -3055,7 +3042,7 @@ int32_t lsm6dsm_aux_xl_full_scale_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_den_polarity_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_den_polarity_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_den_lh_ois_t val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -3077,7 +3064,7 @@ int32_t lsm6dsm_aux_den_polarity_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_aux_den_polarity_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_den_polarity_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_den_lh_ois_t *val)
 {
   lsm6dsm_ctrl3_ois_t ctrl3_ois;
@@ -3119,7 +3106,7 @@ int32_t lsm6dsm_aux_den_polarity_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t val)
+int32_t lsm6dsm_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsm_sim_t val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3140,7 +3127,7 @@ int32_t lsm6dsm_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t *val)
+int32_t lsm6dsm_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsm_sim_t *val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3168,7 +3155,7 @@ int32_t lsm6dsm_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_i2c_interface_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_i2c_interface_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_i2c_disable_t val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
@@ -3190,7 +3177,7 @@ int32_t lsm6dsm_i2c_interface_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_i2c_interface_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_i2c_interface_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_i2c_disable_t *val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
@@ -3234,7 +3221,7 @@ int32_t lsm6dsm_i2c_interface_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pin_int1_route_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_int1_route_t val)
 {
   lsm6dsm_master_config_t master_config;
@@ -3325,7 +3312,7 @@ int32_t lsm6dsm_pin_int1_route_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pin_int1_route_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_int1_route_t *val)
 {
   lsm6dsm_master_config_t master_config;
@@ -3377,7 +3364,7 @@ int32_t lsm6dsm_pin_int1_route_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pin_int2_route_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_int2_route_t val)
 {
   lsm6dsm_int2_ctrl_t int2_ctrl;
@@ -3460,7 +3447,7 @@ int32_t lsm6dsm_pin_int2_route_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pin_int2_route_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pin_int2_route_get(stmdev_ctx_t *ctx,
 lsm6dsm_int2_route_t *val)
 {
   lsm6dsm_int2_ctrl_t int2_ctrl;
@@ -3507,7 +3494,7 @@ lsm6dsm_int2_route_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t val)
+int32_t lsm6dsm_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsm_pp_od_t val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3528,7 +3515,7 @@ int32_t lsm6dsm_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t *val)
+int32_t lsm6dsm_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsm_pp_od_t *val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3557,7 +3544,7 @@ int32_t lsm6dsm_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pin_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t val)
+int32_t lsm6dsm_pin_polarity_set(stmdev_ctx_t *ctx, lsm6dsm_h_lactive_t val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3578,7 +3565,7 @@ int32_t lsm6dsm_pin_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pin_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t *val)
+int32_t lsm6dsm_pin_polarity_get(stmdev_ctx_t *ctx, lsm6dsm_h_lactive_t *val)
 {
   lsm6dsm_ctrl3_c_t ctrl3_c;
   int32_t ret;
@@ -3607,7 +3594,7 @@ int32_t lsm6dsm_pin_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_all_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3628,7 +3615,7 @@ int32_t lsm6dsm_all_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_all_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3647,7 +3634,7 @@ int32_t lsm6dsm_all_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_int_notification_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t val)
+int32_t lsm6dsm_int_notification_set(stmdev_ctx_t *ctx, lsm6dsm_lir_t val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3668,7 +3655,7 @@ int32_t lsm6dsm_int_notification_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_int_notification_get(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t *val)
+int32_t lsm6dsm_int_notification_get(stmdev_ctx_t *ctx, lsm6dsm_lir_t *val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3710,7 +3697,7 @@ int32_t lsm6dsm_int_notification_get(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_wkup_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -3732,7 +3719,7 @@ int32_t lsm6dsm_wkup_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_wkup_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -3751,7 +3738,7 @@ int32_t lsm6dsm_wkup_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_wkup_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -3773,7 +3760,7 @@ int32_t lsm6dsm_wkup_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_wkup_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -3805,7 +3792,7 @@ int32_t lsm6dsm_wkup_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_sleep_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3826,7 +3813,7 @@ int32_t lsm6dsm_gy_sleep_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_gy_sleep_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   int32_t ret;
@@ -3845,7 +3832,7 @@ int32_t lsm6dsm_gy_sleep_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_act_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t val)
+int32_t lsm6dsm_act_mode_set(stmdev_ctx_t *ctx, lsm6dsm_inact_en_t val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3866,7 +3853,7 @@ int32_t lsm6dsm_act_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_act_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t *val)
+int32_t lsm6dsm_act_mode_get(stmdev_ctx_t *ctx, lsm6dsm_inact_en_t *val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3901,7 +3888,7 @@ int32_t lsm6dsm_act_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_act_sleep_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -3923,7 +3910,7 @@ int32_t lsm6dsm_act_sleep_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_act_sleep_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_wake_up_dur_t wake_up_dur;
   int32_t ret;
@@ -3955,7 +3942,7 @@ int32_t lsm6dsm_act_sleep_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_src_get(lsm6dsm_ctx_t *ctx, lsm6dsm_tap_src_t *val)
+int32_t lsm6dsm_tap_src_get(stmdev_ctx_t *ctx, lsm6dsm_tap_src_t *val)
 {
   int32_t ret;
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_TAP_SRC, (uint8_t*) val, 1);
@@ -3969,7 +3956,7 @@ int32_t lsm6dsm_tap_src_get(lsm6dsm_ctx_t *ctx, lsm6dsm_tap_src_t *val)
   * @param  val    Change the values of tap_z_en in reg TAP_CFG
   *
   */
-int32_t lsm6dsm_tap_detection_on_z_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -3990,7 +3977,7 @@ int32_t lsm6dsm_tap_detection_on_z_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_detection_on_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4009,7 +3996,7 @@ int32_t lsm6dsm_tap_detection_on_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_detection_on_y_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4030,7 +4017,7 @@ int32_t lsm6dsm_tap_detection_on_y_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_detection_on_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4049,7 +4036,7 @@ int32_t lsm6dsm_tap_detection_on_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_detection_on_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4070,7 +4057,7 @@ int32_t lsm6dsm_tap_detection_on_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_detection_on_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_tap_cfg_t tap_cfg;
   int32_t ret;
@@ -4089,7 +4076,7 @@ int32_t lsm6dsm_tap_detection_on_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_threshold_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4111,7 +4098,7 @@ int32_t lsm6dsm_tap_threshold_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_threshold_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4135,7 +4122,7 @@ int32_t lsm6dsm_tap_threshold_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_shock_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_int_dur2_t int_dur2;
   int32_t ret;
@@ -4161,7 +4148,7 @@ int32_t lsm6dsm_tap_shock_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_shock_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_int_dur2_t int_dur2;
   int32_t ret;
@@ -4185,7 +4172,7 @@ int32_t lsm6dsm_tap_shock_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_quiet_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_int_dur2_t int_dur2;
   int32_t ret;
@@ -4211,7 +4198,7 @@ int32_t lsm6dsm_tap_quiet_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_quiet_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_int_dur2_t int_dur2;
   int32_t ret;
@@ -4236,7 +4223,7 @@ int32_t lsm6dsm_tap_quiet_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_int_dur2_t int_dur2;
   int32_t ret;
@@ -4263,7 +4250,7 @@ int32_t lsm6dsm_tap_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_int_dur2_t int_dur2;
   int32_t ret;
@@ -4283,7 +4270,7 @@ int32_t lsm6dsm_tap_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_tap_mode_set(stmdev_ctx_t *ctx,
                              lsm6dsm_single_double_tap_t val)
 {
   lsm6dsm_wake_up_ths_t wake_up_ths;
@@ -4307,7 +4294,7 @@ int32_t lsm6dsm_tap_mode_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tap_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_tap_mode_get(stmdev_ctx_t *ctx,
                              lsm6dsm_single_double_tap_t *val)
 {
   lsm6dsm_wake_up_ths_t wake_up_ths;
@@ -4351,7 +4338,7 @@ int32_t lsm6dsm_tap_mode_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_6d_feed_data_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_6d_feed_data_set(stmdev_ctx_t *ctx,
                                  lsm6dsm_low_pass_on_6d_t val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
@@ -4373,7 +4360,7 @@ int32_t lsm6dsm_6d_feed_data_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_6d_feed_data_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_6d_feed_data_get(stmdev_ctx_t *ctx,
                                  lsm6dsm_low_pass_on_6d_t *val)
 {
   lsm6dsm_ctrl8_xl_t ctrl8_xl;
@@ -4403,7 +4390,7 @@ int32_t lsm6dsm_6d_feed_data_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_6d_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t val)
+int32_t lsm6dsm_6d_threshold_set(stmdev_ctx_t *ctx, lsm6dsm_sixd_ths_t val)
 {
   lsm6dsm_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4424,7 +4411,7 @@ int32_t lsm6dsm_6d_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_6d_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t *val)
+int32_t lsm6dsm_6d_threshold_get(stmdev_ctx_t *ctx, lsm6dsm_sixd_ths_t *val)
 {
   lsm6dsm_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4459,7 +4446,7 @@ int32_t lsm6dsm_6d_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_4d_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4481,7 +4468,7 @@ int32_t lsm6dsm_4d_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_4d_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -4513,7 +4500,7 @@ int32_t lsm6dsm_4d_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_ff_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_wake_up_dur_t wake_up_dur;
   lsm6dsm_free_fall_t free_fall;
@@ -4544,7 +4531,7 @@ int32_t lsm6dsm_ff_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_ff_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_wake_up_dur_t wake_up_dur;
   lsm6dsm_free_fall_t free_fall;
@@ -4567,7 +4554,7 @@ int32_t lsm6dsm_ff_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_ff_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t val)
+int32_t lsm6dsm_ff_threshold_set(stmdev_ctx_t *ctx, lsm6dsm_ff_ths_t val)
 {
   lsm6dsm_free_fall_t free_fall;
   int32_t ret;
@@ -4588,7 +4575,7 @@ int32_t lsm6dsm_ff_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_ff_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t *val)
+int32_t lsm6dsm_ff_threshold_get(stmdev_ctx_t *ctx, lsm6dsm_ff_ths_t *val)
 {
   lsm6dsm_free_fall_t free_fall;
   int32_t ret;
@@ -4648,7 +4635,7 @@ int32_t lsm6dsm_ff_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_watermark_set(lsm6dsm_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsm_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   lsm6dsm_fifo_ctrl1_t fifo_ctrl1;
   lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
@@ -4675,7 +4662,7 @@ int32_t lsm6dsm_fifo_watermark_set(lsm6dsm_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_watermark_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsm_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6dsm_fifo_ctrl1_t fifo_ctrl1;
   lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
@@ -4700,7 +4687,7 @@ int32_t lsm6dsm_fifo_watermark_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_data_level_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsm_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6dsm_fifo_status1_t fifo_status1;
   lsm6dsm_fifo_status2_t fifo_status2;
@@ -4726,13 +4713,32 @@ int32_t lsm6dsm_fifo_data_level_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_wtm_flag_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_fifo_status2_t fifo_status2;
   int32_t ret;
 
   ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_STATUS2, (uint8_t*)&fifo_status2, 1);
   *val = fifo_status2.waterm;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO over run.[get]
+  *
+  * @param  ctx    Read / write interface definitions
+  * @param  val    get the value of over run in reg  FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsm_fifo_over_run_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsm_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsm_read_reg(ctx, LSM6DSM_FIFO_STATUS2, (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.over_run;
 
   return ret;
 }
@@ -4746,7 +4752,7 @@ int32_t lsm6dsm_fifo_wtm_flag_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_pattern_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsm_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm6dsm_fifo_status3_t fifo_status3;
   lsm6dsm_fifo_status4_t fifo_status4;
@@ -4771,7 +4777,7 @@ int32_t lsm6dsm_fifo_pattern_get(lsm6dsm_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_temp_batch_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -4794,7 +4800,7 @@ int32_t lsm6dsm_fifo_temp_batch_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_temp_batch_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -4814,7 +4820,7 @@ int32_t lsm6dsm_fifo_temp_batch_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_write_trigger_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_write_trigger_set(stmdev_ctx_t *ctx,
                                        lsm6dsm_trigger_fifo_t val)
 {
   lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
@@ -4849,7 +4855,7 @@ int32_t lsm6dsm_fifo_write_trigger_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_write_trigger_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_write_trigger_get(stmdev_ctx_t *ctx,
                                        lsm6dsm_trigger_fifo_t *val)
 {
   lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
@@ -4890,7 +4896,7 @@ int32_t lsm6dsm_fifo_write_trigger_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_set(stmdev_ctx_t *ctx,
                                                   uint8_t val)
 {
   lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
@@ -4914,7 +4920,7 @@ int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_get(stmdev_ctx_t *ctx,
                                                   uint8_t *val)
 {
   lsm6dsm_fifo_ctrl2_t fifo_ctrl2;
@@ -4935,7 +4941,7 @@ int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_xl_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_dec_fifo_xl_t val)
 {
   lsm6dsm_fifo_ctrl3_t fifo_ctrl3;
@@ -4959,7 +4965,7 @@ int32_t lsm6dsm_fifo_xl_batch_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_xl_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_dec_fifo_xl_t *val)
 {
   lsm6dsm_fifo_ctrl3_t fifo_ctrl3;
@@ -5008,7 +5014,7 @@ int32_t lsm6dsm_fifo_xl_batch_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_gy_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_dec_fifo_gyro_t val)
 {
   lsm6dsm_fifo_ctrl3_t fifo_ctrl3;
@@ -5031,7 +5037,7 @@ int32_t lsm6dsm_fifo_gy_batch_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_gy_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_dec_fifo_gyro_t *val)
 {
   lsm6dsm_fifo_ctrl3_t fifo_ctrl3;
@@ -5080,7 +5086,7 @@ int32_t lsm6dsm_fifo_gy_batch_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_dataset_3_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
                                          lsm6dsm_dec_ds3_fifo_t val)
 {
   lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
@@ -5104,7 +5110,7 @@ int32_t lsm6dsm_fifo_dataset_3_batch_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_dataset_3_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
                                          lsm6dsm_dec_ds3_fifo_t *val)
 {
   lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
@@ -5153,7 +5159,7 @@ int32_t lsm6dsm_fifo_dataset_3_batch_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_dataset_4_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
                                          lsm6dsm_dec_ds4_fifo_t val)
 {
   lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
@@ -5177,7 +5183,7 @@ int32_t lsm6dsm_fifo_dataset_4_batch_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_dataset_4_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
                                          lsm6dsm_dec_ds4_fifo_t *val)
 {
   lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
@@ -5225,7 +5231,7 @@ int32_t lsm6dsm_fifo_dataset_4_batch_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_xl_gy_8bit_format_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -5246,7 +5252,7 @@ int32_t lsm6dsm_fifo_xl_gy_8bit_format_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_xl_gy_8bit_format_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -5266,7 +5272,7 @@ int32_t lsm6dsm_fifo_xl_gy_8bit_format_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_stop_on_wtm_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -5288,7 +5294,7 @@ int32_t lsm6dsm_fifo_stop_on_wtm_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_stop_on_wtm_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -5307,7 +5313,7 @@ int32_t lsm6dsm_fifo_stop_on_wtm_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t val)
+int32_t lsm6dsm_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsm_fifo_mode_t val)
 {
   lsm6dsm_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -5328,7 +5334,7 @@ int32_t lsm6dsm_fifo_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t *val)
+int32_t lsm6dsm_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsm_fifo_mode_t *val)
 {
   lsm6dsm_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -5366,7 +5372,7 @@ int32_t lsm6dsm_fifo_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_fifo_t val)
+int32_t lsm6dsm_fifo_data_rate_set(stmdev_ctx_t *ctx, lsm6dsm_odr_fifo_t val)
 {
   lsm6dsm_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -5387,7 +5393,7 @@ int32_t lsm6dsm_fifo_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_fifo_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_fifo_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_fifo_t *val)
+int32_t lsm6dsm_fifo_data_rate_get(stmdev_ctx_t *ctx, lsm6dsm_odr_fifo_t *val)
 {
   lsm6dsm_fifo_ctrl5_t fifo_ctrl5;
   int32_t ret;
@@ -5456,7 +5462,7 @@ int32_t lsm6dsm_fifo_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_fifo_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
- int32_t lsm6dsm_den_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t val)
+ int32_t lsm6dsm_den_polarity_set(stmdev_ctx_t *ctx, lsm6dsm_den_lh_t val)
 {
   lsm6dsm_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -5477,7 +5483,7 @@ int32_t lsm6dsm_fifo_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_fifo_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t *val)
+int32_t lsm6dsm_den_polarity_get(stmdev_ctx_t *ctx, lsm6dsm_den_lh_t *val)
 {
   lsm6dsm_ctrl5_c_t ctrl5_c;
   int32_t ret;
@@ -5506,7 +5512,7 @@ int32_t lsm6dsm_den_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t val)
+int32_t lsm6dsm_den_mode_set(stmdev_ctx_t *ctx, lsm6dsm_den_mode_t val)
 {
   lsm6dsm_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -5527,7 +5533,7 @@ int32_t lsm6dsm_den_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t *val)
+int32_t lsm6dsm_den_mode_get(stmdev_ctx_t *ctx, lsm6dsm_den_mode_t *val)
 {
   lsm6dsm_ctrl6_c_t ctrl6_c;
   int32_t ret;
@@ -5563,7 +5569,7 @@ int32_t lsm6dsm_den_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_enable_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t val)
+int32_t lsm6dsm_den_enable_set(stmdev_ctx_t *ctx, lsm6dsm_den_xl_en_t val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
@@ -5593,7 +5599,7 @@ int32_t lsm6dsm_den_enable_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_enable_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t *val)
+int32_t lsm6dsm_den_enable_get(stmdev_ctx_t *ctx, lsm6dsm_den_xl_en_t *val)
 {
   lsm6dsm_ctrl4_c_t ctrl4_c;
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
@@ -5629,7 +5635,7 @@ int32_t lsm6dsm_den_enable_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_mark_axis_z_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5650,7 +5656,7 @@ int32_t lsm6dsm_den_mark_axis_z_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_mark_axis_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5669,7 +5675,7 @@ int32_t lsm6dsm_den_mark_axis_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_mark_axis_y_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5690,7 +5696,7 @@ int32_t lsm6dsm_den_mark_axis_y_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_mark_axis_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5709,7 +5715,7 @@ int32_t lsm6dsm_den_mark_axis_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_mark_axis_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5730,7 +5736,7 @@ int32_t lsm6dsm_den_mark_axis_x_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_den_mark_axis_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -5761,7 +5767,7 @@ int32_t lsm6dsm_den_mark_axis_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_step_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5782,7 +5788,7 @@ int32_t lsm6dsm_pedo_step_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_step_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5801,7 +5807,7 @@ int32_t lsm6dsm_pedo_step_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5826,7 +5832,7 @@ int32_t lsm6dsm_pedo_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -5846,7 +5852,7 @@ int32_t lsm6dsm_pedo_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_config_pedo_ths_min_t config_pedo_ths_min;
   int32_t ret;
@@ -5875,7 +5881,7 @@ int32_t lsm6dsm_pedo_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_config_pedo_ths_min_t config_pedo_ths_min;
   int32_t ret;
@@ -5901,7 +5907,7 @@ int32_t lsm6dsm_pedo_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pedo_fs_t val)
+int32_t lsm6dsm_pedo_full_scale_set(stmdev_ctx_t *ctx, lsm6dsm_pedo_fs_t val)
 {
   lsm6dsm_config_pedo_ths_min_t config_pedo_ths_min;
   int32_t ret;
@@ -5931,7 +5937,7 @@ int32_t lsm6dsm_pedo_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pedo_fs_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pedo_fs_t *val)
+int32_t lsm6dsm_pedo_full_scale_get(stmdev_ctx_t *ctx, lsm6dsm_pedo_fs_t *val)
 {
   lsm6dsm_config_pedo_ths_min_t config_pedo_ths_min;
   int32_t ret;
@@ -5966,7 +5972,7 @@ int32_t lsm6dsm_pedo_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pedo_fs_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_debounce_steps_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -5995,7 +6001,7 @@ int32_t lsm6dsm_pedo_debounce_steps_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_debounce_steps_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -6023,7 +6029,7 @@ int32_t lsm6dsm_pedo_debounce_steps_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_timeout_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -6054,7 +6060,7 @@ int32_t lsm6dsm_pedo_timeout_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_timeout_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_pedo_deb_reg_t pedo_deb_reg;
   int32_t ret;
@@ -6079,7 +6085,7 @@ int32_t lsm6dsm_pedo_timeout_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_steps_period_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6101,7 +6107,7 @@ int32_t lsm6dsm_pedo_steps_period_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_pedo_steps_period_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6136,7 +6142,7 @@ int32_t lsm6dsm_pedo_steps_period_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_motion_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -6160,7 +6166,7 @@ int32_t lsm6dsm_motion_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_motion_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -6179,7 +6185,7 @@ int32_t lsm6dsm_motion_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_motion_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6201,7 +6207,7 @@ int32_t lsm6dsm_motion_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_motion_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6236,7 +6242,7 @@ int32_t lsm6dsm_motion_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -6260,7 +6266,7 @@ int32_t lsm6dsm_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -6279,7 +6285,7 @@ int32_t lsm6dsm_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_wrist_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_wrist_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -6303,7 +6309,7 @@ int32_t lsm6dsm_wrist_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_wrist_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_wrist_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -6324,7 +6330,7 @@ int32_t lsm6dsm_wrist_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tilt_latency_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_tilt_latency_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6348,7 +6354,7 @@ int32_t lsm6dsm_tilt_latency_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tilt_latency_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_tilt_latency_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6372,7 +6378,7 @@ int32_t lsm6dsm_tilt_latency_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tilt_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_tilt_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6396,7 +6402,7 @@ int32_t lsm6dsm_tilt_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tilt_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_tilt_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6418,7 +6424,7 @@ int32_t lsm6dsm_tilt_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tilt_src_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_tilt_src_set(stmdev_ctx_t *ctx,
                              lsm6dsm_a_wrist_tilt_mask_t *val)
 {
   int32_t ret;
@@ -6442,7 +6448,7 @@ int32_t lsm6dsm_tilt_src_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_tilt_src_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_tilt_src_get(stmdev_ctx_t *ctx,
                              lsm6dsm_a_wrist_tilt_mask_t *val)
 {
   int32_t ret;
@@ -6480,7 +6486,7 @@ int32_t lsm6dsm_tilt_src_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_soft_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -6501,7 +6507,7 @@ int32_t lsm6dsm_mag_soft_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_soft_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_ctrl9_xl_t ctrl9_xl;
   int32_t ret;
@@ -6520,7 +6526,7 @@ int32_t lsm6dsm_mag_soft_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_hard_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_master_config_t master_config;
   lsm6dsm_ctrl10_c_t ctrl10_c;
@@ -6554,7 +6560,7 @@ int32_t lsm6dsm_mag_hard_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_hard_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -6575,7 +6581,7 @@ int32_t lsm6dsm_mag_hard_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_soft_iron_mat_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_mag_soft_iron_mat_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6598,7 +6604,7 @@ int32_t lsm6dsm_mag_soft_iron_mat_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_soft_iron_mat_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_mag_soft_iron_mat_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6621,7 +6627,7 @@ int32_t lsm6dsm_mag_soft_iron_mat_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6644,7 +6650,7 @@ int32_t lsm6dsm_mag_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_mag_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
+int32_t lsm6dsm_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
 
@@ -6679,7 +6685,7 @@ int32_t lsm6dsm_mag_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_func_en_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_func_en_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_ctrl10_c_t ctrl10_c;
   int32_t ret;
@@ -6702,7 +6708,7 @@ int32_t lsm6dsm_func_en_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_sync_sens_frame_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_sensor_sync_time_frame_t sensor_sync_time_frame;
   int32_t ret;
@@ -6726,7 +6732,7 @@ int32_t lsm6dsm_sh_sync_sens_frame_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_sync_sens_frame_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_sensor_sync_time_frame_t sensor_sync_time_frame;
   int32_t ret;
@@ -6746,7 +6752,7 @@ int32_t lsm6dsm_sh_sync_sens_frame_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_sync_sens_ratio_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t val)
+int32_t lsm6dsm_sh_sync_sens_ratio_set(stmdev_ctx_t *ctx, lsm6dsm_rr_t val)
 {
   lsm6dsm_sensor_sync_res_ratio_t sensor_sync_res_ratio;
   int32_t ret;
@@ -6769,7 +6775,7 @@ int32_t lsm6dsm_sh_sync_sens_ratio_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_sync_sens_ratio_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t *val)
+int32_t lsm6dsm_sh_sync_sens_ratio_get(stmdev_ctx_t *ctx, lsm6dsm_rr_t *val)
 {
   lsm6dsm_sensor_sync_res_ratio_t sensor_sync_res_ratio;
   int32_t ret;
@@ -6806,7 +6812,7 @@ int32_t lsm6dsm_sh_sync_sens_ratio_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_master_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -6829,7 +6835,7 @@ int32_t lsm6dsm_sh_master_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_master_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -6849,7 +6855,7 @@ int32_t lsm6dsm_sh_master_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_pass_through_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -6872,7 +6878,7 @@ int32_t lsm6dsm_sh_pass_through_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_pass_through_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -6892,7 +6898,7 @@ int32_t lsm6dsm_sh_pass_through_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t val)
+int32_t lsm6dsm_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsm_pull_up_en_t val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -6916,7 +6922,7 @@ int32_t lsm6dsm_sh_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t *val)
+int32_t lsm6dsm_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsm_pull_up_en_t *val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -6945,7 +6951,7 @@ int32_t lsm6dsm_sh_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_syncro_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_start_config_t val)
 {
   lsm6dsm_master_config_t master_config;
@@ -6969,7 +6975,7 @@ int32_t lsm6dsm_sh_syncro_mode_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_syncro_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_start_config_t *val)
 {
   lsm6dsm_master_config_t master_config;
@@ -7000,7 +7006,7 @@ int32_t lsm6dsm_sh_syncro_mode_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_drdy_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_sh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -7023,7 +7029,7 @@ int32_t lsm6dsm_sh_drdy_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_drdy_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_sh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_master_config_t master_config;
   int32_t ret;
@@ -7043,7 +7049,7 @@ int32_t lsm6dsm_sh_drdy_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_read_data_raw_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_emb_sh_read_t *val)
 {
   int32_t ret;
@@ -7065,7 +7071,7 @@ int32_t lsm6dsm_sh_read_data_raw_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_cmd_sens_sync_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_sh_cmd_sens_sync_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_master_cmd_code_t master_cmd_code;
   int32_t ret;
@@ -7089,7 +7095,7 @@ int32_t lsm6dsm_sh_cmd_sens_sync_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_cmd_sens_sync_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_sh_cmd_sens_sync_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_master_cmd_code_t master_cmd_code;
   int32_t ret;
@@ -7110,7 +7116,7 @@ int32_t lsm6dsm_sh_cmd_sens_sync_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_spi_sync_error_set(lsm6dsm_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsm_sh_spi_sync_error_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsm_sens_sync_spi_error_code_t sens_sync_spi_error_code;
   int32_t ret;
@@ -7134,7 +7140,7 @@ int32_t lsm6dsm_sh_spi_sync_error_set(lsm6dsm_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_spi_sync_error_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsm_sh_spi_sync_error_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsm_sens_sync_spi_error_code_t sens_sync_spi_error_code;
   int32_t ret;
@@ -7154,7 +7160,7 @@ int32_t lsm6dsm_sh_spi_sync_error_get(lsm6dsm_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_num_of_dev_connected_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
                                             lsm6dsm_aux_sens_on_t val)
 {
   lsm6dsm_slave0_config_t slave0_config;
@@ -7184,7 +7190,7 @@ int32_t lsm6dsm_sh_num_of_dev_connected_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_num_of_dev_connected_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
                                             lsm6dsm_aux_sens_on_t *val)
 {
   lsm6dsm_slave0_config_t slave0_config;
@@ -7230,7 +7236,7 @@ int32_t lsm6dsm_sh_num_of_dev_connected_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_cfg_write(lsm6dsm_ctx_t *ctx, lsm6dsm_sh_cfg_write_t *val)
+int32_t lsm6dsm_sh_cfg_write(stmdev_ctx_t *ctx, lsm6dsm_sh_cfg_write_t *val)
 {
   lsm6dsm_slv0_add_t slv0_add;
   int32_t ret;
@@ -7266,7 +7272,7 @@ int32_t lsm6dsm_sh_cfg_write(lsm6dsm_ctx_t *ctx, lsm6dsm_sh_cfg_write_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slv0_cfg_read(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsm_sh_cfg_read_t *val)
 {
   lsm6dsm_slave0_config_t slave0_config;
@@ -7309,7 +7315,7 @@ int32_t lsm6dsm_sh_slv0_cfg_read(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slv1_cfg_read(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsm_sh_cfg_read_t *val)
 {
   lsm6dsm_slave1_config_t slave1_config;
@@ -7352,7 +7358,7 @@ int32_t lsm6dsm_sh_slv1_cfg_read(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slv2_cfg_read(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsm_sh_cfg_read_t *val)
 {
   lsm6dsm_slv2_add_t slv2_add;
@@ -7396,7 +7402,7 @@ int32_t lsm6dsm_sh_slv2_cfg_read(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slv3_cfg_read(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsm_sh_cfg_read_t *val)
 {
   lsm6dsm_slave3_config_t slave3_config;
@@ -7437,7 +7443,7 @@ int32_t lsm6dsm_sh_slv3_cfg_read(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slave_0_dec_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_0_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave0_rate_t val)
 {
   lsm6dsm_slave0_config_t slave0_config;
@@ -7468,7 +7474,7 @@ int32_t lsm6dsm_sh_slave_0_dec_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slave_0_dec_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_0_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave0_rate_t *val)
 {
   lsm6dsm_slave0_config_t slave0_config;
@@ -7514,7 +7520,7 @@ int32_t lsm6dsm_sh_slave_0_dec_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_write_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_write_once_t val)
+int32_t lsm6dsm_sh_write_mode_set(stmdev_ctx_t *ctx, lsm6dsm_write_once_t val)
 {
   lsm6dsm_slave1_config_t slave1_config;
   int32_t ret;
@@ -7546,7 +7552,7 @@ int32_t lsm6dsm_sh_write_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_write_once_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_write_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_write_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_write_once_t *val)
 {
   lsm6dsm_slave1_config_t slave1_config;
@@ -7584,7 +7590,7 @@ int32_t lsm6dsm_sh_write_mode_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slave_1_dec_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_1_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave1_rate_t val)
 {
   lsm6dsm_slave1_config_t slave1_config;
@@ -7614,7 +7620,7 @@ int32_t lsm6dsm_sh_slave_1_dec_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slave_1_dec_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_1_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave1_rate_t *val)
 {
   lsm6dsm_slave1_config_t slave1_config;
@@ -7658,7 +7664,7 @@ int32_t lsm6dsm_sh_slave_1_dec_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slave_2_dec_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_2_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave2_rate_t val)
 {
   lsm6dsm_slave2_config_t slave2_config;
@@ -7689,7 +7695,7 @@ int32_t lsm6dsm_sh_slave_2_dec_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slave_2_dec_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_2_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave2_rate_t *val)
 {
   lsm6dsm_slave2_config_t slave2_config;
@@ -7733,7 +7739,7 @@ int32_t lsm6dsm_sh_slave_2_dec_get(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slave_3_dec_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_3_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave3_rate_t val)
 {
   lsm6dsm_slave3_config_t slave3_config;
@@ -7764,7 +7770,7 @@ int32_t lsm6dsm_sh_slave_3_dec_set(lsm6dsm_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsm_sh_slave_3_dec_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_3_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave3_rate_t *val)
 {
   lsm6dsm_slave3_config_t slave3_config;

--- a/sensor/stmemsc/lsm6dsm_STdC/driver/lsm6dsm_reg.h
+++ b/sensor/stmemsc/lsm6dsm_STdC/driver/lsm6dsm_reg.h
@@ -7,37 +7,20 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef LSM6DSM_DRIVER_H
-#define LSM6DSM_DRIVER_H
+#ifndef LSM6DSM_REGS_H
+#define LSM6DSM_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LSM6DSM_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LSM9DS1_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lsm6dsm_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lsm6dsm_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lsm6dsm_write_ptr  write_reg;
-  lsm6dsm_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lsm6dsm_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -1058,9 +1030,9 @@ typedef union{
   *
   */
 
-int32_t lsm6dsm_read_reg(lsm6dsm_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsm_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lsm6dsm_write_reg(lsm6dsm_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsm_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float_t lsm6dsm_from_fs2g_to_mg(int16_t lsb);
@@ -1082,8 +1054,8 @@ typedef enum {
   LSM6DSM_4g       = 2,
   LSM6DSM_8g       = 3,
 } lsm6dsm_fs_xl_t;
-int32_t lsm6dsm_xl_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t val);
-int32_t lsm6dsm_xl_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_xl_t *val);
+int32_t lsm6dsm_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6dsm_fs_xl_t val);
+int32_t lsm6dsm_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6dsm_fs_xl_t *val);
 
 typedef enum {
   LSM6DSM_XL_ODR_OFF      =  0,
@@ -1099,8 +1071,8 @@ typedef enum {
   LSM6DSM_XL_ODR_6k66Hz   = 10,
   LSM6DSM_XL_ODR_1Hz6     = 11,
 } lsm6dsm_odr_xl_t;
-int32_t lsm6dsm_xl_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t val);
-int32_t lsm6dsm_xl_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_xl_t *val);
+int32_t lsm6dsm_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dsm_odr_xl_t val);
+int32_t lsm6dsm_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dsm_odr_xl_t *val);
 
 typedef enum {
   LSM6DSM_250dps     = 0,
@@ -1109,8 +1081,8 @@ typedef enum {
   LSM6DSM_1000dps    = 4,
   LSM6DSM_2000dps    = 6,
 } lsm6dsm_fs_g_t;
-int32_t lsm6dsm_gy_full_scale_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t val);
-int32_t lsm6dsm_gy_full_scale_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fs_g_t *val);
+int32_t lsm6dsm_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6dsm_fs_g_t val);
+int32_t lsm6dsm_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6dsm_fs_g_t *val);
 
 typedef enum {
   LSM6DSM_GY_ODR_OFF    =  0,
@@ -1125,46 +1097,46 @@ typedef enum {
   LSM6DSM_GY_ODR_3k33Hz =  9,
   LSM6DSM_GY_ODR_6k66Hz = 10,
 } lsm6dsm_odr_g_t;
-int32_t lsm6dsm_gy_data_rate_set(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t val);
-int32_t lsm6dsm_gy_data_rate_get(lsm6dsm_ctx_t *ctx, lsm6dsm_odr_g_t *val);
+int32_t lsm6dsm_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6dsm_odr_g_t val);
+int32_t lsm6dsm_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6dsm_odr_g_t *val);
 
-int32_t lsm6dsm_block_data_update_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_block_data_update_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_LSb_1mg   = 0,
   LSM6DSM_LSb_16mg  = 1,
 } lsm6dsm_usr_off_w_t;
-int32_t lsm6dsm_xl_offset_weight_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_usr_off_w_t val);
-int32_t lsm6dsm_xl_offset_weight_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_usr_off_w_t *val);
 
 typedef enum {
   LSM6DSM_XL_HIGH_PERFORMANCE  = 0,
   LSM6DSM_XL_NORMAL            = 1,
 } lsm6dsm_xl_hm_mode_t;
-int32_t lsm6dsm_xl_power_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_xl_hm_mode_t val);
-int32_t lsm6dsm_xl_power_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_xl_hm_mode_t *val);
 
 typedef enum {
   LSM6DSM_STAT_RND_DISABLE  = 0,
   LSM6DSM_STAT_RND_ENABLE   = 1,
 } lsm6dsm_rounding_status_t;
-int32_t lsm6dsm_rounding_on_status_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_rounding_on_status_set(stmdev_ctx_t *ctx,
                                        lsm6dsm_rounding_status_t val);
-int32_t lsm6dsm_rounding_on_status_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_rounding_on_status_get(stmdev_ctx_t *ctx,
                                        lsm6dsm_rounding_status_t *val);
 
 typedef enum {
   LSM6DSM_GY_HIGH_PERFORMANCE  = 0,
   LSM6DSM_GY_NORMAL            = 1,
 } lsm6dsm_g_hm_mode_t;
-int32_t lsm6dsm_gy_power_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_g_hm_mode_t val);
-int32_t lsm6dsm_gy_power_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_g_hm_mode_t *val);
 
 typedef struct {
@@ -1177,28 +1149,28 @@ typedef struct {
   lsm6dsm_wrist_tilt_ia_t      wrist_tilt_ia;
   lsm6dsm_a_wrist_tilt_mask_t  a_wrist_tilt_mask;
 } lsm6dsm_all_sources_t;
-int32_t lsm6dsm_all_sources_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_all_sources_get(stmdev_ctx_t *ctx,
                                 lsm6dsm_all_sources_t *val);
 
-int32_t lsm6dsm_status_reg_get(lsm6dsm_ctx_t *ctx, lsm6dsm_status_reg_t *val);
+int32_t lsm6dsm_status_reg_get(stmdev_ctx_t *ctx, lsm6dsm_status_reg_t *val);
 
-int32_t lsm6dsm_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_temp_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_xl_usr_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_xl_usr_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_timestamp_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_timestamp_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_LSB_6ms4    = 0,
   LSM6DSM_LSB_25us    = 1,
 } lsm6dsm_timer_hr_t;
-int32_t lsm6dsm_timestamp_res_set(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t val);
-int32_t lsm6dsm_timestamp_res_get(lsm6dsm_ctx_t *ctx, lsm6dsm_timer_hr_t *val);
+int32_t lsm6dsm_timestamp_res_set(stmdev_ctx_t *ctx, lsm6dsm_timer_hr_t val);
+int32_t lsm6dsm_timestamp_res_get(stmdev_ctx_t *ctx, lsm6dsm_timer_hr_t *val);
 
 typedef enum {
   LSM6DSM_ROUND_DISABLE            = 0,
@@ -1210,16 +1182,16 @@ typedef enum {
   LSM6DSM_ROUND_GY_XL_SH1_TO_SH12  = 6,
   LSM6DSM_ROUND_GY_XL_SH1_TO_SH6   = 7,
 } lsm6dsm_rounding_t;
-int32_t lsm6dsm_rounding_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t val);
-int32_t lsm6dsm_rounding_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rounding_t *val);
+int32_t lsm6dsm_rounding_mode_set(stmdev_ctx_t *ctx, lsm6dsm_rounding_t val);
+int32_t lsm6dsm_rounding_mode_get(stmdev_ctx_t *ctx, lsm6dsm_rounding_t *val);
 
-int32_t lsm6dsm_temperature_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_angular_rate_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_acceleration_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsm_mag_calibrated_raw_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_mag_calibrated_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsm_fifo_raw_data_get(lsm6dsm_ctx_t *ctx, uint8_t *buffer,
+int32_t lsm6dsm_fifo_raw_data_get(stmdev_ctx_t *ctx, uint8_t *buffer,
                                   uint8_t len);
 
 typedef enum {
@@ -1227,70 +1199,70 @@ typedef enum {
   LSM6DSM_BANK_A      = 4,
   LSM6DSM_BANK_B      = 5,
 } lsm6dsm_func_cfg_en_t;
-int32_t lsm6dsm_mem_bank_set(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t val);
-int32_t lsm6dsm_mem_bank_get(lsm6dsm_ctx_t *ctx, lsm6dsm_func_cfg_en_t *val);
+int32_t lsm6dsm_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsm_func_cfg_en_t val);
+int32_t lsm6dsm_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsm_func_cfg_en_t *val);
 
 typedef enum {
   LSM6DSM_DRDY_LATCHED    = 0,
   LSM6DSM_DRDY_PULSED     = 1,
 } lsm6dsm_drdy_pulsed_g_t;
-int32_t lsm6dsm_data_ready_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_data_ready_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dsm_drdy_pulsed_g_t val);
-int32_t lsm6dsm_data_ready_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_data_ready_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dsm_drdy_pulsed_g_t *val);
 
-int32_t lsm6dsm_device_id_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_LSB_AT_LOW_ADD  = 0,
   LSM6DSM_MSB_AT_LOW_ADD  = 1,
 } lsm6dsm_ble_t;
-int32_t lsm6dsm_data_format_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t val);
-int32_t lsm6dsm_data_format_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ble_t *val);
+int32_t lsm6dsm_data_format_set(stmdev_ctx_t *ctx, lsm6dsm_ble_t val);
+int32_t lsm6dsm_data_format_get(stmdev_ctx_t *ctx, lsm6dsm_ble_t *val);
 
-int32_t lsm6dsm_auto_increment_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_auto_increment_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_boot_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_boot_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_XL_ST_DISABLE    = 0,
   LSM6DSM_XL_ST_POSITIVE   = 1,
   LSM6DSM_XL_ST_NEGATIVE   = 2,
 } lsm6dsm_st_xl_t;
-int32_t lsm6dsm_xl_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t val);
-int32_t lsm6dsm_xl_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_xl_t *val);
+int32_t lsm6dsm_xl_self_test_set(stmdev_ctx_t *ctx, lsm6dsm_st_xl_t val);
+int32_t lsm6dsm_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dsm_st_xl_t *val);
 
 typedef enum {
   LSM6DSM_GY_ST_DISABLE    = 0,
   LSM6DSM_GY_ST_POSITIVE   = 1,
   LSM6DSM_GY_ST_NEGATIVE   = 3,
 } lsm6dsm_st_g_t;
-int32_t lsm6dsm_gy_self_test_set(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t val);
-int32_t lsm6dsm_gy_self_test_get(lsm6dsm_ctx_t *ctx, lsm6dsm_st_g_t *val);
+int32_t lsm6dsm_gy_self_test_set(stmdev_ctx_t *ctx, lsm6dsm_st_g_t val);
+int32_t lsm6dsm_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dsm_st_g_t *val);
 
-int32_t lsm6dsm_filter_settling_mask_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_filter_settling_mask_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_USE_SLOPE    = 0,
   LSM6DSM_USE_HPF      = 1,
 } lsm6dsm_slope_fds_t;
-int32_t lsm6dsm_xl_hp_path_internal_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                         lsm6dsm_slope_fds_t val);
-int32_t lsm6dsm_xl_hp_path_internal_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                         lsm6dsm_slope_fds_t *val);
 
 typedef enum {
   LSM6DSM_XL_ANA_BW_1k5Hz = 0,
   LSM6DSM_XL_ANA_BW_400Hz = 1,
 } lsm6dsm_bw0_xl_t;
-int32_t lsm6dsm_xl_filter_analog_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_filter_analog_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_bw0_xl_t val);
-int32_t lsm6dsm_xl_filter_analog_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_filter_analog_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_bw0_xl_t *val);
 
 typedef enum {
@@ -1298,9 +1270,9 @@ typedef enum {
   LSM6DSM_XL_LP1_ODR_DIV_4 = 1,
   LSM6DSM_XL_LP1_NA        = 2,  /* ERROR CODE */
 } lsm6dsm_lpf1_bw_sel_t;
-int32_t lsm6dsm_xl_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_lpf1_bw_sel_t val);
-int32_t lsm6dsm_xl_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_lpf1_bw_sel_t *val);
 
 typedef enum {
@@ -1314,13 +1286,13 @@ typedef enum {
   LSM6DSM_XL_LOW_NOISE_LP_ODR_DIV_400  = 0x13,
   LSM6DSM_XL_LP_NA                     = 0x20, /* ERROR CODE */
 } lsm6dsm_input_composite_t;
-int32_t lsm6dsm_xl_lp2_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_input_composite_t val);
-int32_t lsm6dsm_xl_lp2_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_input_composite_t *val);
 
-int32_t lsm6dsm_xl_reference_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_xl_reference_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_xl_reference_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_xl_reference_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_XL_HP_ODR_DIV_4      = 0x00, /* Slope filter */
@@ -1329,9 +1301,9 @@ typedef enum {
   LSM6DSM_XL_HP_ODR_DIV_400    = 0x03,
   LSM6DSM_XL_HP_NA             = 0x10, /* ERROR CODE */
 } lsm6dsm_hpcf_xl_t;
-int32_t lsm6dsm_xl_hp_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                     lsm6dsm_hpcf_xl_t val);
-int32_t lsm6dsm_xl_hp_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                     lsm6dsm_hpcf_xl_t *val);
 
 typedef enum {
@@ -1339,13 +1311,13 @@ typedef enum {
   LSM6DSM_XL_UI_LP1_ODR_DIV_4 = 1,
   LSM6DSM_XL_UI_LP1_NA        = 2,
 } lsm6dsm_ui_lpf1_bw_sel_t;
-int32_t lsm6dsm_xl_ui_lp1_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_ui_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                         lsm6dsm_ui_lpf1_bw_sel_t val);
-int32_t lsm6dsm_xl_ui_lp1_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_ui_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                         lsm6dsm_ui_lpf1_bw_sel_t *val);
 
-int32_t lsm6dsm_xl_ui_slope_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_xl_ui_slope_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_xl_ui_slope_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_xl_ui_slope_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_AUX_LP_LIGHT          = 2,
@@ -1353,9 +1325,9 @@ typedef enum {
   LSM6DSM_AUX_LP_STRONG         = 0,
   LSM6DSM_AUX_LP_AGGRESSIVE     = 1,
 } lsm6dsm_filter_xl_conf_ois_t;
-int32_t lsm6dsm_xl_aux_lp_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_aux_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                         lsm6dsm_filter_xl_conf_ois_t val);
-int32_t lsm6dsm_xl_aux_lp_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_xl_aux_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                         lsm6dsm_filter_xl_conf_ois_t *val);
 
 typedef enum {
@@ -1376,13 +1348,13 @@ typedef enum {
   LSM6DSM_HP_260mHz_LP1_STRONG        = 0xA8,
   LSM6DSM_HP_1Hz04_LP1_AGGRESSIVE     = 0xBB,
 } lsm6dsm_lpf1_sel_g_t;
-int32_t lsm6dsm_gy_band_pass_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_band_pass_set(stmdev_ctx_t *ctx,
                                     lsm6dsm_lpf1_sel_g_t val);
-int32_t lsm6dsm_gy_band_pass_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_band_pass_get(stmdev_ctx_t *ctx,
                                     lsm6dsm_lpf1_sel_g_t *val);
 
-int32_t lsm6dsm_gy_ui_high_pass_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_gy_ui_high_pass_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_gy_ui_high_pass_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_gy_ui_high_pass_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_HP_DISABLE_LP_173Hz        = 0x02,
@@ -1395,40 +1367,40 @@ typedef enum {
   LSM6DSM_HP_260mHz_LP_351Hz         = 0xA0,
   LSM6DSM_HP_1Hz04_LP_937Hz          = 0xB3,
 } lsm6dsm_hp_en_ois_t;
-int32_t lsm6dsm_gy_aux_bandwidth_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_aux_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_hp_en_ois_t val);
-int32_t lsm6dsm_gy_aux_bandwidth_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_gy_aux_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_hp_en_ois_t *val);
 
-int32_t lsm6dsm_aux_status_reg_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_status_reg_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_status_spiaux_t *val);
 
-int32_t lsm6dsm_aux_xl_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_aux_gy_flag_data_ready_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_aux_gy_flag_settling_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_aux_gy_flag_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_AUX_DEN_DISABLE         = 0,
   LSM6DSM_AUX_DEN_LEVEL_LATCH     = 3,
   LSM6DSM_AUX_DEN_LEVEL_TRIG      = 2,
 } lsm6dsm_lvl_ois_t;
-int32_t lsm6dsm_aux_den_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_den_mode_set(stmdev_ctx_t *ctx,
                                  lsm6dsm_lvl_ois_t val);
-int32_t lsm6dsm_aux_den_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_den_mode_get(stmdev_ctx_t *ctx,
                                  lsm6dsm_lvl_ois_t *val);
 
-int32_t lsm6dsm_aux_drdy_on_int2_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_aux_drdy_on_int2_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_AUX_DISABLE   = 0,
   LSM6DSM_MODE_3_GY     = 1,
   LSM6DSM_MODE_4_GY_XL  = 3,
 } lsm6dsm_ois_en_spi2_t;
-int32_t lsm6dsm_aux_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t val);
-int32_t lsm6dsm_aux_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ois_en_spi2_t *val);
+int32_t lsm6dsm_aux_mode_set(stmdev_ctx_t *ctx, lsm6dsm_ois_en_spi2_t val);
+int32_t lsm6dsm_aux_mode_get(stmdev_ctx_t *ctx, lsm6dsm_ois_en_spi2_t *val);
 
 typedef enum {
   LSM6DSM_250dps_AUX   = 0,
@@ -1437,34 +1409,34 @@ typedef enum {
   LSM6DSM_1000dps_AUX  = 4,
   LSM6DSM_2000dps_AUX  = 6,
 } lsm6dsm_fs_g_ois_t;
-int32_t lsm6dsm_aux_gy_full_scale_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
                                       lsm6dsm_fs_g_ois_t val);
-int32_t lsm6dsm_aux_gy_full_scale_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
                                       lsm6dsm_fs_g_ois_t *val);
 
 typedef enum {
   LSM6DSM_AUX_SPI_4_WIRE = 0,
   LSM6DSM_AUX_SPI_3_WIRE = 1,
 } lsm6dsm_sim_ois_t;
-int32_t lsm6dsm_aux_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t val);
-int32_t lsm6dsm_aux_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_ois_t *val);
+int32_t lsm6dsm_aux_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsm_sim_ois_t val);
+int32_t lsm6dsm_aux_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsm_sim_ois_t *val);
 
 typedef enum {
   LSM6DSM_AUX_LSB_AT_LOW_ADD = 0,
   LSM6DSM_AUX_MSB_AT_LOW_ADD = 1,
 } lsm6dsm_ble_ois_t;
-int32_t lsm6dsm_aux_data_format_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_data_format_set(stmdev_ctx_t *ctx,
                                     lsm6dsm_ble_ois_t val);
-int32_t lsm6dsm_aux_data_format_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_data_format_get(stmdev_ctx_t *ctx,
                                     lsm6dsm_ble_ois_t *val);
 
 typedef enum {
   LSM6DSM_ENABLE_CLAMP    = 0,
   LSM6DSM_DISABLE_CLAMP   = 1,
 } lsm6dsm_st_ois_clampdis_t;
-int32_t lsm6dsm_aux_gy_clamp_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_clamp_set(stmdev_ctx_t *ctx,
                                  lsm6dsm_st_ois_clampdis_t val);
-int32_t lsm6dsm_aux_gy_clamp_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_clamp_get(stmdev_ctx_t *ctx,
                                  lsm6dsm_st_ois_clampdis_t *val);
 
 typedef enum {
@@ -1472,9 +1444,9 @@ typedef enum {
   LSM6DSM_AUX_GY_POS      = 1,
   LSM6DSM_AUX_GY_NEG      = 3,
 } lsm6dsm_st_ois_t;
-int32_t lsm6dsm_aux_gy_self_test_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_self_test_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_st_ois_t val);
-int32_t lsm6dsm_aux_gy_self_test_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_gy_self_test_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_st_ois_t *val);
 
 typedef enum {
@@ -1483,34 +1455,34 @@ typedef enum {
   LSM6DSM_AUX_4g   = 2,
   LSM6DSM_AUX_8g   = 3,
 } lsm6dsm_fs_xl_ois_t;
-int32_t lsm6dsm_aux_xl_full_scale_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
                                       lsm6dsm_fs_xl_ois_t val);
-int32_t lsm6dsm_aux_xl_full_scale_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
                                       lsm6dsm_fs_xl_ois_t *val);
 
 typedef enum {
   LSM6DSM_AUX_DEN_ACTIVE_LOW   = 0,
   LSM6DSM_AUX_DEN_ACTIVE_HIGH  = 1,
 } lsm6dsm_den_lh_ois_t;
-int32_t lsm6dsm_aux_den_polarity_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_den_polarity_set(stmdev_ctx_t *ctx,
                                      lsm6dsm_den_lh_ois_t val);
-int32_t lsm6dsm_aux_den_polarity_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_aux_den_polarity_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_den_lh_ois_t *val);
 
 typedef enum {
   LSM6DSM_SPI_4_WIRE  = 0,
   LSM6DSM_SPI_3_WIRE  = 1,
 } lsm6dsm_sim_t;
-int32_t lsm6dsm_spi_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t val);
-int32_t lsm6dsm_spi_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sim_t *val);
+int32_t lsm6dsm_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsm_sim_t val);
+int32_t lsm6dsm_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsm_sim_t *val);
 
 typedef enum {
   LSM6DSM_I2C_ENABLE   = 0,
   LSM6DSM_I2C_DISABLE  = 1,
 } lsm6dsm_i2c_disable_t;
-int32_t lsm6dsm_i2c_interface_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_i2c_interface_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_i2c_disable_t val);
-int32_t lsm6dsm_i2c_interface_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_i2c_interface_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_i2c_disable_t *val);
 
 typedef struct {
@@ -1533,9 +1505,9 @@ typedef struct {
   uint8_t den_drdy_int1            : 1;
   uint8_t drdy_on_int1             : 1;
 } lsm6dsm_int1_route_t;
-int32_t lsm6dsm_pin_int1_route_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_int1_route_t val);
-int32_t lsm6dsm_pin_int1_route_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_int1_route_t *val);
 
 typedef struct{
@@ -1557,43 +1529,43 @@ typedef struct{
   uint8_t int2_inact_state         : 1;
   uint8_t int2_wrist_tilt          : 1;
 } lsm6dsm_int2_route_t;
-int32_t lsm6dsm_pin_int2_route_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_int2_route_t val);
-int32_t lsm6dsm_pin_int2_route_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pin_int2_route_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_int2_route_t *val);
 
 typedef enum {
   LSM6DSM_PUSH_PULL   = 0,
   LSM6DSM_OPEN_DRAIN  = 1,
 } lsm6dsm_pp_od_t;
-int32_t lsm6dsm_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t val);
-int32_t lsm6dsm_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pp_od_t *val);
+int32_t lsm6dsm_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsm_pp_od_t val);
+int32_t lsm6dsm_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsm_pp_od_t *val);
 
 typedef enum {
   LSM6DSM_ACTIVE_HIGH   = 0,
   LSM6DSM_ACTIVE_LOW    = 1,
 } lsm6dsm_h_lactive_t;
-int32_t lsm6dsm_pin_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t val);
-int32_t lsm6dsm_pin_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_h_lactive_t *val);
+int32_t lsm6dsm_pin_polarity_set(stmdev_ctx_t *ctx, lsm6dsm_h_lactive_t val);
+int32_t lsm6dsm_pin_polarity_get(stmdev_ctx_t *ctx, lsm6dsm_h_lactive_t *val);
 
-int32_t lsm6dsm_all_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_all_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_INT_PULSED   = 0,
   LSM6DSM_INT_LATCHED  = 1,
 } lsm6dsm_lir_t;
-int32_t lsm6dsm_int_notification_set(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t val);
-int32_t lsm6dsm_int_notification_get(lsm6dsm_ctx_t *ctx, lsm6dsm_lir_t *val);
+int32_t lsm6dsm_int_notification_set(stmdev_ctx_t *ctx, lsm6dsm_lir_t val);
+int32_t lsm6dsm_int_notification_get(stmdev_ctx_t *ctx, lsm6dsm_lir_t *val);
 
-int32_t lsm6dsm_wkup_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_wkup_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_wkup_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_wkup_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_gy_sleep_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_gy_sleep_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_PROPERTY_DISABLE          = 0,
@@ -1601,51 +1573,51 @@ typedef enum {
   LSM6DSM_XL_12Hz5_GY_SLEEP         = 2,
   LSM6DSM_XL_12Hz5_GY_PD            = 3,
 } lsm6dsm_inact_en_t;
-int32_t lsm6dsm_act_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t val);
-int32_t lsm6dsm_act_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_inact_en_t *val);
+int32_t lsm6dsm_act_mode_set(stmdev_ctx_t *ctx, lsm6dsm_inact_en_t val);
+int32_t lsm6dsm_act_mode_get(stmdev_ctx_t *ctx, lsm6dsm_inact_en_t *val);
 
-int32_t lsm6dsm_act_sleep_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_act_sleep_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_tap_src_get(lsm6dsm_ctx_t *ctx, lsm6dsm_tap_src_t *val);
+int32_t lsm6dsm_tap_src_get(stmdev_ctx_t *ctx, lsm6dsm_tap_src_t *val);
 
-int32_t lsm6dsm_tap_detection_on_z_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_tap_detection_on_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_tap_detection_on_y_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_tap_detection_on_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_tap_detection_on_x_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_tap_detection_on_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_tap_threshold_x_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_tap_threshold_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_tap_shock_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_tap_shock_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_tap_quiet_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_tap_quiet_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_tap_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_tap_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_ONLY_SINGLE          = 0,
   LSM6DSM_BOTH_SINGLE_DOUBLE   = 1,
 } lsm6dsm_single_double_tap_t;
-int32_t lsm6dsm_tap_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_tap_mode_set(stmdev_ctx_t *ctx,
                              lsm6dsm_single_double_tap_t val);
-int32_t lsm6dsm_tap_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_tap_mode_get(stmdev_ctx_t *ctx,
                              lsm6dsm_single_double_tap_t *val);
 
 typedef enum {
   LSM6DSM_ODR_DIV_2_FEED      = 0,
   LSM6DSM_LPF2_FEED           = 1,
 } lsm6dsm_low_pass_on_6d_t;
-int32_t lsm6dsm_6d_feed_data_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_6d_feed_data_set(stmdev_ctx_t *ctx,
                                  lsm6dsm_low_pass_on_6d_t val);
-int32_t lsm6dsm_6d_feed_data_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_6d_feed_data_get(stmdev_ctx_t *ctx,
                                  lsm6dsm_low_pass_on_6d_t *val);
 
 typedef enum {
@@ -1654,14 +1626,14 @@ typedef enum {
   LSM6DSM_DEG_60      = 2,
   LSM6DSM_DEG_50      = 3,
 } lsm6dsm_sixd_ths_t;
-int32_t lsm6dsm_6d_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t val);
-int32_t lsm6dsm_6d_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_sixd_ths_t *val);
+int32_t lsm6dsm_6d_threshold_set(stmdev_ctx_t *ctx, lsm6dsm_sixd_ths_t val);
+int32_t lsm6dsm_6d_threshold_get(stmdev_ctx_t *ctx, lsm6dsm_sixd_ths_t *val);
 
-int32_t lsm6dsm_4d_mode_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_4d_mode_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_ff_dur_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_ff_dur_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_FF_TSH_156mg = 0,
@@ -1673,34 +1645,35 @@ typedef enum {
   LSM6DSM_FF_TSH_469mg = 6,
   LSM6DSM_FF_TSH_500mg = 7,
 } lsm6dsm_ff_ths_t;
-int32_t lsm6dsm_ff_threshold_set(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t val);
-int32_t lsm6dsm_ff_threshold_get(lsm6dsm_ctx_t *ctx, lsm6dsm_ff_ths_t *val);
+int32_t lsm6dsm_ff_threshold_set(stmdev_ctx_t *ctx, lsm6dsm_ff_ths_t val);
+int32_t lsm6dsm_ff_threshold_get(stmdev_ctx_t *ctx, lsm6dsm_ff_ths_t *val);
 
-int32_t lsm6dsm_fifo_watermark_set(lsm6dsm_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsm_fifo_watermark_get(lsm6dsm_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsm_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsm_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsm_fifo_data_level_get(lsm6dsm_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsm_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsm_fifo_wtm_flag_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_fifo_over_run_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_fifo_pattern_get(lsm6dsm_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsm_fifo_pattern_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsm_fifo_temp_batch_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_fifo_temp_batch_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_TRG_XL_GY_DRDY     = 0,
   LSM6DSM_TRG_STEP_DETECT    = 1,
   LSM6DSM_TRG_SH_DRDY        = 2,
 } lsm6dsm_trigger_fifo_t;
-int32_t lsm6dsm_fifo_write_trigger_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_write_trigger_set(stmdev_ctx_t *ctx,
                                        lsm6dsm_trigger_fifo_t val);
-int32_t lsm6dsm_fifo_write_trigger_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_write_trigger_get(stmdev_ctx_t *ctx,
                                        lsm6dsm_trigger_fifo_t *val);
 
-int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_set(stmdev_ctx_t *ctx,
                                                   uint8_t val);
-int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_pedo_and_timestamp_batch_get(stmdev_ctx_t *ctx,
                                                   uint8_t *val);
 
 typedef enum {
@@ -1713,9 +1686,9 @@ typedef enum {
   LSM6DSM_FIFO_XL_DEC_16   = 6,
   LSM6DSM_FIFO_XL_DEC_32   = 7,
 } lsm6dsm_dec_fifo_xl_t;
-int32_t lsm6dsm_fifo_xl_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_dec_fifo_xl_t val);
-int32_t lsm6dsm_fifo_xl_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_dec_fifo_xl_t *val);
 
 typedef enum {
@@ -1728,9 +1701,9 @@ typedef enum {
   LSM6DSM_FIFO_GY_DEC_16  = 6,
   LSM6DSM_FIFO_GY_DEC_32  = 7,
 } lsm6dsm_dec_fifo_gyro_t;
-int32_t lsm6dsm_fifo_gy_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_dec_fifo_gyro_t val);
-int32_t lsm6dsm_fifo_gy_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_dec_fifo_gyro_t *val);
 
 typedef enum {
@@ -1743,9 +1716,9 @@ typedef enum {
   LSM6DSM_FIFO_DS3_DEC_16    = 6,
   LSM6DSM_FIFO_DS3_DEC_32    = 7,
 } lsm6dsm_dec_ds3_fifo_t;
-int32_t lsm6dsm_fifo_dataset_3_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_dataset_3_batch_set(stmdev_ctx_t *ctx,
                                          lsm6dsm_dec_ds3_fifo_t val);
-int32_t lsm6dsm_fifo_dataset_3_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_dataset_3_batch_get(stmdev_ctx_t *ctx,
                                          lsm6dsm_dec_ds3_fifo_t *val);
 
 typedef enum {
@@ -1758,16 +1731,16 @@ typedef enum {
   LSM6DSM_FIFO_DS4_DEC_16   = 6,
   LSM6DSM_FIFO_DS4_DEC_32   = 7,
 } lsm6dsm_dec_ds4_fifo_t;
-int32_t lsm6dsm_fifo_dataset_4_batch_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_dataset_4_batch_set(stmdev_ctx_t *ctx,
                                          lsm6dsm_dec_ds4_fifo_t val);
-int32_t lsm6dsm_fifo_dataset_4_batch_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_dataset_4_batch_get(stmdev_ctx_t *ctx,
                                          lsm6dsm_dec_ds4_fifo_t *val);
 
-int32_t lsm6dsm_fifo_xl_gy_8bit_format_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_fifo_xl_gy_8bit_format_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_fifo_xl_gy_8bit_format_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_fifo_xl_gy_8bit_format_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_fifo_stop_on_wtm_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_fifo_stop_on_wtm_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_BYPASS_MODE           = 0,
@@ -1776,8 +1749,8 @@ typedef enum {
   LSM6DSM_BYPASS_TO_STREAM_MODE = 4,
   LSM6DSM_STREAM_MODE           = 6,
 } lsm6dsm_fifo_mode_t;
-int32_t lsm6dsm_fifo_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t val);
-int32_t lsm6dsm_fifo_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_fifo_mode_t *val);
+int32_t lsm6dsm_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsm_fifo_mode_t val);
+int32_t lsm6dsm_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsm_fifo_mode_t *val);
 
 typedef enum {
   LSM6DSM_FIFO_DISABLE   =  0,
@@ -1792,17 +1765,17 @@ typedef enum {
   LSM6DSM_FIFO_3k33Hz    =  9,
   LSM6DSM_FIFO_6k66Hz    = 10,
 } lsm6dsm_odr_fifo_t;
-int32_t lsm6dsm_fifo_data_rate_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_data_rate_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_odr_fifo_t val);
-int32_t lsm6dsm_fifo_data_rate_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_fifo_data_rate_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_odr_fifo_t *val);
 
 typedef enum {
   LSM6DSM_DEN_ACT_LOW    = 0,
   LSM6DSM_DEN_ACT_HIGH   = 1,
 } lsm6dsm_den_lh_t;
-int32_t lsm6dsm_den_polarity_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t val);
-int32_t lsm6dsm_den_polarity_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_lh_t *val);
+int32_t lsm6dsm_den_polarity_set(stmdev_ctx_t *ctx, lsm6dsm_den_lh_t val);
+int32_t lsm6dsm_den_polarity_get(stmdev_ctx_t *ctx, lsm6dsm_den_lh_t *val);
 
 typedef enum {
   LSM6DSM_DEN_DISABLE    = 0,
@@ -1811,92 +1784,92 @@ typedef enum {
   LSM6DSM_LEVEL_TRIGGER  = 2,
   LSM6DSM_EDGE_TRIGGER   = 4,
 } lsm6dsm_den_mode_t;
-int32_t lsm6dsm_den_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t val);
-int32_t lsm6dsm_den_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_mode_t *val);
+int32_t lsm6dsm_den_mode_set(stmdev_ctx_t *ctx, lsm6dsm_den_mode_t val);
+int32_t lsm6dsm_den_mode_get(stmdev_ctx_t *ctx, lsm6dsm_den_mode_t *val);
 
 typedef enum {
   LSM6DSM_STAMP_IN_GY_DATA     = 0,
   LSM6DSM_STAMP_IN_XL_DATA     = 1,
   LSM6DSM_STAMP_IN_GY_XL_DATA  = 2,
 } lsm6dsm_den_xl_en_t;
-int32_t lsm6dsm_den_enable_set(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t val);
-int32_t lsm6dsm_den_enable_get(lsm6dsm_ctx_t *ctx, lsm6dsm_den_xl_en_t *val);
+int32_t lsm6dsm_den_enable_set(stmdev_ctx_t *ctx, lsm6dsm_den_xl_en_t val);
+int32_t lsm6dsm_den_enable_get(stmdev_ctx_t *ctx, lsm6dsm_den_xl_en_t *val);
 
-int32_t lsm6dsm_den_mark_axis_z_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_den_mark_axis_z_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_den_mark_axis_y_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_den_mark_axis_y_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_den_mark_axis_x_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_den_mark_axis_x_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_pedo_step_reset_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_pedo_step_reset_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_pedo_step_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_step_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_pedo_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_pedo_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_pedo_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_pedo_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_pedo_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_PEDO_AT_2g = 0,
   LSM6DSM_PEDO_AT_4g = 1,
 } lsm6dsm_pedo_fs_t;
-int32_t lsm6dsm_pedo_full_scale_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pedo_full_scale_set(stmdev_ctx_t *ctx,
                                     lsm6dsm_pedo_fs_t val);
-int32_t lsm6dsm_pedo_full_scale_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_pedo_full_scale_get(stmdev_ctx_t *ctx,
                                     lsm6dsm_pedo_fs_t *val);
 
-int32_t lsm6dsm_pedo_debounce_steps_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_pedo_debounce_steps_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_pedo_timeout_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_pedo_timeout_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_pedo_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_pedo_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_pedo_steps_period_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_pedo_steps_period_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsm_motion_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_motion_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_motion_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_motion_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_motion_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_motion_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsm_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_wrist_tilt_sens_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_wrist_tilt_sens_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_wrist_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_wrist_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_tilt_latency_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_tilt_latency_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_tilt_latency_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_tilt_latency_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsm_tilt_threshold_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_tilt_threshold_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_tilt_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_tilt_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsm_tilt_src_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_tilt_src_set(stmdev_ctx_t *ctx,
                              lsm6dsm_a_wrist_tilt_mask_t *val);
-int32_t lsm6dsm_tilt_src_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_tilt_src_get(stmdev_ctx_t *ctx,
                              lsm6dsm_a_wrist_tilt_mask_t *val);
 
-int32_t lsm6dsm_mag_soft_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_mag_soft_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_mag_hard_iron_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_mag_hard_iron_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_mag_hard_iron_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_mag_hard_iron_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_mag_soft_iron_mat_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_mag_soft_iron_mat_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_mag_soft_iron_mat_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_mag_soft_iron_mat_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsm_mag_offset_set(lsm6dsm_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsm_mag_offset_get(lsm6dsm_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsm_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsm_func_en_set(lsm6dsm_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_func_en_set(stmdev_ctx_t *ctx, uint8_t val);
 
-int32_t lsm6dsm_sh_sync_sens_frame_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_sh_sync_sens_frame_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_sh_sync_sens_frame_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_sync_sens_frame_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_RES_RATIO_2_11  = 0,
@@ -1904,34 +1877,34 @@ typedef enum {
   LSM6DSM_RES_RATIO_2_13  = 2,
   LSM6DSM_RES_RATIO_2_14  = 3,
 } lsm6dsm_rr_t;
-int32_t lsm6dsm_sh_sync_sens_ratio_set(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t val);
-int32_t lsm6dsm_sh_sync_sens_ratio_get(lsm6dsm_ctx_t *ctx, lsm6dsm_rr_t *val);
+int32_t lsm6dsm_sh_sync_sens_ratio_set(stmdev_ctx_t *ctx, lsm6dsm_rr_t val);
+int32_t lsm6dsm_sh_sync_sens_ratio_get(stmdev_ctx_t *ctx, lsm6dsm_rr_t *val);
 
-int32_t lsm6dsm_sh_master_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_sh_master_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_sh_pass_through_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_sh_pass_through_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_EXT_PULL_UP       = 0,
   LSM6DSM_INTERNAL_PULL_UP  = 1,
   LSM6DSM_SH_PIN_MODE       = 2,
 } lsm6dsm_pull_up_en_t;
-int32_t lsm6dsm_sh_pin_mode_set(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t val);
-int32_t lsm6dsm_sh_pin_mode_get(lsm6dsm_ctx_t *ctx, lsm6dsm_pull_up_en_t *val);
+int32_t lsm6dsm_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsm_pull_up_en_t val);
+int32_t lsm6dsm_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsm_pull_up_en_t *val);
 
 typedef enum {
   LSM6DSM_XL_GY_DRDY        = 0,
   LSM6DSM_EXT_ON_INT2_PIN   = 1,
 } lsm6dsm_start_config_t;
-int32_t lsm6dsm_sh_syncro_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_start_config_t val);
-int32_t lsm6dsm_sh_syncro_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_start_config_t *val);
 
-int32_t lsm6dsm_sh_drdy_on_int1_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_sh_drdy_on_int1_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_sh_drdy_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_drdy_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
     lsm6dsm_sensorhub1_reg_t   sh_byte_1;
@@ -1953,22 +1926,22 @@ typedef struct {
     lsm6dsm_sensorhub17_reg_t  sh_byte_17;
     lsm6dsm_sensorhub18_reg_t  sh_byte_18;
 } lsm6dsm_emb_sh_read_t;
-int32_t lsm6dsm_sh_read_data_raw_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                      lsm6dsm_emb_sh_read_t *val);
 
-int32_t lsm6dsm_sh_cmd_sens_sync_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_sh_cmd_sens_sync_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_sh_cmd_sens_sync_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_cmd_sens_sync_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsm_sh_spi_sync_error_set(lsm6dsm_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsm_sh_spi_sync_error_get(lsm6dsm_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsm_sh_spi_sync_error_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsm_sh_spi_sync_error_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSM_NORMAL_MODE_READ  = 0,
   LSM6DSM_SRC_MODE_READ     = 1,
 } lsm6dsm_src_mode_t;
-int32_t lsm6dsm_sh_cfg_slave_0_rd_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_cfg_slave_0_rd_mode_set(stmdev_ctx_t *ctx,
                                            lsm6dsm_src_mode_t val);
-int32_t lsm6dsm_sh_cfg_slave_0_rd_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_cfg_slave_0_rd_mode_get(stmdev_ctx_t *ctx,
                                            lsm6dsm_src_mode_t *val);
 
 typedef enum {
@@ -1977,9 +1950,9 @@ typedef enum {
   LSM6DSM_SLV_0_1_2    = 2,
   LSM6DSM_SLV_0_1_2_3  = 3,
 } lsm6dsm_aux_sens_on_t;
-int32_t lsm6dsm_sh_num_of_dev_connected_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_num_of_dev_connected_set(stmdev_ctx_t *ctx,
                                             lsm6dsm_aux_sens_on_t val);
-int32_t lsm6dsm_sh_num_of_dev_connected_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_num_of_dev_connected_get(stmdev_ctx_t *ctx,
                                             lsm6dsm_aux_sens_on_t *val);
 
 typedef struct{
@@ -1987,20 +1960,20 @@ typedef struct{
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } lsm6dsm_sh_cfg_write_t;
-int32_t lsm6dsm_sh_cfg_write(lsm6dsm_ctx_t *ctx, lsm6dsm_sh_cfg_write_t *val);
+int32_t lsm6dsm_sh_cfg_write(stmdev_ctx_t *ctx, lsm6dsm_sh_cfg_write_t *val);
 
 typedef struct{
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dsm_sh_cfg_read_t;
-int32_t lsm6dsm_sh_slv0_cfg_read(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsm_sh_cfg_read_t *val);
-int32_t lsm6dsm_sh_slv1_cfg_read(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsm_sh_cfg_read_t *val);
-int32_t lsm6dsm_sh_slv2_cfg_read(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsm_sh_cfg_read_t *val);
-int32_t lsm6dsm_sh_slv3_cfg_read(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsm_sh_cfg_read_t *val);
 
 typedef enum {
@@ -2009,18 +1982,18 @@ typedef enum {
   LSM6DSM_SL0_DEC_4    = 2,
   LSM6DSM_SL0_DEC_8    = 3,
 } lsm6dsm_slave0_rate_t;
-int32_t lsm6dsm_sh_slave_0_dec_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_0_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave0_rate_t val);
-int32_t lsm6dsm_sh_slave_0_dec_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_0_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave0_rate_t *val);
 
 typedef enum {
   LSM6DSM_EACH_SH_CYCLE     = 0,
   LSM6DSM_ONLY_FIRST_CYCLE  = 1,
 } lsm6dsm_write_once_t;
-int32_t lsm6dsm_sh_write_mode_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_write_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsm_write_once_t val);
-int32_t lsm6dsm_sh_write_mode_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_write_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsm_write_once_t *val);
 
 typedef enum {
@@ -2029,9 +2002,9 @@ typedef enum {
   LSM6DSM_SL1_DEC_4    = 2,
   LSM6DSM_SL1_DEC_8    = 3,
 } lsm6dsm_slave1_rate_t;
-int32_t lsm6dsm_sh_slave_1_dec_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_1_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave1_rate_t val);
-int32_t lsm6dsm_sh_slave_1_dec_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_1_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave1_rate_t *val);
 
 typedef enum {
@@ -2040,9 +2013,9 @@ typedef enum {
   LSM6DSM_SL2_DEC_4   = 2,
   LSM6DSM_SL2_DEC_8   = 3,
 } lsm6dsm_slave2_rate_t;
-int32_t lsm6dsm_sh_slave_2_dec_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_2_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave2_rate_t val);
-int32_t lsm6dsm_sh_slave_2_dec_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_2_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave2_rate_t *val);
 
 typedef enum {
@@ -2051,9 +2024,9 @@ typedef enum {
   LSM6DSM_SL3_DEC_4   = 2,
   LSM6DSM_SL3_DEC_8   = 3,
 } lsm6dsm_slave3_rate_t;
-int32_t lsm6dsm_sh_slave_3_dec_set(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_3_dec_set(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave3_rate_t val);
-int32_t lsm6dsm_sh_slave_3_dec_get(lsm6dsm_ctx_t *ctx,
+int32_t lsm6dsm_sh_slave_3_dec_get(stmdev_ctx_t *ctx,
                                    lsm6dsm_slave3_rate_t *val);
 
 /**

--- a/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.h
+++ b/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.h
@@ -1,43 +1,26 @@
 /*
  ******************************************************************************
  * @file    lsm6dso_reg.h
- * @author  Sensor Solutions Software Team
+ * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
  *          lsm6dso_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef LSM6DSO_DRIVER_H
-#define LSM6DSO_DRIVER_H
+#ifndef LSM6DSO_REGS_H
+#define LSM6DSO_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LSM6DSO_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LSM6DSO_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lsm6dso_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lsm6dso_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lsm6dso_write_ptr  write_reg;
-  lsm6dso_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lsm6dso_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -1406,6 +1378,8 @@ typedef struct {
   uint8_t wr_once_done             : 1;
 } lsm6dso_status_master_t;
 
+#define LSM6DSO_START_FSM_ADD                0x0400U
+
 /**
   * @defgroup LSM6DSO_Register_Union
   * @brief    This union group all the registers that has a bitfield
@@ -1548,9 +1522,9 @@ typedef union{
   *
   */
 
-int32_t lsm6dso_read_reg(lsm6dso_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dso_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lsm6dso_write_reg(lsm6dso_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dso_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float_t lsm6dso_from_fs2_to_mg(int16_t lsb);
@@ -1571,8 +1545,8 @@ typedef enum {
   LSM6DSO_4g   = 2,
   LSM6DSO_8g   = 3,
 } lsm6dso_fs_xl_t;
-int32_t lsm6dso_xl_full_scale_set(lsm6dso_ctx_t *ctx, lsm6dso_fs_xl_t val);
-int32_t lsm6dso_xl_full_scale_get(lsm6dso_ctx_t *ctx, lsm6dso_fs_xl_t *val);
+int32_t lsm6dso_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6dso_fs_xl_t val);
+int32_t lsm6dso_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6dso_fs_xl_t *val);
 
 typedef enum {
   LSM6DSO_XL_ODR_OFF    = 0,
@@ -1588,8 +1562,8 @@ typedef enum {
   LSM6DSO_XL_ODR_6667Hz = 10,
   LSM6DSO_XL_ODR_6Hz5   = 11, /* (low power only) */
 } lsm6dso_odr_xl_t;
-int32_t lsm6dso_xl_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_odr_xl_t val);
-int32_t lsm6dso_xl_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_odr_xl_t *val);
+int32_t lsm6dso_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dso_odr_xl_t val);
+int32_t lsm6dso_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dso_odr_xl_t *val);
 
 typedef enum {
   LSM6DSO_250dps   = 0,
@@ -1598,8 +1572,8 @@ typedef enum {
   LSM6DSO_1000dps  = 4,
   LSM6DSO_2000dps  = 6,
 } lsm6dso_fs_g_t;
-int32_t lsm6dso_gy_full_scale_set(lsm6dso_ctx_t *ctx, lsm6dso_fs_g_t val);
-int32_t lsm6dso_gy_full_scale_get(lsm6dso_ctx_t *ctx, lsm6dso_fs_g_t *val);
+int32_t lsm6dso_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6dso_fs_g_t val);
+int32_t lsm6dso_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6dso_fs_g_t *val);
 
 typedef enum {
   LSM6DSO_GY_ODR_OFF    = 0,
@@ -1614,19 +1588,19 @@ typedef enum {
   LSM6DSO_GY_ODR_3333Hz = 9,
   LSM6DSO_GY_ODR_6667Hz = 10,
 } lsm6dso_odr_g_t;
-int32_t lsm6dso_gy_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_odr_g_t val);
-int32_t lsm6dso_gy_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_odr_g_t *val);
+int32_t lsm6dso_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6dso_odr_g_t val);
+int32_t lsm6dso_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6dso_odr_g_t *val);
 
-int32_t lsm6dso_block_data_update_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_block_data_update_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_LSb_1mg  = 0,
   LSM6DSO_LSb_16mg = 1,
 } lsm6dso_usr_off_w_t;
-int32_t lsm6dso_xl_offset_weight_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                      lsm6dso_usr_off_w_t val);
-int32_t lsm6dso_xl_offset_weight_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                      lsm6dso_usr_off_w_t *val);
 
 typedef enum {
@@ -1634,18 +1608,18 @@ typedef enum {
   LSM6DSO_LOW_NORMAL_POWER_MD  = 1,
   LSM6DSO_ULTRA_LOW_POWER_MD   = 2,
 } lsm6dso_xl_hm_mode_t;
-int32_t lsm6dso_xl_power_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_xl_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dso_xl_hm_mode_t val);
-int32_t lsm6dso_xl_power_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_xl_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dso_xl_hm_mode_t *val);
 
 typedef enum {
   LSM6DSO_GY_HIGH_PERFORMANCE  = 0,
   LSM6DSO_GY_NORMAL            = 1,
 } lsm6dso_g_hm_mode_t;
-int32_t lsm6dso_gy_power_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_gy_power_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dso_g_hm_mode_t val);
-int32_t lsm6dso_gy_power_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_gy_power_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dso_g_hm_mode_t *val);
 
 typedef struct {
@@ -1658,34 +1632,34 @@ typedef struct {
   lsm6dso_fsm_status_a_t      fsm_status_a;
   lsm6dso_fsm_status_b_t      fsm_status_b;
 } lsm6dso_all_sources_t;
-int32_t lsm6dso_all_sources_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_all_sources_get(stmdev_ctx_t *ctx,
                                 lsm6dso_all_sources_t *val);
 
-int32_t lsm6dso_status_reg_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_status_reg_get(stmdev_ctx_t *ctx,
                                lsm6dso_status_reg_t *val);
 
-int32_t lsm6dso_xl_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_gy_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_temp_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_xl_usr_offset_x_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_xl_usr_offset_x_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_xl_usr_offset_y_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_xl_usr_offset_y_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_xl_usr_offset_z_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_xl_usr_offset_z_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_xl_usr_offset_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_xl_usr_offset_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_timestamp_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_timestamp_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_timestamp_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM6DSO_NO_ROUND      = 0,
@@ -1693,88 +1667,88 @@ typedef enum {
   LSM6DSO_ROUND_GY      = 2,
   LSM6DSO_ROUND_GY_XL   = 3,
 } lsm6dso_rounding_t;
-int32_t lsm6dso_rounding_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_rounding_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dso_rounding_t val);
-int32_t lsm6dso_rounding_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_rounding_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dso_rounding_t *val);
 
-int32_t lsm6dso_temperature_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_angular_rate_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_acceleration_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_fifo_out_raw_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_number_of_steps_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_steps_reset(lsm6dso_ctx_t *ctx);
+int32_t lsm6dso_steps_reset(stmdev_ctx_t *ctx);
 
-int32_t lsm6dso_odr_cal_reg_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_odr_cal_reg_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_USER_BANK           = 0,
   LSM6DSO_SENSOR_HUB_BANK     = 1,
   LSM6DSO_EMBEDDED_FUNC_BANK  = 2,
 } lsm6dso_reg_access_t;
-int32_t lsm6dso_mem_bank_set(lsm6dso_ctx_t *ctx, lsm6dso_reg_access_t val);
-int32_t lsm6dso_mem_bank_get(lsm6dso_ctx_t *ctx, lsm6dso_reg_access_t *val);
+int32_t lsm6dso_mem_bank_set(stmdev_ctx_t *ctx, lsm6dso_reg_access_t val);
+int32_t lsm6dso_mem_bank_get(stmdev_ctx_t *ctx, lsm6dso_reg_access_t *val);
 
-int32_t lsm6dso_ln_pg_write_byte(lsm6dso_ctx_t *ctx, uint16_t address,
+int32_t lsm6dso_ln_pg_write_byte(stmdev_ctx_t *ctx, uint16_t address,
                                  uint8_t *val);
-int32_t lsm6dso_ln_pg_read_byte(lsm6dso_ctx_t *ctx, uint16_t address,
+int32_t lsm6dso_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t address,
                                 uint8_t *val);
-int32_t lsm6dso_ln_pg_write(lsm6dso_ctx_t *ctx, uint16_t address,
+int32_t lsm6dso_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
                             uint8_t *buf, uint8_t len);
-int32_t lsm6dso_ln_pg_read(lsm6dso_ctx_t *ctx, uint16_t address,
+int32_t lsm6dso_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address,
                            uint8_t *val);
 
 typedef enum {
   LSM6DSO_DRDY_LATCHED = 0,
   LSM6DSO_DRDY_PULSED  = 1,
 } lsm6dso_dataready_pulsed_t;
-int32_t lsm6dso_data_ready_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_data_ready_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dso_dataready_pulsed_t val);
-int32_t lsm6dso_data_ready_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_data_ready_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dso_dataready_pulsed_t *val);
 
-int32_t lsm6dso_device_id_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_reset_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_reset_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_auto_increment_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_auto_increment_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_boot_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_boot_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_XL_ST_DISABLE  = 0,
   LSM6DSO_XL_ST_POSITIVE = 1,
   LSM6DSO_XL_ST_NEGATIVE = 2,
 } lsm6dso_st_xl_t;
-int32_t lsm6dso_xl_self_test_set(lsm6dso_ctx_t *ctx, lsm6dso_st_xl_t val);
-int32_t lsm6dso_xl_self_test_get(lsm6dso_ctx_t *ctx, lsm6dso_st_xl_t *val);
+int32_t lsm6dso_xl_self_test_set(stmdev_ctx_t *ctx, lsm6dso_st_xl_t val);
+int32_t lsm6dso_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dso_st_xl_t *val);
 
 typedef enum {
   LSM6DSO_GY_ST_DISABLE  = 0,
   LSM6DSO_GY_ST_POSITIVE = 1,
   LSM6DSO_GY_ST_NEGATIVE = 3,
 } lsm6dso_st_g_t;
-int32_t lsm6dso_gy_self_test_set(lsm6dso_ctx_t *ctx, lsm6dso_st_g_t val);
-int32_t lsm6dso_gy_self_test_get(lsm6dso_ctx_t *ctx, lsm6dso_st_g_t *val);
+int32_t lsm6dso_gy_self_test_set(stmdev_ctx_t *ctx, lsm6dso_st_g_t val);
+int32_t lsm6dso_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dso_st_g_t *val);
 
-int32_t lsm6dso_xl_filter_lp2_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_xl_filter_lp2_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_gy_filter_lp1_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_gy_filter_lp1_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_gy_filter_lp1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_gy_filter_lp1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_filter_settling_mask_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_filter_settling_mask_set(stmdev_ctx_t *ctx,
                                          uint8_t val);
-int32_t lsm6dso_filter_settling_mask_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_filter_settling_mask_get(stmdev_ctx_t *ctx,
                                          uint8_t *val);
 
 typedef enum {
@@ -1787,13 +1761,13 @@ typedef enum {
   LSM6DSO_AGGRESSIVE   = 6, /* not available for data rate > 1k670Hz */
   LSM6DSO_XTREME       = 7, /* not available for data rate > 1k670Hz */
 } lsm6dso_ftype_t;
-int32_t lsm6dso_gy_lp1_bandwidth_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dso_ftype_t val);
-int32_t lsm6dso_gy_lp1_bandwidth_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dso_ftype_t *val);
 
-int32_t lsm6dso_xl_lp2_on_6d_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_xl_lp2_on_6d_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_xl_lp2_on_6d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_lp2_on_6d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_HP_PATH_DISABLE_ON_OUT    = 0x00,
@@ -1820,21 +1794,21 @@ typedef enum {
   LSM6DSO_LP_ODR_DIV_400            = 0x06,
   LSM6DSO_LP_ODR_DIV_800            = 0x07,
 } lsm6dso_hp_slope_xl_en_t;
-int32_t lsm6dso_xl_hp_path_on_out_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
                                       lsm6dso_hp_slope_xl_en_t val);
-int32_t lsm6dso_xl_hp_path_on_out_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
                                       lsm6dso_hp_slope_xl_en_t *val);
 
-int32_t lsm6dso_xl_fast_settling_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_xl_fast_settling_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_USE_SLOPE = 0,
   LSM6DSO_USE_HPF   = 1,
 } lsm6dso_slope_fds_t;
-int32_t lsm6dso_xl_hp_path_internal_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                          lsm6dso_slope_fds_t val);
-int32_t lsm6dso_xl_hp_path_internal_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                          lsm6dso_slope_fds_t *val);
 
 typedef enum {
@@ -1844,62 +1818,62 @@ typedef enum {
   LSM6DSO_HP_FILTER_260mHz   = 0x82,
   LSM6DSO_HP_FILTER_1Hz04    = 0x83,
 } lsm6dso_hpm_g_t;
-int32_t lsm6dso_gy_hp_path_internal_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_gy_hp_path_internal_set(stmdev_ctx_t *ctx,
                                          lsm6dso_hpm_g_t val);
-int32_t lsm6dso_gy_hp_path_internal_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_gy_hp_path_internal_get(stmdev_ctx_t *ctx,
                                          lsm6dso_hpm_g_t *val);
 
 typedef enum {
   LSM6DSO_AUX_PULL_UP_DISC       = 0,
   LSM6DSO_AUX_PULL_UP_CONNECT    = 1,
 } lsm6dso_ois_pu_dis_t;
-int32_t lsm6dso_aux_sdo_ocs_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_sdo_ocs_mode_set(stmdev_ctx_t *ctx,
                                      lsm6dso_ois_pu_dis_t val);
-int32_t lsm6dso_aux_sdo_ocs_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_sdo_ocs_mode_get(stmdev_ctx_t *ctx,
                                      lsm6dso_ois_pu_dis_t *val);
 
 typedef enum {
   LSM6DSO_AUX_ON                    = 1,
   LSM6DSO_AUX_ON_BY_AUX_INTERFACE   = 0,
 } lsm6dso_ois_on_t;
-int32_t lsm6dso_aux_pw_on_ctrl_set(lsm6dso_ctx_t *ctx, lsm6dso_ois_on_t val);
-int32_t lsm6dso_aux_pw_on_ctrl_get(lsm6dso_ctx_t *ctx, lsm6dso_ois_on_t *val);
+int32_t lsm6dso_aux_pw_on_ctrl_set(stmdev_ctx_t *ctx, lsm6dso_ois_on_t val);
+int32_t lsm6dso_aux_pw_on_ctrl_get(stmdev_ctx_t *ctx, lsm6dso_ois_on_t *val);
 
 typedef enum {
   LSM6DSO_USE_SAME_XL_FS        = 0,
   LSM6DSO_USE_DIFFERENT_XL_FS   = 1,
 } lsm6dso_xl_fs_mode_t;
-int32_t lsm6dso_aux_xl_fs_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_xl_fs_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dso_xl_fs_mode_t val);
-int32_t lsm6dso_aux_xl_fs_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_xl_fs_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dso_xl_fs_mode_t *val);
 
-int32_t lsm6dso_aux_status_reg_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_status_reg_get(stmdev_ctx_t *ctx,
                                    lsm6dso_status_spiaux_t *val);
 
-int32_t lsm6dso_aux_xl_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_aux_gy_flag_data_ready_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_aux_gy_flag_settling_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_aux_gy_flag_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_AUX_XL_DISABLE = 0,
   LSM6DSO_AUX_XL_POS     = 1,
   LSM6DSO_AUX_XL_NEG     = 2,
 } lsm6dso_st_xl_ois_t;
-int32_t lsm6dso_aux_xl_self_test_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_xl_self_test_set(stmdev_ctx_t *ctx,
                                      lsm6dso_st_xl_ois_t val);
-int32_t lsm6dso_aux_xl_self_test_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_xl_self_test_get(stmdev_ctx_t *ctx,
                                      lsm6dso_st_xl_ois_t *val);
 
 typedef enum {
   LSM6DSO_AUX_DEN_ACTIVE_LOW     = 0,
   LSM6DSO_AUX_DEN_ACTIVE_HIGH    = 1,
 } lsm6dso_den_lh_ois_t;
-int32_t lsm6dso_aux_den_polarity_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_den_polarity_set(stmdev_ctx_t *ctx,
                                      lsm6dso_den_lh_ois_t val);
-int32_t lsm6dso_aux_den_polarity_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_den_polarity_get(stmdev_ctx_t *ctx,
                                      lsm6dso_den_lh_ois_t *val);
 
 typedef enum {
@@ -1907,19 +1881,19 @@ typedef enum {
   LSM6DSO_AUX_DEN_LEVEL_LATCH     = 3,
   LSM6DSO_AUX_DEN_LEVEL_TRIG      = 2,
 } lsm6dso_lvl2_ois_t;
-int32_t lsm6dso_aux_den_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_lvl2_ois_t val);
-int32_t lsm6dso_aux_den_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_lvl2_ois_t *val);
+int32_t lsm6dso_aux_den_mode_set(stmdev_ctx_t *ctx, lsm6dso_lvl2_ois_t val);
+int32_t lsm6dso_aux_den_mode_get(stmdev_ctx_t *ctx, lsm6dso_lvl2_ois_t *val);
 
-int32_t lsm6dso_aux_drdy_on_int2_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_aux_drdy_on_int2_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_AUX_DISABLE  = 0,
   LSM6DSO_MODE_3_GY    = 1,
   LSM6DSO_MODE_4_GY_XL = 3,
 } lsm6dso_ois_en_spi2_t;
-int32_t lsm6dso_aux_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_ois_en_spi2_t val);
-int32_t lsm6dso_aux_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_ois_en_spi2_t *val);
+int32_t lsm6dso_aux_mode_set(stmdev_ctx_t *ctx, lsm6dso_ois_en_spi2_t val);
+int32_t lsm6dso_aux_mode_get(stmdev_ctx_t *ctx, lsm6dso_ois_en_spi2_t *val);
 
 typedef enum {
   LSM6DSO_250dps_AUX  = 0,
@@ -1928,17 +1902,17 @@ typedef enum {
   LSM6DSO_1000dps_AUX = 4,
   LSM6DSO_2000dps_AUX = 6,
 } lsm6dso_fs_g_ois_t;
-int32_t lsm6dso_aux_gy_full_scale_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
                                       lsm6dso_fs_g_ois_t val);
-int32_t lsm6dso_aux_gy_full_scale_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
                                       lsm6dso_fs_g_ois_t *val);
 
 typedef enum {
   LSM6DSO_AUX_SPI_4_WIRE = 0,
   LSM6DSO_AUX_SPI_3_WIRE = 1,
 } lsm6dso_sim_ois_t;
-int32_t lsm6dso_aux_spi_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_sim_ois_t val);
-int32_t lsm6dso_aux_spi_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_sim_ois_t *val);
+int32_t lsm6dso_aux_spi_mode_set(stmdev_ctx_t *ctx, lsm6dso_sim_ois_t val);
+int32_t lsm6dso_aux_spi_mode_get(stmdev_ctx_t *ctx, lsm6dso_sim_ois_t *val);
 
 typedef enum {
   LSM6DSO_351Hz39 = 0,
@@ -1946,9 +1920,9 @@ typedef enum {
   LSM6DSO_172Hz70 = 2,
   LSM6DSO_937Hz91 = 3,
 } lsm6dso_ftype_ois_t;
-int32_t lsm6dso_aux_gy_lp1_bandwidth_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                           lsm6dso_ftype_ois_t val);
-int32_t lsm6dso_aux_gy_lp1_bandwidth_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                           lsm6dso_ftype_ois_t *val);
 
 typedef enum {
@@ -1958,18 +1932,18 @@ typedef enum {
   LSM6DSO_AUX_HP_Hz260   = 0x12,
   LSM6DSO_AUX_HP_1Hz040  = 0x13,
 } lsm6dso_hpm_ois_t;
-int32_t lsm6dso_aux_gy_hp_bandwidth_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                          lsm6dso_hpm_ois_t val);
-int32_t lsm6dso_aux_gy_hp_bandwidth_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                          lsm6dso_hpm_ois_t *val);
 
 typedef enum {
   LSM6DSO_ENABLE_CLAMP  = 0,
   LSM6DSO_DISABLE_CLAMP = 1,
 } lsm6dso_st_ois_clampdis_t;
-int32_t lsm6dso_aux_gy_clamp_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_clamp_set(stmdev_ctx_t *ctx,
                                  lsm6dso_st_ois_clampdis_t val);
-int32_t lsm6dso_aux_gy_clamp_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_clamp_get(stmdev_ctx_t *ctx,
                                  lsm6dso_st_ois_clampdis_t *val);
 
 typedef enum {
@@ -1977,9 +1951,9 @@ typedef enum {
   LSM6DSO_AUX_GY_POS     = 1,
   LSM6DSO_AUX_GY_NEG     = 3,
 } lsm6dso_st_ois_t;
-int32_t lsm6dso_aux_gy_self_test_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_self_test_set(stmdev_ctx_t *ctx,
                                      lsm6dso_st_ois_t val);
-int32_t lsm6dso_aux_gy_self_test_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_gy_self_test_get(stmdev_ctx_t *ctx,
                                      lsm6dso_st_ois_t *val);
 
 typedef enum {
@@ -1992,9 +1966,9 @@ typedef enum {
   LSM6DSO_8Hz30 = 6,
   LSM6DSO_4Hz15 = 7,
 } lsm6dso_filter_xl_conf_ois_t;
-int32_t lsm6dso_aux_xl_bandwidth_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_xl_bandwidth_set(stmdev_ctx_t *ctx,
                                      lsm6dso_filter_xl_conf_ois_t val);
-int32_t lsm6dso_aux_xl_bandwidth_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_xl_bandwidth_get(stmdev_ctx_t *ctx,
                                      lsm6dso_filter_xl_conf_ois_t *val);
 
 typedef enum {
@@ -2003,55 +1977,55 @@ typedef enum {
   LSM6DSO_AUX_4g  = 2,
   LSM6DSO_AUX_8g  = 3,
 } lsm6dso_fs_xl_ois_t;
-int32_t lsm6dso_aux_xl_full_scale_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
                                       lsm6dso_fs_xl_ois_t val);
-int32_t lsm6dso_aux_xl_full_scale_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
                                       lsm6dso_fs_xl_ois_t *val);
 
 typedef enum {
   LSM6DSO_PULL_UP_DISC       = 0,
   LSM6DSO_PULL_UP_CONNECT    = 1,
 } lsm6dso_sdo_pu_en_t;
-int32_t lsm6dso_sdo_sa0_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                  lsm6dso_sdo_pu_en_t val);
-int32_t lsm6dso_sdo_sa0_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                  lsm6dso_sdo_pu_en_t *val);
 
 typedef enum {
   LSM6DSO_SPI_4_WIRE = 0,
   LSM6DSO_SPI_3_WIRE = 1,
 } lsm6dso_sim_t;
-int32_t lsm6dso_spi_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_sim_t val);
-int32_t lsm6dso_spi_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_sim_t *val);
+int32_t lsm6dso_spi_mode_set(stmdev_ctx_t *ctx, lsm6dso_sim_t val);
+int32_t lsm6dso_spi_mode_get(stmdev_ctx_t *ctx, lsm6dso_sim_t *val);
 
 typedef enum {
   LSM6DSO_I2C_ENABLE  = 0,
   LSM6DSO_I2C_DISABLE = 1,
 } lsm6dso_i2c_disable_t;
-int32_t lsm6dso_i2c_interface_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_i2c_interface_set(stmdev_ctx_t *ctx,
                                   lsm6dso_i2c_disable_t val);
-int32_t lsm6dso_i2c_interface_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_i2c_interface_get(stmdev_ctx_t *ctx,
                                   lsm6dso_i2c_disable_t *val);
 
 typedef enum {
-  LSM6DSO_I3C_DISABLE         = 0x00,
-  LSM6DSO_I3C_ENABLE_T_50us   = 0x80,
-  LSM6DSO_I3C_ENABLE_T_2us    = 0x81,
-  LSM6DSO_I3C_ENABLE_T_1ms    = 0x82,
-  LSM6DSO_I3C_ENABLE_T_25ms   = 0x83,
+  LSM6DSO_I3C_DISABLE         = 0x80,
+  LSM6DSO_I3C_ENABLE_T_50us   = 0x00,
+  LSM6DSO_I3C_ENABLE_T_2us    = 0x01,
+  LSM6DSO_I3C_ENABLE_T_1ms    = 0x02,
+  LSM6DSO_I3C_ENABLE_T_25ms   = 0x03,
 } lsm6dso_i3c_disable_t;
-int32_t lsm6dso_i3c_disable_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_i3c_disable_set(stmdev_ctx_t *ctx,
                                 lsm6dso_i3c_disable_t val);
-int32_t lsm6dso_i3c_disable_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_i3c_disable_get(stmdev_ctx_t *ctx,
                                 lsm6dso_i3c_disable_t *val);
 
 typedef enum {
   LSM6DSO_PULL_DOWN_DISC       = 0,
   LSM6DSO_PULL_DOWN_CONNECT    = 1,
 } lsm6dso_int1_pd_en_t;
-int32_t lsm6dso_int1_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_int1_mode_set(stmdev_ctx_t *ctx,
                               lsm6dso_int1_pd_en_t val);
-int32_t lsm6dso_int1_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_int1_mode_get(stmdev_ctx_t *ctx,
                               lsm6dso_int1_pd_en_t *val);
 
 typedef struct {
@@ -2061,9 +2035,9 @@ typedef struct {
     lsm6dso_fsm_int1_a_t         fsm_int1_a;
     lsm6dso_fsm_int1_b_t         fsm_int1_b;
 } lsm6dso_pin_int1_route_t;
-int32_t lsm6dso_pin_int1_route_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm6dso_pin_int1_route_t *val);
-int32_t lsm6dso_pin_int1_route_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm6dso_pin_int1_route_t *val);
 
 typedef struct {
@@ -2073,29 +2047,29 @@ typedef struct {
   lsm6dso_fsm_int2_a_t         fsm_int2_a;
   lsm6dso_fsm_int2_b_t         fsm_int2_b;
 } lsm6dso_pin_int2_route_t;
-int32_t lsm6dso_pin_int2_route_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    lsm6dso_pin_int2_route_t *val);
-int32_t lsm6dso_pin_int2_route_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pin_int2_route_get(stmdev_ctx_t *ctx,
                                    lsm6dso_pin_int2_route_t *val);
 
 typedef enum {
   LSM6DSO_PUSH_PULL   = 0,
   LSM6DSO_OPEN_DRAIN  = 1,
 } lsm6dso_pp_od_t;
-int32_t lsm6dso_pin_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_pp_od_t val);
-int32_t lsm6dso_pin_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_pp_od_t *val);
+int32_t lsm6dso_pin_mode_set(stmdev_ctx_t *ctx, lsm6dso_pp_od_t val);
+int32_t lsm6dso_pin_mode_get(stmdev_ctx_t *ctx, lsm6dso_pp_od_t *val);
 
 typedef enum {
   LSM6DSO_ACTIVE_HIGH = 0,
   LSM6DSO_ACTIVE_LOW  = 1,
 } lsm6dso_h_lactive_t;
-int32_t lsm6dso_pin_polarity_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pin_polarity_set(stmdev_ctx_t *ctx,
                                  lsm6dso_h_lactive_t val);
-int32_t lsm6dso_pin_polarity_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pin_polarity_get(stmdev_ctx_t *ctx,
                                  lsm6dso_h_lactive_t *val);
 
-int32_t lsm6dso_all_on_int1_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_all_on_int1_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_ALL_INT_PULSED            = 0,
@@ -2103,37 +2077,37 @@ typedef enum {
   LSM6DSO_BASE_PULSED_EMB_LATCHED   = 2,
   LSM6DSO_ALL_INT_LATCHED           = 3,
 } lsm6dso_lir_t;
-int32_t lsm6dso_int_notification_set(lsm6dso_ctx_t *ctx, lsm6dso_lir_t val);
-int32_t lsm6dso_int_notification_get(lsm6dso_ctx_t *ctx, lsm6dso_lir_t *val);
+int32_t lsm6dso_int_notification_set(stmdev_ctx_t *ctx, lsm6dso_lir_t val);
+int32_t lsm6dso_int_notification_get(stmdev_ctx_t *ctx, lsm6dso_lir_t *val);
 
 typedef enum {
   LSM6DSO_LSb_FS_DIV_64       = 0,
   LSM6DSO_LSb_FS_DIV_256      = 1,
 } lsm6dso_wake_ths_w_t;
-int32_t lsm6dso_wkup_ths_weight_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_wkup_ths_weight_set(stmdev_ctx_t *ctx,
                                       lsm6dso_wake_ths_w_t val);
-int32_t lsm6dso_wkup_ths_weight_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_wkup_ths_weight_get(stmdev_ctx_t *ctx,
                                        lsm6dso_wake_ths_w_t *val);
 
-int32_t lsm6dso_wkup_threshold_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_wkup_threshold_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_xl_usr_offset_on_wkup_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_xl_usr_offset_on_wkup_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_wkup_dur_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_wkup_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_gy_sleep_mode_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_gy_sleep_mode_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_DRIVE_SLEEP_CHG_EVENT = 0,
   LSM6DSO_DRIVE_SLEEP_STATUS    = 1,
 } lsm6dso_sleep_status_on_int_t;
-int32_t lsm6dso_act_pin_notification_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_act_pin_notification_set(stmdev_ctx_t *ctx,
                                          lsm6dso_sleep_status_on_int_t val);
-int32_t lsm6dso_act_pin_notification_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_act_pin_notification_get(stmdev_ctx_t *ctx,
                                          lsm6dso_sleep_status_on_int_t *val);
 
 typedef enum {
@@ -2142,23 +2116,23 @@ typedef enum {
   LSM6DSO_XL_12Hz5_GY_SLEEP           = 2,
   LSM6DSO_XL_12Hz5_GY_PD              = 3,
 } lsm6dso_inact_en_t;
-int32_t lsm6dso_act_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_inact_en_t val);
-int32_t lsm6dso_act_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_inact_en_t *val);
+int32_t lsm6dso_act_mode_set(stmdev_ctx_t *ctx, lsm6dso_inact_en_t val);
+int32_t lsm6dso_act_mode_get(stmdev_ctx_t *ctx, lsm6dso_inact_en_t *val);
 
-int32_t lsm6dso_act_sleep_dur_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_act_sleep_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tap_detection_on_z_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_detection_on_z_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tap_detection_on_y_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_detection_on_y_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tap_detection_on_x_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_detection_on_x_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tap_threshold_x_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_threshold_x_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_XYZ = 0,
@@ -2168,33 +2142,33 @@ typedef enum {
   LSM6DSO_YZX = 5,
   LSM6DSO_ZXY = 6,
 } lsm6dso_tap_priority_t;
-int32_t lsm6dso_tap_axis_priority_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_tap_axis_priority_set(stmdev_ctx_t *ctx,
                                       lsm6dso_tap_priority_t val);
-int32_t lsm6dso_tap_axis_priority_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                       lsm6dso_tap_priority_t *val);
 
-int32_t lsm6dso_tap_threshold_y_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_threshold_y_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tap_threshold_z_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_threshold_z_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tap_shock_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_shock_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tap_quiet_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_quiet_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tap_dur_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tap_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_ONLY_SINGLE = 0,
   LSM6DSO_BOTH_SINGLE_DOUBLE = 1,
 } lsm6dso_single_double_tap_t;
-int32_t lsm6dso_tap_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_tap_mode_set(stmdev_ctx_t *ctx,
                              lsm6dso_single_double_tap_t val);
-int32_t lsm6dso_tap_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_tap_mode_get(stmdev_ctx_t *ctx,
                              lsm6dso_single_double_tap_t *val);
 
 typedef enum {
@@ -2203,11 +2177,11 @@ typedef enum {
   LSM6DSO_DEG_60  = 2,
   LSM6DSO_DEG_50  = 3,
 } lsm6dso_sixd_ths_t;
-int32_t lsm6dso_6d_threshold_set(lsm6dso_ctx_t *ctx, lsm6dso_sixd_ths_t val);
-int32_t lsm6dso_6d_threshold_get(lsm6dso_ctx_t *ctx, lsm6dso_sixd_ths_t *val);
+int32_t lsm6dso_6d_threshold_set(stmdev_ctx_t *ctx, lsm6dso_sixd_ths_t val);
+int32_t lsm6dso_6d_threshold_get(stmdev_ctx_t *ctx, lsm6dso_sixd_ths_t *val);
 
-int32_t lsm6dso_4d_mode_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_4d_mode_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_FF_TSH_156mg = 0,
@@ -2219,17 +2193,17 @@ typedef enum {
   LSM6DSO_FF_TSH_469mg = 6,
   LSM6DSO_FF_TSH_500mg = 7,
 } lsm6dso_ff_ths_t;
-int32_t lsm6dso_ff_threshold_set(lsm6dso_ctx_t *ctx, lsm6dso_ff_ths_t val);
-int32_t lsm6dso_ff_threshold_get(lsm6dso_ctx_t *ctx, lsm6dso_ff_ths_t *val);
+int32_t lsm6dso_ff_threshold_set(stmdev_ctx_t *ctx, lsm6dso_ff_ths_t val);
+int32_t lsm6dso_ff_threshold_get(stmdev_ctx_t *ctx, lsm6dso_ff_ths_t *val);
 
-int32_t lsm6dso_ff_dur_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_ff_dur_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_fifo_watermark_set(lsm6dso_ctx_t *ctx, uint16_t val);
-int32_t lsm6dso_fifo_watermark_get(lsm6dso_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dso_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dso_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dso_compression_algo_init_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_compression_algo_init_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_compression_algo_init_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_compression_algo_init_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_CMP_DISABLE  = 0x00,
@@ -2238,23 +2212,23 @@ typedef enum {
   LSM6DSO_CMP_16_TO_1  = 0x06,
   LSM6DSO_CMP_32_TO_1  = 0x07,
 } lsm6dso_uncoptr_rate_t;
-int32_t lsm6dso_compression_algo_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_compression_algo_set(stmdev_ctx_t *ctx,
                                      lsm6dso_uncoptr_rate_t val);
-int32_t lsm6dso_compression_algo_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_compression_algo_get(stmdev_ctx_t *ctx,
                                      lsm6dso_uncoptr_rate_t *val);
 
-int32_t lsm6dso_fifo_virtual_sens_odr_chg_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
                                               uint8_t val);
-int32_t lsm6dso_fifo_virtual_sens_odr_chg_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
-int32_t lsm6dso_compression_algo_real_time_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_compression_algo_real_time_set(stmdev_ctx_t *ctx,
                                                uint8_t val);
-int32_t lsm6dso_compression_algo_real_time_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_compression_algo_real_time_get(stmdev_ctx_t *ctx,
                                                uint8_t *val);
 
-int32_t lsm6dso_fifo_stop_on_wtm_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_fifo_stop_on_wtm_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_XL_NOT_BATCHED     	=  0,
@@ -2270,8 +2244,8 @@ typedef enum {
   LSM6DSO_XL_BATCHED_AT_6667Hz  = 10,
   LSM6DSO_XL_BATCHED_AT_6Hz5    = 11,
 } lsm6dso_bdr_xl_t;
-int32_t lsm6dso_fifo_xl_batch_set(lsm6dso_ctx_t *ctx, lsm6dso_bdr_xl_t val);
-int32_t lsm6dso_fifo_xl_batch_get(lsm6dso_ctx_t *ctx, lsm6dso_bdr_xl_t *val);
+int32_t lsm6dso_fifo_xl_batch_set(stmdev_ctx_t *ctx, lsm6dso_bdr_xl_t val);
+int32_t lsm6dso_fifo_xl_batch_get(stmdev_ctx_t *ctx, lsm6dso_bdr_xl_t *val);
 
 typedef enum {
   LSM6DSO_GY_NOT_BATCHED         = 0,
@@ -2287,8 +2261,8 @@ typedef enum {
   LSM6DSO_GY_BATCHED_AT_6667Hz   = 10,
   LSM6DSO_GY_BATCHED_AT_6Hz5     = 11,
 } lsm6dso_bdr_gy_t;
-int32_t lsm6dso_fifo_gy_batch_set(lsm6dso_ctx_t *ctx, lsm6dso_bdr_gy_t val);
-int32_t lsm6dso_fifo_gy_batch_get(lsm6dso_ctx_t *ctx, lsm6dso_bdr_gy_t *val);
+int32_t lsm6dso_fifo_gy_batch_set(stmdev_ctx_t *ctx, lsm6dso_bdr_gy_t val);
+int32_t lsm6dso_fifo_gy_batch_get(stmdev_ctx_t *ctx, lsm6dso_bdr_gy_t *val);
 
 typedef enum {
   LSM6DSO_BYPASS_MODE             = 0,
@@ -2298,8 +2272,8 @@ typedef enum {
   LSM6DSO_STREAM_MODE             = 6,
   LSM6DSO_BYPASS_TO_FIFO_MODE     = 7,
 } lsm6dso_fifo_mode_t;
-int32_t lsm6dso_fifo_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_fifo_mode_t val);
-int32_t lsm6dso_fifo_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_fifo_mode_t *val);
+int32_t lsm6dso_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dso_fifo_mode_t val);
+int32_t lsm6dso_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dso_fifo_mode_t *val);
 
 typedef enum {
   LSM6DSO_TEMP_NOT_BATCHED        = 0,
@@ -2307,9 +2281,9 @@ typedef enum {
   LSM6DSO_TEMP_BATCHED_AT_12Hz5   = 2,
   LSM6DSO_TEMP_BATCHED_AT_52Hz    = 3,
 } lsm6dso_odr_t_batch_t;
-int32_t lsm6dso_fifo_temp_batch_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_temp_batch_set(stmdev_ctx_t *ctx,
                                     lsm6dso_odr_t_batch_t val);
-int32_t lsm6dso_fifo_temp_batch_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_temp_batch_get(stmdev_ctx_t *ctx,
                                     lsm6dso_odr_t_batch_t *val);
 
 typedef enum {
@@ -2318,9 +2292,9 @@ typedef enum {
   LSM6DSO_DEC_8         = 2,
   LSM6DSO_DEC_32        = 3,
 } lsm6dso_odr_ts_batch_t;
-int32_t lsm6dso_fifo_timestamp_decimation_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
                                               lsm6dso_odr_ts_batch_t val);
-int32_t lsm6dso_fifo_timestamp_decimation_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
                                               lsm6dso_odr_ts_batch_t *val);
 
 typedef enum {
@@ -2352,47 +2326,47 @@ typedef enum {
   LSM6DSO_ROTATION_TAG,
   LSM6DSO_SENSORHUB_NACK_TAG	= 0x19,
 } lsm6dso_fifo_tag_t;
-int32_t lsm6dso_fifo_cnt_event_batch_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_cnt_event_batch_set(stmdev_ctx_t *ctx,
                                           lsm6dso_trig_counter_bdr_t val);
-int32_t lsm6dso_fifo_cnt_event_batch_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_cnt_event_batch_get(stmdev_ctx_t *ctx,
                                           lsm6dso_trig_counter_bdr_t *val);
 
-int32_t lsm6dso_rst_batch_counter_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_rst_batch_counter_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_batch_counter_threshold_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_batch_counter_threshold_set(stmdev_ctx_t *ctx,
                                             uint16_t val);
-int32_t lsm6dso_batch_counter_threshold_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_batch_counter_threshold_get(stmdev_ctx_t *ctx,
                                             uint16_t *val);
 
-int32_t lsm6dso_fifo_data_level_get(lsm6dso_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dso_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dso_fifo_status_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_status_get(stmdev_ctx_t *ctx,
                                 lsm6dso_fifo_status2_t *val);
 
-int32_t lsm6dso_fifo_full_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_fifo_ovr_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_fifo_wtm_flag_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_fifo_sensor_tag_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
 				    lsm6dso_fifo_tag_t *val);
 
-int32_t lsm6dso_fifo_pedo_batch_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_fifo_pedo_batch_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_sh_batch_slave_0_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_batch_slave_0_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_sh_batch_slave_0_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_sh_batch_slave_1_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_batch_slave_1_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_sh_batch_slave_1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_sh_batch_slave_2_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_batch_slave_2_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_sh_batch_slave_2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_sh_batch_slave_3_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_batch_slave_3_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_sh_batch_slave_3_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_batch_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_DEN_DISABLE    = 0,
@@ -2401,82 +2375,81 @@ typedef enum {
   LSM6DSO_LEVEL_TRIGGER  = 2,
   LSM6DSO_EDGE_TRIGGER   = 4,
 } lsm6dso_den_mode_t;
-int32_t lsm6dso_den_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_den_mode_t val);
-int32_t lsm6dso_den_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_den_mode_t *val);
+int32_t lsm6dso_den_mode_set(stmdev_ctx_t *ctx, lsm6dso_den_mode_t val);
+int32_t lsm6dso_den_mode_get(stmdev_ctx_t *ctx, lsm6dso_den_mode_t *val);
 
 typedef enum {
   LSM6DSO_DEN_ACT_LOW  = 0,
   LSM6DSO_DEN_ACT_HIGH = 1,
 } lsm6dso_den_lh_t;
-int32_t lsm6dso_den_polarity_set(lsm6dso_ctx_t *ctx, lsm6dso_den_lh_t val);
-int32_t lsm6dso_den_polarity_get(lsm6dso_ctx_t *ctx, lsm6dso_den_lh_t *val);
+int32_t lsm6dso_den_polarity_set(stmdev_ctx_t *ctx, lsm6dso_den_lh_t val);
+int32_t lsm6dso_den_polarity_get(stmdev_ctx_t *ctx, lsm6dso_den_lh_t *val);
 
 typedef enum {
   LSM6DSO_STAMP_IN_GY_DATA     = 0,
   LSM6DSO_STAMP_IN_XL_DATA     = 1,
   LSM6DSO_STAMP_IN_GY_XL_DATA  = 2,
 } lsm6dso_den_xl_g_t;
-int32_t lsm6dso_den_enable_set(lsm6dso_ctx_t *ctx, lsm6dso_den_xl_g_t val);
-int32_t lsm6dso_den_enable_get(lsm6dso_ctx_t *ctx, lsm6dso_den_xl_g_t *val);
+int32_t lsm6dso_den_enable_set(stmdev_ctx_t *ctx, lsm6dso_den_xl_g_t val);
+int32_t lsm6dso_den_enable_get(stmdev_ctx_t *ctx, lsm6dso_den_xl_g_t *val);
 
-int32_t lsm6dso_den_mark_axis_x_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_den_mark_axis_x_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_den_mark_axis_y_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_den_mark_axis_y_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_den_mark_axis_z_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_den_mark_axis_z_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_PEDO_DISABLE              = 0x00,
   LSM6DSO_PEDO_BASE_MODE            = 0x01,
-  LSM6DSO_PEDO_ADV_MODE             = 0x03,
   LSM6DSO_FALSE_STEP_REJ            = 0x13,
   LSM6DSO_FALSE_STEP_REJ_ADV_MODE   = 0x33,
 } lsm6dso_pedo_md_t;
-int32_t lsm6dso_pedo_sens_set(lsm6dso_ctx_t *ctx, lsm6dso_pedo_md_t val);
-int32_t lsm6dso_pedo_sens_get(lsm6dso_ctx_t *ctx, lsm6dso_pedo_md_t *val);
+int32_t lsm6dso_pedo_sens_set(stmdev_ctx_t *ctx, lsm6dso_pedo_md_t val);
+int32_t lsm6dso_pedo_sens_get(stmdev_ctx_t *ctx, lsm6dso_pedo_md_t *val);
 
-int32_t lsm6dso_pedo_step_detect_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_pedo_step_detect_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_pedo_debounce_steps_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pedo_debounce_steps_set(stmdev_ctx_t *ctx,
                                              uint8_t *buff);
-int32_t lsm6dso_pedo_debounce_steps_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pedo_debounce_steps_get(stmdev_ctx_t *ctx,
                                              uint8_t *buff);
 
-int32_t lsm6dso_pedo_steps_period_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_pedo_steps_period_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM6DSO_EVERY_STEP     = 0,
   LSM6DSO_COUNT_OVERFLOW = 1,
 } lsm6dso_carry_count_en_t;
-int32_t lsm6dso_pedo_int_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pedo_int_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dso_carry_count_en_t val);
-int32_t lsm6dso_pedo_int_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_pedo_int_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dso_carry_count_en_t *val);
 
-int32_t lsm6dso_motion_sens_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_motion_sens_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_motion_flag_data_ready_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_motion_flag_data_ready_get(stmdev_ctx_t *ctx,
                                                 uint8_t *val);
 
-int32_t lsm6dso_tilt_sens_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_tilt_sens_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_tilt_flag_data_ready_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_tilt_flag_data_ready_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
-int32_t lsm6dso_mag_sensitivity_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_mag_sensitivity_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_sensitivity_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_sensitivity_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_mag_offset_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_mag_offset_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dso_mag_soft_iron_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_mag_soft_iron_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM6DSO_Z_EQ_Y     = 0,
@@ -2486,9 +2459,9 @@ typedef enum {
   LSM6DSO_Z_EQ_MIN_Z = 4,
   LSM6DSO_Z_EQ_Z     = 5,
 } lsm6dso_mag_z_axis_t;
-int32_t lsm6dso_mag_z_orient_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_mag_z_orient_set(stmdev_ctx_t *ctx,
                                          lsm6dso_mag_z_axis_t val);
-int32_t lsm6dso_mag_z_orient_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_mag_z_orient_get(stmdev_ctx_t *ctx,
                                          lsm6dso_mag_z_axis_t *val);
 
 typedef enum {
@@ -2499,9 +2472,9 @@ typedef enum {
   LSM6DSO_Y_EQ_MIN_Z = 4,
   LSM6DSO_Y_EQ_Z     = 5,
 } lsm6dso_mag_y_axis_t;
-int32_t lsm6dso_mag_y_orient_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_mag_y_orient_set(stmdev_ctx_t *ctx,
                                          lsm6dso_mag_y_axis_t val);
-int32_t lsm6dso_mag_y_orient_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_mag_y_orient_get(stmdev_ctx_t *ctx,
                                          lsm6dso_mag_y_axis_t *val);
 
 typedef enum {
@@ -2512,36 +2485,36 @@ typedef enum {
   LSM6DSO_X_EQ_MIN_Z = 4,
   LSM6DSO_X_EQ_Z     = 5,
 } lsm6dso_mag_x_axis_t;
-int32_t lsm6dso_mag_x_orient_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_mag_x_orient_set(stmdev_ctx_t *ctx,
                                          lsm6dso_mag_x_axis_t val);
-int32_t lsm6dso_mag_x_orient_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_mag_x_orient_get(stmdev_ctx_t *ctx,
                                          lsm6dso_mag_x_axis_t *val);
 
-int32_t lsm6dso_long_cnt_flag_data_ready_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_long_cnt_flag_data_ready_get(stmdev_ctx_t *ctx,
                                              uint8_t *val);
 
-int32_t lsm6dso_emb_fsm_en_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_emb_fsm_en_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_emb_fsm_en_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_emb_fsm_en_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
     lsm6dso_fsm_enable_a_t          fsm_enable_a;
     lsm6dso_fsm_enable_b_t          fsm_enable_b;
 } lsm6dso_emb_fsm_enable_t;
-int32_t lsm6dso_fsm_enable_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fsm_enable_set(stmdev_ctx_t *ctx,
                                lsm6dso_emb_fsm_enable_t *val);
-int32_t lsm6dso_fsm_enable_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_fsm_enable_get(stmdev_ctx_t *ctx,
                                lsm6dso_emb_fsm_enable_t *val);
 
-int32_t lsm6dso_long_cnt_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_long_cnt_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_long_cnt_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_long_cnt_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM6DSO_LC_NORMAL     = 0,
   LSM6DSO_LC_CLEAR      = 1,
   LSM6DSO_LC_CLEAR_DONE = 2,
 } lsm6dso_fsm_lc_clr_t;
-int32_t lsm6dso_long_clr_set(lsm6dso_ctx_t *ctx, lsm6dso_fsm_lc_clr_t val);
-int32_t lsm6dso_long_clr_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_lc_clr_t *val);
+int32_t lsm6dso_long_clr_set(stmdev_ctx_t *ctx, lsm6dso_fsm_lc_clr_t val);
+int32_t lsm6dso_long_clr_get(stmdev_ctx_t *ctx, lsm6dso_fsm_lc_clr_t *val);
 
 typedef struct {
     lsm6dso_fsm_outs1_t    fsm_outs1;
@@ -2552,16 +2525,16 @@ typedef struct {
     lsm6dso_fsm_outs6_t    fsm_outs6;
     lsm6dso_fsm_outs7_t    fsm_outs7;
     lsm6dso_fsm_outs8_t    fsm_outs8;
-    lsm6dso_fsm_outs1_t    fsm_outs9;
-    lsm6dso_fsm_outs2_t    fsm_outs10;
-    lsm6dso_fsm_outs3_t    fsm_outs11;
-    lsm6dso_fsm_outs4_t    fsm_outs12;
-    lsm6dso_fsm_outs5_t    fsm_outs13;
-    lsm6dso_fsm_outs6_t    fsm_outs14;
-    lsm6dso_fsm_outs7_t    fsm_outs15;
-    lsm6dso_fsm_outs8_t    fsm_outs16;
+    lsm6dso_fsm_outs9_t    fsm_outs9;
+    lsm6dso_fsm_outs10_t   fsm_outs10;
+    lsm6dso_fsm_outs11_t   fsm_outs11;
+    lsm6dso_fsm_outs12_t   fsm_outs12;
+    lsm6dso_fsm_outs13_t   fsm_outs13;
+    lsm6dso_fsm_outs14_t   fsm_outs14;
+    lsm6dso_fsm_outs15_t   fsm_outs15;
+    lsm6dso_fsm_outs16_t   fsm_outs16;
 } lsm6dso_fsm_out_t;
-int32_t lsm6dso_fsm_out_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_out_t *val);
+int32_t lsm6dso_fsm_out_get(stmdev_ctx_t *ctx, lsm6dso_fsm_out_t *val);
 
 typedef enum {
   LSM6DSO_ODR_FSM_12Hz5 = 0,
@@ -2569,43 +2542,23 @@ typedef enum {
   LSM6DSO_ODR_FSM_52Hz  = 2,
   LSM6DSO_ODR_FSM_104Hz = 3,
 } lsm6dso_fsm_odr_t;
-int32_t lsm6dso_fsm_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_fsm_odr_t val);
-int32_t lsm6dso_fsm_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_fsm_odr_t *val);
+int32_t lsm6dso_fsm_data_rate_set(stmdev_ctx_t *ctx, lsm6dso_fsm_odr_t val);
+int32_t lsm6dso_fsm_data_rate_get(stmdev_ctx_t *ctx, lsm6dso_fsm_odr_t *val);
 
-int32_t lsm6dso_fsm_init_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_fsm_init_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_long_cnt_int_value_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_long_cnt_int_value_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_long_cnt_int_value_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dso_long_cnt_int_value_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dso_fsm_number_of_programs_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_fsm_number_of_programs_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_fsm_number_of_programs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_fsm_number_of_programs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dso_fsm_start_address_set(lsm6dso_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dso_fsm_start_address_get(lsm6dso_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dso_fsm_start_address_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dso_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-typedef struct {
-    lsm6dso_sensor_hub_1_t   sh_byte_1;
-    lsm6dso_sensor_hub_2_t   sh_byte_2;
-    lsm6dso_sensor_hub_3_t   sh_byte_3;
-    lsm6dso_sensor_hub_4_t   sh_byte_4;
-    lsm6dso_sensor_hub_5_t   sh_byte_5;
-    lsm6dso_sensor_hub_6_t   sh_byte_6;
-    lsm6dso_sensor_hub_7_t   sh_byte_7;
-    lsm6dso_sensor_hub_8_t   sh_byte_8;
-    lsm6dso_sensor_hub_9_t   sh_byte_9;
-    lsm6dso_sensor_hub_10_t  sh_byte_10;
-    lsm6dso_sensor_hub_11_t  sh_byte_11;
-    lsm6dso_sensor_hub_12_t  sh_byte_12;
-    lsm6dso_sensor_hub_13_t  sh_byte_13;
-    lsm6dso_sensor_hub_14_t  sh_byte_14;
-    lsm6dso_sensor_hub_15_t  sh_byte_15;
-    lsm6dso_sensor_hub_16_t  sh_byte_16;
-    lsm6dso_sensor_hub_17_t  sh_byte_17;
-    lsm6dso_sensor_hub_18_t  sh_byte_18;
-} lsm6dso_emb_sh_read_t;
-int32_t lsm6dso_sh_read_data_raw_get(lsm6dso_ctx_t *ctx,
-                                     lsm6dso_emb_sh_read_t *val);
+int32_t lsm6dso_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
+                                     uint8_t len);
 
 typedef enum {
   LSM6DSO_SLV_0       = 0,
@@ -2613,44 +2566,44 @@ typedef enum {
   LSM6DSO_SLV_0_1_2   = 2,
   LSM6DSO_SLV_0_1_2_3 = 3,
 } lsm6dso_aux_sens_on_t;
-int32_t lsm6dso_sh_slave_connected_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_slave_connected_set(stmdev_ctx_t *ctx,
                                        lsm6dso_aux_sens_on_t val);
-int32_t lsm6dso_sh_slave_connected_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_slave_connected_get(stmdev_ctx_t *ctx,
                                        lsm6dso_aux_sens_on_t *val);
 
-int32_t lsm6dso_sh_master_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_master_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_EXT_PULL_UP      = 0,
   LSM6DSO_INTERNAL_PULL_UP = 1,
 } lsm6dso_shub_pu_en_t;
-int32_t lsm6dso_sh_pin_mode_set(lsm6dso_ctx_t *ctx, lsm6dso_shub_pu_en_t val);
-int32_t lsm6dso_sh_pin_mode_get(lsm6dso_ctx_t *ctx, lsm6dso_shub_pu_en_t *val);
+int32_t lsm6dso_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6dso_shub_pu_en_t val);
+int32_t lsm6dso_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6dso_shub_pu_en_t *val);
 
-int32_t lsm6dso_sh_pass_through_set(lsm6dso_ctx_t *ctx, uint8_t val);
-int32_t lsm6dso_sh_pass_through_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dso_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_EXT_ON_INT2_PIN = 0,
   LSM6DSO_XL_GY_DRDY      = 1,
 } lsm6dso_start_config_t;
-int32_t lsm6dso_sh_syncro_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dso_start_config_t val);
-int32_t lsm6dso_sh_syncro_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dso_start_config_t *val);
 
 typedef enum {
   LSM6DSO_EACH_SH_CYCLE    = 0,
   LSM6DSO_ONLY_FIRST_CYCLE = 1,
 } lsm6dso_write_once_t;
-int32_t lsm6dso_sh_write_mode_set(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_write_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dso_write_once_t val);
-int32_t lsm6dso_sh_write_mode_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_write_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dso_write_once_t *val);
 
-int32_t lsm6dso_sh_reset_set(lsm6dso_ctx_t *ctx);
-int32_t lsm6dso_sh_reset_get(lsm6dso_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dso_sh_reset_set(stmdev_ctx_t *ctx);
+int32_t lsm6dso_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSO_SH_ODR_104Hz = 0,
@@ -2658,31 +2611,31 @@ typedef enum {
   LSM6DSO_SH_ODR_26Hz  = 2,
   LSM6DSO_SH_ODR_13Hz  = 3,
 } lsm6dso_shub_odr_t;
-int32_t lsm6dso_sh_data_rate_set(lsm6dso_ctx_t *ctx, lsm6dso_shub_odr_t val);
-int32_t lsm6dso_sh_data_rate_get(lsm6dso_ctx_t *ctx, lsm6dso_shub_odr_t *val);
+int32_t lsm6dso_sh_data_rate_set(stmdev_ctx_t *ctx, lsm6dso_shub_odr_t val);
+int32_t lsm6dso_sh_data_rate_get(stmdev_ctx_t *ctx, lsm6dso_shub_odr_t *val);
 
 typedef struct{
   uint8_t   slv0_add;
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } lsm6dso_sh_cfg_write_t;
-int32_t lsm6dso_sh_cfg_write(lsm6dso_ctx_t *ctx, lsm6dso_sh_cfg_write_t *val);
+int32_t lsm6dso_sh_cfg_write(stmdev_ctx_t *ctx, lsm6dso_sh_cfg_write_t *val);
 
 typedef struct{
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dso_sh_cfg_read_t;
-int32_t lsm6dso_sh_slv0_cfg_read(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dso_sh_cfg_read_t *val);
-int32_t lsm6dso_sh_slv1_cfg_read(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dso_sh_cfg_read_t *val);
-int32_t lsm6dso_sh_slv2_cfg_read(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dso_sh_cfg_read_t *val);
-int32_t lsm6dso_sh_slv3_cfg_read(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dso_sh_cfg_read_t *val);
 
-int32_t lsm6dso_sh_status_get(lsm6dso_ctx_t *ctx,
+int32_t lsm6dso_sh_status_get(stmdev_ctx_t *ctx,
                               lsm6dso_status_master_t *val);
 
 /**

--- a/sensor/stmemsc/lsm6dsox_STdC/driver/lsm6dsox_reg.h
+++ b/sensor/stmemsc/lsm6dsox_STdC/driver/lsm6dsox_reg.h
@@ -1,43 +1,26 @@
 /*
  ******************************************************************************
  * @file    lsm6dsox_reg.h
- * @author  Sensor Solutions Software Team
+ * @author  Sensors Software Solution Team
  * @brief   This file contains all the functions prototypes for the
  *          lsm6dsox_reg.c driver.
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef LSM6DSOX_DRIVER_H
-#define LSM6DSOX_DRIVER_H
+#ifndef LSM6DSOX_REGS_H
+#define LSM6DSOX_REGS_H
 
 #ifdef __cplusplus
   extern "C" {
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup LSM6DSOX_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LSM6DSOX_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lsm6dsox_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lsm6dsox_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lsm6dsox_write_ptr  write_reg;
-  lsm6dsox_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lsm6dsox_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -457,7 +429,7 @@ typedef struct {
   uint8_t is_fsm16                : 1;
 } lsm6dsox_fsm_status_b_mainpage_t;
 
-#define LSM6DSOX_PROGSENS_STATUS_MAINPAGE     0x38U
+#define LSM6DSOX_MLC_STATUS_MAINPAGE     0x38U
 typedef struct {
   uint8_t is_mlc1             : 1;
   uint8_t is_mlc2             : 1;
@@ -467,7 +439,7 @@ typedef struct {
   uint8_t is_mlc6             : 1;
   uint8_t is_mlc7             : 1;
   uint8_t is_mlc8             : 1;
-} lsm6dsox_progsens_status_mainpage_t;
+} lsm6dsox_mlc_status_mainpage_t;
 
 #define LSM6DSOX_STATUS_MASTER_MAINPAGE       0x39U
 typedef struct {
@@ -502,7 +474,7 @@ typedef struct {
 #define LSM6DSOX_TIMESTAMP3                   0x43U
 #define LSM6DSOX_UI_STATUS_REG_OIS            0x49U
 typedef struct {
-  uint8_t xlda                     : 3;
+  uint8_t xlda                     : 1;
   uint8_t gda                      : 1;
   uint8_t gyro_settling            : 1;
   uint8_t not_used_01              : 5;
@@ -632,7 +604,7 @@ typedef struct {
 typedef struct {
   uint8_t not_used_01              : 3;
   uint8_t spi2_read_en             : 1;
-  uint8_t not_used_02              : 1;  
+  uint8_t not_used_02              : 1;
   uint8_t den_lh_ois               : 1;
   uint8_t lvl2_ois                 : 1;
   uint8_t int2_drdy_ois            : 1;
@@ -1574,6 +1546,8 @@ typedef struct {
   uint8_t wr_once_done             : 1;
 } lsm6dsox_status_master_t;
 
+#define LSM6DSOX_START_FSM_ADD                0x0400U
+
 /**
   * @defgroup LSM6DSOX_Register_Union
   * @brief    This union group all the registers that has a bitfield
@@ -1657,7 +1631,7 @@ typedef union{
   lsm6dsox_fsm_status_a_t                  fsm_status_a;
   lsm6dsox_fsm_status_b_t                  fsm_status_b;
   lsm6dsox_page_rw_t                       page_rw;
-  lsm6dsox_emb_func_fifo_cfg_t	           emb_func_fifo_cfg;
+  lsm6dsox_emb_func_fifo_cfg_t             emb_func_fifo_cfg;
   lsm6dsox_fsm_enable_a_t                  fsm_enable_a;
   lsm6dsox_fsm_enable_b_t                  fsm_enable_b;
   lsm6dsox_fsm_long_counter_clear_t        fsm_long_counter_clear;
@@ -1678,7 +1652,7 @@ typedef union{
   lsm6dsox_fsm_outs15_t                    fsm_outs15;
   lsm6dsox_fsm_outs16_t                    fsm_outs16;
   lsm6dsox_emb_func_odr_cfg_b_t            emb_func_odr_cfg_b;
-  lsm6dsox_emb_func_odr_cfg_c_t            emb_func_odr_cfg_c;  
+  lsm6dsox_emb_func_odr_cfg_c_t            emb_func_odr_cfg_c;
   lsm6dsox_emb_func_src_t                  emb_func_src;
   lsm6dsox_emb_func_init_a_t               emb_func_init_a;
   lsm6dsox_emb_func_init_b_t               emb_func_init_b;
@@ -1727,9 +1701,9 @@ typedef union{
   *
   */
 
-int32_t lsm6dsox_read_reg(lsm6dsox_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsox_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t lsm6dsox_write_reg(lsm6dsox_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm6dsox_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float_t lsm6dsox_from_fs2_to_mg(int16_t lsb);
@@ -1750,8 +1724,8 @@ typedef enum {
   LSM6DSOX_4g   = 2,
   LSM6DSOX_8g   = 3,
 } lsm6dsox_fs_xl_t;
-int32_t lsm6dsox_xl_full_scale_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_xl_t val);
-int32_t lsm6dsox_xl_full_scale_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_xl_t *val);
+int32_t lsm6dsox_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6dsox_fs_xl_t val);
+int32_t lsm6dsox_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6dsox_fs_xl_t *val);
 
 typedef enum {
   LSM6DSOX_XL_ODR_OFF    = 0,
@@ -1767,8 +1741,8 @@ typedef enum {
   LSM6DSOX_XL_ODR_6667Hz = 10,
   LSM6DSOX_XL_ODR_6Hz5   = 11, /* (low power only) */
 } lsm6dsox_odr_xl_t;
-int32_t lsm6dsox_xl_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_xl_t val);
-int32_t lsm6dsox_xl_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_xl_t *val);
+int32_t lsm6dsox_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dsox_odr_xl_t val);
+int32_t lsm6dsox_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dsox_odr_xl_t *val);
 
 typedef enum {
   LSM6DSOX_250dps   = 0,
@@ -1777,8 +1751,8 @@ typedef enum {
   LSM6DSOX_1000dps  = 4,
   LSM6DSOX_2000dps  = 6,
 } lsm6dsox_fs_g_t;
-int32_t lsm6dsox_gy_full_scale_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_g_t val);
-int32_t lsm6dsox_gy_full_scale_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fs_g_t *val);
+int32_t lsm6dsox_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6dsox_fs_g_t val);
+int32_t lsm6dsox_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6dsox_fs_g_t *val);
 
 typedef enum {
   LSM6DSOX_GY_ODR_OFF    = 0,
@@ -1793,19 +1767,19 @@ typedef enum {
   LSM6DSOX_GY_ODR_3333Hz = 9,
   LSM6DSOX_GY_ODR_6667Hz = 10,
 } lsm6dsox_odr_g_t;
-int32_t lsm6dsox_gy_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_g_t val);
-int32_t lsm6dsox_gy_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_odr_g_t *val);
+int32_t lsm6dsox_gy_data_rate_set(stmdev_ctx_t *ctx, lsm6dsox_odr_g_t val);
+int32_t lsm6dsox_gy_data_rate_get(stmdev_ctx_t *ctx, lsm6dsox_odr_g_t *val);
 
-int32_t lsm6dsox_block_data_update_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_block_data_update_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_LSb_1mg  = 0,
   LSM6DSOX_LSb_16mg = 1,
 } lsm6dsox_usr_off_w_t;
-int32_t lsm6dsox_xl_offset_weight_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_xl_offset_weight_set(stmdev_ctx_t *ctx,
                                       lsm6dsox_usr_off_w_t val);
-int32_t lsm6dsox_xl_offset_weight_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_xl_offset_weight_get(stmdev_ctx_t *ctx,
                                       lsm6dsox_usr_off_w_t *val);
 
 typedef enum {
@@ -1813,58 +1787,59 @@ typedef enum {
   LSM6DSOX_LOW_NORMAL_POWER_MD  = 1,
   LSM6DSOX_ULTRA_LOW_POWER_MD   = 2,
 } lsm6dsox_xl_hm_mode_t;
-int32_t lsm6dsox_xl_power_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_xl_power_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsox_xl_hm_mode_t val);
-int32_t lsm6dsox_xl_power_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_xl_power_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsox_xl_hm_mode_t *val);
 
 typedef enum {
   LSM6DSOX_GY_HIGH_PERFORMANCE  = 0,
   LSM6DSOX_GY_NORMAL            = 1,
 } lsm6dsox_g_hm_mode_t;
-int32_t lsm6dsox_gy_power_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_gy_power_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsox_g_hm_mode_t val);
-int32_t lsm6dsox_gy_power_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_gy_power_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsox_g_hm_mode_t *val);
 
 typedef struct {
-  lsm6dsox_all_int_src_t       all_int_src;
-  lsm6dsox_wake_up_src_t       wake_up_src;
-  lsm6dsox_tap_src_t           tap_src;
-  lsm6dsox_d6d_src_t           d6d_src;
-  lsm6dsox_status_reg_t        status_reg;
-  lsm6dsox_emb_func_status_t   emb_func_status;
-  lsm6dsox_fsm_status_a_t      fsm_status_a;
-  lsm6dsox_fsm_status_b_t      fsm_status_b;
+  lsm6dsox_all_int_src_t           all_int_src;
+  lsm6dsox_wake_up_src_t           wake_up_src;
+  lsm6dsox_tap_src_t               tap_src;
+  lsm6dsox_d6d_src_t               d6d_src;
+  lsm6dsox_status_reg_t            status_reg;
+  lsm6dsox_emb_func_status_t       emb_func_status;
+  lsm6dsox_fsm_status_a_t          fsm_status_a;
+  lsm6dsox_fsm_status_b_t          fsm_status_b;
+  lsm6dsox_mlc_status_mainpage_t   mlc_status;
 } lsm6dsox_all_sources_t;
-int32_t lsm6dsox_all_sources_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_all_sources_get(stmdev_ctx_t *ctx,
                                  lsm6dsox_all_sources_t *val);
 
-int32_t lsm6dsox_status_reg_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_status_reg_get(stmdev_ctx_t *ctx,
                                 lsm6dsox_status_reg_t *val);
 
-int32_t lsm6dsox_xl_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_gy_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_temp_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_xl_usr_offset_x_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_xl_usr_offset_x_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_xl_usr_offset_y_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_xl_usr_offset_y_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_xl_usr_offset_z_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_xl_usr_offset_z_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_xl_usr_offset_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_xl_usr_offset_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_timestamp_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_timestamp_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_timestamp_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM6DSOX_NO_ROUND      = 0,
@@ -1872,110 +1847,110 @@ typedef enum {
   LSM6DSOX_ROUND_GY      = 2,
   LSM6DSOX_ROUND_GY_XL   = 3,
 } lsm6dsox_rounding_t;
-int32_t lsm6dsox_rounding_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_rounding_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsox_rounding_t val);
-int32_t lsm6dsox_rounding_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_rounding_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsox_rounding_t *val);
 
 typedef enum {
   LSM6DSOX_STAT_RND_DISABLE  = 0,
   LSM6DSOX_STAT_RND_ENABLE   = 1,
 } lsm6dsox_rounding_status_t;
-int32_t lsm6dsox_rounding_on_status_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_rounding_on_status_set(stmdev_ctx_t *ctx,
                                         lsm6dsox_rounding_status_t val);
-int32_t lsm6dsox_rounding_on_status_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_rounding_on_status_get(stmdev_ctx_t *ctx,
                                         lsm6dsox_rounding_status_t *val);
 
-int32_t lsm6dsox_temperature_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_fifo_out_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_ois_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_ois_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_ois_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_aux_temperature_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_aux_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_aux_ois_angular_rate_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_aux_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_aux_ois_acceleration_raw_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_aux_ois_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_number_of_steps_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_steps_reset(lsm6dsox_ctx_t *ctx);
+int32_t lsm6dsox_steps_reset(stmdev_ctx_t *ctx);
 
-int32_t lsm6dsox_mlc_out_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mlc_out_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_odr_cal_reg_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_odr_cal_reg_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_USER_BANK           = 0,
   LSM6DSOX_SENSOR_HUB_BANK     = 1,
   LSM6DSOX_EMBEDDED_FUNC_BANK  = 2,
 } lsm6dsox_reg_access_t;
-int32_t lsm6dsox_mem_bank_set(lsm6dsox_ctx_t *ctx, lsm6dsox_reg_access_t val);
-int32_t lsm6dsox_mem_bank_get(lsm6dsox_ctx_t *ctx, lsm6dsox_reg_access_t *val);
+int32_t lsm6dsox_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsox_reg_access_t val);
+int32_t lsm6dsox_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsox_reg_access_t *val);
 
-int32_t lsm6dsox_ln_pg_write_byte(lsm6dsox_ctx_t *ctx, uint16_t address,
+int32_t lsm6dsox_ln_pg_write_byte(stmdev_ctx_t *ctx, uint16_t address,
                                   uint8_t *val);
-int32_t lsm6dsox_ln_pg_read_byte(lsm6dsox_ctx_t *ctx, uint16_t address,
+int32_t lsm6dsox_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t address,
                                  uint8_t *val);
-                                
-int32_t lsm6dsox_ln_pg_write(lsm6dsox_ctx_t *ctx, uint16_t address,
+
+int32_t lsm6dsox_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
                              uint8_t *buf, uint8_t len);
-int32_t lsm6dsox_ln_pg_read(lsm6dsox_ctx_t *ctx, uint16_t address,
+int32_t lsm6dsox_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address,
                             uint8_t *val);
 
 typedef enum {
   LSM6DSOX_DRDY_LATCHED = 0,
   LSM6DSOX_DRDY_PULSED  = 1,
 } lsm6dsox_dataready_pulsed_t;
-int32_t lsm6dsox_data_ready_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_data_ready_mode_set(stmdev_ctx_t *ctx,
                                      lsm6dsox_dataready_pulsed_t val);
-int32_t lsm6dsox_data_ready_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_data_ready_mode_get(stmdev_ctx_t *ctx,
                                      lsm6dsox_dataready_pulsed_t *val);
 
-int32_t lsm6dsox_device_id_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_reset_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_reset_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_auto_increment_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_auto_increment_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_boot_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_boot_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_XL_ST_DISABLE  = 0,
   LSM6DSOX_XL_ST_POSITIVE = 1,
   LSM6DSOX_XL_ST_NEGATIVE = 2,
 } lsm6dsox_st_xl_t;
-int32_t lsm6dsox_xl_self_test_set(lsm6dsox_ctx_t *ctx, lsm6dsox_st_xl_t val);
-int32_t lsm6dsox_xl_self_test_get(lsm6dsox_ctx_t *ctx, lsm6dsox_st_xl_t *val);
+int32_t lsm6dsox_xl_self_test_set(stmdev_ctx_t *ctx, lsm6dsox_st_xl_t val);
+int32_t lsm6dsox_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dsox_st_xl_t *val);
 
 typedef enum {
   LSM6DSOX_GY_ST_DISABLE  = 0,
   LSM6DSOX_GY_ST_POSITIVE = 1,
   LSM6DSOX_GY_ST_NEGATIVE = 3,
 } lsm6dsox_st_g_t;
-int32_t lsm6dsox_gy_self_test_set(lsm6dsox_ctx_t *ctx, lsm6dsox_st_g_t val);
-int32_t lsm6dsox_gy_self_test_get(lsm6dsox_ctx_t *ctx, lsm6dsox_st_g_t *val);
+int32_t lsm6dsox_gy_self_test_set(stmdev_ctx_t *ctx, lsm6dsox_st_g_t val);
+int32_t lsm6dsox_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dsox_st_g_t *val);
 
-int32_t lsm6dsox_xl_filter_lp2_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_xl_filter_lp2_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_gy_filter_lp1_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_gy_filter_lp1_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_gy_filter_lp1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_gy_filter_lp1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_filter_settling_mask_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_filter_settling_mask_set(stmdev_ctx_t *ctx,
                                           uint8_t val);
-int32_t lsm6dsox_filter_settling_mask_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_filter_settling_mask_get(stmdev_ctx_t *ctx,
                                           uint8_t *val);
 
 typedef enum {
@@ -1988,13 +1963,13 @@ typedef enum {
   LSM6DSOX_AGGRESSIVE   = 6,
   LSM6DSOX_XTREME       = 7,
 } lsm6dsox_ftype_t;
-int32_t lsm6dsox_gy_lp1_bandwidth_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                       lsm6dsox_ftype_t val);
-int32_t lsm6dsox_gy_lp1_bandwidth_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                       lsm6dsox_ftype_t *val);
 
-int32_t lsm6dsox_xl_lp2_on_6d_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_xl_lp2_on_6d_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_xl_lp2_on_6d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_lp2_on_6d_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_HP_PATH_DISABLE_ON_OUT    = 0x00,
@@ -2021,21 +1996,21 @@ typedef enum {
   LSM6DSOX_LP_ODR_DIV_400            = 0x06,
   LSM6DSOX_LP_ODR_DIV_800            = 0x07,
 } lsm6dsox_hp_slope_xl_en_t;
-int32_t lsm6dsox_xl_hp_path_on_out_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
                                        lsm6dsox_hp_slope_xl_en_t val);
-int32_t lsm6dsox_xl_hp_path_on_out_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
                                        lsm6dsox_hp_slope_xl_en_t *val);
 
-int32_t lsm6dsox_xl_fast_settling_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_xl_fast_settling_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_USE_SLOPE = 0,
   LSM6DSOX_USE_HPF   = 1,
 } lsm6dsox_slope_fds_t;
-int32_t lsm6dsox_xl_hp_path_internal_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
                                          lsm6dsox_slope_fds_t val);
-int32_t lsm6dsox_xl_hp_path_internal_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
                                          lsm6dsox_slope_fds_t *val);
 
 typedef enum {
@@ -2045,9 +2020,9 @@ typedef enum {
   LSM6DSOX_HP_FILTER_260mHz   = 0x82,
   LSM6DSOX_HP_FILTER_1Hz04    = 0x83,
 } lsm6dsox_hpm_g_t;
-int32_t lsm6dsox_gy_hp_path_internal_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_gy_hp_path_internal_set(stmdev_ctx_t *ctx,
                                          lsm6dsox_hpm_g_t val);
-int32_t lsm6dsox_gy_hp_path_internal_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_gy_hp_path_internal_get(stmdev_ctx_t *ctx,
                                          lsm6dsox_hpm_g_t *val);
 
 typedef enum {
@@ -2056,52 +2031,52 @@ typedef enum {
   LSM6DSOX_OIS_CTRL_UI_AUX_DATA_UI       = 0x02,
   LSM6DSOX_OIS_CTRL_UI_AUX_DATA_UI_AUX   = 0x03,
 } lsm6dsox_spi2_read_en_t;
-int32_t lsm6dsox_ois_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_ois_mode_set(stmdev_ctx_t *ctx,
                               lsm6dsox_spi2_read_en_t val);
-int32_t lsm6dsox_ois_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_ois_mode_get(stmdev_ctx_t *ctx,
                               lsm6dsox_spi2_read_en_t *val);
 
 typedef enum {
   LSM6DSOX_AUX_PULL_UP_DISC       = 0,
   LSM6DSOX_AUX_PULL_UP_CONNECT    = 1,
 } lsm6dsox_ois_pu_dis_t;
-int32_t lsm6dsox_aux_sdo_ocs_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_sdo_ocs_mode_set(stmdev_ctx_t *ctx,
                                       lsm6dsox_ois_pu_dis_t val);
-int32_t lsm6dsox_aux_sdo_ocs_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_sdo_ocs_mode_get(stmdev_ctx_t *ctx,
                                       lsm6dsox_ois_pu_dis_t *val);
 
 typedef enum {
   LSM6DSOX_AUX_ON                    = 1,
   LSM6DSOX_AUX_ON_BY_AUX_INTERFACE   = 0,
 } lsm6dsox_ois_on_t;
-int32_t lsm6dsox_aux_pw_on_ctrl_set(lsm6dsox_ctx_t *ctx, lsm6dsox_ois_on_t val);
-int32_t lsm6dsox_aux_pw_on_ctrl_get(lsm6dsox_ctx_t *ctx, lsm6dsox_ois_on_t *val);
+int32_t lsm6dsox_aux_pw_on_ctrl_set(stmdev_ctx_t *ctx, lsm6dsox_ois_on_t val);
+int32_t lsm6dsox_aux_pw_on_ctrl_get(stmdev_ctx_t *ctx, lsm6dsox_ois_on_t *val);
 
 typedef enum {
   LSM6DSOX_USE_SAME_XL_FS        = 0,
   LSM6DSOX_USE_DIFFERENT_XL_FS   = 1,
 } lsm6dsox_xl_fs_mode_t;
-int32_t lsm6dsox_aux_xl_fs_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_xl_fs_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dsox_xl_fs_mode_t val);
-int32_t lsm6dsox_aux_xl_fs_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_xl_fs_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dsox_xl_fs_mode_t *val);
 
-int32_t lsm6dsox_aux_status_reg_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_status_reg_get(stmdev_ctx_t *ctx,
                                     lsm6dsox_spi2_status_reg_ois_t *val);
 
-int32_t lsm6dsox_aux_xl_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_aux_gy_flag_data_ready_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_aux_gy_flag_settling_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_aux_gy_flag_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_AUX_DEN_ACTIVE_LOW     = 0,
   LSM6DSOX_AUX_DEN_ACTIVE_HIGH    = 1,
 } lsm6dsox_den_lh_ois_t;
-int32_t lsm6dsox_aux_den_polarity_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_den_polarity_set(stmdev_ctx_t *ctx,
                                       lsm6dsox_den_lh_ois_t val);
-int32_t lsm6dsox_aux_den_polarity_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_den_polarity_get(stmdev_ctx_t *ctx,
                                       lsm6dsox_den_lh_ois_t *val);
 
 typedef enum {
@@ -2109,22 +2084,22 @@ typedef enum {
   LSM6DSOX_AUX_DEN_LEVEL_LATCH     = 3,
   LSM6DSOX_AUX_DEN_LEVEL_TRIG      = 2,
 } lsm6dsox_lvl2_ois_t;
-int32_t lsm6dsox_aux_den_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_den_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_lvl2_ois_t val);
-int32_t lsm6dsox_aux_den_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_den_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_lvl2_ois_t *val);
 
-int32_t lsm6dsox_aux_drdy_on_int2_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_aux_drdy_on_int2_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_AUX_DISABLE  = 0,
   LSM6DSOX_MODE_3_GY    = 1,
   LSM6DSOX_MODE_4_GY_XL = 3,
 } lsm6dsox_ois_en_spi2_t;
-int32_t lsm6dsox_aux_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_mode_set(stmdev_ctx_t *ctx,
                               lsm6dsox_ois_en_spi2_t val);
-int32_t lsm6dsox_aux_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_mode_get(stmdev_ctx_t *ctx,
                               lsm6dsox_ois_en_spi2_t *val);
 
 typedef enum {
@@ -2134,18 +2109,18 @@ typedef enum {
   LSM6DSOX_1000dps_AUX = 4,
   LSM6DSOX_2000dps_AUX = 6,
 } lsm6dsox_fs_g_ois_t;
-int32_t lsm6dsox_aux_gy_full_scale_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
                                        lsm6dsox_fs_g_ois_t val);
-int32_t lsm6dsox_aux_gy_full_scale_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
                                        lsm6dsox_fs_g_ois_t *val);
 
 typedef enum {
   LSM6DSOX_AUX_SPI_4_WIRE = 0,
   LSM6DSOX_AUX_SPI_3_WIRE = 1,
 } lsm6dsox_sim_ois_t;
-int32_t lsm6dsox_aux_spi_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_spi_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_sim_ois_t val);
-int32_t lsm6dsox_aux_spi_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_spi_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_sim_ois_t *val);
 
 typedef enum {
@@ -2154,9 +2129,9 @@ typedef enum {
   LSM6DSOX_172Hz70 = 2,
   LSM6DSOX_937Hz91 = 3,
 } lsm6dsox_ftype_ois_t;
-int32_t lsm6dsox_aux_gy_lp1_bandwidth_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                           lsm6dsox_ftype_ois_t val);
-int32_t lsm6dsox_aux_gy_lp1_bandwidth_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                           lsm6dsox_ftype_ois_t *val);
 
 typedef enum {
@@ -2166,18 +2141,18 @@ typedef enum {
   LSM6DSOX_AUX_HP_Hz260   = 0x12,
   LSM6DSOX_AUX_HP_1Hz040  = 0x13,
 } lsm6dsox_hpm_ois_t;
-int32_t lsm6dsox_aux_gy_hp_bandwidth_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_gy_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                          lsm6dsox_hpm_ois_t val);
-int32_t lsm6dsox_aux_gy_hp_bandwidth_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_gy_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                          lsm6dsox_hpm_ois_t *val);
 
 typedef enum {
   LSM6DSOX_ENABLE_CLAMP  = 0,
   LSM6DSOX_DISABLE_CLAMP = 1,
 } lsm6dsox_st_ois_clampdis_t;
-int32_t lsm6dsox_aux_gy_clamp_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_gy_clamp_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_st_ois_clampdis_t val);
-int32_t lsm6dsox_aux_gy_clamp_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_gy_clamp_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_st_ois_clampdis_t *val);
 
 typedef enum {
@@ -2190,9 +2165,9 @@ typedef enum {
   LSM6DSOX_8Hz30 = 6,
   LSM6DSOX_4Hz15 = 7,
 } lsm6dsox_filter_xl_conf_ois_t;
-int32_t lsm6dsox_aux_xl_bandwidth_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_xl_bandwidth_set(stmdev_ctx_t *ctx,
                                       lsm6dsox_filter_xl_conf_ois_t val);
-int32_t lsm6dsox_aux_xl_bandwidth_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_xl_bandwidth_get(stmdev_ctx_t *ctx,
                                       lsm6dsox_filter_xl_conf_ois_t *val);
 
 typedef enum {
@@ -2201,46 +2176,46 @@ typedef enum {
   LSM6DSOX_AUX_4g  = 2,
   LSM6DSOX_AUX_8g  = 3,
 } lsm6dsox_fs_xl_ois_t;
-int32_t lsm6dsox_aux_xl_full_scale_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
                                        lsm6dsox_fs_xl_ois_t val);
-int32_t lsm6dsox_aux_xl_full_scale_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
                                        lsm6dsox_fs_xl_ois_t *val);
 
 typedef enum {
   LSM6DSOX_PULL_UP_DISC       = 0,
   LSM6DSOX_PULL_UP_CONNECT    = 1,
 } lsm6dsox_sdo_pu_en_t;
-int32_t lsm6dsox_sdo_sa0_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_sdo_pu_en_t val);
-int32_t lsm6dsox_sdo_sa0_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_sdo_pu_en_t *val);
 
 typedef enum {
   LSM6DSOX_SPI_4_WIRE = 0,
   LSM6DSOX_SPI_3_WIRE = 1,
 } lsm6dsox_sim_t;
-int32_t lsm6dsox_spi_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_sim_t val);
-int32_t lsm6dsox_spi_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_sim_t *val);
+int32_t lsm6dsox_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsox_sim_t val);
+int32_t lsm6dsox_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsox_sim_t *val);
 
 typedef enum {
   LSM6DSOX_I2C_ENABLE  = 0,
   LSM6DSOX_I2C_DISABLE = 1,
 } lsm6dsox_i2c_disable_t;
-int32_t lsm6dsox_i2c_interface_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_i2c_interface_set(stmdev_ctx_t *ctx,
                                    lsm6dsox_i2c_disable_t val);
-int32_t lsm6dsox_i2c_interface_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_i2c_interface_get(stmdev_ctx_t *ctx,
                                    lsm6dsox_i2c_disable_t *val);
 
 typedef enum {
-  LSM6DSOX_I3C_DISABLE         = 0x00,
-  LSM6DSOX_I3C_ENABLE_T_50us   = 0x80,
-  LSM6DSOX_I3C_ENABLE_T_2us    = 0x81,
-  LSM6DSOX_I3C_ENABLE_T_1ms    = 0x82,
-  LSM6DSOX_I3C_ENABLE_T_25ms   = 0x83,
+  LSM6DSOX_I3C_DISABLE         = 0x80,
+  LSM6DSOX_I3C_ENABLE_T_50us   = 0x00,
+  LSM6DSOX_I3C_ENABLE_T_2us    = 0x01,
+  LSM6DSOX_I3C_ENABLE_T_1ms    = 0x02,
+  LSM6DSOX_I3C_ENABLE_T_25ms   = 0x03,
 } lsm6dsox_i3c_disable_t;
-int32_t lsm6dsox_i3c_disable_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_i3c_disable_set(stmdev_ctx_t *ctx,
                                  lsm6dsox_i3c_disable_t val);
-int32_t lsm6dsox_i3c_disable_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_i3c_disable_get(stmdev_ctx_t *ctx,
                                  lsm6dsox_i3c_disable_t *val);
 typedef struct {
     lsm6dsox_int1_ctrl_t          int1_ctrl;
@@ -2250,9 +2225,9 @@ typedef struct {
     lsm6dsox_fsm_int1_b_t         fsm_int1_b;
     lsm6dsox_mlc_int1_t           mlc_int1;
 } lsm6dsox_pin_int1_route_t;
-int32_t lsm6dsox_pin_int1_route_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pin_int1_route_set(stmdev_ctx_t *ctx,
                                     lsm6dsox_pin_int1_route_t *val);
-int32_t lsm6dsox_pin_int1_route_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pin_int1_route_get(stmdev_ctx_t *ctx,
                                     lsm6dsox_pin_int1_route_t *val);
 
 typedef struct {
@@ -2263,9 +2238,9 @@ typedef struct {
   lsm6dsox_fsm_int2_b_t         fsm_int2_b;
   lsm6dsox_mlc_int2_t           mlc_int2;
 } lsm6dsox_pin_int2_route_t;
-int32_t lsm6dsox_pin_int2_route_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pin_int2_route_set(stmdev_ctx_t *ctx,
                                     lsm6dsox_pin_int2_route_t *val);
-int32_t lsm6dsox_pin_int2_route_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pin_int2_route_get(stmdev_ctx_t *ctx,
                                     lsm6dsox_pin_int2_route_t *val);
 
 typedef enum {
@@ -2274,20 +2249,20 @@ typedef enum {
   LSM6DSOX_INT1_NOPULL_DOWN_INT2_PUSH_PULL   = 0x02,
   LSM6DSOX_INT1_NOPULL_DOWN_INT2_OPEN_DRAIN  = 0x03,
 } lsm6dsox_pp_od_t;
-int32_t lsm6dsox_pin_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_pp_od_t val);
-int32_t lsm6dsox_pin_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_pp_od_t *val);
+int32_t lsm6dsox_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsox_pp_od_t val);
+int32_t lsm6dsox_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsox_pp_od_t *val);
 
 typedef enum {
   LSM6DSOX_ACTIVE_HIGH = 0,
   LSM6DSOX_ACTIVE_LOW  = 1,
 } lsm6dsox_h_lactive_t;
-int32_t lsm6dsox_pin_polarity_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pin_polarity_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_h_lactive_t val);
-int32_t lsm6dsox_pin_polarity_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pin_polarity_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_h_lactive_t *val);
 
-int32_t lsm6dsox_all_on_int1_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_all_on_int1_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_ALL_INT_PULSED            = 0,
@@ -2295,37 +2270,37 @@ typedef enum {
   LSM6DSOX_BASE_PULSED_EMB_LATCHED   = 2,
   LSM6DSOX_ALL_INT_LATCHED           = 3,
 } lsm6dsox_lir_t;
-int32_t lsm6dsox_int_notification_set(lsm6dsox_ctx_t *ctx, lsm6dsox_lir_t val);
-int32_t lsm6dsox_int_notification_get(lsm6dsox_ctx_t *ctx, lsm6dsox_lir_t *val);
+int32_t lsm6dsox_int_notification_set(stmdev_ctx_t *ctx, lsm6dsox_lir_t val);
+int32_t lsm6dsox_int_notification_get(stmdev_ctx_t *ctx, lsm6dsox_lir_t *val);
 
 typedef enum {
   LSM6DSOX_LSb_FS_DIV_64       = 0,
   LSM6DSOX_LSb_FS_DIV_256      = 1,
 } lsm6dsox_wake_ths_w_t;
-int32_t lsm6dsox_wkup_ths_weight_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_wkup_ths_weight_set(stmdev_ctx_t *ctx,
                                      lsm6dsox_wake_ths_w_t val);
-int32_t lsm6dsox_wkup_ths_weight_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_wkup_ths_weight_get(stmdev_ctx_t *ctx,
                                      lsm6dsox_wake_ths_w_t *val);
 
-int32_t lsm6dsox_wkup_threshold_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_wkup_threshold_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_xl_usr_offset_on_wkup_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_xl_usr_offset_on_wkup_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_wkup_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_wkup_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_gy_sleep_mode_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_gy_sleep_mode_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_DRIVE_SLEEP_CHG_EVENT = 0,
   LSM6DSOX_DRIVE_SLEEP_STATUS    = 1,
 } lsm6dsox_sleep_status_on_int_t;
-int32_t lsm6dsox_act_pin_notification_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_act_pin_notification_set(stmdev_ctx_t *ctx,
                                           lsm6dsox_sleep_status_on_int_t val);
-int32_t lsm6dsox_act_pin_notification_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_act_pin_notification_get(stmdev_ctx_t *ctx,
                                           lsm6dsox_sleep_status_on_int_t *val);
 
 typedef enum {
@@ -2334,23 +2309,23 @@ typedef enum {
   LSM6DSOX_XL_12Hz5_GY_SLEEP           = 2,
   LSM6DSOX_XL_12Hz5_GY_PD              = 3,
 } lsm6dsox_inact_en_t;
-int32_t lsm6dsox_act_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_inact_en_t val);
-int32_t lsm6dsox_act_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_inact_en_t *val);
+int32_t lsm6dsox_act_mode_set(stmdev_ctx_t *ctx, lsm6dsox_inact_en_t val);
+int32_t lsm6dsox_act_mode_get(stmdev_ctx_t *ctx, lsm6dsox_inact_en_t *val);
 
-int32_t lsm6dsox_act_sleep_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_act_sleep_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tap_detection_on_z_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_detection_on_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tap_detection_on_y_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_detection_on_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tap_detection_on_x_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_detection_on_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tap_threshold_x_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_threshold_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_XYZ = 0,
@@ -2360,33 +2335,33 @@ typedef enum {
   LSM6DSOX_YZX = 5,
   LSM6DSOX_ZXY = 6,
 } lsm6dsox_tap_priority_t;
-int32_t lsm6dsox_tap_axis_priority_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_tap_axis_priority_set(stmdev_ctx_t *ctx,
                                        lsm6dsox_tap_priority_t val);
-int32_t lsm6dsox_tap_axis_priority_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                        lsm6dsox_tap_priority_t *val);
 
-int32_t lsm6dsox_tap_threshold_y_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_threshold_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tap_threshold_z_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_threshold_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tap_shock_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_shock_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tap_quiet_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_quiet_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tap_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tap_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_ONLY_SINGLE = 0,
   LSM6DSOX_BOTH_SINGLE_DOUBLE = 1,
 } lsm6dsox_single_double_tap_t;
-int32_t lsm6dsox_tap_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_tap_mode_set(stmdev_ctx_t *ctx,
                               lsm6dsox_single_double_tap_t val);
-int32_t lsm6dsox_tap_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_tap_mode_get(stmdev_ctx_t *ctx,
                               lsm6dsox_single_double_tap_t *val);
 
 typedef enum {
@@ -2395,13 +2370,13 @@ typedef enum {
   LSM6DSOX_DEG_60  = 2,
   LSM6DSOX_DEG_50  = 3,
 } lsm6dsox_sixd_ths_t;
-int32_t lsm6dsox_6d_threshold_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_6d_threshold_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_sixd_ths_t val);
-int32_t lsm6dsox_6d_threshold_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_6d_threshold_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_sixd_ths_t *val);
 
-int32_t lsm6dsox_4d_mode_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_4d_mode_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_FF_TSH_156mg = 0,
@@ -2413,17 +2388,17 @@ typedef enum {
   LSM6DSOX_FF_TSH_469mg = 6,
   LSM6DSOX_FF_TSH_500mg = 7,
 } lsm6dsox_ff_ths_t;
-int32_t lsm6dsox_ff_threshold_set(lsm6dsox_ctx_t *ctx, lsm6dsox_ff_ths_t val);
-int32_t lsm6dsox_ff_threshold_get(lsm6dsox_ctx_t *ctx, lsm6dsox_ff_ths_t *val);
+int32_t lsm6dsox_ff_threshold_set(stmdev_ctx_t *ctx, lsm6dsox_ff_ths_t val);
+int32_t lsm6dsox_ff_threshold_get(stmdev_ctx_t *ctx, lsm6dsox_ff_ths_t *val);
 
-int32_t lsm6dsox_ff_dur_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_ff_dur_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_fifo_watermark_set(lsm6dsox_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsox_fifo_watermark_get(lsm6dsox_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsox_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsox_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsox_compression_algo_init_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_compression_algo_init_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_compression_algo_init_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_compression_algo_init_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_CMP_DISABLE  = 0x00,
@@ -2432,26 +2407,26 @@ typedef enum {
   LSM6DSOX_CMP_16_TO_1  = 0x06,
   LSM6DSOX_CMP_32_TO_1  = 0x07,
 } lsm6dsox_uncoptr_rate_t;
-int32_t lsm6dsox_compression_algo_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_compression_algo_set(stmdev_ctx_t *ctx,
                                      lsm6dsox_uncoptr_rate_t val);
-int32_t lsm6dsox_compression_algo_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_compression_algo_get(stmdev_ctx_t *ctx,
                                      lsm6dsox_uncoptr_rate_t *val);
 
-int32_t lsm6dsox_fifo_virtual_sens_odr_chg_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
                                               uint8_t val);
-int32_t lsm6dsox_fifo_virtual_sens_odr_chg_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
-int32_t lsm6dsox_compression_algo_real_time_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_compression_algo_real_time_set(stmdev_ctx_t *ctx,
                                                uint8_t val);
-int32_t lsm6dsox_compression_algo_real_time_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_compression_algo_real_time_get(stmdev_ctx_t *ctx,
                                                uint8_t *val);
 
-int32_t lsm6dsox_fifo_stop_on_wtm_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_fifo_stop_on_wtm_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
-  LSM6DSOX_XL_NOT_BATCHED     	=  0,
+  LSM6DSOX_XL_NOT_BATCHED       =  0,
   LSM6DSOX_XL_BATCHED_AT_12Hz5   =  1,
   LSM6DSOX_XL_BATCHED_AT_26Hz    =  2,
   LSM6DSOX_XL_BATCHED_AT_52Hz    =  3,
@@ -2464,8 +2439,8 @@ typedef enum {
   LSM6DSOX_XL_BATCHED_AT_6667Hz  = 10,
   LSM6DSOX_XL_BATCHED_AT_6Hz5    = 11,
 } lsm6dsox_bdr_xl_t;
-int32_t lsm6dsox_fifo_xl_batch_set(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_xl_t val);
-int32_t lsm6dsox_fifo_xl_batch_get(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_xl_t *val);
+int32_t lsm6dsox_fifo_xl_batch_set(stmdev_ctx_t *ctx, lsm6dsox_bdr_xl_t val);
+int32_t lsm6dsox_fifo_xl_batch_get(stmdev_ctx_t *ctx, lsm6dsox_bdr_xl_t *val);
 
 typedef enum {
   LSM6DSOX_GY_NOT_BATCHED         = 0,
@@ -2481,8 +2456,8 @@ typedef enum {
   LSM6DSOX_GY_BATCHED_AT_6667Hz   = 10,
   LSM6DSOX_GY_BATCHED_AT_6Hz5     = 11,
 } lsm6dsox_bdr_gy_t;
-int32_t lsm6dsox_fifo_gy_batch_set(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_gy_t val);
-int32_t lsm6dsox_fifo_gy_batch_get(lsm6dsox_ctx_t *ctx, lsm6dsox_bdr_gy_t *val);
+int32_t lsm6dsox_fifo_gy_batch_set(stmdev_ctx_t *ctx, lsm6dsox_bdr_gy_t val);
+int32_t lsm6dsox_fifo_gy_batch_get(stmdev_ctx_t *ctx, lsm6dsox_bdr_gy_t *val);
 
 typedef enum {
   LSM6DSOX_BYPASS_MODE             = 0,
@@ -2492,8 +2467,8 @@ typedef enum {
   LSM6DSOX_STREAM_MODE             = 6,
   LSM6DSOX_BYPASS_TO_FIFO_MODE     = 7,
 } lsm6dsox_fifo_mode_t;
-int32_t lsm6dsox_fifo_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fifo_mode_t val);
-int32_t lsm6dsox_fifo_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fifo_mode_t *val);
+int32_t lsm6dsox_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsox_fifo_mode_t val);
+int32_t lsm6dsox_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsox_fifo_mode_t *val);
 
 typedef enum {
   LSM6DSOX_TEMP_NOT_BATCHED        = 0,
@@ -2501,9 +2476,9 @@ typedef enum {
   LSM6DSOX_TEMP_BATCHED_AT_12Hz5   = 2,
   LSM6DSOX_TEMP_BATCHED_AT_52Hz    = 3,
 } lsm6dsox_odr_t_batch_t;
-int32_t lsm6dsox_fifo_temp_batch_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_temp_batch_set(stmdev_ctx_t *ctx,
                                     lsm6dsox_odr_t_batch_t val);
-int32_t lsm6dsox_fifo_temp_batch_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_temp_batch_get(stmdev_ctx_t *ctx,
                                     lsm6dsox_odr_t_batch_t *val);
 
 typedef enum {
@@ -2512,9 +2487,9 @@ typedef enum {
   LSM6DSOX_DEC_8         = 2,
   LSM6DSOX_DEC_32        = 3,
 } lsm6dsox_odr_ts_batch_t;
-int32_t lsm6dsox_fifo_timestamp_decimation_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
                                               lsm6dsox_odr_ts_batch_t val);
-int32_t lsm6dsox_fifo_timestamp_decimation_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
                                               lsm6dsox_odr_ts_batch_t *val);
 
 typedef enum {
@@ -2523,7 +2498,7 @@ typedef enum {
 } lsm6dsox_trig_counter_bdr_t;
 
 typedef enum {
-  LSM6DSOX_GYRO_NC_TAG		= 1,
+  LSM6DSOX_GYRO_NC_TAG    = 1,
   LSM6DSOX_XL_NC_TAG,
   LSM6DSOX_TEMPERATURE_TAG,
   LSM6DSOX_TIMESTAMP_TAG,
@@ -2544,49 +2519,49 @@ typedef enum {
   LSM6DSOX_GAME_ROTATION_TAG,
   LSM6DSOX_GEOMAG_ROTATION_TAG,
   LSM6DSOX_ROTATION_TAG,
-  LSM6DSOX_SENSORHUB_NACK_TAG	= 0x19,
+  LSM6DSOX_SENSORHUB_NACK_TAG  = 0x19,
 } lsm6dsox_fifo_tag_t;
-int32_t lsm6dsox_fifo_cnt_event_batch_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_cnt_event_batch_set(stmdev_ctx_t *ctx,
                                           lsm6dsox_trig_counter_bdr_t val);
-int32_t lsm6dsox_fifo_cnt_event_batch_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_cnt_event_batch_get(stmdev_ctx_t *ctx,
                                           lsm6dsox_trig_counter_bdr_t *val);
 
-int32_t lsm6dsox_rst_batch_counter_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_rst_batch_counter_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_batch_counter_threshold_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_batch_counter_threshold_set(stmdev_ctx_t *ctx,
                                             uint16_t val);
-int32_t lsm6dsox_batch_counter_threshold_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_batch_counter_threshold_get(stmdev_ctx_t *ctx,
                                             uint16_t *val);
 
-int32_t lsm6dsox_fifo_data_level_get(lsm6dsox_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsox_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsox_fifo_status_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fifo_status_get(stmdev_ctx_t *ctx,
                                 lsm6dsox_fifo_status2_t *val);
 
-int32_t lsm6dsox_fifo_full_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_fifo_ovr_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_fifo_wtm_flag_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_fifo_sensor_tag_get(lsm6dsox_ctx_t *ctx,
-				    lsm6dsox_fifo_tag_t *val);
+int32_t lsm6dsox_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
+            lsm6dsox_fifo_tag_t *val);
 
-int32_t lsm6dsox_fifo_pedo_batch_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_fifo_pedo_batch_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_sh_batch_slave_0_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_sh_batch_slave_0_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_sh_batch_slave_0_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_batch_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_sh_batch_slave_1_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_sh_batch_slave_1_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_sh_batch_slave_1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_batch_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_sh_batch_slave_2_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_sh_batch_slave_2_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_sh_batch_slave_2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_batch_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_sh_batch_slave_3_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_sh_batch_slave_3_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_sh_batch_slave_3_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_batch_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_DEN_DISABLE    = 0,
@@ -2595,93 +2570,92 @@ typedef enum {
   LSM6DSOX_LEVEL_TRIGGER  = 2,
   LSM6DSOX_EDGE_TRIGGER   = 4,
 } lsm6dsox_den_mode_t;
-int32_t lsm6dsox_den_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_mode_t val);
-int32_t lsm6dsox_den_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_mode_t *val);
+int32_t lsm6dsox_den_mode_set(stmdev_ctx_t *ctx, lsm6dsox_den_mode_t val);
+int32_t lsm6dsox_den_mode_get(stmdev_ctx_t *ctx, lsm6dsox_den_mode_t *val);
 
 typedef enum {
   LSM6DSOX_DEN_ACT_LOW  = 0,
   LSM6DSOX_DEN_ACT_HIGH = 1,
 } lsm6dsox_den_lh_t;
-int32_t lsm6dsox_den_polarity_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_lh_t val);
-int32_t lsm6dsox_den_polarity_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_lh_t *val);
+int32_t lsm6dsox_den_polarity_set(stmdev_ctx_t *ctx, lsm6dsox_den_lh_t val);
+int32_t lsm6dsox_den_polarity_get(stmdev_ctx_t *ctx, lsm6dsox_den_lh_t *val);
 
 typedef enum {
   LSM6DSOX_STAMP_IN_GY_DATA     = 0,
   LSM6DSOX_STAMP_IN_XL_DATA     = 1,
   LSM6DSOX_STAMP_IN_GY_XL_DATA  = 2,
 } lsm6dsox_den_xl_g_t;
-int32_t lsm6dsox_den_enable_set(lsm6dsox_ctx_t *ctx, lsm6dsox_den_xl_g_t val);
-int32_t lsm6dsox_den_enable_get(lsm6dsox_ctx_t *ctx, lsm6dsox_den_xl_g_t *val);
+int32_t lsm6dsox_den_enable_set(stmdev_ctx_t *ctx, lsm6dsox_den_xl_g_t val);
+int32_t lsm6dsox_den_enable_get(stmdev_ctx_t *ctx, lsm6dsox_den_xl_g_t *val);
 
-int32_t lsm6dsox_den_mark_axis_x_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_den_mark_axis_x_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_den_mark_axis_y_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_den_mark_axis_y_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_den_mark_axis_z_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_den_mark_axis_z_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_PEDO_DISABLE              = 0x00,
   LSM6DSOX_PEDO_BASE_MODE            = 0x01,
-  LSM6DSOX_PEDO_ADV_MODE             = 0x03,
   LSM6DSOX_FALSE_STEP_REJ            = 0x13,
   LSM6DSOX_FALSE_STEP_REJ_ADV_MODE   = 0x33,
 } lsm6dsox_pedo_md_t;
-int32_t lsm6dsox_pedo_sens_set(lsm6dsox_ctx_t *ctx, lsm6dsox_pedo_md_t val);
-int32_t lsm6dsox_pedo_sens_get(lsm6dsox_ctx_t *ctx, lsm6dsox_pedo_md_t *val);
+int32_t lsm6dsox_pedo_sens_set(stmdev_ctx_t *ctx, lsm6dsox_pedo_md_t val);
+int32_t lsm6dsox_pedo_sens_get(stmdev_ctx_t *ctx, lsm6dsox_pedo_md_t *val);
 
-int32_t lsm6dsox_pedo_step_detect_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_pedo_step_detect_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_pedo_debounce_steps_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pedo_debounce_steps_set(stmdev_ctx_t *ctx,
                                              uint8_t *buff);
-int32_t lsm6dsox_pedo_debounce_steps_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pedo_debounce_steps_get(stmdev_ctx_t *ctx,
                                              uint8_t *buff);
 
-int32_t lsm6dsox_pedo_steps_period_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_pedo_steps_period_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_pedo_adv_detection_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_pedo_adv_detection_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_pedo_adv_detection_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_pedo_adv_detection_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_pedo_false_step_rejection_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pedo_false_step_rejection_set(stmdev_ctx_t *ctx,
                                               uint8_t val);
-int32_t lsm6dsox_pedo_false_step_rejection_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pedo_false_step_rejection_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
 typedef enum {
   LSM6DSOX_EVERY_STEP     = 0,
   LSM6DSOX_COUNT_OVERFLOW = 1,
 } lsm6dsox_carry_count_en_t;
-int32_t lsm6dsox_pedo_int_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pedo_int_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_carry_count_en_t val);
-int32_t lsm6dsox_pedo_int_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_pedo_int_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_carry_count_en_t *val);
 
-int32_t lsm6dsox_motion_sens_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_motion_sens_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_motion_flag_data_ready_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_motion_flag_data_ready_get(stmdev_ctx_t *ctx,
                                                 uint8_t *val);
 
-int32_t lsm6dsox_tilt_sens_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_tilt_sens_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_tilt_flag_data_ready_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_tilt_flag_data_ready_get(stmdev_ctx_t *ctx,
                                               uint8_t *val);
 
-int32_t lsm6dsox_sh_mag_sensitivity_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_sh_mag_sensitivity_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_sh_mag_sensitivity_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_sh_mag_sensitivity_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_mlc_mag_sensitivity_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_mlc_mag_sensitivity_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mlc_mag_sensitivity_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mlc_mag_sensitivity_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_mag_offset_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_mag_offset_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm6dsox_mag_soft_iron_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_mag_soft_iron_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM6DSOX_Z_EQ_Y     = 0,
@@ -2691,9 +2665,9 @@ typedef enum {
   LSM6DSOX_Z_EQ_MIN_Z = 4,
   LSM6DSOX_Z_EQ_Z     = 5,
 } lsm6dsox_mag_z_axis_t;
-int32_t lsm6dsox_mag_z_orient_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_mag_z_orient_set(stmdev_ctx_t *ctx,
                                          lsm6dsox_mag_z_axis_t val);
-int32_t lsm6dsox_mag_z_orient_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_mag_z_orient_get(stmdev_ctx_t *ctx,
                                          lsm6dsox_mag_z_axis_t *val);
 
 typedef enum {
@@ -2704,9 +2678,9 @@ typedef enum {
   LSM6DSOX_Y_EQ_MIN_Z = 4,
   LSM6DSOX_Y_EQ_Z     = 5,
 } lsm6dsox_mag_y_axis_t;
-int32_t lsm6dsox_mag_y_orient_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_mag_y_orient_set(stmdev_ctx_t *ctx,
                                          lsm6dsox_mag_y_axis_t val);
-int32_t lsm6dsox_mag_y_orient_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_mag_y_orient_get(stmdev_ctx_t *ctx,
                                          lsm6dsox_mag_y_axis_t *val);
 
 typedef enum {
@@ -2717,36 +2691,36 @@ typedef enum {
   LSM6DSOX_X_EQ_MIN_Z = 4,
   LSM6DSOX_X_EQ_Z     = 5,
 } lsm6dsox_mag_x_axis_t;
-int32_t lsm6dsox_mag_x_orient_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_mag_x_orient_set(stmdev_ctx_t *ctx,
                                          lsm6dsox_mag_x_axis_t val);
-int32_t lsm6dsox_mag_x_orient_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_mag_x_orient_get(stmdev_ctx_t *ctx,
                                          lsm6dsox_mag_x_axis_t *val);
 
-int32_t lsm6dsox_long_cnt_flag_data_ready_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_long_cnt_flag_data_ready_get(stmdev_ctx_t *ctx,
                                              uint8_t *val);
 
-int32_t lsm6dsox_emb_fsm_en_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_emb_fsm_en_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_emb_fsm_en_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_emb_fsm_en_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
     lsm6dsox_fsm_enable_a_t          fsm_enable_a;
     lsm6dsox_fsm_enable_b_t          fsm_enable_b;
 } lsm6dsox_emb_fsm_enable_t;
-int32_t lsm6dsox_fsm_enable_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fsm_enable_set(stmdev_ctx_t *ctx,
                                lsm6dsox_emb_fsm_enable_t *val);
-int32_t lsm6dsox_fsm_enable_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_fsm_enable_get(stmdev_ctx_t *ctx,
                                lsm6dsox_emb_fsm_enable_t *val);
 
-int32_t lsm6dsox_long_cnt_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_long_cnt_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_long_cnt_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_long_cnt_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM6DSOX_LC_NORMAL     = 0,
   LSM6DSOX_LC_CLEAR      = 1,
   LSM6DSOX_LC_CLEAR_DONE = 2,
 } lsm6dsox_fsm_lc_clr_t;
-int32_t lsm6dsox_long_clr_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_lc_clr_t val);
-int32_t lsm6dsox_long_clr_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_lc_clr_t *val);
+int32_t lsm6dsox_long_clr_set(stmdev_ctx_t *ctx, lsm6dsox_fsm_lc_clr_t val);
+int32_t lsm6dsox_long_clr_get(stmdev_ctx_t *ctx, lsm6dsox_fsm_lc_clr_t *val);
 
 typedef struct {
     lsm6dsox_fsm_outs1_t    fsm_outs1;
@@ -2766,7 +2740,7 @@ typedef struct {
     lsm6dsox_fsm_outs7_t    fsm_outs15;
     lsm6dsox_fsm_outs8_t    fsm_outs16;
 } lsm6dsox_fsm_out_t;
-int32_t lsm6dsox_fsm_out_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_out_t *val);
+int32_t lsm6dsox_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsox_fsm_out_t *val);
 
 typedef enum {
   LSM6DSOX_ODR_FSM_12Hz5 = 0,
@@ -2774,26 +2748,26 @@ typedef enum {
   LSM6DSOX_ODR_FSM_52Hz  = 2,
   LSM6DSOX_ODR_FSM_104Hz = 3,
 } lsm6dsox_fsm_odr_t;
-int32_t lsm6dsox_fsm_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_odr_t val);
-int32_t lsm6dsox_fsm_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_fsm_odr_t *val);
+int32_t lsm6dsox_fsm_data_rate_set(stmdev_ctx_t *ctx, lsm6dsox_fsm_odr_t val);
+int32_t lsm6dsox_fsm_data_rate_get(stmdev_ctx_t *ctx, lsm6dsox_fsm_odr_t *val);
 
-int32_t lsm6dsox_fsm_init_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_fsm_init_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_long_cnt_int_value_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_long_cnt_int_value_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_long_cnt_int_value_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsox_long_cnt_int_value_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsox_fsm_number_of_programs_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_fsm_number_of_programs_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_fsm_number_of_programs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_fsm_number_of_programs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_fsm_start_address_set(lsm6dsox_ctx_t *ctx, uint8_t *buff);
-int32_t lsm6dsox_fsm_start_address_get(lsm6dsox_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsox_fsm_start_address_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsox_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsox_mlc_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_mlc_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_mlc_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_mlc_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_mlc_status_get(lsm6dsox_ctx_t *ctx,
-                                    lsm6dsox_progsens_status_mainpage_t *val);
+int32_t lsm6dsox_mlc_status_get(stmdev_ctx_t *ctx,
+                                lsm6dsox_mlc_status_mainpage_t *val);
 
 typedef enum {
   LSM6DSOX_ODR_PRGS_12Hz5 = 0,
@@ -2801,9 +2775,9 @@ typedef enum {
   LSM6DSOX_ODR_PRGS_52Hz  = 2,
   LSM6DSOX_ODR_PRGS_104Hz = 3,
 } lsm6dsox_mlc_odr_t;
-int32_t lsm6dsox_mlc_data_rate_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_mlc_data_rate_set(stmdev_ctx_t *ctx,
                                    lsm6dsox_mlc_odr_t val);
-int32_t lsm6dsox_mlc_data_rate_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_mlc_data_rate_get(stmdev_ctx_t *ctx,
                                    lsm6dsox_mlc_odr_t *val);
 
 typedef struct {
@@ -2826,7 +2800,7 @@ typedef struct {
     lsm6dsox_sensor_hub_17_t  sh_byte_17;
     lsm6dsox_sensor_hub_18_t  sh_byte_18;
 } lsm6dsox_emb_sh_read_t;
-int32_t lsm6dsox_sh_read_data_raw_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_read_data_raw_get(stmdev_ctx_t *ctx,
                                      lsm6dsox_emb_sh_read_t *val);
 
 typedef enum {
@@ -2835,44 +2809,44 @@ typedef enum {
   LSM6DSOX_SLV_0_1_2   = 2,
   LSM6DSOX_SLV_0_1_2_3 = 3,
 } lsm6dsox_aux_sens_on_t;
-int32_t lsm6dsox_sh_slave_connected_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_slave_connected_set(stmdev_ctx_t *ctx,
                                        lsm6dsox_aux_sens_on_t val);
-int32_t lsm6dsox_sh_slave_connected_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_slave_connected_get(stmdev_ctx_t *ctx,
                                        lsm6dsox_aux_sens_on_t *val);
 
-int32_t lsm6dsox_sh_master_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_sh_master_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_EXT_PULL_UP      = 0,
   LSM6DSOX_INTERNAL_PULL_UP = 1,
 } lsm6dsox_shub_pu_en_t;
-int32_t lsm6dsox_sh_pin_mode_set(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_pu_en_t val);
-int32_t lsm6dsox_sh_pin_mode_get(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_pu_en_t *val);
+int32_t lsm6dsox_sh_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsox_shub_pu_en_t val);
+int32_t lsm6dsox_sh_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsox_shub_pu_en_t *val);
 
-int32_t lsm6dsox_sh_pass_through_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_sh_pass_through_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_EXT_ON_INT2_PIN = 0,
   LSM6DSOX_XL_GY_DRDY      = 1,
 } lsm6dsox_start_config_t;
-int32_t lsm6dsox_sh_syncro_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsox_start_config_t val);
-int32_t lsm6dsox_sh_syncro_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsox_start_config_t *val);
 
 typedef enum {
   LSM6DSOX_EACH_SH_CYCLE    = 0,
   LSM6DSOX_ONLY_FIRST_CYCLE = 1,
 } lsm6dsox_write_once_t;
-int32_t lsm6dsox_sh_write_mode_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_write_mode_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_write_once_t val);
-int32_t lsm6dsox_sh_write_mode_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_write_mode_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_write_once_t *val);
 
-int32_t lsm6dsox_sh_reset_set(lsm6dsox_ctx_t *ctx);
-int32_t lsm6dsox_sh_reset_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_sh_reset_set(stmdev_ctx_t *ctx);
+int32_t lsm6dsox_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSOX_SH_ODR_104Hz = 0,
@@ -2880,43 +2854,43 @@ typedef enum {
   LSM6DSOX_SH_ODR_26Hz  = 2,
   LSM6DSOX_SH_ODR_13Hz  = 3,
 } lsm6dsox_shub_odr_t;
-int32_t lsm6dsox_sh_data_rate_set(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_odr_t val);
-int32_t lsm6dsox_sh_data_rate_get(lsm6dsox_ctx_t *ctx, lsm6dsox_shub_odr_t *val);
+int32_t lsm6dsox_sh_data_rate_set(stmdev_ctx_t *ctx, lsm6dsox_shub_odr_t val);
+int32_t lsm6dsox_sh_data_rate_get(stmdev_ctx_t *ctx, lsm6dsox_shub_odr_t *val);
 
 typedef struct{
   uint8_t   slv0_add;
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } lsm6dsox_sh_cfg_write_t;
-int32_t lsm6dsox_sh_cfg_write(lsm6dsox_ctx_t *ctx, lsm6dsox_sh_cfg_write_t *val);
+int32_t lsm6dsox_sh_cfg_write(stmdev_ctx_t *ctx, lsm6dsox_sh_cfg_write_t *val);
 
 typedef struct{
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dsox_sh_cfg_read_t;
-int32_t lsm6dsox_sh_slv0_cfg_read(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsox_sh_cfg_read_t *val);
-int32_t lsm6dsox_sh_slv1_cfg_read(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsox_sh_cfg_read_t *val);
-int32_t lsm6dsox_sh_slv2_cfg_read(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsox_sh_cfg_read_t *val);
-int32_t lsm6dsox_sh_slv3_cfg_read(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
                                  lsm6dsox_sh_cfg_read_t *val);
 
-int32_t lsm6dsox_sh_status_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_sh_status_get(stmdev_ctx_t *ctx,
                               lsm6dsox_status_master_t *val);
 typedef enum {
   LSM6DSOX_S4S_TPH_7bit   = 0,
   LSM6DSOX_S4S_TPH_15bit  = 1,
 } lsm6dsox_s4s_tph_res_t;
-int32_t lsm6dsox_s4s_tph_res_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_s4s_tph_res_set(stmdev_ctx_t *ctx,
                                 lsm6dsox_s4s_tph_res_t val);
-int32_t lsm6dsox_s4s_tph_res_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_s4s_tph_res_get(stmdev_ctx_t *ctx,
                                 lsm6dsox_s4s_tph_res_t *val);
 
-int32_t lsm6dsox_s4s_tph_val_set(lsm6dsox_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsox_s4s_tph_val_get(lsm6dsox_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsox_s4s_tph_val_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsox_s4s_tph_val_get(stmdev_ctx_t *ctx, uint16_t *val);
 
 typedef enum {
   LSM6DSOX_S4S_DT_RES_11 = 0,
@@ -2924,16 +2898,16 @@ typedef enum {
   LSM6DSOX_S4S_DT_RES_13 = 2,
   LSM6DSOX_S4S_DT_RES_14 = 3,
 } lsm6dsox_s4s_res_ratio_t;
-int32_t lsm6dsox_s4s_res_ratio_set(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_s4s_res_ratio_set(stmdev_ctx_t *ctx,
                                   lsm6dsox_s4s_res_ratio_t val);
-int32_t lsm6dsox_s4s_res_ratio_get(lsm6dsox_ctx_t *ctx,
+int32_t lsm6dsox_s4s_res_ratio_get(stmdev_ctx_t *ctx,
                                   lsm6dsox_s4s_res_ratio_t *val);
 
-int32_t lsm6dsox_s4s_command_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_s4s_command_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_s4s_command_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_s4s_command_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsox_s4s_dt_set(lsm6dsox_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsox_s4s_dt_get(lsm6dsox_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsox_s4s_dt_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsox_s4s_dt_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 /**
   * @}

--- a/sensor/stmemsc/lsm6dsr_STdC/driver/lsm6dsr_reg.c
+++ b/sensor/stmemsc/lsm6dsr_STdC/driver/lsm6dsr_reg.c
@@ -1,0 +1,9832 @@
+/*
+ ******************************************************************************
+ * @file    lsm6dsr_reg.c
+ * @author  Sensors Software Solution Team
+ * @brief   LSM6DSR driver file
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#include "lsm6dsr_reg.h"
+
+/**
+  * @defgroup    LSM6DSR
+  * @brief       This file provides a set of functions needed to drive the
+  *              lsm6dsr enhanced inertial module.
+  * @{
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSR_Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Read generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to read
+  * @param  data  pointer to buffer that store the data read(ptr)
+  * @param  len   number of consecutive register to read
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsr_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                           uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->read_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @brief  Write generic device register
+  *
+  * @param  ctx   read / write interface definitions(ptr)
+  * @param  reg   register to write
+  * @param  data  pointer to data to write in register reg(ptr)
+  * @param  len   number of consecutive register to write
+  * @retval       interface status (MANDATORY: return 0 -> no Error)
+  *
+  */
+int32_t lsm6dsr_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
+                            uint16_t len)
+{
+  int32_t ret;
+  ret = ctx->write_reg(ctx->handle, reg, data, len);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup    LSM6DSR_Sensitivity
+  * @brief       These functions convert raw-data into engineering units.
+  * @{
+  *
+  */
+
+float_t lsm6dsr_from_fs2g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.061f);
+}
+
+float_t lsm6dsr_from_fs4g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.122f);
+}
+
+float_t lsm6dsr_from_fs8g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.244f);
+}
+
+float_t lsm6dsr_from_fs16g_to_mg(int16_t lsb)
+{
+  return ((float_t)lsb * 0.488f);
+}
+
+float_t lsm6dsr_from_fs125dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 4.375f);
+}
+
+float_t lsm6dsr_from_fs250dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 8.75f);
+}
+
+float_t lsm6dsr_from_fs500dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 17.50f);
+}
+
+float_t lsm6dsr_from_fs1000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 35.0f);
+}
+
+float_t lsm6dsr_from_fs2000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 70.0f);
+}
+
+float_t lsm6dsr_from_fs4000dps_to_mdps(int16_t lsb)
+{
+  return ((float_t)lsb * 140.0f);
+}
+
+float_t lsm6dsr_from_lsb_to_celsius(int16_t lsb)
+{
+  return (((float_t)lsb / 256.0f) + 25.0f);
+}
+
+float_t lsm6dsr_from_lsb_to_nsec(int32_t lsb)
+{
+  return ((float_t)lsb * 25000.0f);
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM9DS1_Data_generation
+  * @brief      This section groups all the functions concerning data
+  *             generation
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer full-scale selection[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_fs_xl_t val)
+{
+  lsm6dsr_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.fs_xl = (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_fs_xl_t *val)
+{
+  lsm6dsr_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.fs_xl){
+    case LSM6DSR_2g:
+      *val = LSM6DSR_2g;
+      break;
+    case LSM6DSR_16g:
+      *val = LSM6DSR_16g;
+      break;
+    case LSM6DSR_4g:
+      *val = LSM6DSR_4g;
+      break;
+    case LSM6DSR_8g:
+      *val = LSM6DSR_8g;
+      break;
+    default:
+      *val = LSM6DSR_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_data_rate_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_odr_xl_t val)
+{
+  lsm6dsr_odr_xl_t odr_xl =  val;
+  lsm6dsr_emb_fsm_enable_t fsm_enable;
+  lsm6dsr_fsm_odr_t fsm_odr;
+  lsm6dsr_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  /* Check the Finite State Machine data rate constraints */
+  ret =  lsm6dsr_fsm_enable_get(ctx, &fsm_enable);
+  if (ret == 0) {
+    if ( (fsm_enable.fsm_enable_a.fsm1_en  |
+          fsm_enable.fsm_enable_a.fsm2_en  |
+          fsm_enable.fsm_enable_a.fsm3_en  |
+          fsm_enable.fsm_enable_a.fsm4_en  |
+          fsm_enable.fsm_enable_a.fsm5_en  |
+          fsm_enable.fsm_enable_a.fsm6_en  |
+          fsm_enable.fsm_enable_a.fsm7_en  |
+          fsm_enable.fsm_enable_a.fsm8_en  |
+          fsm_enable.fsm_enable_b.fsm9_en  |
+          fsm_enable.fsm_enable_b.fsm10_en |
+          fsm_enable.fsm_enable_b.fsm11_en |
+          fsm_enable.fsm_enable_b.fsm12_en |
+          fsm_enable.fsm_enable_b.fsm13_en |
+          fsm_enable.fsm_enable_b.fsm14_en |
+          fsm_enable.fsm_enable_b.fsm15_en |
+          fsm_enable.fsm_enable_b.fsm16_en ) == PROPERTY_ENABLE ){
+
+      ret =  lsm6dsr_fsm_data_rate_get(ctx, &fsm_odr);
+      if (ret == 0) {
+        switch (fsm_odr) {
+          case LSM6DSR_ODR_FSM_12Hz5:
+
+            if (val == LSM6DSR_XL_ODR_OFF){
+              odr_xl = LSM6DSR_XL_ODR_12Hz5;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case LSM6DSR_ODR_FSM_26Hz:
+
+            if (val == LSM6DSR_XL_ODR_OFF){
+              odr_xl = LSM6DSR_XL_ODR_26Hz;
+
+            } else if (val == LSM6DSR_XL_ODR_12Hz5){
+              odr_xl = LSM6DSR_XL_ODR_26Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case LSM6DSR_ODR_FSM_52Hz:
+
+            if (val == LSM6DSR_XL_ODR_OFF){
+              odr_xl = LSM6DSR_XL_ODR_52Hz;
+
+            } else if (val == LSM6DSR_XL_ODR_12Hz5){
+              odr_xl = LSM6DSR_XL_ODR_52Hz;
+
+            } else if (val == LSM6DSR_XL_ODR_26Hz){
+              odr_xl = LSM6DSR_XL_ODR_52Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          case LSM6DSR_ODR_FSM_104Hz:
+
+            if (val == LSM6DSR_XL_ODR_OFF){
+              odr_xl = LSM6DSR_XL_ODR_104Hz;
+
+            } else if (val == LSM6DSR_XL_ODR_12Hz5){
+              odr_xl = LSM6DSR_XL_ODR_104Hz;
+
+            } else if (val == LSM6DSR_XL_ODR_26Hz){
+              odr_xl = LSM6DSR_XL_ODR_104Hz;
+
+            } else if (val == LSM6DSR_XL_ODR_52Hz){
+              odr_xl = LSM6DSR_XL_ODR_104Hz;
+
+            } else {
+              odr_xl = val;
+            }
+            break;
+          default:
+            odr_xl = val;
+            break;
+        }
+      }
+    }
+  }
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  }
+  if(ret == 0){
+    ctrl1_xl.odr_xl= (uint8_t)odr_xl;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer UI data rate selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_xl in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_data_rate_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_odr_xl_t *val)
+{
+  lsm6dsr_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  switch (ctrl1_xl.odr_xl){
+    case LSM6DSR_XL_ODR_OFF:
+      *val = LSM6DSR_XL_ODR_OFF;
+      break;
+    case LSM6DSR_XL_ODR_12Hz5:
+      *val = LSM6DSR_XL_ODR_12Hz5;
+      break;
+    case LSM6DSR_XL_ODR_26Hz:
+      *val = LSM6DSR_XL_ODR_26Hz;
+      break;
+    case LSM6DSR_XL_ODR_52Hz:
+      *val = LSM6DSR_XL_ODR_52Hz;
+      break;
+    case LSM6DSR_XL_ODR_104Hz:
+      *val = LSM6DSR_XL_ODR_104Hz;
+      break;
+    case LSM6DSR_XL_ODR_208Hz:
+      *val = LSM6DSR_XL_ODR_208Hz;
+      break;
+    case LSM6DSR_XL_ODR_417Hz:
+      *val = LSM6DSR_XL_ODR_417Hz;
+      break;
+    case LSM6DSR_XL_ODR_833Hz:
+      *val = LSM6DSR_XL_ODR_833Hz;
+      break;
+    case LSM6DSR_XL_ODR_1667Hz:
+      *val = LSM6DSR_XL_ODR_1667Hz;
+      break;
+    case LSM6DSR_XL_ODR_3333Hz:
+      *val = LSM6DSR_XL_ODR_3333Hz;
+      break;
+    case LSM6DSR_XL_ODR_6667Hz:
+      *val = LSM6DSR_XL_ODR_6667Hz;
+      break;
+    case LSM6DSR_XL_ODR_6Hz5:
+      *val = LSM6DSR_XL_ODR_6Hz5;
+      break;
+    default:
+      *val = LSM6DSR_XL_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_full_scale_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_fs_g_t val)
+{
+  lsm6dsr_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  if(ret == 0){
+    ctrl2_g.fs_g= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_full_scale_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_fs_g_t *val)
+{
+  lsm6dsr_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.fs_g){
+    case LSM6DSR_125dps:
+      *val = LSM6DSR_125dps;
+      break;
+    case LSM6DSR_250dps:
+      *val = LSM6DSR_250dps;
+      break;
+    case LSM6DSR_500dps:
+      *val = LSM6DSR_500dps;
+      break;
+    case LSM6DSR_1000dps:
+      *val = LSM6DSR_1000dps;
+      break;
+    case LSM6DSR_2000dps:
+      *val = LSM6DSR_2000dps;
+      break;
+    case LSM6DSR_4000dps:
+      *val = LSM6DSR_4000dps;
+      break;
+    default:
+      *val = LSM6DSR_125dps;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_data_rate_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_odr_g_t val)
+{
+  lsm6dsr_odr_g_t odr_gy =  val;
+  lsm6dsr_emb_fsm_enable_t fsm_enable;
+  lsm6dsr_fsm_odr_t fsm_odr;
+  lsm6dsr_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  /* Check the Finite State Machine data rate constraints */
+  ret =  lsm6dsr_fsm_enable_get(ctx, &fsm_enable);
+  if (ret == 0) {
+    if ( (fsm_enable.fsm_enable_a.fsm1_en  |
+          fsm_enable.fsm_enable_a.fsm2_en  |
+          fsm_enable.fsm_enable_a.fsm3_en  |
+          fsm_enable.fsm_enable_a.fsm4_en  |
+          fsm_enable.fsm_enable_a.fsm5_en  |
+          fsm_enable.fsm_enable_a.fsm6_en  |
+          fsm_enable.fsm_enable_a.fsm7_en  |
+          fsm_enable.fsm_enable_a.fsm8_en  |
+          fsm_enable.fsm_enable_b.fsm9_en  |
+          fsm_enable.fsm_enable_b.fsm10_en |
+          fsm_enable.fsm_enable_b.fsm11_en |
+          fsm_enable.fsm_enable_b.fsm12_en |
+          fsm_enable.fsm_enable_b.fsm13_en |
+          fsm_enable.fsm_enable_b.fsm14_en |
+          fsm_enable.fsm_enable_b.fsm15_en |
+          fsm_enable.fsm_enable_b.fsm16_en ) == PROPERTY_ENABLE ){
+
+      ret =  lsm6dsr_fsm_data_rate_get(ctx, &fsm_odr);
+      if (ret == 0) {
+        switch (fsm_odr) {
+          case LSM6DSR_ODR_FSM_12Hz5:
+
+            if (val == LSM6DSR_GY_ODR_OFF){
+              odr_gy = LSM6DSR_GY_ODR_12Hz5;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case LSM6DSR_ODR_FSM_26Hz:
+
+            if (val == LSM6DSR_GY_ODR_OFF){
+              odr_gy = LSM6DSR_GY_ODR_26Hz;
+
+            } else if (val == LSM6DSR_GY_ODR_12Hz5){
+              odr_gy = LSM6DSR_GY_ODR_26Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case LSM6DSR_ODR_FSM_52Hz:
+
+            if (val == LSM6DSR_GY_ODR_OFF){
+              odr_gy = LSM6DSR_GY_ODR_52Hz;
+
+            } else if (val == LSM6DSR_GY_ODR_12Hz5){
+              odr_gy = LSM6DSR_GY_ODR_52Hz;
+
+            } else if (val == LSM6DSR_GY_ODR_26Hz){
+              odr_gy = LSM6DSR_GY_ODR_52Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          case LSM6DSR_ODR_FSM_104Hz:
+
+            if (val == LSM6DSR_GY_ODR_OFF){
+              odr_gy = LSM6DSR_GY_ODR_104Hz;
+
+            } else if (val == LSM6DSR_GY_ODR_12Hz5){
+              odr_gy = LSM6DSR_GY_ODR_104Hz;
+
+            } else if (val == LSM6DSR_GY_ODR_26Hz){
+              odr_gy = LSM6DSR_GY_ODR_104Hz;
+
+            } else if (val == LSM6DSR_GY_ODR_52Hz){
+              odr_gy = LSM6DSR_GY_ODR_104Hz;
+
+            } else {
+              odr_gy = val;
+            }
+            break;
+          default:
+            odr_gy = val;
+            break;
+        }
+      }
+    }
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  if(ret == 0){
+   ctrl2_g.odr_g= (uint8_t)odr_gy;
+   ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope data rate.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_g in reg CTRL2_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_data_rate_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_odr_g_t *val)
+{
+  lsm6dsr_ctrl2_g_t ctrl2_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_G, (uint8_t*)&ctrl2_g, 1);
+  switch (ctrl2_g.odr_g){
+    case LSM6DSR_GY_ODR_OFF:
+      *val = LSM6DSR_GY_ODR_OFF;
+      break;
+    case LSM6DSR_GY_ODR_12Hz5:
+      *val = LSM6DSR_GY_ODR_12Hz5;
+      break;
+    case LSM6DSR_GY_ODR_26Hz:
+      *val = LSM6DSR_GY_ODR_26Hz;
+      break;
+    case LSM6DSR_GY_ODR_52Hz:
+      *val = LSM6DSR_GY_ODR_52Hz;
+      break;
+    case LSM6DSR_GY_ODR_104Hz:
+      *val = LSM6DSR_GY_ODR_104Hz;
+      break;
+    case LSM6DSR_GY_ODR_208Hz:
+      *val = LSM6DSR_GY_ODR_208Hz;
+      break;
+    case LSM6DSR_GY_ODR_417Hz:
+      *val = LSM6DSR_GY_ODR_417Hz;
+      break;
+    case LSM6DSR_GY_ODR_833Hz:
+      *val = LSM6DSR_GY_ODR_833Hz;
+      break;
+    case LSM6DSR_GY_ODR_1667Hz:
+      *val = LSM6DSR_GY_ODR_1667Hz;
+      break;
+    case LSM6DSR_GY_ODR_3333Hz:
+      *val = LSM6DSR_GY_ODR_3333Hz;
+      break;
+    case LSM6DSR_GY_ODR_6667Hz:
+      *val = LSM6DSR_GY_ODR_6667Hz;
+      break;
+    default:
+      *val = LSM6DSR_GY_ODR_OFF;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.bdu= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Block data update.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdu in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.bdu;
+
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_offset_weight_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_usr_off_w_t val)
+{
+  lsm6dsr_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.usr_off_w= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of XL user offset bits of registers X_OFS_USR (73h),
+  *         Y_OFS_USR (74h), Z_OFS_USR (75h).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of usr_off_w in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_offset_weight_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_usr_off_w_t *val)
+{
+  lsm6dsr_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.usr_off_w){
+    case LSM6DSR_LSb_1mg:
+      *val = LSM6DSR_LSb_1mg;
+      break;
+    case LSM6DSR_LSb_16mg:
+      *val = LSM6DSR_LSb_16mg;
+      break;
+    default:
+      *val = LSM6DSR_LSb_1mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer power mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_power_mode_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_xl_hm_mode_t val)
+{
+  lsm6dsr_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.xl_hm_mode = (uint8_t)val & 0x01U;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer power mode[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of xl_hm_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_power_mode_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_xl_hm_mode_t *val)
+{
+  lsm6dsr_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  switch (ctrl6_c.xl_hm_mode){
+    case LSM6DSR_HIGH_PERFORMANCE_MD:
+      *val = LSM6DSR_HIGH_PERFORMANCE_MD;
+      break;
+    case LSM6DSR_LOW_NORMAL_POWER_MD:
+      *val = LSM6DSR_LOW_NORMAL_POWER_MD;
+      break;
+    default:
+      *val = LSM6DSR_HIGH_PERFORMANCE_MD;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Operating mode for gyroscope.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_power_mode_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_g_hm_mode_t val)
+{
+  lsm6dsr_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.g_hm_mode= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  gy_power_mode: [get]  Operating mode for gyroscope.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of g_hm_mode in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_power_mode_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_g_hm_mode_t *val)
+{
+  lsm6dsr_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  switch (ctrl7_g.g_hm_mode){
+    case LSM6DSR_GY_HIGH_PERFORMANCE:
+      *val = LSM6DSR_GY_HIGH_PERFORMANCE;
+      break;
+    case LSM6DSR_GY_NORMAL:
+      *val = LSM6DSR_GY_NORMAL;
+      break;
+    default:
+      *val = LSM6DSR_GY_HIGH_PERFORMANCE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read all the interrupt flag of the device.
+  *[get]
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get registers ALL_INT_SRC; WAKE_UP_SRC;
+  *                              TAP_SRC; D6D_SRC; STATUS_REG;
+  *                              EMB_FUNC_STATUS; FSM_STATUS_A/B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_all_sources_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_all_sources_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_ALL_INT_SRC,
+                           (uint8_t*)&val->all_int_src, 1);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_SRC,
+                             (uint8_t*)&val->wake_up_src, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_SRC,
+                             (uint8_t*)&val->tap_src, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_D6D_SRC,
+                             (uint8_t*)&val->d6d_src, 1);
+  }
+  if(ret == 0){
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_REG,
+                           (uint8_t*)&val->status_reg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_STATUS,
+                             (uint8_t*)&val->emb_func_status, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_STATUS_A,
+                             (uint8_t*)&val->fsm_status_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_STATUS_B,
+                             (uint8_t*)&val->fsm_status_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_REG register is read by the primary interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get register STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_status_reg_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_status_reg_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_REG, (uint8_t*) val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xlda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  Temperature new data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tda in reg STATUS_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_status_reg_t status_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_REG,
+                           (uint8_t*)&status_reg, 1);
+  *val = status_reg.tda;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_write_reg(ctx, LSM6DSR_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_X_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_write_reg(ctx, LSM6DSR_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_Y_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_write_reg(ctx, LSM6DSR_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
+  *         The value must be in the range [-127 127].[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_Z_OFS_USR, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Enables user offset on out.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_out in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.usr_off_on_out= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Get user offset on out flag.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get values of usr_off_on_out in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  *val = ctrl7_g.usr_off_on_out;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_Timestamp
+  * @brief      This section groups all the functions that manage the
+  *             timestamp generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables timestamp counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  if(ret == 0){
+    ctrl10_c.timestamp_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL10_C,
+                              (uint8_t*)&ctrl10_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables timestamp counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of timestamp_en in reg CTRL10_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl10_c_t ctrl10_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL10_C, (uint8_t*)&ctrl10_c, 1);
+  *val = ctrl10_c.timestamp_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Timestamp first data output register (r).
+  *         The value is expressed as a 32-bit word and the bit resolution
+  *         is 25 μs.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TIMESTAMP0, buff, 4);
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_Data output
+  * @brief      This section groups all the data output functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Circular burst-mode (rounding) read of the output registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_rounding_mode_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_rounding_t val)
+{
+  lsm6dsr_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.rounding= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope UI chain full-scale selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of rounding in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_rounding_mode_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_rounding_t *val)
+{
+  lsm6dsr_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  switch (ctrl5_c.rounding){
+    case LSM6DSR_NO_ROUND:
+      *val = LSM6DSR_NO_ROUND;
+      break;
+    case LSM6DSR_ROUND_XL:
+      *val = LSM6DSR_ROUND_XL;
+      break;
+    case LSM6DSR_ROUND_GY:
+      *val = LSM6DSR_ROUND_GY;
+      break;
+    case LSM6DSR_ROUND_GY_XL:
+      *val = LSM6DSR_ROUND_GY_XL;
+      break;
+    default:
+      *val = LSM6DSR_NO_ROUND;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Temperature data output register (r).
+  *         L and H registers together express a 16-bit word in two’s
+  *         complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_OUT_TEMP_L, buff, 2);
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor. The value is expressed as a 16-bit
+  *         word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_OUTX_L_G, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration output register. The value is expressed as a
+  *         16-bit word in two’s complement.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_OUTX_L_A, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  FIFO data output.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_DATA_OUT_X_L, buff, 6);
+  return ret;
+}
+
+/**
+  * @brief  Step counter output register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_STEP_COUNTER_L, buff, 2);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Reset step counter register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_steps_reset(stmdev_ctx_t *ctx)
+{
+  lsm6dsr_emb_func_src_t emb_func_src;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_SRC,
+                             (uint8_t*)&emb_func_src, 1);
+  }
+  if(ret == 0){
+    emb_func_src.pedo_rst_step = PROPERTY_ENABLE;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_SRC,
+                              (uint8_t*)&emb_func_src, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_common
+  * @brief      This section groups common usefull functions.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate)
+  *         with respect to the typical.[set]
+  *         Step:  0.15%. 8-bit format, 2's complement.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_internal_freq_fine_t internal_freq_fine;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INTERNAL_FREQ_FINE,
+                           (uint8_t*)&internal_freq_fine, 1);
+  if(ret == 0){
+    internal_freq_fine.freq_fine= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INTERNAL_FREQ_FINE,
+                              (uint8_t*)&internal_freq_fine, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Difference in percentage of the effective ODR (and timestamp rate)
+  *         with respect to the typical.[get]
+  *         Step:  0.15%. 8-bit format, 2's complement.
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of freq_fine in reg INTERNAL_FREQ_FINE
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_internal_freq_fine_t internal_freq_fine;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INTERNAL_FREQ_FINE,
+                           (uint8_t*)&internal_freq_fine, 1);
+  *val = internal_freq_fine.freq_fine;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of reg_access in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mem_bank_set(stmdev_ctx_t *ctx,
+                               lsm6dsr_reg_access_t val)
+{
+  lsm6dsr_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FUNC_CFG_ACCESS,
+                           (uint8_t*)&func_cfg_access, 1);
+  if(ret == 0){
+    func_cfg_access.reg_access= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FUNC_CFG_ACCESS,
+                              (uint8_t*)&func_cfg_access, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable access to the embedded functions/sensor hub configuration
+  *         registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of reg_access in reg FUNC_CFG_ACCESS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mem_bank_get(stmdev_ctx_t *ctx,
+                               lsm6dsr_reg_access_t *val)
+{
+  lsm6dsr_func_cfg_access_t func_cfg_access;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FUNC_CFG_ACCESS,
+                           (uint8_t*)&func_cfg_access, 1);
+  switch (func_cfg_access.reg_access){
+    case LSM6DSR_USER_BANK:
+      *val = LSM6DSR_USER_BANK;
+      break;
+    case LSM6DSR_SENSOR_HUB_BANK:
+      *val = LSM6DSR_SENSOR_HUB_BANK;
+      break;
+    case LSM6DSR_EMBEDDED_FUNC_BANK:
+      *val = LSM6DSR_EMBEDDED_FUNC_BANK;
+      break;
+    default:
+      *val = LSM6DSR_USER_BANK;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write a line(byte) in a page.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  add    Page line address
+  * @param  val    Value to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_ln_pg_write_byte(stmdev_ctx_t *ctx, uint16_t add,
+                                   uint8_t *val)
+{
+  lsm6dsr_page_rw_t page_rw;
+  lsm6dsr_page_sel_t page_sel;
+  lsm6dsr_page_address_t page_address;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x02U; /* page_write enable */
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL, (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_sel.page_sel = (uint8_t)((add >> 8) & 0x0FU);
+    page_sel.not_used_01 = 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_address.page_addr = (uint8_t)(add & 0xFFU);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_ADDRESS,
+                              (uint8_t*)&page_address, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_VALUE, val, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x00; /* page_write disable */
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Write buffer in a page.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buf    Page line address.(ptr)
+  * @param  val    Value to write.
+  * @param  len    buffer lengh.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_ln_pg_write(stmdev_ctx_t *ctx, uint16_t add,
+                              uint8_t *buf, uint8_t len)
+{
+  lsm6dsr_page_rw_t page_rw;
+  lsm6dsr_page_sel_t page_sel;
+  lsm6dsr_page_address_t page_address;
+  int32_t ret;
+  uint8_t msb, lsb;
+  uint8_t i ;
+
+  msb = (uint8_t)((add >> 8) & 0x0FU);
+  lsb = (uint8_t)(add & 0xFFU);
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x02U; /* page_write enable*/
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL, (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_sel.page_sel = msb;
+    page_sel.not_used_01 = 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_address.page_addr = lsb;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_ADDRESS,
+                              (uint8_t*)&page_address, 1);
+  }
+  for (i = 0; i < len; i++){
+    if(ret == 0){
+      ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_VALUE, &buf[i], 1);
+      if(ret == 0){
+        /* Check if page wrap */
+        if (lsb == 0x00U){
+          msb++;
+          ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL,
+                                   (uint8_t*)&page_sel, 1);
+        }
+        lsb++;
+      }
+      if(ret == 0){
+        page_sel.page_sel = msb;
+        page_sel.not_used_01 = 1;
+        ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_SEL,
+                                  (uint8_t*)&page_sel, 1);
+      }
+    }
+  }
+
+  if(ret == 0){
+    page_sel.page_sel = 0;
+    page_sel.not_used_01 = 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x00U; /* page_write disable */
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Read a line(byte) in a page.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  add    Page line address.
+  * @param  val    Read value.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t add,
+                                  uint8_t *val)
+{
+  lsm6dsr_page_rw_t page_rw;
+  lsm6dsr_page_sel_t page_sel;
+  lsm6dsr_page_address_t page_address;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x01U; /* page_read enable*/
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_SEL, (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_sel.page_sel = (uint8_t)((add >> 8) & 0x0FU);
+    page_sel.not_used_01 = 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_SEL,
+                              (uint8_t*)&page_sel, 1);
+  }
+  if(ret == 0){
+    page_address.page_addr = (uint8_t)(add & 0x00FFU);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_ADDRESS,
+                              (uint8_t*)&page_address, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_VALUE, val, 2);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.page_rw = 0x00U; /* page_read disable */
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dataready_pulsed in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                      lsm6dsr_dataready_pulsed_t val)
+{
+  lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.dataready_pulsed= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Data-ready pulsed / letched mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of dataready_pulsed in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_dataready_pulsed_t *val)
+{
+  lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  switch (counter_bdr_reg1.dataready_pulsed){
+    case LSM6DSR_DRDY_LATCHED:
+      *val = LSM6DSR_DRDY_LATCHED;
+      break;
+    case LSM6DSR_DRDY_PULSED:
+      *val = LSM6DSR_DRDY_PULSED;
+      break;
+    default:
+      *val = LSM6DSR_DRDY_LATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Device Who am I.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WHO_AM_I, buff, 1);
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sw_reset= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Software reset. Restore the default values in user registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sw_reset in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.sw_reset;
+
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.if_inc= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Register address automatically incremented during a multiple byte
+  *         access with a serial interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of if_inc in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.if_inc;
+
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_boot_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.boot= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reboot memory content. Reload the calibration parameters.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of boot in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_boot_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  *val = ctrl3_c.boot;
+
+  return ret;
+}
+
+
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_self_test_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_st_xl_t val)
+{
+  lsm6dsr_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_xl= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Linear acceleration sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_xl in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_self_test_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_st_xl_t *val)
+{
+  lsm6dsr_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_xl){
+    case LSM6DSR_XL_ST_DISABLE:
+      *val = LSM6DSR_XL_ST_DISABLE;
+      break;
+    case LSM6DSR_XL_ST_POSITIVE:
+      *val = LSM6DSR_XL_ST_POSITIVE;
+      break;
+    case LSM6DSR_XL_ST_NEGATIVE:
+      *val = LSM6DSR_XL_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSR_XL_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_self_test_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_st_g_t val)
+{
+  lsm6dsr_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  if(ret == 0){
+    ctrl5_c.st_g= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Angular rate sensor self-test enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_g in reg CTRL5_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_self_test_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_st_g_t *val)
+{
+  lsm6dsr_ctrl5_c_t ctrl5_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL5_C, (uint8_t*)&ctrl5_c, 1);
+
+  switch (ctrl5_c.st_g){
+    case LSM6DSR_GY_ST_DISABLE:
+      *val = LSM6DSR_GY_ST_DISABLE;
+      break;
+    case LSM6DSR_GY_ST_POSITIVE:
+      *val = LSM6DSR_GY_ST_POSITIVE;
+      break;
+    case LSM6DSR_GY_ST_NEGATIVE:
+      *val = LSM6DSR_GY_ST_NEGATIVE;
+      break;
+    default:
+      *val = LSM6DSR_GY_ST_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_filters
+  * @brief      This section group all the functions concerning the
+  *             filters configuration
+  * @{
+  *
+  */
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf2_xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  if(ret == 0){
+    ctrl1_xl.lpf2_xl_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL1_XL,
+                              (uint8_t*)&ctrl1_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer output from LPF2 filtering stage selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf2_xl_en in reg CTRL1_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl1_xl_t ctrl1_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_XL, (uint8_t*)&ctrl1_xl, 1);
+  *val = ctrl1_xl.lpf2_xl_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0] in CTRL6_C.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf1_sel_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_filter_lp1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.lpf1_sel_g= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital LPF1 if auxiliary SPI is disabled;
+  *         the bandwidth can be selected through FTYPE [2:0] in CTRL6_C.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lpf1_sel_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_filter_lp1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.lpf1_sel_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.drdy_mask= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Mask DRDY on pin (both XL & Gyro) until filter settling ends
+  *         (XL and Gyro independently masked).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of drdy_mask in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_filter_settling_mask_get(stmdev_ctx_t *ctx,
+                                           uint8_t *val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.drdy_mask;
+
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass filter 1 bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ftype in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_ftype_t val)
+{
+  lsm6dsr_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.ftype= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Gyroscope low pass filter 1 bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ftype in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_ftype_t *val)
+{
+  lsm6dsr_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.ftype){
+    case LSM6DSR_ULTRA_LIGHT:
+      *val = LSM6DSR_ULTRA_LIGHT;
+      break;
+    case LSM6DSR_VERY_LIGHT:
+      *val = LSM6DSR_VERY_LIGHT;
+      break;
+    case LSM6DSR_LIGHT:
+      *val = LSM6DSR_LIGHT;
+      break;
+    case LSM6DSR_MEDIUM:
+      *val = LSM6DSR_MEDIUM;
+      break;
+    case LSM6DSR_STRONG:
+      *val = LSM6DSR_STRONG;
+      break;
+    case LSM6DSR_VERY_STRONG:
+      *val = LSM6DSR_VERY_STRONG;
+      break;
+    case LSM6DSR_AGGRESSIVE:
+      *val = LSM6DSR_AGGRESSIVE;
+      break;
+    case LSM6DSR_XTREME:
+      *val = LSM6DSR_XTREME;
+      break;
+    default:
+      *val = LSM6DSR_ULTRA_LIGHT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_lp2_on_6d_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.low_pass_on_6d= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Low pass filter 2 on 6D function selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of low_pass_on_6d in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_lp2_on_6d_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.low_pass_on_6d;
+
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection
+  *         on output.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
+                                        lsm6dsr_hp_slope_xl_en_t val)
+{
+  lsm6dsr_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.hp_slope_xl_en = (((uint8_t)val & 0x10U) >> 4);
+    ctrl8_xl.hp_ref_mode_xl = (((uint8_t)val & 0x20U) >> 5);
+    ctrl8_xl.hpcf_xl = (uint8_t)val & 0x07U;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Accelerometer slope filter / high-pass filter selection on
+  *         output.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_slope_xl_en in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
+                                        lsm6dsr_hp_slope_xl_en_t *val)
+{
+  lsm6dsr_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  switch (( (ctrl8_xl.hp_ref_mode_xl << 5) +(ctrl8_xl.hp_slope_xl_en << 4) +
+             ctrl8_xl.hpcf_xl )){
+    case LSM6DSR_HP_PATH_DISABLE_ON_OUT:
+      *val = LSM6DSR_HP_PATH_DISABLE_ON_OUT;
+      break;
+    case LSM6DSR_SLOPE_ODR_DIV_4:
+      *val = LSM6DSR_SLOPE_ODR_DIV_4;
+      break;
+    case LSM6DSR_HP_ODR_DIV_10:
+      *val = LSM6DSR_HP_ODR_DIV_10;
+      break;
+    case LSM6DSR_HP_ODR_DIV_20:
+      *val = LSM6DSR_HP_ODR_DIV_20;
+      break;
+    case LSM6DSR_HP_ODR_DIV_45:
+      *val = LSM6DSR_HP_ODR_DIV_45;
+      break;
+    case LSM6DSR_HP_ODR_DIV_100:
+      *val = LSM6DSR_HP_ODR_DIV_100;
+      break;
+    case LSM6DSR_HP_ODR_DIV_200:
+      *val = LSM6DSR_HP_ODR_DIV_200;
+      break;
+    case LSM6DSR_HP_ODR_DIV_400:
+      *val = LSM6DSR_HP_ODR_DIV_400;
+      break;
+    case LSM6DSR_HP_ODR_DIV_800:
+      *val = LSM6DSR_HP_ODR_DIV_800;
+      break;
+    case LSM6DSR_HP_REF_MD_ODR_DIV_10:
+      *val = LSM6DSR_HP_REF_MD_ODR_DIV_10;
+      break;
+    case LSM6DSR_HP_REF_MD_ODR_DIV_20:
+      *val = LSM6DSR_HP_REF_MD_ODR_DIV_20;
+      break;
+    case LSM6DSR_HP_REF_MD_ODR_DIV_45:
+      *val = LSM6DSR_HP_REF_MD_ODR_DIV_45;
+      break;
+    case LSM6DSR_HP_REF_MD_ODR_DIV_100:
+      *val = LSM6DSR_HP_REF_MD_ODR_DIV_100;
+      break;
+    case LSM6DSR_HP_REF_MD_ODR_DIV_200:
+      *val = LSM6DSR_HP_REF_MD_ODR_DIV_200;
+      break;
+    case LSM6DSR_HP_REF_MD_ODR_DIV_400:
+      *val = LSM6DSR_HP_REF_MD_ODR_DIV_400;
+      break;
+    case LSM6DSR_HP_REF_MD_ODR_DIV_800:
+      *val = LSM6DSR_HP_REF_MD_ODR_DIV_800;
+      break;
+    case LSM6DSR_LP_ODR_DIV_10:
+      *val = LSM6DSR_LP_ODR_DIV_10;
+      break;
+    case LSM6DSR_LP_ODR_DIV_20:
+      *val = LSM6DSR_LP_ODR_DIV_20;
+      break;
+    case LSM6DSR_LP_ODR_DIV_45:
+      *val = LSM6DSR_LP_ODR_DIV_45;
+      break;
+    case LSM6DSR_LP_ODR_DIV_100:
+      *val = LSM6DSR_LP_ODR_DIV_100;
+      break;
+    case LSM6DSR_LP_ODR_DIV_200:
+      *val = LSM6DSR_LP_ODR_DIV_200;
+      break;
+    case LSM6DSR_LP_ODR_DIV_400:
+      *val = LSM6DSR_LP_ODR_DIV_400;
+      break;
+    case LSM6DSR_LP_ODR_DIV_800:
+      *val = LSM6DSR_LP_ODR_DIV_800;
+      break;
+    default:
+      *val = LSM6DSR_HP_PATH_DISABLE_ON_OUT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing this bit.
+  *         Active only during device exit from powerdown mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fastsettl_mode_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  if(ret == 0){
+    ctrl8_xl.fastsettl_mode_xl= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL8_XL,
+                              (uint8_t*)&ctrl8_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables accelerometer LPF2 and HPF fast-settling mode.
+  *         The filter sets the second samples after writing
+  *         this bit. Active only during device exit from powerdown mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fastsettl_mode_xl in reg CTRL8_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl8_xl_t ctrl8_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL8_XL, (uint8_t*)&ctrl8_xl, 1);
+  *val = ctrl8_xl.fastsettl_mode_xl;
+
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of slope_fds in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                          lsm6dsr_slope_fds_t val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.slope_fds= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  HPF or SLOPE filter selection on wake-up and Activity/Inactivity
+  *         functions.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of slope_fds in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                          lsm6dsr_slope_fds_t *val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  switch (tap_cfg0.slope_fds){
+    case LSM6DSR_USE_SLOPE:
+      *val = LSM6DSR_USE_SLOPE;
+      break;
+    case LSM6DSR_USE_HPF:
+      *val = LSM6DSR_USE_HPF;
+      break;
+    default:
+      *val = LSM6DSR_USE_SLOPE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope digital high-pass filter. The filter is enabled
+  *         only if the gyro is in HP mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_en_g and hp_en_g in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                          lsm6dsr_hpm_g_t val)
+{
+  lsm6dsr_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.hp_en_g = (((uint8_t)val & 0x80U) >> 7);
+    ctrl7_g.hpm_g = (uint8_t)val & 0x03U;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief    Enables gyroscope digital high-pass filter. The filter is
+  *           enabled only if the gyro is in HP mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hp_en_g and hp_en_g in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                          lsm6dsr_hpm_g_t *val)
+{
+  lsm6dsr_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  switch ((ctrl7_g.hp_en_g << 7) + ctrl7_g.hpm_g){
+    case LSM6DSR_HP_FILTER_NONE:
+      *val = LSM6DSR_HP_FILTER_NONE;
+      break;
+    case LSM6DSR_HP_FILTER_16mHz:
+      *val = LSM6DSR_HP_FILTER_16mHz;
+      break;
+    case LSM6DSR_HP_FILTER_65mHz:
+      *val = LSM6DSR_HP_FILTER_65mHz;
+      break;
+    case LSM6DSR_HP_FILTER_260mHz:
+      *val = LSM6DSR_HP_FILTER_260mHz;
+      break;
+    case LSM6DSR_HP_FILTER_1Hz04:
+      *val = LSM6DSR_HP_FILTER_1Hz04;
+      break;
+    default:
+      *val = LSM6DSR_HP_FILTER_NONE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_ Auxiliary_interface
+  * @brief      This section groups all the functions concerning
+  *             auxiliary interface.
+  * @{
+  *
+  */
+
+/**
+  * @brief  On auxiliary interface connect/disconnect SDO and OCS
+  *         internal pull-up.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ois_pu_dis in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_sdo_ocs_mode_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_ois_pu_dis_t val)
+{
+  lsm6dsr_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+  if(ret == 0){
+    pin_ctrl.ois_pu_dis= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PIN_CTRL,
+                              (uint8_t*)&pin_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  On auxiliary interface connect/disconnect SDO and OCS
+  *         internal pull-up.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ois_pu_dis in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_sdo_ocs_mode_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_ois_pu_dis_t *val)
+{
+  lsm6dsr_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+
+  switch (pin_ctrl.ois_pu_dis){
+    case LSM6DSR_AUX_PULL_UP_DISC:
+      *val = LSM6DSR_AUX_PULL_UP_DISC;
+      break;
+    case LSM6DSR_AUX_PULL_UP_CONNECT:
+      *val = LSM6DSR_AUX_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LSM6DSR_AUX_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  OIS chain on aux interface power on mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ois_on in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_pw_on_ctrl_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_ois_on_t val)
+{
+  lsm6dsr_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  if(ret == 0){
+    ctrl7_g.ois_on_en = (uint8_t)val & 0x01U;
+    ctrl7_g.ois_on = (uint8_t)val & 0x01U;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  OIS chain on aux interface power on mode[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ois_on in reg CTRL7_G
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_pw_on_ctrl_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_ois_on_t *val)
+{
+  lsm6dsr_ctrl7_g_t ctrl7_g;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL7_G, (uint8_t*)&ctrl7_g, 1);
+
+  switch (ctrl7_g.ois_on){
+    case LSM6DSR_AUX_ON:
+      *val = LSM6DSR_AUX_ON;
+      break;
+    case LSM6DSR_AUX_ON_BY_AUX_INTERFACE:
+      *val = LSM6DSR_AUX_ON_BY_AUX_INTERFACE;
+      break;
+    default:
+      *val = LSM6DSR_AUX_ON;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  The STATUS_SPIAux register is read by the auxiliary SPI.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  lsm6dsr_status_spiaux_t: registers STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_status_reg_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_status_spiaux_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_SPIAUX, (uint8_t*)val, 1);
+  return ret;
+}
+
+/**
+  * @brief  AUX accelerometer data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of xlda in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  lsm6dsr_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_SPIAUX,
+                           (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.xlda;
+
+  return ret;
+}
+
+/**
+  * @brief  AUX gyroscope data available.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gda in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  lsm6dsr_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_SPIAUX,
+                           (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.gda;
+
+  return ret;
+}
+
+/**
+  * @brief  High when the gyroscope output is in the settling phase.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gyro_settling in reg STATUS_SPIAUX
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_flag_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_status_spiaux_t status_spiaux;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_SPIAUX,
+                           (uint8_t*)&status_spiaux, 1);
+  *val = status_spiaux.gyro_settling;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer self-test. Effective only if XL OIS chain is
+  *         enabled.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_xl_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_xl_self_test_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_st_xl_ois_t val)
+{
+  lsm6dsr_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.st_xl_ois= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer self-test. Effective only if XL OIS chain
+  *         is enabled.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_xl_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_xl_self_test_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_st_xl_ois_t *val)
+{
+  lsm6dsr_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+
+  switch (int_ois.st_xl_ois){
+    case LSM6DSR_AUX_XL_DISABLE:
+      *val = LSM6DSR_AUX_XL_DISABLE;
+      break;
+    case LSM6DSR_AUX_XL_POS:
+      *val = LSM6DSR_AUX_XL_POS;
+      break;
+    case LSM6DSR_AUX_XL_NEG:
+      *val = LSM6DSR_AUX_XL_NEG;
+      break;
+    default:
+      *val = LSM6DSR_AUX_XL_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_lh_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_den_polarity_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_den_lh_ois_t val)
+{
+  lsm6dsr_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.den_lh_ois= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Indicates polarity of DEN signal on OIS chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_lh_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_den_polarity_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_den_lh_ois_t *val)
+{
+  lsm6dsr_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+
+  switch (int_ois.den_lh_ois){
+    case LSM6DSR_AUX_DEN_ACTIVE_LOW:
+      *val = LSM6DSR_AUX_DEN_ACTIVE_LOW;
+      break;
+    case LSM6DSR_AUX_DEN_ACTIVE_HIGH:
+      *val = LSM6DSR_AUX_DEN_ACTIVE_HIGH;
+      break;
+    default:
+      *val = LSM6DSR_AUX_DEN_ACTIVE_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lvl2_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_den_mode_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_lvl2_ois_t val)
+{
+  lsm6dsr_int_ois_t int_ois;
+  lsm6dsr_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.lvl2_ois = (uint8_t)val & 0x01U;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+  if(ret == 0){
+    ctrl1_ois.lvl1_ois = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure DEN mode on the OIS chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lvl2_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_den_mode_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_lvl2_ois_t *val)
+{
+  lsm6dsr_int_ois_t int_ois;
+  lsm6dsr_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS,
+                             (uint8_t*)&ctrl1_ois, 1);
+  }
+
+  switch ((ctrl1_ois.lvl1_ois << 1) + int_ois.lvl2_ois){
+    case LSM6DSR_AUX_DEN_DISABLE:
+      *val = LSM6DSR_AUX_DEN_DISABLE;
+      break;
+    case LSM6DSR_AUX_DEN_LEVEL_LATCH:
+      *val = LSM6DSR_AUX_DEN_LEVEL_LATCH;
+      break;
+    case LSM6DSR_AUX_DEN_LEVEL_TRIG:
+      *val = LSM6DSR_AUX_DEN_LEVEL_TRIG;
+      break;
+    default:
+      *val = LSM6DSR_AUX_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin. This setting has
+  *         priority over all other INT2 settings.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_drdy_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  if(ret == 0){
+    int_ois.int2_drdy_ois= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disable OIS chain DRDY on INT2 pin. This setting has
+  *         priority over all other INT2 settings.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_drdy_ois in reg INT_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_int_ois_t int_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_OIS, (uint8_t*)&int_ois, 1);
+  *val = int_ois.int2_drdy_ois;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro in Mode 3 and Mode 4
+  *         (mode4_en = 1) and accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are available
+  *         through the SPI2 in registers OUTX_L_G (22h) through OUTZ_H_G(27h)
+  *         and STATUS_REG (1Eh) / STATUS_SPIAux, and LPF1 is dedicated to
+  *         this chain.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ois_en_spi2 in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_mode_set(stmdev_ctx_t *ctx,
+                               lsm6dsr_ois_en_spi2_t val)
+{
+  lsm6dsr_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.ois_en_spi2 = (uint8_t)val & 0x01U;
+    ctrl1_ois.mode4_en = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables OIS chain data processing for gyro in Mode 3 and Mode 4
+  *         (mode4_en = 1) and accelerometer data in and Mode 4 (mode4_en = 1).
+  *         When the OIS chain is enabled, the OIS outputs are available
+  *         through the SPI2 in registers OUTX_L_G (22h) through OUTZ_H_G(27h)
+  *         and STATUS_REG (1Eh) / STATUS_SPIAux, and LPF1 is dedicated to
+  *         this chain.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ois_en_spi2 in
+  *                                reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_mode_get(stmdev_ctx_t *ctx,
+                               lsm6dsr_ois_en_spi2_t *val)
+{
+  lsm6dsr_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+
+  switch (((ctrl1_ois.mode4_en << 1) + ctrl1_ois.ois_en_spi2)){
+    case LSM6DSR_AUX_DISABLE:
+      *val = LSM6DSR_AUX_DISABLE;
+      break;
+    case LSM6DSR_MODE_3_GY:
+      *val = LSM6DSR_MODE_3_GY;
+      break;
+    case LSM6DSR_MODE_4_GY_XL:
+      *val = LSM6DSR_MODE_4_GY_XL;
+      break;
+    default:
+      *val = LSM6DSR_AUX_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_g_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
+                                        lsm6dsr_fs_g_ois_t val)
+{
+  lsm6dsr_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.fs_g_ois = (uint8_t)val & 0x03U;
+    ctrl1_ois.fs_125_ois = ((uint8_t)val & 0x04U) >> 2;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain full-scale.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_g_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_fs_g_ois_t *val)
+{
+  lsm6dsr_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS,
+                         (uint8_t*)&ctrl1_ois, 1);
+
+  switch ( ( ctrl1_ois.fs_125_ois << 2 ) + ctrl1_ois.fs_g_ois ){
+    case LSM6DSR_250dps_AUX:
+      *val = LSM6DSR_250dps_AUX;
+      break;
+    case LSM6DSR_125dps_AUX:
+      *val = LSM6DSR_125dps_AUX;
+      break;
+    case LSM6DSR_500dps_AUX:
+      *val = LSM6DSR_500dps_AUX;
+      break;
+    case LSM6DSR_1000dps_AUX:
+      *val = LSM6DSR_1000dps_AUX;
+      break;
+    case LSM6DSR_2000dps_AUX:
+      *val = LSM6DSR_2000dps_AUX;
+      break;
+    default:
+      *val = LSM6DSR_250dps_AUX;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_spi_mode_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sim_ois_t val)
+{
+  lsm6dsr_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+  if(ret == 0){
+    ctrl1_ois.sim_ois= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL1_OIS,
+                              (uint8_t*)&ctrl1_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI2 3- or 4-wire interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim_ois in reg CTRL1_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_spi_mode_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sim_ois_t *val)
+{
+  lsm6dsr_ctrl1_ois_t ctrl1_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL1_OIS, (uint8_t*)&ctrl1_ois, 1);
+
+  switch (ctrl1_ois.sim_ois){
+    case LSM6DSR_AUX_SPI_4_WIRE:
+      *val = LSM6DSR_AUX_SPI_4_WIRE;
+      break;
+    case LSM6DSR_AUX_SPI_3_WIRE:
+      *val = LSM6DSR_AUX_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSR_AUX_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope digital LPF1 filter bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ftype_ois in reg CTRL2_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                           lsm6dsr_ftype_ois_t val)
+{
+  lsm6dsr_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  if(ret == 0){
+    ctrl2_ois.ftype_ois= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL2_OIS,
+                              (uint8_t*)&ctrl2_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope digital LPF1 filter bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ftype_ois in reg CTRL2_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                           lsm6dsr_ftype_ois_t *val)
+{
+  lsm6dsr_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+
+  switch (ctrl2_ois.ftype_ois){
+    case LSM6DSR_351Hz39:
+      *val = LSM6DSR_351Hz39;
+      break;
+    case LSM6DSR_236Hz63:
+      *val = LSM6DSR_236Hz63;
+      break;
+    case LSM6DSR_172Hz70:
+      *val = LSM6DSR_172Hz70;
+      break;
+    case LSM6DSR_937Hz91:
+      *val = LSM6DSR_937Hz91;
+      break;
+    default:
+      *val = LSM6DSR_351Hz39;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain digital high-pass filter cutoff.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of hpm_ois in reg CTRL2_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_hp_bandwidth_set(stmdev_ctx_t *ctx,
+                                          lsm6dsr_hpm_ois_t val)
+{
+  lsm6dsr_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+  if(ret == 0){
+    ctrl2_ois.hpm_ois = (uint8_t)val & 0x03U;
+    ctrl2_ois.hp_en_ois = ((uint8_t)val & 0x10U) >> 4;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL2_OIS,
+                              (uint8_t*)&ctrl2_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain digital high-pass filter cutoff.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of hpm_ois in reg CTRL2_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_hp_bandwidth_get(stmdev_ctx_t *ctx,
+                                          lsm6dsr_hpm_ois_t *val)
+{
+  lsm6dsr_ctrl2_ois_t ctrl2_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL2_OIS, (uint8_t*)&ctrl2_ois, 1);
+
+  switch ((ctrl2_ois.hp_en_ois << 4) + ctrl2_ois.hpm_ois){
+    case LSM6DSR_AUX_HP_DISABLE:
+      *val = LSM6DSR_AUX_HP_DISABLE;
+      break;
+    case LSM6DSR_AUX_HP_Hz016:
+      *val = LSM6DSR_AUX_HP_Hz016;
+      break;
+    case LSM6DSR_AUX_HP_Hz065:
+      *val = LSM6DSR_AUX_HP_Hz065;
+      break;
+    case LSM6DSR_AUX_HP_Hz260:
+      *val = LSM6DSR_AUX_HP_Hz260;
+      break;
+    case LSM6DSR_AUX_HP_1Hz040:
+      *val = LSM6DSR_AUX_HP_1Hz040;
+      break;
+    default:
+      *val = LSM6DSR_AUX_HP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp. Enable: All OIS chain
+  *         outputs = 8000h during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full scale selected.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_ois_clampdis in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_clamp_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_st_ois_clampdis_t val)
+{
+  lsm6dsr_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.st_ois_clampdis= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable / Disables OIS chain clamp. Enable: All OIS chain
+  *         outputs = 8000h during self-test; Disable: OIS chain self-test
+  *         outputs dependent from the aux gyro full scale selected.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_ois_clampdis in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_clamp_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_st_ois_clampdis_t *val)
+{
+  lsm6dsr_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+
+  switch (ctrl3_ois.st_ois_clampdis){
+    case LSM6DSR_ENABLE_CLAMP:
+      *val = LSM6DSR_ENABLE_CLAMP;
+      break;
+    case LSM6DSR_DISABLE_CLAMP:
+      *val = LSM6DSR_DISABLE_CLAMP;
+      break;
+    default:
+      *val = LSM6DSR_ENABLE_CLAMP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of st_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_self_test_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_st_ois_t val)
+{
+  lsm6dsr_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.st_ois= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects gyroscope OIS chain self-test.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of st_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_gy_self_test_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_st_ois_t *val)
+{
+  lsm6dsr_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+
+  switch (ctrl3_ois.st_ois){
+    case LSM6DSR_AUX_GY_DISABLE:
+      *val = LSM6DSR_AUX_GY_DISABLE;
+      break;
+    case LSM6DSR_AUX_GY_POS:
+      *val = LSM6DSR_AUX_GY_POS;
+      break;
+    case LSM6DSR_AUX_GY_NEG:
+      *val = LSM6DSR_AUX_GY_NEG;
+      break;
+    default:
+      *val = LSM6DSR_AUX_GY_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of filter_xl_conf_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_xl_bandwidth_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_filter_xl_conf_ois_t val)
+{
+  lsm6dsr_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.filter_xl_conf_ois= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel bandwidth.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of filter_xl_conf_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_xl_bandwidth_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_filter_xl_conf_ois_t *val)
+{
+  lsm6dsr_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+
+  switch (ctrl3_ois.filter_xl_conf_ois){
+    case LSM6DSR_631Hz:
+      *val = LSM6DSR_631Hz;
+      break;
+    case LSM6DSR_295Hz:
+      *val = LSM6DSR_295Hz;
+      break;
+    case LSM6DSR_140Hz:
+      *val = LSM6DSR_140Hz;
+      break;
+    case LSM6DSR_68Hz2:
+      *val = LSM6DSR_68Hz2;
+      break;
+    case LSM6DSR_33Hz6:
+      *val = LSM6DSR_33Hz6;
+      break;
+    case LSM6DSR_16Hz7:
+      *val = LSM6DSR_16Hz7;
+      break;
+    case LSM6DSR_8Hz3:
+      *val = LSM6DSR_8Hz3;
+      break;
+    case LSM6DSR_4Hz11:
+      *val = LSM6DSR_4Hz11;
+      break;
+    default:
+      *val = LSM6DSR_631Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fs_xl_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                        lsm6dsr_fs_xl_ois_t val)
+{
+  lsm6dsr_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+  if(ret == 0){
+    ctrl3_ois.fs_xl_ois= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_OIS,
+                              (uint8_t*)&ctrl3_ois, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects accelerometer OIS channel full-scale.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fs_xl_ois in reg CTRL3_OIS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                        lsm6dsr_fs_xl_ois_t *val)
+{
+  lsm6dsr_ctrl3_ois_t ctrl3_ois;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_OIS, (uint8_t*)&ctrl3_ois, 1);
+
+  switch (ctrl3_ois.fs_xl_ois){
+    case LSM6DSR_AUX_2g:
+      *val = LSM6DSR_AUX_2g;
+      break;
+    case LSM6DSR_AUX_16g:
+      *val = LSM6DSR_AUX_16g;
+      break;
+    case LSM6DSR_AUX_4g:
+      *val = LSM6DSR_AUX_4g;
+      break;
+    case LSM6DSR_AUX_8g:
+      *val = LSM6DSR_AUX_8g;
+      break;
+    default:
+      *val = LSM6DSR_AUX_2g;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_ main_serial_interface
+  * @brief      This section groups all the functions concerning main
+  *             serial interface management (not auxiliary)
+  * @{
+  *
+  */
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sdo_pu_en in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sdo_sa0_mode_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sdo_pu_en_t val)
+{
+  lsm6dsr_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+  if(ret == 0){
+    pin_ctrl.sdo_pu_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Connect/Disconnect SDO/SA0 internal pull-up.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sdo_pu_en in reg PIN_CTRL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sdo_sa0_mode_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sdo_pu_en_t *val)
+{
+  lsm6dsr_pin_ctrl_t pin_ctrl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_PIN_CTRL, (uint8_t*)&pin_ctrl, 1);
+
+  switch (pin_ctrl.sdo_pu_en){
+    case LSM6DSR_PULL_UP_DISC:
+      *val = LSM6DSR_PULL_UP_DISC;
+      break;
+    case LSM6DSR_PULL_UP_CONNECT:
+      *val = LSM6DSR_PULL_UP_CONNECT;
+      break;
+    default:
+      *val = LSM6DSR_PULL_UP_DISC;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsr_sim_t val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.sim= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  SPI Serial Interface Mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sim in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsr_sim_t *val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.sim){
+    case LSM6DSR_SPI_4_WIRE:
+      *val = LSM6DSR_SPI_4_WIRE;
+      break;
+    case LSM6DSR_SPI_3_WIRE:
+      *val = LSM6DSR_SPI_3_WIRE;
+      break;
+    default:
+      *val = LSM6DSR_SPI_4_WIRE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i2c_disable in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_i2c_interface_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_i2c_disable_t val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.i2c_disable= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Disable / Enable I2C interface.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of i2c reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_i2c_interface_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_i2c_disable_t *val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+
+  switch (ctrl4_c.i2c_disable){
+    case LSM6DSR_I2C_ENABLE:
+      *val = LSM6DSR_I2C_ENABLE;
+      break;
+    case LSM6DSR_I2C_DISABLE:
+      *val = LSM6DSR_I2C_DISABLE;
+      break;
+    default:
+      *val = LSM6DSR_I2C_ENABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i3c_disable in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_i3c_disable_set(stmdev_ctx_t *ctx,
+                                lsm6dsr_i3c_disable_t val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  lsm6dsr_i3c_bus_avb_t i3c_bus_avb;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.i3c_disable = ((uint8_t)val & 0x80U) >> 7;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_I3C_BUS_AVB,
+                             (uint8_t*)&i3c_bus_avb, 1);
+  }
+  if(ret == 0){
+    i3c_bus_avb.i3c_bus_avb_sel = (uint8_t)val & 0x03U;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_I3C_BUS_AVB,
+                              (uint8_t*)&i3c_bus_avb, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I3C Enable/Disable communication protocol.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of i3c_disable in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_i3c_disable_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_i3c_disable_t *val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  lsm6dsr_i3c_bus_avb_t i3c_bus_avb;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_I3C_BUS_AVB,
+                             (uint8_t*)&i3c_bus_avb, 1);
+  }
+  switch ((ctrl9_xl.i3c_disable << 7) + i3c_bus_avb.i3c_bus_avb_sel){
+    case LSM6DSR_I3C_DISABLE:
+      *val = LSM6DSR_I3C_DISABLE;
+      break;
+    case LSM6DSR_I3C_ENABLE_T_50us:
+      *val = LSM6DSR_I3C_ENABLE_T_50us;
+      break;
+    case LSM6DSR_I3C_ENABLE_T_2us:
+      *val = LSM6DSR_I3C_ENABLE_T_2us;
+      break;
+    case LSM6DSR_I3C_ENABLE_T_1ms:
+      *val = LSM6DSR_I3C_ENABLE_T_1ms;
+      break;
+    case LSM6DSR_I3C_ENABLE_T_25ms:
+      *val = LSM6DSR_I3C_ENABLE_T_25ms;
+      break;
+    default:
+      *val = LSM6DSR_I3C_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_interrupt_pins
+  * @brief      This section groups all the functions that manage
+  *             interrup pins
+  * @{
+  *
+  */
+
+/**
+  * @brief   Select the signal that need to route on int1 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL,MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_pin_int1_route_t *val)
+{
+  lsm6dsr_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_INT1,
+                              (uint8_t*)&val->emb_func_int1, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_INT1_A,
+                              (uint8_t*)&val->fsm_int1_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_INT1_B,
+                              (uint8_t*)&val->fsm_int1_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  if(ret == 0){
+    if ((val->emb_func_int1.int1_fsm_lc |
+         val->emb_func_int1.int1_sig_mot |
+         val->emb_func_int1.int1_step_detector |
+         val->emb_func_int1.int1_tilt |
+         val->fsm_int1_a.int1_fsm1 |
+         val->fsm_int1_a.int1_fsm2 |
+         val->fsm_int1_a.int1_fsm3 |
+         val->fsm_int1_a.int1_fsm4 |
+         val->fsm_int1_a.int1_fsm5 |
+         val->fsm_int1_a.int1_fsm6 |
+         val->fsm_int1_a.int1_fsm7 |
+         val->fsm_int1_a.int1_fsm8 |
+         val->fsm_int1_b.int1_fsm9 |
+         val->fsm_int1_b.int1_fsm10 |
+         val->fsm_int1_b.int1_fsm11 |
+         val->fsm_int1_b.int1_fsm12 |
+         val->fsm_int1_b.int1_fsm13 |
+         val->fsm_int1_b.int1_fsm14 |
+         val->fsm_int1_b.int1_fsm15 |
+         val->fsm_int1_b.int1_fsm16) != PROPERTY_DISABLE){
+      val->md1_cfg.int1_emb_func = PROPERTY_ENABLE;
+    }
+    else{
+      val->md1_cfg.int1_emb_func = PROPERTY_DISABLE;
+    }
+  ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT1_CTRL,
+                            (uint8_t*)&val->int1_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MD1_CFG,
+                              (uint8_t*)&val->md1_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+    if ((val->int1_ctrl.den_drdy_flag |
+         val->int1_ctrl.int1_boot |
+         val->int1_ctrl.int1_cnt_bdr |
+         val->int1_ctrl.int1_drdy_g |
+         val->int1_ctrl.int1_drdy_xl |
+         val->int1_ctrl.int1_fifo_full |
+         val->int1_ctrl.int1_fifo_ovr |
+         val->int1_ctrl.int1_fifo_th |
+         val->md1_cfg.int1_6d |
+         val->md1_cfg.int1_double_tap |
+         val->md1_cfg.int1_ff |
+         val->md1_cfg.int1_wu |
+         val->md1_cfg.int1_single_tap |
+         val->md1_cfg.int1_sleep_change)!= PROPERTY_DISABLE){
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG2,
+                              (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int1 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers: INT1_CTRL, MD1_CFG,
+  *                EMB_FUNC_INT1, FSM_INT1_A, FSM_INT1_B.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_pin_int1_route_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_INT1,
+                             (uint8_t*)&val->emb_func_int1, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_INT1_A,
+                             (uint8_t*)&val->fsm_int1_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_INT1_B,
+                             (uint8_t*)&val->fsm_int1_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT1_CTRL,
+                             (uint8_t*)&val->int1_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MD1_CFG,
+                             (uint8_t*)&val->md1_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_pin_int2_route_t *val)
+{
+  lsm6dsr_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_INT2,
+                              (uint8_t*)&val->emb_func_int2, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_INT2_A,
+                              (uint8_t*)&val->fsm_int2_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_INT2_B,
+                              (uint8_t*)&val->fsm_int2_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  if(ret == 0){
+    if ((val->emb_func_int2.int2_step_detector |
+         val->emb_func_int2.int2_tilt |
+         val->emb_func_int2.int2_sig_mot |
+         val->emb_func_int2.int2_fsm_lc |
+         val->fsm_int2_a.int2_fsm1 |
+         val->fsm_int2_a.int2_fsm2 |
+         val->fsm_int2_a.int2_fsm3 |
+         val->fsm_int2_a.int2_fsm4 |
+         val->fsm_int2_a.int2_fsm5 |
+         val->fsm_int2_a.int2_fsm6 |
+         val->fsm_int2_a.int2_fsm7 |
+         val->fsm_int2_a.int2_fsm8 |
+         val->fsm_int2_b.int2_fsm9 |
+         val->fsm_int2_b.int2_fsm10 |
+         val->fsm_int2_b.int2_fsm11 |
+         val->fsm_int2_b.int2_fsm12 |
+         val->fsm_int2_b.int2_fsm13 |
+         val->fsm_int2_b.int2_fsm14 |
+         val->fsm_int2_b.int2_fsm15 |
+         val->fsm_int2_b.int2_fsm16) != PROPERTY_DISABLE){
+      val->md2_cfg.int2_emb_func = PROPERTY_ENABLE;
+    }
+    else{
+      val->md2_cfg.int2_emb_func = PROPERTY_DISABLE;
+    }
+  ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT2_CTRL,
+                            (uint8_t*)&val->int2_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MD2_CFG,
+                              (uint8_t*)&val->md2_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2,
+                             (uint8_t*)&tap_cfg2, 1);
+  }
+  if(ret == 0){
+    if ((val->int2_ctrl.int2_drdy_xl |
+         val->int2_ctrl.int2_drdy_g |
+         val->int2_ctrl.int2_drdy_temp |
+         val->int2_ctrl.int2_fifo_th |
+         val->int2_ctrl.int2_fifo_ovr |
+         val->int2_ctrl.int2_fifo_full |
+         val->int2_ctrl.int2_cnt_bdr |
+         val->md2_cfg.int2_6d |
+         val->md2_cfg.int2_double_tap |
+         val->md2_cfg.int2_ff |
+         val->md2_cfg.int2_wu |
+         val->md2_cfg.int2_single_tap |
+         val->md2_cfg.int2_sleep_change) != PROPERTY_DISABLE){
+      tap_cfg2.interrupts_enable = PROPERTY_ENABLE;
+    }
+    else{
+      tap_cfg2.interrupts_enable = PROPERTY_DISABLE;
+    }
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG2,
+                              (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Select the signal that need to route on int2 pad.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers INT2_CTRL,  MD2_CFG,
+  *                EMB_FUNC_INT2, FSM_INT2_A, FSM_INT2_B.[get]
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_pin_int2_route_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_INT2,
+                             (uint8_t*)&val->emb_func_int2, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_INT2_A,
+                             (uint8_t*)&val->fsm_int2_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_INT2_B,
+                             (uint8_t*)&val->fsm_int2_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT2_CTRL,
+                             (uint8_t*)&val->int2_ctrl, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MD2_CFG,
+                             (uint8_t*)&val->md2_cfg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsr_pp_od_t val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.pp_od= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Push-pull/open drain selection on interrupt pads.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of pp_od in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsr_pp_od_t *val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.pp_od){
+    case LSM6DSR_PUSH_PULL:
+      *val = LSM6DSR_PUSH_PULL;
+      break;
+    case LSM6DSR_OPEN_DRAIN:
+      *val = LSM6DSR_OPEN_DRAIN;
+      break;
+    default:
+      *val = LSM6DSR_PUSH_PULL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pin_polarity_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_h_lactive_t val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  if(ret == 0){
+    ctrl3_c.h_lactive= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt active-high/low.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of h_lactive in reg CTRL3_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pin_polarity_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_h_lactive_t *val)
+{
+  lsm6dsr_ctrl3_c_t ctrl3_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL3_C, (uint8_t*)&ctrl3_c, 1);
+
+  switch (ctrl3_c.h_lactive){
+    case LSM6DSR_ACTIVE_HIGH:
+      *val = LSM6DSR_ACTIVE_HIGH;
+      break;
+    case LSM6DSR_ACTIVE_LOW:
+      *val = LSM6DSR_ACTIVE_LOW;
+      break;
+    default:
+      *val = LSM6DSR_ACTIVE_HIGH;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.int2_on_int1= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals become available on INT1 pin.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of int2_on_int1 in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.int2_on_int1;
+
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals notification mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of lir in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_int_notification_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_lir_t val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  lsm6dsr_page_rw_t page_rw;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.lir = (uint8_t)val & 0x01U;
+    tap_cfg0.int_clr_on_read = (uint8_t)val & 0x01U;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    page_rw.emb_func_lir = ((uint8_t)val & 0x02U) >> 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  All interrupt signals notification mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of lir in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_int_notification_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_lir_t *val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  lsm6dsr_page_rw_t page_rw;
+  int32_t ret;
+
+  *val = LSM6DSR_ALL_INT_PULSED;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_PAGE_RW, (uint8_t*)&page_rw, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  switch ((page_rw.emb_func_lir << 1) + tap_cfg0.lir){
+    case LSM6DSR_ALL_INT_PULSED:
+      *val = LSM6DSR_ALL_INT_PULSED;
+      break;
+    case LSM6DSR_BASE_LATCHED_EMB_PULSED:
+      *val = LSM6DSR_BASE_LATCHED_EMB_PULSED;
+      break;
+    case LSM6DSR_BASE_PULSED_EMB_LATCHED:
+      *val = LSM6DSR_BASE_PULSED_EMB_LATCHED;
+      break;
+    case LSM6DSR_ALL_INT_LATCHED:
+      *val = LSM6DSR_ALL_INT_LATCHED;
+      break;
+    default:
+      *val = LSM6DSR_ALL_INT_PULSED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_Wake_Up_event
+  * @brief      This section groups all the functions that manage the
+  *             Wake Up event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[set]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_ths_w in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_wkup_ths_weight_set(stmdev_ctx_t *ctx,
+                                      lsm6dsr_wake_ths_w_t val)
+{
+  lsm6dsr_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_ths_w= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Weight of 1 LSB of wakeup threshold.[get]
+  *         0: 1 LSB =FS_XL  /  64
+  *         1: 1 LSB = FS_XL / 256
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of wake_ths_w in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_wkup_ths_weight_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_wake_ths_w_t *val)
+{
+  lsm6dsr_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+
+  switch (wake_up_dur.wake_ths_w){
+    case LSM6DSR_LSb_FS_DIV_64:
+      *val = LSM6DSR_LSb_FS_DIV_64;
+      break;
+    case LSM6DSR_LSb_FS_DIV_256:
+      *val = LSM6DSR_LSb_FS_DIV_256;
+      break;
+    default:
+      *val = LSM6DSR_LSb_FS_DIV_64;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.wk_ths= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for wakeup: 1 LSB weight depends on WAKE_THS_W in
+  *         WAKE_UP_DUR.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wk_ths in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.wk_ths;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event( 1LSb = 1 / ODR ).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_wu in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.usr_off_on_wu= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event( 1LSb = 1 / ODR ).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of usr_off_on_wu in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  lsm6dsr_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  *val = wake_up_ths.usr_off_on_wu;
+
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.wake_dur= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Wake up duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wake_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.wake_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_ Activity/Inactivity_detection
+  * @brief      This section groups all the functions concerning
+  *             activity/inactivity detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  if(ret == 0){
+    ctrl4_c.sleep_g= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables gyroscope Sleep mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_g in reg CTRL4_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl4_c_t ctrl4_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL4_C, (uint8_t*)&ctrl4_c, 1);
+  *val = ctrl4_c.sleep_g;
+
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of sleep change on INT pins
+  *         (only if INT1_SLEEP_CHANGE or INT2_SLEEP_CHANGE bits
+  *         are enabled).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_status_on_int in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_act_pin_notification_set(stmdev_ctx_t *ctx,
+                                           lsm6dsr_sleep_status_on_int_t val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0. sleep_status_on_int= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Drives the sleep status instead of sleep change on INT pins
+  *         (only if INT1_SLEEP_CHANGE or INT2_SLEEP_CHANGE bits
+  *         are enabled).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sleep_status_on_int in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_act_pin_notification_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_sleep_status_on_int_t *val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  switch (tap_cfg0. sleep_status_on_int){
+    case LSM6DSR_DRIVE_SLEEP_CHG_EVENT:
+      *val = LSM6DSR_DRIVE_SLEEP_CHG_EVENT;
+      break;
+    case LSM6DSR_DRIVE_SLEEP_STATUS:
+      *val = LSM6DSR_DRIVE_SLEEP_STATUS;
+      break;
+    default:
+      *val = LSM6DSR_DRIVE_SLEEP_CHG_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of inact_en in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_act_mode_set(stmdev_ctx_t *ctx, lsm6dsr_inact_en_t val)
+{
+  lsm6dsr_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+  if(ret == 0){
+    tap_cfg2.inact_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable inactivity function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of inact_en in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_act_mode_get(stmdev_ctx_t *ctx,
+                               lsm6dsr_inact_en_t *val)
+{
+  lsm6dsr_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+
+  switch (tap_cfg2.inact_en){
+    case LSM6DSR_XL_AND_GY_NOT_AFFECTED:
+      *val = LSM6DSR_XL_AND_GY_NOT_AFFECTED;
+      break;
+    case LSM6DSR_XL_12Hz5_GY_NOT_AFFECTED:
+      *val = LSM6DSR_XL_12Hz5_GY_NOT_AFFECTED;
+      break;
+    case LSM6DSR_XL_12Hz5_GY_SLEEP:
+      *val = LSM6DSR_XL_12Hz5_GY_SLEEP;
+      break;
+    case LSM6DSR_XL_12Hz5_GY_PD:
+      *val = LSM6DSR_XL_12Hz5_GY_PD;
+      break;
+    default:
+      *val = LSM6DSR_XL_AND_GY_NOT_AFFECTED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode (1 LSb = 512 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.sleep_dur= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Duration to go in sleep mode.(1 LSb = 512 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sleep_dur in reg WAKE_UP_DUR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_wake_up_dur_t wake_up_dur;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  *val = wake_up_dur.sleep_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_tap_generator
+  * @brief      This section groups all the functions that manage the
+  *             tap and double tap event generation.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable Z direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.tap_z_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Z direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_z_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  *val = tap_cfg0.tap_z_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.tap_y_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable Y direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_y_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  *val = tap_cfg0.tap_y_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  if(ret == 0){
+    tap_cfg0.tap_x_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG0,
+                              (uint8_t*)&tap_cfg0, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable X direction in tap recognition.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_x_en in reg TAP_CFG0
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_tap_cfg0_t tap_cfg0;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG0, (uint8_t*)&tap_cfg0, 1);
+  *val = tap_cfg0.tap_x_en;
+
+  return ret;
+}
+
+/**
+  * @brief  X-axis tap recognition threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_x in reg TAP_CFG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+  if(ret == 0){
+    tap_cfg1.tap_ths_x= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG1,
+                              (uint8_t*)&tap_cfg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  X-axis tap recognition threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_x in reg TAP_CFG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+  *val = tap_cfg1.tap_ths_x;
+
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_priority in reg TAP_CFG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_axis_priority_set(stmdev_ctx_t *ctx,
+                                        lsm6dsr_tap_priority_t val)
+{
+  lsm6dsr_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+  if(ret == 0){
+    tap_cfg1.tap_priority= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selection of axis priority for TAP detection[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tap_priority in reg TAP_CFG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_axis_priority_get(stmdev_ctx_t *ctx,
+                                        lsm6dsr_tap_priority_t *val)
+{
+  lsm6dsr_tap_cfg1_t tap_cfg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG1, (uint8_t*)&tap_cfg1, 1);
+
+  switch (tap_cfg1.tap_priority){
+    case LSM6DSR_XYZ:
+      *val = LSM6DSR_XYZ;
+      break;
+    case LSM6DSR_YXZ:
+      *val = LSM6DSR_YXZ;
+      break;
+    case LSM6DSR_XZY:
+      *val = LSM6DSR_XZY;
+      break;
+    case LSM6DSR_ZYX:
+      *val = LSM6DSR_ZYX;
+      break;
+    case LSM6DSR_YZX:
+      *val = LSM6DSR_YZX;
+      break;
+    case LSM6DSR_ZXY:
+      *val = LSM6DSR_ZXY;
+      break;
+    default:
+      *val = LSM6DSR_XYZ;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y-axis tap recognition threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_y in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+  if(ret == 0){
+    tap_cfg2.tap_ths_y= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_CFG2,
+                              (uint8_t*)&tap_cfg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Y-axis tap recognition threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_y in reg TAP_CFG2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_tap_cfg2_t tap_cfg2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_CFG2, (uint8_t*)&tap_cfg2, 1);
+  *val = tap_cfg2.tap_ths_y;
+
+  return ret;
+}
+
+/**
+  * @brief  Z-axis recognition threshold.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_z in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.tap_ths_z= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Z-axis recognition threshold.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tap_ths_z in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.tap_ths_z;
+
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value of
+  *         these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.shock= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_DUR2,
+                              (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Maximum duration is the maximum time of an overthreshold signal
+  *         detection to be recognized as a tap event. The default value of
+  *         these bits is 00b which corresponds to 4*ODR_XL time.
+  *         If the SHOCK[1:0] bits are set to a different value, 1LSB
+  *         corresponds to 8*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of shock in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.shock;
+
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.quiet= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_DUR2,
+                              (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Quiet time is the time after the first detected tap in which
+  *         there must not be any overthreshold event.
+  *         The default value of these bits is 00b which corresponds to
+  *         2*ODR_XL time. If the QUIET[1:0] bits are set to a different
+  *         value, 1LSB corresponds to 4*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of quiet in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.quiet;
+
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses
+  *         the maximum time between two consecutive detected taps to
+  *         determine a double tap event.
+  *         The default value of these bits is 0000b which corresponds to
+  *         16*ODR_XL time.
+  *         If the DUR[3:0] bits are set to a different value, 1LSB
+  *         corresponds to 32*ODR_XL time.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  if(ret == 0){
+    int_dur2.dur= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_INT_DUR2,
+                              (uint8_t*)&int_dur2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  When double tap recognition is enabled, this register expresses the
+  *         maximum time between two consecutive detected taps to determine
+  *         a double tap event. The default value of these bits is 0000b which
+  *         corresponds to 16*ODR_XL time. If the DUR[3:0] bits are set to
+  *         a different value, 1LSB corresponds to 32*ODR_XL time.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of dur in reg INT_DUR2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_int_dur2_t int_dur2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_INT_DUR2, (uint8_t*)&int_dur2, 1);
+  *val = int_dur2.dur;
+
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_mode_set(stmdev_ctx_t *ctx,
+                               lsm6dsr_single_double_tap_t val)
+{
+  lsm6dsr_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+  if(ret == 0){
+    wake_up_ths.single_double_tap= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                              (uint8_t*)&wake_up_ths, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Single/double-tap event enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of single_double_tap in reg WAKE_UP_THS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tap_mode_get(stmdev_ctx_t *ctx,
+                               lsm6dsr_single_double_tap_t *val)
+{
+  lsm6dsr_wake_up_ths_t wake_up_ths;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_THS,
+                           (uint8_t*)&wake_up_ths, 1);
+
+  switch (wake_up_ths.single_double_tap){
+    case LSM6DSR_ONLY_SINGLE:
+      *val = LSM6DSR_ONLY_SINGLE;
+      break;
+    case LSM6DSR_BOTH_SINGLE_DOUBLE:
+      *val = LSM6DSR_BOTH_SINGLE_DOUBLE;
+      break;
+    default:
+      *val = LSM6DSR_ONLY_SINGLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_ Six_position_detection(6D/4D)
+  * @brief      This section groups all the functions concerning six
+  *             position detection (6D).
+  * @{
+  *
+  */
+
+/**
+  * @brief  Threshold for 4D/6D function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_6d_threshold_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sixd_ths_t val)
+{
+  lsm6dsr_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.sixd_ths= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Threshold for 4D/6D function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of sixd_ths in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_6d_threshold_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sixd_ths_t *val)
+{
+  lsm6dsr_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+
+  switch (tap_ths_6d.sixd_ths){
+    case LSM6DSR_DEG_80:
+      *val = LSM6DSR_DEG_80;
+      break;
+    case LSM6DSR_DEG_70:
+      *val = LSM6DSR_DEG_70;
+      break;
+    case LSM6DSR_DEG_60:
+      *val = LSM6DSR_DEG_60;
+      break;
+    case LSM6DSR_DEG_50:
+      *val = LSM6DSR_DEG_50;
+      break;
+    default:
+      *val = LSM6DSR_DEG_80;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  if(ret == 0){
+    tap_ths_6d.d4d_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_TAP_THS_6D,
+                              (uint8_t*)&tap_ths_6d, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  4D orientation detection enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of d4d_en in reg TAP_THS_6D
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_tap_ths_6d_t tap_ths_6d;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_TAP_THS_6D,
+                           (uint8_t*)&tap_ths_6d, 1);
+  *val = tap_ths_6d.d4d_en;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_free_fall
+  * @brief      This section group all the functions concerning the free
+  *             fall detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Free fall threshold setting.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_ff_threshold_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_ff_ths_t val)
+{
+  lsm6dsr_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FREE_FALL, (uint8_t*)&free_fall, 1);
+  if(ret == 0){
+    free_fall.ff_ths= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FREE_FALL,
+                              (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free fall threshold setting.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of ff_ths in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_ff_threshold_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_ff_ths_t *val)
+{
+  lsm6dsr_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FREE_FALL, (uint8_t*)&free_fall, 1);
+
+  switch (free_fall.ff_ths){
+    case LSM6DSR_FF_TSH_156mg:
+      *val = LSM6DSR_FF_TSH_156mg;
+      break;
+    case LSM6DSR_FF_TSH_219mg:
+      *val = LSM6DSR_FF_TSH_219mg;
+      break;
+    case LSM6DSR_FF_TSH_250mg:
+      *val = LSM6DSR_FF_TSH_250mg;
+      break;
+    case LSM6DSR_FF_TSH_312mg:
+      *val = LSM6DSR_FF_TSH_312mg;
+      break;
+    case LSM6DSR_FF_TSH_344mg:
+      *val = LSM6DSR_FF_TSH_344mg;
+      break;
+    case LSM6DSR_FF_TSH_406mg:
+      *val = LSM6DSR_FF_TSH_406mg;
+      break;
+    case LSM6DSR_FF_TSH_469mg:
+      *val = LSM6DSR_FF_TSH_469mg;
+      break;
+    case LSM6DSR_FF_TSH_500mg:
+      *val = LSM6DSR_FF_TSH_500mg;
+      break;
+    default:
+      *val = LSM6DSR_FF_TSH_156mg;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event(1LSb = 1 / ODR).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_dur in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_wake_up_dur_t wake_up_dur;
+  lsm6dsr_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+  if(ret == 0){
+    wake_up_dur.ff_dur = (val & 0x20U) >> 5;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                              (uint8_t*)&wake_up_dur, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FREE_FALL,
+                             (uint8_t*)&free_fall, 1);
+  }
+  if(ret == 0){
+    free_fall.ff_dur = val & 0x1FU;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FREE_FALL,
+                              (uint8_t*)&free_fall, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Free-fall duration event(1LSb = 1 / ODR).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ff_dur in reg FREE_FALL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_wake_up_dur_t wake_up_dur;
+  lsm6dsr_free_fall_t free_fall;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_WAKE_UP_DUR,
+                           (uint8_t*)&wake_up_dur, 1);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FREE_FALL,
+                             (uint8_t*)&free_fall, 1);
+  }
+  *val = (wake_up_dur.ff_dur << 5) + free_fall.ff_dur;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_fifo
+  * @brief      This section group all the functions concerning
+  *             the fifo usage
+  * @{
+  *
+  */
+
+/**
+  * @brief  FIFO watermark level selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  lsm6dsr_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl1.wtm = (uint8_t)(0x00FFU & val);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL1,
+                              (uint8_t*)&fifo_ctrl1, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl2.wtm = (uint8_t)(( 0x0100U & val ) >> 8);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark level selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of wtm in reg FIFO_CTRL1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsr_fifo_ctrl1_t fifo_ctrl1;
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL1,
+                             (uint8_t*)&fifo_ctrl1, 1);
+  }
+  *val = fifo_ctrl2.wtm;
+  *val = *val << 8;
+  *val += fifo_ctrl1.wtm;
+  return ret;
+}
+
+/**
+  * @brief  FIFO compression feature initialization request.[set].
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of FIFO_COMPR_INIT in reg EMB_FUNC_INIT_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_compression_algo_init_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_INIT_B,
+                             (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    emb_func_init_b.fifo_compr_init= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_INIT_B,
+                              (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO compression feature initialization request.[get].
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    change the values of FIFO_COMPR_INIT in
+  *                reg EMB_FUNC_INIT_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_compression_algo_init_get(stmdev_ctx_t *ctx,
+                                            uint8_t *val)
+{
+  lsm6dsr_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_INIT_B,
+                             (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_init_b.fifo_compr_init;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable and configure compression algo.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of uncoptr_rate in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_compression_algo_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_uncoptr_rate_t val)
+{
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  lsm6dsr_emb_func_en_b_t emb_func_en_b;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    emb_func_en_b.fifo_compr_en = ((uint8_t)val & 0x04U) >> 2;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                              (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                             (uint8_t*)&fifo_ctrl2, 1);
+  }
+  if(ret == 0){
+    fifo_ctrl2.fifo_compr_rt_en = ((uint8_t)val & 0x04U) >> 2;
+    fifo_ctrl2.uncoptr_rate = (uint8_t)val & 0x03U;
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable and configure compression algo.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of uncoptr_rate in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_compression_algo_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_uncoptr_rate_t *val)
+{
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+
+  switch (( fifo_ctrl2.fifo_compr_rt_en << 2) + fifo_ctrl2.uncoptr_rate ){
+    case LSM6DSR_CMP_DISABLE:
+      *val = LSM6DSR_CMP_DISABLE;
+      break;
+    case LSM6DSR_CMP_ALWAYS:
+      *val = LSM6DSR_CMP_ALWAYS;
+      break;
+    case LSM6DSR_CMP_8_TO_1:
+      *val = LSM6DSR_CMP_8_TO_1;
+      break;
+    case LSM6DSR_CMP_16_TO_1:
+      *val = LSM6DSR_CMP_16_TO_1;
+      break;
+    case LSM6DSR_CMP_32_TO_1:
+      *val = LSM6DSR_CMP_32_TO_1;
+      break;
+    default:
+      *val = LSM6DSR_CMP_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odrchg_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
+                                                uint8_t val)
+{
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.odrchg_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables ODR CHANGE virtual sensor to be batched in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odrchg_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
+                                                uint8_t *val)
+{
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.odrchg_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_compr_rt_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_compression_algo_real_time_set(stmdev_ctx_t *ctx,
+                                                 uint8_t val)
+{
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.fifo_compr_rt_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables/Disables compression algorithm runtime.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_compr_rt_en in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_compression_algo_real_time_get(stmdev_ctx_t *ctx,
+                                                 uint8_t *val)
+{
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.fifo_compr_rt_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_wtm in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  if(ret == 0){
+    fifo_ctrl2.stop_on_wtm= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                              (uint8_t*)&fifo_ctrl2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensing chain FIFO stop values memorization at threshold
+  *         level.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of stop_on_wtm in reg FIFO_CTRL2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_fifo_ctrl2_t fifo_ctrl2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL2,
+                           (uint8_t*)&fifo_ctrl2, 1);
+  *val = fifo_ctrl2.stop_on_wtm;
+
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdr_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_xl_batch_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_bdr_xl_t val)
+{
+  lsm6dsr_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.bdr_xl= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for accelerometer data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdr_xl in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_xl_batch_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_bdr_xl_t *val)
+{
+  lsm6dsr_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.bdr_xl){
+    case LSM6DSR_XL_NOT_BATCHED:
+      *val = LSM6DSR_XL_NOT_BATCHED;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_12Hz5:
+      *val = LSM6DSR_XL_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_26Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_26Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_52Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_52Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_104Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_104Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_208Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_208Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_417Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_417Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_833Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_833Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_1667Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_1667Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_3333Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_3333Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_6667Hz:
+      *val = LSM6DSR_XL_BATCHED_AT_6667Hz;
+      break;
+    case LSM6DSR_XL_BATCHED_AT_6Hz5:
+      *val = LSM6DSR_XL_BATCHED_AT_6Hz5;
+      break;
+    default:
+      *val = LSM6DSR_XL_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of bdr_gy in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_gy_batch_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_bdr_gy_t val)
+{
+  lsm6dsr_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+  if(ret == 0){
+    fifo_ctrl3.bdr_gy= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL3,
+                              (uint8_t*)&fifo_ctrl3, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for gyroscope data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of bdr_gy in reg FIFO_CTRL3
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_gy_batch_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_bdr_gy_t *val)
+{
+  lsm6dsr_fifo_ctrl3_t fifo_ctrl3;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL3,
+                           (uint8_t*)&fifo_ctrl3, 1);
+
+  switch (fifo_ctrl3.bdr_gy){
+    case LSM6DSR_GY_NOT_BATCHED:
+      *val = LSM6DSR_GY_NOT_BATCHED;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_12Hz5:
+      *val = LSM6DSR_GY_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_26Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_26Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_52Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_52Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_104Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_104Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_208Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_208Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_417Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_417Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_833Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_833Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_1667Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_1667Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_3333Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_3333Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_AT_6667Hz:
+      *val = LSM6DSR_GY_BATCHED_AT_6667Hz;
+      break;
+    case LSM6DSR_GY_BATCHED_6Hz5:
+      *val = LSM6DSR_GY_BATCHED_6Hz5;
+      break;
+    default:
+      *val = LSM6DSR_GY_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_mode in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_mode_set(stmdev_ctx_t *ctx,
+                                lsm6dsr_fifo_mode_t val)
+{
+  lsm6dsr_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.fifo_mode= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FIFO mode selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fifo_mode in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_mode_get(stmdev_ctx_t *ctx,
+                                lsm6dsr_fifo_mode_t *val)
+{
+  lsm6dsr_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.fifo_mode){
+    case LSM6DSR_BYPASS_MODE:
+      *val = LSM6DSR_BYPASS_MODE;
+      break;
+    case LSM6DSR_FIFO_MODE:
+      *val = LSM6DSR_FIFO_MODE;
+      break;
+    case LSM6DSR_STREAM_TO_FIFO_MODE:
+      *val = LSM6DSR_STREAM_TO_FIFO_MODE;
+      break;
+    case LSM6DSR_BYPASS_TO_STREAM_MODE:
+      *val = LSM6DSR_BYPASS_TO_STREAM_MODE;
+      break;
+    case LSM6DSR_STREAM_MODE:
+      *val = LSM6DSR_STREAM_MODE;
+      break;
+    case LSM6DSR_BYPASS_TO_FIFO_MODE:
+      *val = LSM6DSR_BYPASS_TO_FIFO_MODE;
+      break;
+    default:
+      *val = LSM6DSR_BYPASS_MODE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_t_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_temp_batch_set(stmdev_ctx_t *ctx,
+                                      lsm6dsr_odr_t_batch_t val)
+{
+  lsm6dsr_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.odr_t_batch= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects Batching Data Rate (writing frequency in FIFO)
+  *         for temperature data.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_t_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_temp_batch_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_odr_t_batch_t *val)
+{
+  lsm6dsr_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.odr_t_batch){
+    case LSM6DSR_TEMP_NOT_BATCHED:
+      *val = LSM6DSR_TEMP_NOT_BATCHED;
+      break;
+    case LSM6DSR_TEMP_BATCHED_AT_52Hz:
+      *val = LSM6DSR_TEMP_BATCHED_AT_52Hz;
+      break;
+    case LSM6DSR_TEMP_BATCHED_AT_12Hz5:
+      *val = LSM6DSR_TEMP_BATCHED_AT_12Hz5;
+      break;
+    case LSM6DSR_TEMP_BATCHED_AT_1Hz6:
+      *val = LSM6DSR_TEMP_BATCHED_AT_1Hz6;
+      break;
+    default:
+      *val = LSM6DSR_TEMP_NOT_BATCHED;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of odr_ts_batch in reg FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
+                                                lsm6dsr_odr_ts_batch_t val)
+{
+  lsm6dsr_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+  if(ret == 0){
+    fifo_ctrl4.odr_ts_batch= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                              (uint8_t*)&fifo_ctrl4, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects decimation for timestamp batching in FIFO.
+  *         Writing rate will be the maximum rate between XL and
+  *         GYRO BDR divided by decimation decoder.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of odr_ts_batch in reg
+  *                                 FIFO_CTRL4
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
+                                                lsm6dsr_odr_ts_batch_t *val)
+{
+  lsm6dsr_fifo_ctrl4_t fifo_ctrl4;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_CTRL4,
+                           (uint8_t*)&fifo_ctrl4, 1);
+
+  switch (fifo_ctrl4.odr_ts_batch){
+    case LSM6DSR_NO_DECIMATION:
+      *val = LSM6DSR_NO_DECIMATION;
+      break;
+    case LSM6DSR_DEC_1:
+      *val = LSM6DSR_DEC_1;
+      break;
+    case LSM6DSR_DEC_8:
+      *val = LSM6DSR_DEC_8;
+      break;
+    case LSM6DSR_DEC_32:
+      *val = LSM6DSR_DEC_32;
+      break;
+    default:
+      *val = LSM6DSR_NO_DECIMATION;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *         between XL and gyro.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of trig_counter_bdr in
+  *                reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_cnt_event_batch_set(stmdev_ctx_t *ctx,
+                                           lsm6dsr_trig_counter_bdr_t val)
+{
+  lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.trig_counter_bdr= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Selects the trigger for the internal counter of batching events
+  *          between XL and gyro.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of trig_counter_bdr
+  *                in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_cnt_event_batch_get(stmdev_ctx_t *ctx,
+                                           lsm6dsr_trig_counter_bdr_t *val)
+{
+  lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+
+  switch (counter_bdr_reg1.trig_counter_bdr){
+    case LSM6DSR_XL_BATCH_EVENT:
+      *val = LSM6DSR_XL_BATCH_EVENT;
+      break;
+    case LSM6DSR_GYRO_BATCH_EVENT:
+      *val = LSM6DSR_GYRO_BATCH_EVENT;
+      break;
+    default:
+      *val = LSM6DSR_XL_BATCH_EVENT;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if(ret == 0){
+    counter_bdr_reg1.rst_counter_bdr= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                              (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Resets the internal counter of batching events for a single sensor.
+  *         This bit is automatically reset to zero if it was set to ‘1’.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_counter_bdr in reg COUNTER_BDR_REG1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  *val = counter_bdr_reg1.rst_counter_bdr;
+
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of cnt_bdr_th in reg COUNTER_BDR_REG2
+  *                and COUNTER_BDR_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_batch_counter_threshold_set(stmdev_ctx_t *ctx,
+                                              uint16_t val)
+{
+  lsm6dsr_counter_bdr_reg2_t counter_bdr_reg1;
+  lsm6dsr_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0){
+    counter_bdr_reg1.cnt_bdr_th = (uint8_t)((0x0700U & val) >> 8);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_COUNTER_BDR_REG1, (uint8_t*)&counter_bdr_reg1, 1);
+  }
+  if (ret == 0){
+    counter_bdr_reg2.cnt_bdr_th = (uint8_t)(0x00FFU & val);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_COUNTER_BDR_REG2,
+                              (uint8_t*)&counter_bdr_reg2, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Batch data rate counter.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of cnt_bdr_th in reg COUNTER_BDR_REG2
+  *                and COUNTER_BDR_REG1.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_batch_counter_threshold_get(stmdev_ctx_t *ctx,
+                                              uint16_t *val)
+{
+  lsm6dsr_counter_bdr_reg1_t counter_bdr_reg1;
+  lsm6dsr_counter_bdr_reg2_t counter_bdr_reg2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG1,
+                           (uint8_t*)&counter_bdr_reg1, 1);
+  if (ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_COUNTER_BDR_REG2,
+                             (uint8_t*)&counter_bdr_reg2, 1);
+  }
+
+  *val = counter_bdr_reg1.cnt_bdr_th;
+  *val = *val << 8;
+  *val += counter_bdr_reg2.cnt_bdr_th;
+  return ret;
+}
+
+/**
+  * @brief  Number of unread sensor data (TAG + 6 bytes) stored in FIFO.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of diff_fifo in reg FIFO_STATUS1
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsr_fifo_status1_t fifo_status1;
+  lsm6dsr_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS1,
+                           (uint8_t*)&fifo_status1, 1);
+  if (ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2,
+                             (uint8_t*)&fifo_status2, 1);
+    *val = fifo_status2.diff_fifo;
+    *val = *val << 8;
+    *val += fifo_status1.diff_fifo;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Registers FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_status_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_fifo_status2_t *val)
+{
+  int32_t ret;
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2, (uint8_t*)val, 1);
+  return ret;
+}
+
+/**
+  * @brief  Smart FIFO full status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_full_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.fifo_full_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO overrun status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  fifo_over_run_latched in
+  *                reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2. fifo_ovr_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  FIFO watermark status.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fifo_wtm_ia in reg FIFO_STATUS2
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_fifo_status2_t fifo_status2;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_STATUS2,
+                           (uint8_t*)&fifo_status2, 1);
+  *val = fifo_status2.fifo_wtm_ia;
+
+  return ret;
+}
+
+/**
+  * @brief  Identifies the sensor in FIFO_DATA_OUT.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tag_sensor in reg FIFO_DATA_OUT_TAG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_fifo_tag_t *val)
+{
+  lsm6dsr_fifo_data_out_tag_t fifo_data_out_tag;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_FIFO_DATA_OUT_TAG,
+                           (uint8_t*)&fifo_data_out_tag, 1);
+
+  switch (fifo_data_out_tag.tag_sensor){
+    case LSM6DSR_GYRO_NC_TAG:
+      *val = LSM6DSR_GYRO_NC_TAG;
+      break;
+    case LSM6DSR_XL_NC_TAG:
+      *val = LSM6DSR_XL_NC_TAG;
+      break;
+    case LSM6DSR_TEMPERATURE_TAG:
+      *val = LSM6DSR_TEMPERATURE_TAG;
+      break;
+    case LSM6DSR_TIMESTAMP_TAG:
+      *val = LSM6DSR_TIMESTAMP_TAG;
+      break;
+    case LSM6DSR_CFG_CHANGE_TAG:
+      *val = LSM6DSR_CFG_CHANGE_TAG;
+      break;
+    case LSM6DSR_XL_NC_T_2_TAG:
+      *val = LSM6DSR_XL_NC_T_2_TAG;
+      break;
+    case LSM6DSR_XL_NC_T_1_TAG:
+      *val = LSM6DSR_XL_NC_T_1_TAG;
+      break;
+    case LSM6DSR_XL_2XC_TAG:
+      *val = LSM6DSR_XL_2XC_TAG;
+      break;
+    case LSM6DSR_XL_3XC_TAG:
+      *val = LSM6DSR_XL_3XC_TAG;
+      break;
+    case LSM6DSR_GYRO_NC_T_2_TAG:
+      *val = LSM6DSR_GYRO_NC_T_2_TAG;
+      break;
+    case LSM6DSR_GYRO_NC_T_1_TAG:
+      *val = LSM6DSR_GYRO_NC_T_1_TAG;
+      break;
+    case LSM6DSR_GYRO_2XC_TAG:
+      *val = LSM6DSR_GYRO_2XC_TAG;
+      break;
+    case LSM6DSR_GYRO_3XC_TAG:
+      *val = LSM6DSR_GYRO_3XC_TAG;
+      break;
+    case LSM6DSR_SENSORHUB_SLAVE0_TAG:
+      *val = LSM6DSR_SENSORHUB_SLAVE0_TAG;
+      break;
+    case LSM6DSR_SENSORHUB_SLAVE1_TAG:
+      *val = LSM6DSR_SENSORHUB_SLAVE1_TAG;
+      break;
+    case LSM6DSR_SENSORHUB_SLAVE2_TAG:
+      *val = LSM6DSR_SENSORHUB_SLAVE2_TAG;
+      break;
+    case LSM6DSR_SENSORHUB_SLAVE3_TAG:
+      *val = LSM6DSR_SENSORHUB_SLAVE3_TAG;
+      break;
+    case LSM6DSR_STEP_CPUNTER_TAG:
+      *val = LSM6DSR_STEP_CPUNTER_TAG;
+      break;
+    case LSM6DSR_GAME_ROTATION_TAG:
+      *val = LSM6DSR_GAME_ROTATION_TAG;
+      break;
+    case LSM6DSR_GEOMAG_ROTATION_TAG:
+      *val = LSM6DSR_GEOMAG_ROTATION_TAG;
+      break;
+    case LSM6DSR_ROTATION_TAG:
+      *val = LSM6DSR_ROTATION_TAG;
+      break;
+    case LSM6DSR_SENSORHUB_NACK_TAG:
+      *val = LSM6DSR_SENSORHUB_NACK_TAG;
+      break;
+    default:
+      *val = LSM6DSR_SENSORHUB_NACK_TAG;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching of pedometer embedded function values.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of gbias_fifo_en in
+  *                reg LSM6DSR_EMB_FUNC_FIFO_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_emb_func_fifo_cfg_t emb_func_fifo_cfg;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+     ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_FIFO_CFG,
+                              (uint8_t*)&emb_func_fifo_cfg, 1);
+  }
+  if(ret == 0){
+    emb_func_fifo_cfg.pedo_fifo_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_FIFO_CFG,
+                              (uint8_t*)&emb_func_fifo_cfg, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching of pedometer embedded function values.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pedo_fifo_en in reg
+  *                LSM6DSR_EMB_FUNC_FIFO_CFG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_emb_func_fifo_cfg_t emb_func_fifo_cfg;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_FIFO_CFG,
+                             (uint8_t*)&emb_func_fifo_cfg, 1);
+    *val = emb_func_fifo_cfg.pedo_fifo_en;
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of first slave.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_0_en in reg SLV0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_batch_slave_0_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    slv0_config. batch_ext_sens_0_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV0_CONFIG,
+                              (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of first slave.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_0_en in
+  *                reg SLV0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_batch_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    *val = slv0_config. batch_ext_sens_0_en;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of second slave.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_1_en in
+  *                reg SLV1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_batch_slave_1_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_slv1_config_t slv1_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV1_CONFIG,
+                             (uint8_t*)&slv1_config, 1);
+  }
+  if(ret == 0){
+    slv1_config. batch_ext_sens_1_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV1_CONFIG,
+                              (uint8_t*)&slv1_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of second slave.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_1_en in
+  *                reg SLV1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_batch_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_slv1_config_t slv1_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV1_CONFIG,
+                             (uint8_t*)&slv1_config, 1);
+    *val = slv1_config. batch_ext_sens_1_en;
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of third slave.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_2_en in
+  *                reg SLV2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_batch_slave_2_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_slv2_config_t slv2_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV2_CONFIG,
+                             (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    slv2_config. batch_ext_sens_2_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV2_CONFIG,
+                              (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of third slave.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_2_en in
+  *                reg SLV2_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_batch_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_slv2_config_t slv2_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV2_CONFIG,
+                             (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    *val = slv2_config. batch_ext_sens_2_en;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of fourth slave.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_3_en in
+  *                reg SLV3_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_batch_slave_3_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_slv3_config_t slv3_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV3_CONFIG,
+                             (uint8_t*)&slv3_config, 1);
+  }
+  if(ret == 0){
+    slv3_config. batch_ext_sens_3_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV3_CONFIG,
+                              (uint8_t*)&slv3_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable FIFO batching data of fourth slave.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of  batch_ext_sens_3_en in
+  *                reg SLV3_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_batch_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_slv3_config_t slv3_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV3_CONFIG,
+                             (uint8_t*)&slv3_config, 1);
+    *val = slv3_config. batch_ext_sens_3_en;
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_DEN_functionality
+  * @brief      This section groups all the functions concerning
+  *             DEN functionality.
+  * @{
+  *
+  */
+
+/**
+  * @brief  DEN functionality marking mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_mode_set(stmdev_ctx_t *ctx, lsm6dsr_den_mode_t val)
+{
+  lsm6dsr_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  if(ret == 0){
+    ctrl6_c.den_mode= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN functionality marking mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_mode in reg CTRL6_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_mode_get(stmdev_ctx_t *ctx,
+                               lsm6dsr_den_mode_t *val)
+{
+  lsm6dsr_ctrl6_c_t ctrl6_c;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL6_C, (uint8_t*)&ctrl6_c, 1);
+
+  switch (ctrl6_c.den_mode){
+    case LSM6DSR_DEN_DISABLE:
+      *val = LSM6DSR_DEN_DISABLE;
+      break;
+    case LSM6DSR_LEVEL_FIFO:
+      *val = LSM6DSR_LEVEL_FIFO;
+      break;
+    case LSM6DSR_LEVEL_LETCHED:
+      *val = LSM6DSR_LEVEL_LETCHED;
+      break;
+    case LSM6DSR_LEVEL_TRIGGER:
+      *val = LSM6DSR_LEVEL_TRIGGER;
+      break;
+    case LSM6DSR_EDGE_TRIGGER:
+      *val = LSM6DSR_EDGE_TRIGGER;
+      break;
+    default:
+      *val = LSM6DSR_DEN_DISABLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_lh in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_polarity_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_den_lh_t val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_lh= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN active level configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_lh in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_polarity_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_den_lh_t *val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+
+  switch (ctrl9_xl.den_lh){
+    case LSM6DSR_DEN_ACT_LOW:
+      *val = LSM6DSR_DEN_ACT_LOW;
+      break;
+    case LSM6DSR_DEN_ACT_HIGH:
+      *val = LSM6DSR_DEN_ACT_HIGH;
+      break;
+    default:
+      *val = LSM6DSR_DEN_ACT_LOW;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_xl_g in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_enable_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_den_xl_g_t val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_xl_g= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of den_xl_g in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_enable_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_den_xl_g_t *val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+
+  switch (ctrl9_xl.den_xl_g){
+    case LSM6DSR_STAMP_IN_GY_DATA:
+      *val = LSM6DSR_STAMP_IN_GY_DATA;
+      break;
+    case LSM6DSR_STAMP_IN_XL_DATA:
+      *val = LSM6DSR_STAMP_IN_XL_DATA;
+      break;
+    case LSM6DSR_STAMP_IN_GY_XL_DATA:
+      *val = LSM6DSR_STAMP_IN_GY_XL_DATA;
+      break;
+    default:
+      *val = LSM6DSR_STAMP_IN_GY_DATA;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_z= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of X-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_z in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_z;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_y= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL9_XL,
+                              (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Y-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_y in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_y;
+
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  if(ret == 0){
+    ctrl9_xl.den_x= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  DEN value stored in LSB of Z-axis.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of den_x in reg CTRL9_XL
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_ctrl9_xl_t ctrl9_xl;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_CTRL9_XL, (uint8_t*)&ctrl9_xl, 1);
+  *val = ctrl9_xl.den_x;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_Pedometer
+  * @brief      This section groups all the functions that manage pedometer.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable pedometer algorithm.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pedo_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_A,
+                             (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    emb_func_en_a.pedo_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_EN_A,
+                              (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable pedometer algorithm.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pedo_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_A,
+                             (uint8_t*)&emb_func_en_a, 1);
+    *val = emb_func_en_a.pedo_en;
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer algorithm working mode.[set]
+  *
+  * @param  ctx    read / write interface definitions
+  * @param  val    Change the values of:
+  *                   - pedo_fpr_adf_dis in reg ADV_PEDO
+  *                   - pedo_adv_en in reg EMB_FUNC_EN_B
+  *                   - ad_det_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_mode_set(stmdev_ctx_t *ctx, lsm6dsr_pedo_mode_t val)
+{
+  lsm6dsr_adv_pedo_t adv_pedo;
+  lsm6dsr_emb_func_en_b_t emb_func_en_b;
+  lsm6dsr_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_ADV_PEDO, (uint8_t*)&adv_pedo, 1);
+  }
+  if(ret == 0){
+    adv_pedo.pedo_fpr_adf_dis = (~((uint8_t)val) & 0x01U);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_ADV_PEDO, (uint8_t*)&adv_pedo, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                           (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    emb_func_en_b.pedo_adv_en = (uint8_t)val & 0x01U;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                            (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                  (uint8_t*)&pedo_cmd_reg);
+    pedo_cmd_reg.fp_rejection_en = ((uint8_t)val & 0x01U);
+    pedo_cmd_reg.ad_det_en = ((uint8_t)val & 0x02U)>>1;
+  }
+  if(ret == 0){
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                   (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer algorithm working mode.[get]
+  *
+  * @param  ctx    read / write interface definitions
+  * @param  val    Get the values of:
+  *                   - pedo_fpr_adf_dis in reg ADV_PEDO
+  *                   - pedo_adv_en in reg EMB_FUNC_EN_B
+  *                   - ad_det_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_mode_get(stmdev_ctx_t *ctx, lsm6dsr_pedo_mode_t *val)
+{
+  lsm6dsr_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                (uint8_t*)&pedo_cmd_reg);
+
+  switch ((pedo_cmd_reg.ad_det_en << 1) | pedo_cmd_reg.fp_rejection_en){
+    case LSM6DSR_PEDO_BASE:
+      *val = LSM6DSR_PEDO_BASE;
+      break;
+    case LSM6DSR_PEDO_BASE_FALSE_STEP_REJ:
+      *val = LSM6DSR_PEDO_BASE_FALSE_STEP_REJ;
+      break;
+    case LSM6DSR_PEDO_ADV_FALSE_STEP_REJ:
+      *val = LSM6DSR_PEDO_ADV_FALSE_STEP_REJ;
+      break;
+    default:
+      *val = LSM6DSR_PEDO_BASE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for step detection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_step_det in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_step_detect_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_STATUS,
+                             (uint8_t*)&emb_func_status, 1);
+    *val = emb_func_status.is_step_det;
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_PEDO_DEB_STEPS_CONF, buff);
+  return ret;
+}
+
+/**
+  * @brief  Pedometer debounce configuration register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_DEB_STEPS_CONF, buff);
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_PEDO_SC_DELTAT_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_PEDO_SC_DELTAT_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Time period register for step detection on delta time (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_SC_DELTAT_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_SC_DELTAT_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the advanced detection feature.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ad_det_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_adv_detection_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                  (uint8_t*)&pedo_cmd_reg);
+
+  if(ret == 0){
+    pedo_cmd_reg.ad_det_en= (uint8_t)val;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                     (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the advanced detection feature.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of ad_det_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_adv_detection_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_CMD_REG, (uint8_t*)&pedo_cmd_reg);
+  *val = pedo_cmd_reg.ad_det_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the false-positive rejection feature.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fp_rejection_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_false_step_rejection_set(stmdev_ctx_t *ctx,
+                                                uint8_t val)
+{
+  lsm6dsr_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                  (uint8_t*)&pedo_cmd_reg);
+
+  if(ret == 0){
+    pedo_cmd_reg.fp_rejection_en= (uint8_t)val;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                     (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enables the false-positive rejection feature.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fp_rejection_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_false_step_rejection_get(stmdev_ctx_t *ctx,
+                                                uint8_t *val)
+{
+  lsm6dsr_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                  (uint8_t*)&pedo_cmd_reg);
+  *val = pedo_cmd_reg.fp_rejection_en;
+
+  return ret;
+}
+
+/**
+  * @brief  Set when user wants to generate interrupt on count overflow
+  *         event/every step.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of carry_count_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_int_mode_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_carry_count_en_t val)
+{
+  lsm6dsr_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                  (uint8_t*)&pedo_cmd_reg);
+
+  if(ret == 0){
+    pedo_cmd_reg.carry_count_en= (uint8_t)val;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                     (uint8_t*)&pedo_cmd_reg);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Set when user wants to generate interrupt on count overflow
+  *         event/every step.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of carry_count_en in reg PEDO_CMD_REG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_pedo_int_mode_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_carry_count_en_t *val)
+{
+  lsm6dsr_pedo_cmd_reg_t pedo_cmd_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_PEDO_CMD_REG,
+                                  (uint8_t*)&pedo_cmd_reg);
+
+  switch (pedo_cmd_reg.carry_count_en){
+    case LSM6DSR_EVERY_STEP:
+      *val = LSM6DSR_EVERY_STEP;
+      break;
+    case LSM6DSR_COUNT_OVERFLOW:
+      *val = LSM6DSR_COUNT_OVERFLOW;
+      break;
+    default:
+      *val = LSM6DSR_EVERY_STEP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_significant_motion
+  * @brief      This section groups all the functions that manage the
+  *             significant motion detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable significant motion detection function.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sign_motion_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_A,
+                             (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    emb_func_en_a.sign_motion_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_EN_A,
+                              (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable significant motion detection function.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of sign_motion_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_A,
+                             (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_en_a.sign_motion_en;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for significant motion detection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_sigmot in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_motion_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val)
+{
+  lsm6dsr_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_STATUS,
+                             (uint8_t*)&emb_func_status, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_status.is_sigmot;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_tilt_detection
+  * @brief      This section groups all the functions that manage the tilt
+  *             event detection.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Enable tilt calculation.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tilt_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_A,
+                             (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    emb_func_en_a.tilt_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_EN_A,
+                              (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Enable tilt calculation.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tilt_en in reg EMB_FUNC_EN_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_emb_func_en_a_t emb_func_en_a;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_A, (uint8_t*)&emb_func_en_a, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_en_a.tilt_en;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Interrupt status bit for tilt detection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_tilt in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_tilt_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_STATUS,
+                             (uint8_t*)&emb_func_status, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_status.is_tilt;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_ magnetometer_sensor
+  * @brief      This section groups all the functions that manage additional
+  *             magnetometer sensor.
+  * @{
+  *
+  */
+
+/**
+  * @brief  External magnetometer sensitivity value register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_sensitivity_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SENSITIVITY_L,
+                                   &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SENSITIVITY_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  External magnetometer sensitivity value register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_sensitivity_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SENSITIVITY_L, &buff[i]);
+
+if(ret == 0){
+  i++;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SENSITIVITY_H, &buff[i]);
+}
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_OFFX_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_OFFX_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_OFFY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_OFFY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_OFFZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_OFFZ_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Offset for hard-iron compensation register (r/w).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_OFFX_L, &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_OFFX_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_OFFY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_OFFY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_OFFZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_OFFZ_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft-iron (3x3 symmetric) matrix correction register (r/w).
+  *         The value is expressed as half-precision floating-point format:
+  *         SEEEEEFFFFFFFFFF
+  *         S: 1 sign bit;
+  *         E: 5 exponent bits;
+  *         F: 10 fraction bits).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XX_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XX_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_XZ_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_YZ_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_ZZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_SI_ZZ_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Soft-iron (3x3 symmetric) matrix correction register (r/w).
+  *         The value is expressed as half-precision floating-point format:
+  *         SEEEEEFFFFFFFFFF
+  *         S: 1 sign bit;
+  *         E: 5 exponent bits;
+  *         F: 10 fraction bits).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XX_L, &buff[i]);
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XX_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XZ_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_XZ_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YY_L, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YY_H, &buff[i]);
+  }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YZ_L, &buff[i]);
+    }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_YZ_H, &buff[i]);
+    }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_ZZ_L, &buff[i]);
+    }
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_SI_ZZ_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Z-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of mag_z_axis in reg MAG_CFG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_z_orient_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_mag_z_axis_t val)
+{
+  lsm6dsr_mag_cfg_a_t mag_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_CFG_A,
+                                  (uint8_t*)&mag_cfg_a);
+
+  if(ret == 0){
+    mag_cfg_a.mag_z_axis= (uint8_t)val;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_CFG_A,
+                                     (uint8_t*)&mag_cfg_a);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Z-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of mag_z_axis in reg MAG_CFG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_z_orient_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_mag_z_axis_t *val)
+{
+  lsm6dsr_mag_cfg_a_t mag_cfg_a;
+  int32_t ret;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_CFG_A,
+                                  (uint8_t*)&mag_cfg_a);
+
+  switch (mag_cfg_a.mag_z_axis){
+    case LSM6DSR_Z_EQ_Y:
+      *val = LSM6DSR_Z_EQ_Y;
+      break;
+    case LSM6DSR_Z_EQ_MIN_Y:
+      *val = LSM6DSR_Z_EQ_MIN_Y;
+      break;
+    case LSM6DSR_Z_EQ_X:
+      *val = LSM6DSR_Z_EQ_X;
+      break;
+    case LSM6DSR_Z_EQ_MIN_X:
+      *val = LSM6DSR_Z_EQ_MIN_X;
+      break;
+    case LSM6DSR_Z_EQ_MIN_Z:
+      *val = LSM6DSR_Z_EQ_MIN_Z;
+      break;
+    case LSM6DSR_Z_EQ_Z:
+      *val = LSM6DSR_Z_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSR_Z_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Y-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of mag_y_axis in
+  *                               reg MAG_CFG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_y_orient_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_mag_y_axis_t val)
+{
+  lsm6dsr_mag_cfg_a_t mag_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_CFG_A,
+                                  (uint8_t*)&mag_cfg_a);
+  if(ret == 0){
+    mag_cfg_a.mag_y_axis= (uint8_t)val;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_CFG_A,
+                                     (uint8_t*)&mag_cfg_a);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer Y-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of mag_y_axis in reg MAG_CFG_A
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_y_orient_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_mag_y_axis_t *val)
+{
+  lsm6dsr_mag_cfg_a_t mag_cfg_a;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_CFG_A,
+                                  (uint8_t*)&mag_cfg_a);
+
+  switch (mag_cfg_a.mag_y_axis){
+    case LSM6DSR_Y_EQ_Y:
+      *val = LSM6DSR_Y_EQ_Y;
+      break;
+    case LSM6DSR_Y_EQ_MIN_Y:
+      *val = LSM6DSR_Y_EQ_MIN_Y;
+      break;
+    case LSM6DSR_Y_EQ_X:
+      *val = LSM6DSR_Y_EQ_X;
+      break;
+    case LSM6DSR_Y_EQ_MIN_X:
+      *val = LSM6DSR_Y_EQ_MIN_X;
+      break;
+    case LSM6DSR_Y_EQ_MIN_Z:
+      *val = LSM6DSR_Y_EQ_MIN_Z;
+      break;
+    case LSM6DSR_Y_EQ_Z:
+      *val = LSM6DSR_Y_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSR_Y_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+   * @brief  Magnetometer X-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of mag_x_axis in reg MAG_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_x_orient_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_mag_x_axis_t val)
+{
+  lsm6dsr_mag_cfg_b_t mag_cfg_b;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_CFG_B,
+                                  (uint8_t*)&mag_cfg_b);
+  if(ret == 0){
+    mag_cfg_b.mag_x_axis= (uint8_t)val;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_MAG_CFG_B,
+                                     (uint8_t*)&mag_cfg_b);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Magnetometer X-axis coordinates rotation (to be aligned to
+  *         accelerometer/gyroscope axes orientation).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of mag_x_axis in reg MAG_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_mag_x_orient_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_mag_x_axis_t *val)
+{
+  lsm6dsr_mag_cfg_b_t mag_cfg_b;
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_MAG_CFG_B,
+                                  (uint8_t*)&mag_cfg_b);
+
+  switch (mag_cfg_b.mag_x_axis){
+    case LSM6DSR_X_EQ_Y:
+      *val = LSM6DSR_X_EQ_Y;
+      break;
+    case LSM6DSR_X_EQ_MIN_Y:
+      *val = LSM6DSR_X_EQ_MIN_Y;
+      break;
+    case LSM6DSR_X_EQ_X:
+      *val = LSM6DSR_X_EQ_X;
+      break;
+    case LSM6DSR_X_EQ_MIN_X:
+      *val = LSM6DSR_X_EQ_MIN_X;
+      break;
+    case LSM6DSR_X_EQ_MIN_Z:
+      *val = LSM6DSR_X_EQ_MIN_Z;
+      break;
+    case LSM6DSR_X_EQ_Z:
+      *val = LSM6DSR_X_EQ_Z;
+      break;
+    default:
+      *val = LSM6DSR_X_EQ_Y;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_finite_state_machine
+  * @brief      This section groups all the functions that manage the
+  *             state_machine.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Interrupt status bit for FSM long counter timeout interrupt
+  *         event.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of is_fsm_lc in reg EMB_FUNC_STATUS
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_long_cnt_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                               uint8_t *val)
+{
+  lsm6dsr_emb_func_status_t emb_func_status;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_STATUS,
+                             (uint8_t*)&emb_func_status, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_status.is_fsm_lc;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_en in reg EMB_FUNC_EN_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_emb_fsm_en_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  int32_t ret;
+  lsm6dsr_emb_func_en_b_t emb_func_en_b;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    emb_func_en_b.fsm_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                              (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fsm_en in reg EMB_FUNC_EN_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_emb_fsm_en_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  int32_t ret;
+  lsm6dsr_emb_func_en_b_t emb_func_en_b;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_en_b.fsm_en;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                              (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_enable_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_emb_fsm_enable_t *val)
+{
+  lsm6dsr_emb_func_en_b_t emb_func_en_b;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_ENABLE_A,
+                              (uint8_t*)&val->fsm_enable_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_ENABLE_B,
+                              (uint8_t*)&val->fsm_enable_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                             (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    if ( (val->fsm_enable_a.fsm1_en |
+          val->fsm_enable_a.fsm2_en |
+          val->fsm_enable_a.fsm3_en |
+          val->fsm_enable_a.fsm4_en |
+          val->fsm_enable_a.fsm5_en |
+          val->fsm_enable_a.fsm6_en |
+          val->fsm_enable_a.fsm7_en |
+          val->fsm_enable_a.fsm8_en |
+          val->fsm_enable_b.fsm9_en |
+          val->fsm_enable_b.fsm10_en |
+          val->fsm_enable_b.fsm11_en |
+          val->fsm_enable_b.fsm12_en |
+          val->fsm_enable_b.fsm13_en |
+          val->fsm_enable_b.fsm14_en |
+          val->fsm_enable_b.fsm15_en |
+          val->fsm_enable_b.fsm16_en ) != PROPERTY_DISABLE){
+      emb_func_en_b.fsm_en = PROPERTY_ENABLE;
+    }
+    else{
+      emb_func_en_b.fsm_en = PROPERTY_DISABLE;
+    }
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_EN_B,
+                              (uint8_t*)&emb_func_en_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Embedded final state machine functions mode.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_ENABLE_A to FSM_ENABLE_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_enable_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_emb_fsm_enable_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_ENABLE_A,
+                             (uint8_t*)&val->fsm_enable_a, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_ENABLE_B,
+                             (uint8_t*)&val->fsm_enable_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_long_cnt_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_L, buff, 2);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter status register. Long counter value is an
+  *         unsigned integer value (16-bit format).[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_long_cnt_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_L, buff, 2);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Clear FSM long counter value.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_lc_clr in reg
+  *                FSM_LONG_COUNTER_CLEAR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_long_clr_set(stmdev_ctx_t *ctx,
+                               lsm6dsr_fsm_lc_clr_t val)
+{
+  lsm6dsr_fsm_long_counter_clear_t fsm_long_counter_clear;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_CLEAR,
+                             (uint8_t*)&fsm_long_counter_clear, 1);
+  }
+  if(ret == 0){
+     fsm_long_counter_clear.fsm_lc_clr= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_CLEAR,
+                              (uint8_t*)&fsm_long_counter_clear, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Clear FSM long counter value.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fsm_lc_clr in reg  FSM_LONG_COUNTER_CLEAR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_long_clr_get(stmdev_ctx_t *ctx,
+                               lsm6dsr_fsm_lc_clr_t *val)
+{
+  lsm6dsr_fsm_long_counter_clear_t fsm_long_counter_clear;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_LONG_COUNTER_CLEAR,
+                             (uint8_t*)&fsm_long_counter_clear, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  switch (fsm_long_counter_clear.fsm_lc_clr){
+    case LSM6DSR_LC_NORMAL:
+      *val = LSM6DSR_LC_NORMAL;
+      break;
+    case LSM6DSR_LC_CLEAR:
+      *val = LSM6DSR_LC_CLEAR;
+      break;
+    case LSM6DSR_LC_CLEAR_DONE:
+      *val = LSM6DSR_LC_CLEAR_DONE;
+      break;
+    default:
+      *val = LSM6DSR_LC_NORMAL;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from FSM_OUTS1 to FSM_OUTS16
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsr_fsm_out_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_FSM_OUTS1,
+                             (uint8_t*)&val->fsm_outs1, 16);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_data_rate_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_fsm_odr_t val)
+{
+  lsm6dsr_emb_func_odr_cfg_b_t emb_func_odr_cfg_b;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_ODR_CFG_B,
+                             (uint8_t*)&emb_func_odr_cfg_b, 1);
+  }
+  if(ret == 0){
+    emb_func_odr_cfg_b.not_used_01 = 3; /* set default values */
+    emb_func_odr_cfg_b.not_used_02 = 1; /* set default values */
+    emb_func_odr_cfg_b.fsm_odr= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_ODR_CFG_B,
+                              (uint8_t*)&emb_func_odr_cfg_b, 1);
+ }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Finite State Machine ODR configuration.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of fsm_odr in reg EMB_FUNC_ODR_CFG_B
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_data_rate_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_fsm_odr_t *val)
+{
+  lsm6dsr_emb_func_odr_cfg_b_t emb_func_odr_cfg_b;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_ODR_CFG_B,
+                             (uint8_t*)&emb_func_odr_cfg_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  switch (emb_func_odr_cfg_b.fsm_odr){
+    case LSM6DSR_ODR_FSM_12Hz5:
+      *val = LSM6DSR_ODR_FSM_12Hz5;
+      break;
+    case LSM6DSR_ODR_FSM_26Hz:
+      *val = LSM6DSR_ODR_FSM_26Hz;
+      break;
+    case LSM6DSR_ODR_FSM_52Hz:
+      *val = LSM6DSR_ODR_FSM_52Hz;
+      break;
+    case LSM6DSR_ODR_FSM_104Hz:
+      *val = LSM6DSR_ODR_FSM_104Hz;
+      break;
+    default:
+      *val = LSM6DSR_ODR_FSM_12Hz5;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_init in reg FSM_INIT
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_INIT_B,
+                             (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    emb_func_init_b.fsm_init= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_EMB_FUNC_INIT_B,
+                              (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM initialization request.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of fsm_init in reg FSM_INIT
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_emb_func_init_b_t emb_func_init_b;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_EMBEDDED_FUNC_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_EMB_FUNC_INIT_B,
+                             (uint8_t*)&emb_func_init_b, 1);
+  }
+  if(ret == 0){
+    *val = emb_func_init_b.fsm_init;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value, the FSM
+  *         generates an interrupt.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_long_cnt_int_value_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_FSM_LC_TIMEOUT_L, &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_FSM_LC_TIMEOUT_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM long counter timeout register (r/w). The long counter
+  *         timeout value is an unsigned integer value (16-bit format).
+  *         When the long counter value reached this value, the FSM generates
+  *         an interrupt.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_long_cnt_int_value_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_LC_TIMEOUT_L, &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_LC_TIMEOUT_H,
+                                    &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_number_of_programs_set(stmdev_ctx_t *ctx,
+                                             uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_FSM_PROGRAMS, buff);
+
+  if(ret == 0){
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_FSM_PROGRAMS + 0x01U,
+                                     buff);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM number of programs register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_number_of_programs_get(stmdev_ctx_t *ctx,
+                                             uint8_t *buff)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_PROGRAMS, buff);
+
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w). First available address is
+  *         0x033C.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that contains data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_start_address_set(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_FSM_START_ADD_L, &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_write_byte(ctx, LSM6DSR_FSM_START_ADD_H,
+                                     &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @brief  FSM start address register (r/w). First available address
+  *         is 0x033C.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  buff   Buffer that stores data read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_fsm_start_address_get(stmdev_ctx_t *ctx, uint8_t *buff)
+{
+  int32_t ret;
+  uint8_t i;
+
+  i = 0x00U;
+  ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_START_ADD_L, &buff[i]);
+
+  if(ret == 0){
+    i++;
+    ret = lsm6dsr_ln_pg_read_byte(ctx, LSM6DSR_FSM_START_ADD_H, &buff[i]);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_Sensor_hub
+  * @brief      This section groups all the functions that manage the
+  *             sensor hub.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sensor hub output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure of registers from SENSOR_HUB_1 to SENSOR_HUB_18
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_read_data_raw_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_emb_sh_read_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SENSOR_HUB_1, (uint8_t*)val, 18);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of aux_sens_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_slave_connected_set(stmdev_ctx_t *ctx,
+                                         lsm6dsr_aux_sens_on_t val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.aux_sens_on= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Number of external sensors to be read by the sensor hub.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of aux_sens_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_slave_connected_get(stmdev_ctx_t *ctx,
+                                         lsm6dsr_aux_sens_on_t *val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  switch (master_config.aux_sens_on){
+    case LSM6DSR_SLV_0:
+      *val = LSM6DSR_SLV_0;
+      break;
+    case LSM6DSR_SLV_0_1:
+      *val = LSM6DSR_SLV_0_1;
+      break;
+    case LSM6DSR_SLV_0_1_2:
+      *val = LSM6DSR_SLV_0_1_2;
+      break;
+    case LSM6DSR_SLV_0_1_2_3:
+      *val = LSM6DSR_SLV_0_1_2_3;
+      break;
+    default:
+      *val = LSM6DSR_SLV_0;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.master_on= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub I2C master enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of master_on in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    *val = master_config.master_on;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of shub_pu_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_pin_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_shub_pu_en_t val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.shub_pu_en= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Master I2C pull-up enable.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of shub_pu_en in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_pin_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_shub_pu_en_t *val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  switch (master_config.shub_pu_en){
+    case LSM6DSR_EXT_PULL_UP:
+      *val = LSM6DSR_EXT_PULL_UP;
+      break;
+    case LSM6DSR_INTERNAL_PULL_UP:
+      *val = LSM6DSR_INTERNAL_PULL_UP;
+      break;
+    default:
+      *val = LSM6DSR_EXT_PULL_UP;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.pass_through_mode= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  I2C interface pass-through.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of pass_through_mode in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    *val = master_config.pass_through_mode;
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_syncro_mode_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_start_config_t val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.start_config= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub trigger signal selection.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of start_config in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_syncro_mode_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_start_config_t *val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  switch (master_config.start_config){
+    case LSM6DSR_EXT_ON_INT2_PIN:
+      *val = LSM6DSR_EXT_ON_INT2_PIN;
+      break;
+    case LSM6DSR_XL_GY_DRDY:
+      *val = LSM6DSR_XL_GY_DRDY;
+      break;
+    default:
+      *val = LSM6DSR_EXT_ON_INT2_PIN;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of write_once in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_write_mode_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_write_once_t val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.write_once= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Slave 0 write operation is performed only at the first sensor
+  *         hub cycle.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of write_once in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_write_mode_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_write_once_t *val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  switch (master_config.write_once){
+    case LSM6DSR_EACH_SH_CYCLE:
+      *val = LSM6DSR_EACH_SH_CYCLE;
+      break;
+    case LSM6DSR_ONLY_FIRST_CYCLE:
+      *val = LSM6DSR_ONLY_FIRST_CYCLE;
+      break;
+    default:
+      *val = LSM6DSR_EACH_SH_CYCLE;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Master logic and output registers.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_reset_set(stmdev_ctx_t *ctx)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.rst_master_regs = PROPERTY_ENABLE;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    master_config.rst_master_regs = PROPERTY_DISABLE;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                              (uint8_t*)&master_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Reset Master logic and output registers.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rst_master_regs in reg MASTER_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_master_config_t master_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_MASTER_CONFIG,
+                             (uint8_t*)&master_config, 1);
+    *val = master_config.rst_master_regs;
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the master communicates.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of shub_odr in reg SLV0_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_data_rate_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_shub_odr_t val)
+{
+  lsm6dsr_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    slv0_config.shub_odr = (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV0_CONFIG,
+                              (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Rate at which the master communicates.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of shub_odr in reg slv1_CONFIG
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_data_rate_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_shub_odr_t *val)
+{
+  lsm6dsr_slv0_config_t slv0_config;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  switch (slv0_config.shub_odr){
+    case LSM6DSR_SH_ODR_104Hz:
+      *val = LSM6DSR_SH_ODR_104Hz;
+      break;
+    case LSM6DSR_SH_ODR_52Hz:
+      *val = LSM6DSR_SH_ODR_52Hz;
+      break;
+    case LSM6DSR_SH_ODR_26Hz:
+      *val = LSM6DSR_SH_ODR_26Hz;
+      break;
+    case LSM6DSR_SH_ODR_13Hz:
+      *val = LSM6DSR_SH_ODR_13Hz;
+      break;
+    default:
+      *val = LSM6DSR_SH_ODR_104Hz;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv0_add;    8 bit i2c device address
+  *                - uint8_t slv0_subadd; 8 bit register device address
+  *                - uint8_t slv0_data;   8 bit data to write
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_cfg_write(stmdev_ctx_t *ctx,
+                               lsm6dsr_sh_cfg_write_t *val)
+{
+  lsm6dsr_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    slv0_add.slave0 = (uint8_t) (val->slv0_add >> 1);
+    slv0_add.rw_0 = 0;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV0_ADD,
+                              (uint8_t*)&(slv0_add), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV0_SUBADD,
+                              (uint8_t*)&(val->slv0_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_DATAWRITE_SLV0,
+                              (uint8_t*)&(val->slv0_data), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief Configure slave 0 for perform a write/read.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv_add;    8 bit i2c device address
+  *                - uint8_t slv_subadd; 8 bit register device address
+  *                - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sh_cfg_read_t *val)
+{
+  lsm6dsr_slv0_config_t slv0_config;
+  lsm6dsr_slv0_add_t slv0_add;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    slv0_add.slave0 = (uint8_t) val->slv_add >> 1;
+    slv0_add.rw_0 = 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV0_ADD,
+                              (uint8_t*)&(slv0_add), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV0_SUBADD,
+                              &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV0_CONFIG,
+                             (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    slv0_config.slave0_numop = val->slv_len;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV0_CONFIG,
+                              (uint8_t*)&slv0_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 0 for perform a write/read.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv_add;    8 bit i2c device address
+  *                - uint8_t slv_subadd; 8 bit register device address
+  *                - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sh_cfg_read_t *val)
+{
+  lsm6dsr_slv1_config_t slv1_config;
+  lsm6dsr_slv1_add_t slv1_add;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+  if(ret == 0){
+    slv1_add.slave1_add = (uint8_t) (val->slv_add >> 1);
+    slv1_add.r_1 = 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV1_ADD, (uint8_t*)&slv1_add, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV1_SUBADD,
+                              &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV1_CONFIG,
+                             (uint8_t*)&slv1_config, 1);
+  }
+  if(ret == 0){
+    slv1_config.slave1_numop = val->slv_len;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV1_CONFIG,
+                              (uint8_t*)&slv1_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+}
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 2 for perform a write/read.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv_add;    8 bit i2c device address
+  *                - uint8_t slv_subadd; 8 bit register device address
+  *                - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sh_cfg_read_t *val)
+{
+  lsm6dsr_slv2_config_t slv2_config;
+  lsm6dsr_slv2_add_t slv2_add;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    slv2_add.slave2_add = (uint8_t) (val->slv_add >> 1);
+    slv2_add.r_2 = 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV2_ADD,
+                              (uint8_t*)&slv2_add, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV2_SUBADD,
+                              (uint8_t*)&(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV2_CONFIG,
+                             (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    slv2_config.slave2_numop = val->slv_len;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV2_CONFIG,
+                              (uint8_t*)&slv2_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Configure slave 3 for perform a write/read.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Structure that contain
+  *                - uint8_t slv_add;    8 bit i2c device address
+  *                - uint8_t slv_subadd; 8 bit register device address
+  *                - uint8_t slv_len;    num of bit to read
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
+                                   lsm6dsr_sh_cfg_read_t *val)
+{
+  lsm6dsr_slv3_config_t slv3_config;
+  lsm6dsr_slv3_add_t slv3_add;
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    slv3_add.slave3_add = (uint8_t) (val->slv_add >> 1);
+    slv3_add.r_3 = 1;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV3_ADD,
+                              (uint8_t*)&slv3_add, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV3_SUBADD,
+                              &(val->slv_subadd), 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_SLV3_CONFIG,
+                             (uint8_t*)&slv3_config, 1);
+  }
+  if(ret == 0){
+    slv3_config.slave3_numop = val->slv_len;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_SLV3_CONFIG,
+                              (uint8_t*)&slv3_config, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor hub source register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Registers from STATUS_MASTER
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_sh_status_get(stmdev_ctx_t *ctx,
+                                lsm6dsr_status_master_t *val)
+{
+  int32_t ret;
+
+  ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_SENSOR_HUB_BANK);
+
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_STATUS_MASTER, (uint8_t*)val, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_mem_bank_set(ctx, LSM6DSR_USER_BANK);
+  }
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @defgroup   LSM6DSR_Sensors for Smart Mobile Devices
+  * @brief      This section groups all the functions that manage the
+  *             Sensors for Smart Mobile Devices.
+  * @{
+  *
+  */
+
+/**
+  * @brief  Sensor synchronization time frame resolution[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tph_h_sel in LSM6DSR_S4S_TPH_L
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_tph_res_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_s4s_tph_res_t val)
+{
+  lsm6dsr_s4s_tph_l_t s4s_tph_l;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_TPH_L, (uint8_t*)&s4s_tph_l, 1);
+  if(ret == 0){
+    s4s_tph_l.tph_h_sel= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_S4S_TPH_L,
+                              (uint8_t*)&s4s_tph_l, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame resolution.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tph_h_sel in LSM6DSR_S4S_TPH_L
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_tph_res_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_s4s_tph_res_t *val)
+{
+  lsm6dsr_s4s_tph_l_t s4s_tph_l;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_TPH_L, (uint8_t*)&s4s_tph_l, 1);
+
+  switch (s4s_tph_l.tph_h_sel){
+    case LSM6DSR_S4S_TPH_7bit:
+      *val = LSM6DSR_S4S_TPH_7bit;
+      break;
+    case LSM6DSR_S4S_TPH_15bit:
+      *val = LSM6DSR_S4S_TPH_15bit;
+      break;
+    default:
+      *val = LSM6DSR_S4S_TPH_7bit;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of tph_l in S4S_TPH_L and
+  *                tph_h in S4S_TPH_H
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_tph_val_set(stmdev_ctx_t *ctx, uint16_t val)
+{
+  lsm6dsr_s4s_tph_l_t s4s_tph_l;
+  lsm6dsr_s4s_tph_h_t s4s_tph_h;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_TPH_L, (uint8_t*)&s4s_tph_l, 1);
+  if(ret == 0){
+    s4s_tph_l.tph_l = (uint8_t)(val & 0x007FU);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_S4S_TPH_L,
+                              (uint8_t*)&s4s_tph_l, 1);
+  }
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_TPH_H,
+                             (uint8_t*)&s4s_tph_h, 1);
+  }
+  if(ret == 0){
+    s4s_tph_h.tph_h = (uint8_t)((val & 0x7F80U) >> 7);
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_S4S_TPH_H,
+                              (uint8_t*)&s4s_tph_h, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization time frame.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Get the values of tph_l in S4S_TPH_L and tph_h in S4S_TPH_H
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_tph_val_get(stmdev_ctx_t *ctx, uint16_t *val)
+{
+  lsm6dsr_s4s_tph_l_t s4s_tph_l;
+  lsm6dsr_s4s_tph_h_t s4s_tph_h;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_TPH_L, (uint8_t*)&s4s_tph_l, 1);
+  if(ret == 0){
+    ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_TPH_H,
+                             (uint8_t*)&s4s_tph_h, 1);
+  }
+  *val = s4s_tph_h.tph_h;
+  *val = *val << 7;
+  *val += s4s_tph_l.tph_l;
+
+  return ret;
+}
+
+/**
+  * @brief  Sensor synchronization resolution ratio register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of rr in S4S_RR.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_res_ratio_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_s4s_res_ratio_t val)
+{
+  lsm6dsr_s4s_rr_t s4s_rr;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_RR, (uint8_t*)&s4s_rr, 1);
+  if(ret == 0){
+    s4s_rr.rr= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_S4S_RR, (uint8_t*)&s4s_rr, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief   Sensor synchronization resolution ratio register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    get the values of rr in S4S_RR
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_res_ratio_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_s4s_res_ratio_t *val)
+{
+  lsm6dsr_s4s_rr_t s4s_rr;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_RR, (uint8_t*)&s4s_rr, 1);
+
+  switch ( s4s_rr.rr){
+    case LSM6DSR_S4S_DT_RES_11:
+      *val = LSM6DSR_S4S_DT_RES_11;
+      break;
+    case LSM6DSR_S4S_DT_RES_12:
+      *val = LSM6DSR_S4S_DT_RES_12;
+      break;
+    case LSM6DSR_S4S_DT_RES_13:
+      *val = LSM6DSR_S4S_DT_RES_13;
+      break;
+    case LSM6DSR_S4S_DT_RES_14:
+      *val = LSM6DSR_S4S_DT_RES_14;
+      break;
+    default:
+      *val = LSM6DSR_S4S_DT_RES_11;
+      break;
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s master command.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of S4S_ST_CMD_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_command_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_s4s_st_cmd_code_t s4s_st_cmd_code;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_ST_CMD_CODE,
+                           (uint8_t*)&s4s_st_cmd_code, 1);
+  if(ret == 0){
+    s4s_st_cmd_code.s4s_st_cmd_code= (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_S4S_ST_CMD_CODE,
+                              (uint8_t*)&s4s_st_cmd_code, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  s4s master command.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    get the values of S4S_ST_CMD_CODE.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_command_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_s4s_st_cmd_code_t s4s_st_cmd_code;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_ST_CMD_CODE,
+                           (uint8_t*)&s4s_st_cmd_code, 1);
+  *val = s4s_st_cmd_code.s4s_st_cmd_code;
+
+  return ret;
+}
+
+/**
+  * @brief S4S DT register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of S4S_DT_REG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_dt_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  lsm6dsr_s4s_dt_reg_t s4s_dt_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_DT_REG,
+                           (uint8_t*)&s4s_dt_reg, 1);
+  if(ret == 0){
+    s4s_dt_reg.dt = (uint8_t)val;
+    ret = lsm6dsr_write_reg(ctx, LSM6DSR_S4S_DT_REG,
+                              (uint8_t*)&s4s_dt_reg, 1);
+  }
+  return ret;
+}
+
+/**
+  * @brief  S4S DT register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    get the values of S4S_DT_REG.
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t lsm6dsr_s4s_dt_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  lsm6dsr_s4s_dt_reg_t s4s_dt_reg;
+  int32_t ret;
+
+  ret = lsm6dsr_read_reg(ctx, LSM6DSR_S4S_DT_REG,
+                           (uint8_t*)&s4s_dt_reg, 1);
+  *val = s4s_dt_reg.dt;
+
+  return ret;
+}
+
+/**
+  * @}
+  *
+  */
+
+/**
+  * @}
+  *
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm6dsr_STdC/driver/lsm6dsr_reg.h
+++ b/sensor/stmemsc/lsm6dsr_STdC/driver/lsm6dsr_reg.h
@@ -1,0 +1,2746 @@
+/*
+ ******************************************************************************
+ * @file    lsm6dsr_reg.h
+ * @author  Sensors Software Solution Team
+ * @brief   This file contains all the functions prototypes for the
+ *          lsm6dsr_reg.c driver.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef LSM6DSR_REGS_H
+#define LSM6DSR_REGS_H
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <math.h>
+
+/** @addtogroup LSM6DSR
+  * @{
+  *
+  */
+
+/** @defgroup STMicroelectronics sensors common types
+  * @{
+  *
+  */
+
+#ifndef MEMS_SHARED_TYPES
+#define MEMS_SHARED_TYPES
+
+typedef struct{
+  uint8_t bit0       : 1;
+  uint8_t bit1       : 1;
+  uint8_t bit2       : 1;
+  uint8_t bit3       : 1;
+  uint8_t bit4       : 1;
+  uint8_t bit5       : 1;
+  uint8_t bit6       : 1;
+  uint8_t bit7       : 1;
+} bitwise_t;
+
+#define PROPERTY_DISABLE                (0U)
+#define PROPERTY_ENABLE                 (1U)
+
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+
+typedef struct {
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
+
+/**
+  * @}
+  *
+  */
+
+/** @defgroup LSM6DSR Infos
+  * @{
+  *
+  */
+
+/** I2C Device Address 8 bit format  if SA0=0 -> D5 if SA0=1 -> D7 **/
+#define LSM6DSR_I2C_ADD_L                    0xD5U
+#define LSM6DSR_I2C_ADD_H                    0xD7U
+
+/** Device Identification (Who am I) **/
+#define LSM6DSR_ID                           0x6BU
+
+/**
+  * @}
+  *
+  */
+
+#define LSM6DSR_FUNC_CFG_ACCESS              0x01U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t reg_access               : 2; /* shub_reg_access + func_cfg_access */
+} lsm6dsr_func_cfg_access_t;
+
+#define LSM6DSR_PIN_CTRL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t sdo_pu_en                : 1;
+  uint8_t ois_pu_dis               : 1;
+} lsm6dsr_pin_ctrl_t;
+
+#define LSM6DSR_S4S_TPH_L                    0x04U
+typedef struct {
+  uint8_t tph_l                    : 7;
+  uint8_t tph_h_sel                : 1;
+} lsm6dsr_s4s_tph_l_t;
+
+#define LSM6DSR_S4S_TPH_H                    0x05U
+typedef struct {
+  uint8_t tph_h                    : 8;
+} lsm6dsr_s4s_tph_h_t;
+
+#define LSM6DSR_S4S_RR                       0x06U
+typedef struct {
+  uint8_t rr                       : 2;
+  uint8_t not_used_01              : 6;
+} lsm6dsr_s4s_rr_t;
+
+#define LSM6DSR_FIFO_CTRL1                   0x07U
+typedef struct {
+  uint8_t wtm                      : 8;
+} lsm6dsr_fifo_ctrl1_t;
+
+#define LSM6DSR_FIFO_CTRL2                   0x08U
+typedef struct {
+  uint8_t wtm                      : 1;
+  uint8_t uncoptr_rate             : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t odrchg_en                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t fifo_compr_rt_en         : 1;
+  uint8_t stop_on_wtm              : 1;
+} lsm6dsr_fifo_ctrl2_t;
+
+#define LSM6DSR_FIFO_CTRL3                   0x09U
+typedef struct {
+  uint8_t bdr_xl                   : 4;
+  uint8_t bdr_gy                   : 4;
+} lsm6dsr_fifo_ctrl3_t;
+
+#define LSM6DSR_FIFO_CTRL4                   0x0AU
+typedef struct {
+  uint8_t fifo_mode                : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t odr_t_batch              : 2;
+  uint8_t odr_ts_batch             : 2;
+} lsm6dsr_fifo_ctrl4_t;
+
+#define LSM6DSR_COUNTER_BDR_REG1             0x0BU
+typedef struct {
+  uint8_t cnt_bdr_th               : 3;
+  uint8_t not_used_01              : 2;
+  uint8_t trig_counter_bdr         : 1;
+  uint8_t rst_counter_bdr          : 1;
+  uint8_t dataready_pulsed         : 1;
+} lsm6dsr_counter_bdr_reg1_t;
+
+#define LSM6DSR_COUNTER_BDR_REG2             0x0CU
+typedef struct {
+  uint8_t cnt_bdr_th               : 8;
+} lsm6dsr_counter_bdr_reg2_t;
+
+#define LSM6DSR_INT1_CTRL                    0x0DU
+typedef struct {
+  uint8_t int1_drdy_xl             : 1;
+  uint8_t int1_drdy_g              : 1;
+  uint8_t int1_boot                : 1;
+  uint8_t int1_fifo_th             : 1;
+  uint8_t int1_fifo_ovr            : 1;
+  uint8_t int1_fifo_full           : 1;
+  uint8_t int1_cnt_bdr             : 1;
+  uint8_t den_drdy_flag            : 1;
+} lsm6dsr_int1_ctrl_t;
+
+#define LSM6DSR_INT2_CTRL                    0x0EU
+typedef struct {
+  uint8_t int2_drdy_xl             : 1;
+  uint8_t int2_drdy_g              : 1;
+  uint8_t int2_drdy_temp           : 1;
+  uint8_t int2_fifo_th             : 1;
+  uint8_t int2_fifo_ovr            : 1;
+  uint8_t int2_fifo_full           : 1;
+  uint8_t int2_cnt_bdr             : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsr_int2_ctrl_t;
+
+#define LSM6DSR_WHO_AM_I                     0x0FU
+#define LSM6DSR_CTRL1_XL                     0x10U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf2_xl_en               : 1;
+  uint8_t fs_xl                    : 2;
+  uint8_t odr_xl                   : 4;
+} lsm6dsr_ctrl1_xl_t;
+
+#define LSM6DSR_CTRL2_G                      0x11U
+typedef struct {
+  uint8_t fs_g                     : 4; /* fs_4000 + fs_125 + fs_g */
+  uint8_t odr_g                    : 4;
+} lsm6dsr_ctrl2_g_t;
+
+#define LSM6DSR_CTRL3_C                      0x12U
+typedef struct {
+  uint8_t sw_reset                 : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t if_inc                   : 1;
+  uint8_t sim                      : 1;
+  uint8_t pp_od                    : 1;
+  uint8_t h_lactive                : 1;
+  uint8_t bdu                      : 1;
+  uint8_t boot                     : 1;
+} lsm6dsr_ctrl3_c_t;
+
+#define LSM6DSR_CTRL4_C                      0x13U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t lpf1_sel_g               : 1;
+  uint8_t i2c_disable              : 1;
+  uint8_t drdy_mask                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_on_int1             : 1;
+  uint8_t sleep_g                  : 1;
+  uint8_t not_used_03              : 1;
+} lsm6dsr_ctrl4_c_t;
+
+#define LSM6DSR_CTRL5_C                      0x14U
+typedef struct {
+  uint8_t st_xl                    : 2;
+  uint8_t st_g                     : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t rounding                 : 2;
+  uint8_t not_used_02              : 1;
+} lsm6dsr_ctrl5_c_t;
+
+#define LSM6DSR_CTRL6_C                      0x15U
+typedef struct {
+  uint8_t ftype                    : 3;
+  uint8_t usr_off_w                : 1;
+  uint8_t xl_hm_mode               : 1;
+  uint8_t den_mode                 : 3;   /* trig_en + lvl1_en + lvl2_en */
+} lsm6dsr_ctrl6_c_t;
+
+#define LSM6DSR_CTRL7_G                      0x16U
+typedef struct {
+  uint8_t ois_on                   : 1;
+  uint8_t usr_off_on_out           : 1;
+  uint8_t ois_on_en                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_g                    : 2;
+  uint8_t hp_en_g                  : 1;
+  uint8_t g_hm_mode                : 1;
+} lsm6dsr_ctrl7_g_t;
+
+#define LSM6DSR_CTRL8_XL                     0x17U
+typedef struct {
+  uint8_t low_pass_on_6d           : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t hp_slope_xl_en           : 1;
+  uint8_t fastsettl_mode_xl        : 1;
+  uint8_t hp_ref_mode_xl           : 1;
+  uint8_t hpcf_xl                  : 3;
+} lsm6dsr_ctrl8_xl_t;
+
+#define LSM6DSR_CTRL9_XL                     0x18U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t i3c_disable              : 1;
+  uint8_t den_lh                   : 1;
+  uint8_t den_xl_g                 : 2;   /* den_xl_en + den_xl_g */
+  uint8_t den_z                    : 1;
+  uint8_t den_y                    : 1;
+  uint8_t den_x                    : 1;
+} lsm6dsr_ctrl9_xl_t;
+
+#define LSM6DSR_CTRL10_C                     0x19U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t timestamp_en             : 1;
+  uint8_t not_used_02              : 2;
+} lsm6dsr_ctrl10_c_t;
+
+#define LSM6DSR_ALL_INT_SRC                  0x1AU
+typedef struct {
+  uint8_t ff_ia                    : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t single_tap               : 1;
+  uint8_t double_tap               : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t sleep_change_ia          : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t timestamp_endcount       : 1;
+} lsm6dsr_all_int_src_t;
+
+#define LSM6DSR_WAKE_UP_SRC                  0x1BU
+typedef struct {
+  uint8_t z_wu                     : 1;
+  uint8_t y_wu                     : 1;
+  uint8_t x_wu                     : 1;
+  uint8_t wu_ia                    : 1;
+  uint8_t sleep_state              : 1;
+  uint8_t ff_ia                    : 1;
+  uint8_t sleep_change_ia          : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsr_wake_up_src_t;
+
+#define LSM6DSR_TAP_SRC                      0x1CU
+typedef struct {
+  uint8_t z_tap                    : 1;
+  uint8_t y_tap                    : 1;
+  uint8_t x_tap                    : 1;
+  uint8_t tap_sign                 : 1;
+  uint8_t double_tap               : 1;
+  uint8_t single_tap               : 1;
+  uint8_t tap_ia                   : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsr_tap_src_t;
+
+#define LSM6DSR_D6D_SRC                      0x1DU
+typedef struct {
+  uint8_t xl                       : 1;
+  uint8_t xh                       : 1;
+  uint8_t yl                       : 1;
+  uint8_t yh                       : 1;
+  uint8_t zl                       : 1;
+  uint8_t zh                       : 1;
+  uint8_t d6d_ia                   : 1;
+  uint8_t den_drdy                 : 1;
+} lsm6dsr_d6d_src_t;
+
+#define LSM6DSR_STATUS_REG                   0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t tda                      : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dsr_status_reg_t;
+
+#define LSM6DSR_STATUS_SPIAUX                0x1EU
+typedef struct {
+  uint8_t xlda                     : 1;
+  uint8_t gda                      : 1;
+  uint8_t gyro_settling            : 1;
+  uint8_t not_used_01              : 5;
+} lsm6dsr_status_spiaux_t;
+
+#define LSM6DSR_OUT_TEMP_L                   0x20U
+#define LSM6DSR_OUT_TEMP_H                   0x21U
+#define LSM6DSR_OUTX_L_G                     0x22U
+#define LSM6DSR_OUTX_H_G                     0x23U
+#define LSM6DSR_OUTY_L_G                     0x24U
+#define LSM6DSR_OUTY_H_G                     0x25U
+#define LSM6DSR_OUTZ_L_G                     0x26U
+#define LSM6DSR_OUTZ_H_G                     0x27U
+#define LSM6DSR_OUTX_L_A                     0x28U
+#define LSM6DSR_OUTX_H_A                     0x29U
+#define LSM6DSR_OUTY_L_A                     0x2AU
+#define LSM6DSR_OUTY_H_A                     0x2BU
+#define LSM6DSR_OUTZ_L_A                     0x2CU
+#define LSM6DSR_OUTZ_H_A                     0x2DU
+#define LSM6DSR_EMB_FUNC_STATUS_MAINPAGE     0x35U
+typedef struct {
+  uint8_t not_used_01             : 3;
+  uint8_t is_step_det             : 1;
+  uint8_t is_tilt                 : 1;
+  uint8_t is_sigmot               : 1;
+  uint8_t not_used_02             : 1;
+  uint8_t is_fsm_lc               : 1;
+} lsm6dsr_emb_func_status_mainpage_t;
+
+#define LSM6DSR_FSM_STATUS_A_MAINPAGE        0x36U
+typedef struct {
+  uint8_t is_fsm1                 : 1;
+  uint8_t is_fsm2                 : 1;
+  uint8_t is_fsm3                 : 1;
+  uint8_t is_fsm4                 : 1;
+  uint8_t is_fsm5                 : 1;
+  uint8_t is_fsm6                 : 1;
+  uint8_t is_fsm7                 : 1;
+  uint8_t is_fsm8                 : 1;
+} lsm6dsr_fsm_status_a_mainpage_t;
+
+#define LSM6DSR_FSM_STATUS_B_MAINPAGE        0x37U
+typedef struct {
+  uint8_t is_fsm9                 : 1;
+  uint8_t is_fsm10                : 1;
+  uint8_t is_fsm11                : 1;
+  uint8_t is_fsm12                : 1;
+  uint8_t is_fsm13                : 1;
+  uint8_t is_fsm14                : 1;
+  uint8_t is_fsm15                : 1;
+  uint8_t is_fsm16                : 1;
+} lsm6dsr_fsm_status_b_mainpage_t;
+
+#define LSM6DSR_STATUS_MASTER_MAINPAGE       0x39U
+typedef struct {
+  uint8_t sens_hub_endop          : 1;
+  uint8_t not_used_01             : 2;
+  uint8_t slave0_nack             : 1;
+  uint8_t slave1_nack             : 1;
+  uint8_t slave2_nack             : 1;
+  uint8_t slave3_nack             : 1;
+  uint8_t wr_once_done            : 1;
+} lsm6dsr_status_master_mainpage_t;
+
+#define LSM6DSR_FIFO_STATUS1                 0x3AU
+typedef struct {
+  uint8_t diff_fifo                : 8;
+} lsm6dsr_fifo_status1_t;
+
+#define LSM6DSR_FIFO_STATUS2                 0x3BU
+typedef struct {
+  uint8_t diff_fifo                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t over_run_latched         : 1;
+  uint8_t counter_bdr_ia           : 1;
+  uint8_t fifo_full_ia             : 1;
+  uint8_t fifo_ovr_ia              : 1;
+  uint8_t fifo_wtm_ia              : 1;
+} lsm6dsr_fifo_status2_t;
+
+#define LSM6DSR_TIMESTAMP0                   0x40U
+#define LSM6DSR_TIMESTAMP1                   0x41U
+#define LSM6DSR_TIMESTAMP2                   0x42U
+#define LSM6DSR_TIMESTAMP3                   0x43U
+#define LSM6DSR_TAP_CFG0                     0x56U
+typedef struct {
+  uint8_t lir                      : 1;
+  uint8_t tap_z_en                 : 1;
+  uint8_t tap_y_en                 : 1;
+  uint8_t tap_x_en                 : 1;
+  uint8_t slope_fds                : 1;
+  uint8_t sleep_status_on_int      : 1;
+  uint8_t int_clr_on_read          : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsr_tap_cfg0_t;
+
+#define LSM6DSR_TAP_CFG1                     0x57U
+typedef struct {
+  uint8_t tap_ths_x                : 5;
+  uint8_t tap_priority             : 3;
+} lsm6dsr_tap_cfg1_t;
+
+#define LSM6DSR_TAP_CFG2                     0x58U
+typedef struct {
+  uint8_t tap_ths_y                : 5;
+  uint8_t inact_en                 : 2;
+  uint8_t interrupts_enable        : 1;
+} lsm6dsr_tap_cfg2_t;
+
+#define LSM6DSR_TAP_THS_6D                   0x59U
+typedef struct {
+  uint8_t tap_ths_z                : 5;
+  uint8_t sixd_ths                 : 2;
+  uint8_t d4d_en                   : 1;
+} lsm6dsr_tap_ths_6d_t;
+
+#define LSM6DSR_INT_DUR2                     0x5AU
+typedef struct {
+  uint8_t shock                    : 2;
+  uint8_t quiet                    : 2;
+  uint8_t dur                      : 4;
+} lsm6dsr_int_dur2_t;
+
+#define LSM6DSR_WAKE_UP_THS                  0x5BU
+typedef struct {
+  uint8_t wk_ths                   : 6;
+  uint8_t usr_off_on_wu            : 1;
+  uint8_t single_double_tap        : 1;
+} lsm6dsr_wake_up_ths_t;
+
+#define LSM6DSR_WAKE_UP_DUR                  0x5CU
+typedef struct {
+  uint8_t sleep_dur                : 4;
+  uint8_t wake_ths_w               : 1;
+  uint8_t wake_dur                 : 2;
+  uint8_t ff_dur                   : 1;
+} lsm6dsr_wake_up_dur_t;
+
+#define LSM6DSR_FREE_FALL                    0x5DU
+typedef struct {
+  uint8_t ff_ths                   : 3;
+  uint8_t ff_dur                   : 5;
+} lsm6dsr_free_fall_t;
+
+#define LSM6DSR_MD1_CFG                      0x5EU
+typedef struct {
+  uint8_t int1_shub                : 1;
+  uint8_t int1_emb_func            : 1;
+  uint8_t int1_6d                  : 1;
+  uint8_t int1_double_tap          : 1;
+  uint8_t int1_ff                  : 1;
+  uint8_t int1_wu                  : 1;
+  uint8_t int1_single_tap          : 1;
+  uint8_t int1_sleep_change        : 1;
+} lsm6dsr_md1_cfg_t;
+
+#define LSM6DSR_MD2_CFG                      0x5FU
+typedef struct {
+  uint8_t int2_timestamp           : 1;
+  uint8_t int2_emb_func            : 1;
+  uint8_t int2_6d                  : 1;
+  uint8_t int2_double_tap          : 1;
+  uint8_t int2_ff                  : 1;
+  uint8_t int2_wu                  : 1;
+  uint8_t int2_single_tap          : 1;
+  uint8_t int2_sleep_change        : 1;
+} lsm6dsr_md2_cfg_t;
+
+#define LSM6DSR_S4S_ST_CMD_CODE              0x60U
+typedef struct {
+  uint8_t s4s_st_cmd_code          : 8;
+} lsm6dsr_s4s_st_cmd_code_t;
+
+#define LSM6DSR_S4S_DT_REG                   0x61U
+typedef struct {
+  uint8_t dt                       : 8;
+} lsm6dsr_s4s_dt_reg_t;
+
+#define LSM6DSR_I3C_BUS_AVB                  0x62U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t i3c_bus_avb_sel          : 2;
+  uint8_t not_used_02              : 3;
+} lsm6dsr_i3c_bus_avb_t;
+
+#define LSM6DSR_INTERNAL_FREQ_FINE           0x63U
+typedef struct {
+  uint8_t freq_fine                : 8;
+} lsm6dsr_internal_freq_fine_t;
+
+#define LSM6DSR_INT_OIS                      0x6FU
+typedef struct {
+  uint8_t st_xl_ois                : 2;
+  uint8_t not_used_01              : 3;
+  uint8_t den_lh_ois               : 1;
+  uint8_t lvl2_ois                 : 1;
+  uint8_t int2_drdy_ois            : 1;
+} lsm6dsr_int_ois_t;
+
+#define LSM6DSR_CTRL1_OIS                    0x70U
+typedef struct {
+  uint8_t ois_en_spi2              : 1;
+  uint8_t fs_125_ois               : 1;
+  uint8_t fs_g_ois                 : 2;
+  uint8_t mode4_en                 : 1;
+  uint8_t sim_ois                  : 1;
+  uint8_t lvl1_ois                 : 1;
+  uint8_t not_used_01              : 1;
+} lsm6dsr_ctrl1_ois_t;
+
+#define LSM6DSR_CTRL2_OIS                    0x71U
+typedef struct {
+  uint8_t hp_en_ois                : 1;
+  uint8_t ftype_ois                : 2;
+  uint8_t not_used_01              : 1;
+  uint8_t hpm_ois                  : 2;
+  uint8_t not_used_02              : 2;
+} lsm6dsr_ctrl2_ois_t;
+
+#define LSM6DSR_CTRL3_OIS                    0x72U
+typedef struct {
+  uint8_t st_ois_clampdis          : 1;
+  uint8_t st_ois                   : 2;
+  uint8_t filter_xl_conf_ois       : 3;
+  uint8_t fs_xl_ois                : 2;
+} lsm6dsr_ctrl3_ois_t;
+
+#define LSM6DSR_X_OFS_USR                    0x73U
+#define LSM6DSR_Y_OFS_USR                    0x74U
+#define LSM6DSR_Z_OFS_USR                    0x75U
+#define LSM6DSR_FIFO_DATA_OUT_TAG            0x78U
+typedef struct {
+  uint8_t tag_parity               : 1;
+  uint8_t tag_cnt                  : 2;
+  uint8_t tag_sensor               : 5;
+} lsm6dsr_fifo_data_out_tag_t;
+
+#define LSM6DSR_FIFO_DATA_OUT_X_L            0x79U
+#define LSM6DSR_FIFO_DATA_OUT_X_H            0x7AU
+#define LSM6DSR_FIFO_DATA_OUT_Y_L            0x7BU
+#define LSM6DSR_FIFO_DATA_OUT_Y_H            0x7CU
+#define LSM6DSR_FIFO_DATA_OUT_Z_L            0x7DU
+#define LSM6DSR_FIFO_DATA_OUT_Z_H            0x7EU
+#define LSM6DSR_PAGE_SEL                     0x02U
+typedef struct {
+  uint8_t not_used_01              : 4;
+  uint8_t page_sel                 : 4;
+} lsm6dsr_page_sel_t;
+
+#define LSM6DSR_ADV_PEDO                     0x03U
+typedef struct {
+  uint8_t not_used_01              : 1;
+  uint8_t pedo_fpr_adf_dis         : 1;
+  uint8_t not_used_02              : 6;
+} lsm6dsr_adv_pedo_t;
+
+#define LSM6DSR_EMB_FUNC_EN_A                0x04U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t pedo_en                  : 1;
+  uint8_t tilt_en                  : 1;
+  uint8_t sign_motion_en           : 1;
+  uint8_t not_used_02              : 2;
+} lsm6dsr_emb_func_en_a_t;
+
+#define LSM6DSR_EMB_FUNC_EN_B                0x05U
+typedef struct {
+  uint8_t fsm_en                   : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t fifo_compr_en            : 1;
+  uint8_t pedo_adv_en              : 1;
+  uint8_t not_used_02              : 3;
+} lsm6dsr_emb_func_en_b_t;
+
+#define LSM6DSR_PAGE_ADDRESS                 0x08U
+typedef struct {
+  uint8_t page_addr                : 8;
+} lsm6dsr_page_address_t;
+
+#define LSM6DSR_PAGE_VALUE                   0x09U
+typedef struct {
+  uint8_t page_value               : 8;
+} lsm6dsr_page_value_t;
+
+#define LSM6DSR_EMB_FUNC_INT1                0x0AU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t int1_step_detector       : 1;
+  uint8_t int1_tilt                : 1;
+  uint8_t int1_sig_mot             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int1_fsm_lc              : 1;
+} lsm6dsr_emb_func_int1_t;
+
+#define LSM6DSR_FSM_INT1_A                   0x0BU
+typedef struct {
+  uint8_t int1_fsm1                : 1;
+  uint8_t int1_fsm2                : 1;
+  uint8_t int1_fsm3                : 1;
+  uint8_t int1_fsm4                : 1;
+  uint8_t int1_fsm5                : 1;
+  uint8_t int1_fsm6                : 1;
+  uint8_t int1_fsm7                : 1;
+  uint8_t int1_fsm8                : 1;
+} lsm6dsr_fsm_int1_a_t;
+
+#define LSM6DSR_FSM_INT1_B                   0x0CU
+typedef struct {
+  uint8_t int1_fsm9                : 1;
+  uint8_t int1_fsm10               : 1;
+  uint8_t int1_fsm11               : 1;
+  uint8_t int1_fsm12               : 1;
+  uint8_t int1_fsm13               : 1;
+  uint8_t int1_fsm14               : 1;
+  uint8_t int1_fsm15               : 1;
+  uint8_t int1_fsm16               : 1;
+} lsm6dsr_fsm_int1_b_t;
+
+#define LSM6DSR_EMB_FUNC_INT2                0x0EU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t int2_step_detector       : 1;
+  uint8_t int2_tilt                : 1;
+  uint8_t int2_sig_mot             : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t int2_fsm_lc              : 1;
+} lsm6dsr_emb_func_int2_t;
+
+#define LSM6DSR_FSM_INT2_A                   0x0FU
+typedef struct {
+  uint8_t int2_fsm1                : 1;
+  uint8_t int2_fsm2                : 1;
+  uint8_t int2_fsm3                : 1;
+  uint8_t int2_fsm4                : 1;
+  uint8_t int2_fsm5                : 1;
+  uint8_t int2_fsm6                : 1;
+  uint8_t int2_fsm7                : 1;
+  uint8_t int2_fsm8                : 1;
+} lsm6dsr_fsm_int2_a_t;
+
+#define LSM6DSR_FSM_INT2_B                   0x10U
+typedef struct {
+  uint8_t int2_fsm9                : 1;
+  uint8_t int2_fsm10               : 1;
+  uint8_t int2_fsm11               : 1;
+  uint8_t int2_fsm12               : 1;
+  uint8_t int2_fsm13               : 1;
+  uint8_t int2_fsm14               : 1;
+  uint8_t int2_fsm15               : 1;
+  uint8_t int2_fsm16               : 1;
+} lsm6dsr_fsm_int2_b_t;
+
+#define LSM6DSR_EMB_FUNC_STATUS              0x12U
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t is_step_det              : 1;
+  uint8_t is_tilt                  : 1;
+  uint8_t is_sigmot                : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t is_fsm_lc                : 1;
+} lsm6dsr_emb_func_status_t;
+
+#define LSM6DSR_FSM_STATUS_A                 0x13U
+typedef struct {
+  uint8_t is_fsm1                  : 1;
+  uint8_t is_fsm2                  : 1;
+  uint8_t is_fsm3                  : 1;
+  uint8_t is_fsm4                  : 1;
+  uint8_t is_fsm5                  : 1;
+  uint8_t is_fsm6                  : 1;
+  uint8_t is_fsm7                  : 1;
+  uint8_t is_fsm8                  : 1;
+} lsm6dsr_fsm_status_a_t;
+
+#define LSM6DSR_FSM_STATUS_B                 0x14U
+typedef struct {
+  uint8_t is_fsm9                  : 1;
+  uint8_t is_fsm10                 : 1;
+  uint8_t is_fsm11                 : 1;
+  uint8_t is_fsm12                 : 1;
+  uint8_t is_fsm13                 : 1;
+  uint8_t is_fsm14                 : 1;
+  uint8_t is_fsm15                 : 1;
+  uint8_t is_fsm16                 : 1;
+} lsm6dsr_fsm_status_b_t;
+
+#define LSM6DSR_PAGE_RW                      0x17U
+typedef struct {
+  uint8_t not_used_01              : 5;
+  uint8_t page_rw                  : 2;  /* page_write + page_read */
+  uint8_t emb_func_lir             : 1;
+} lsm6dsr_page_rw_t;
+
+#define LSM6DSR_EMB_FUNC_FIFO_CFG            0x44U
+typedef struct {
+  uint8_t not_used_01              : 6;
+  uint8_t pedo_fifo_en             : 1;
+  uint8_t not_used_02              : 1;
+} lsm6dsr_emb_func_fifo_cfg_t;
+
+#define LSM6DSR_FSM_ENABLE_A                 0x46U
+typedef struct {
+  uint8_t fsm1_en                  : 1;
+  uint8_t fsm2_en                  : 1;
+  uint8_t fsm3_en                  : 1;
+  uint8_t fsm4_en                  : 1;
+  uint8_t fsm5_en                  : 1;
+  uint8_t fsm6_en                  : 1;
+  uint8_t fsm7_en                  : 1;
+  uint8_t fsm8_en                  : 1;
+} lsm6dsr_fsm_enable_a_t;
+
+#define LSM6DSR_FSM_ENABLE_B                 0x47U
+typedef struct {
+  uint8_t fsm9_en                  : 1;
+  uint8_t fsm10_en                 : 1;
+  uint8_t fsm11_en                 : 1;
+  uint8_t fsm12_en                 : 1;
+  uint8_t fsm13_en                 : 1;
+  uint8_t fsm14_en                 : 1;
+  uint8_t fsm15_en                 : 1;
+  uint8_t fsm16_en                 : 1;
+} lsm6dsr_fsm_enable_b_t;
+
+#define LSM6DSR_FSM_LONG_COUNTER_L           0x48U
+#define LSM6DSR_FSM_LONG_COUNTER_H           0x49U
+#define LSM6DSR_FSM_LONG_COUNTER_CLEAR       0x4AU
+typedef struct {
+  uint8_t fsm_lc_clr               : 2;  /* fsm_lc_cleared + fsm_lc_clear */
+  uint8_t not_used_01              : 6;
+} lsm6dsr_fsm_long_counter_clear_t;
+
+#define LSM6DSR_FSM_OUTS1                    0x4CU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs1_t;
+
+#define LSM6DSR_FSM_OUTS2                    0x4DU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs2_t;
+
+#define LSM6DSR_FSM_OUTS3                    0x4EU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs3_t;
+
+#define LSM6DSR_FSM_OUTS4                    0x4FU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs4_t;
+
+#define LSM6DSR_FSM_OUTS5                    0x50U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs5_t;
+
+#define LSM6DSR_FSM_OUTS6                    0x51U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs6_t;
+
+#define LSM6DSR_FSM_OUTS7                    0x52U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs7_t;
+
+#define LSM6DSR_FSM_OUTS8                    0x53U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs8_t;
+
+#define LSM6DSR_FSM_OUTS9                    0x54U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs9_t;
+
+#define LSM6DSR_FSM_OUTS10                   0x55U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs10_t;
+
+#define LSM6DSR_FSM_OUTS11                   0x56U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs11_t;
+
+#define LSM6DSR_FSM_OUTS12                   0x57U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs12_t;
+
+#define LSM6DSR_FSM_OUTS13                   0x58U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs13_t;
+
+#define LSM6DSR_FSM_OUTS14                   0x59U
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs14_t;
+
+#define LSM6DSR_FSM_OUTS15                   0x5AU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs15_t;
+
+#define LSM6DSR_FSM_OUTS16                   0x5BU
+typedef struct {
+  uint8_t n_v                      : 1;
+  uint8_t p_v                      : 1;
+  uint8_t n_z                      : 1;
+  uint8_t p_z                      : 1;
+  uint8_t n_y                      : 1;
+  uint8_t p_y                      : 1;
+  uint8_t n_x                      : 1;
+  uint8_t p_x                      : 1;
+} lsm6dsr_fsm_outs16_t;
+
+#define LSM6DSR_EMB_FUNC_ODR_CFG_B           0x5FU
+typedef struct {
+  uint8_t not_used_01              : 3;
+  uint8_t fsm_odr                  : 2;
+  uint8_t not_used_02              : 3;
+} lsm6dsr_emb_func_odr_cfg_b_t;
+
+#define LSM6DSR_STEP_COUNTER_L               0x62U
+#define LSM6DSR_STEP_COUNTER_H               0x63U
+#define LSM6DSR_EMB_FUNC_SRC                 0x64U
+typedef struct {
+  uint8_t not_used_01              : 2;
+  uint8_t stepcounter_bit_set      : 1;
+  uint8_t step_overflow            : 1;
+  uint8_t step_count_delta_ia      : 1;
+  uint8_t step_detected            : 1;
+  uint8_t not_used_02              : 1;
+  uint8_t pedo_rst_step            : 1;
+} lsm6dsr_emb_func_src_t;
+
+#define LSM6DSR_EMB_FUNC_INIT_A              0x66U
+typedef struct {
+  uint8_t not_used_01               : 3;
+  uint8_t step_det_init             : 1;
+  uint8_t tilt_init                 : 1;
+  uint8_t sig_mot_init              : 1;
+  uint8_t not_used_02               : 2;
+} lsm6dsr_emb_func_init_a_t;
+
+#define LSM6DSR_EMB_FUNC_INIT_B              0x67U
+typedef struct {
+  uint8_t fsm_init                 : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t fifo_compr_init          : 1;
+  uint8_t not_used_02              : 4;
+} lsm6dsr_emb_func_init_b_t;
+
+#define LSM6DSR_MAG_SENSITIVITY_L            0xBAU
+#define LSM6DSR_MAG_SENSITIVITY_H            0xBBU
+#define LSM6DSR_MAG_OFFX_L                   0xC0U
+#define LSM6DSR_MAG_OFFX_H                   0xC1U
+#define LSM6DSR_MAG_OFFY_L                   0xC2U
+#define LSM6DSR_MAG_OFFY_H                   0xC3U
+#define LSM6DSR_MAG_OFFZ_L                   0xC4U
+#define LSM6DSR_MAG_OFFZ_H                   0xC5U
+#define LSM6DSR_MAG_SI_XX_L                  0xC6U
+#define LSM6DSR_MAG_SI_XX_H                  0xC7U
+#define LSM6DSR_MAG_SI_XY_L                  0xC8U
+#define LSM6DSR_MAG_SI_XY_H                  0xC9U
+#define LSM6DSR_MAG_SI_XZ_L                  0xCAU
+#define LSM6DSR_MAG_SI_XZ_H                  0xCBU
+#define LSM6DSR_MAG_SI_YY_L                  0xCCU
+#define LSM6DSR_MAG_SI_YY_H                  0xCDU
+#define LSM6DSR_MAG_SI_YZ_L                  0xCEU
+#define LSM6DSR_MAG_SI_YZ_H                  0xCFU
+#define LSM6DSR_MAG_SI_ZZ_L                  0xD0U
+#define LSM6DSR_MAG_SI_ZZ_H                  0xD1U
+#define LSM6DSR_MAG_CFG_A                    0xD4U
+typedef struct {
+  uint8_t mag_z_axis               : 3;
+  uint8_t not_used_01              : 1;
+  uint8_t mag_y_axis               : 3;
+  uint8_t not_used_02              : 1;
+} lsm6dsr_mag_cfg_a_t;
+
+#define LSM6DSR_MAG_CFG_B                    0xD5U
+typedef struct {
+  uint8_t mag_x_axis               : 3;
+  uint8_t not_used_01              : 5;
+} lsm6dsr_mag_cfg_b_t;
+
+#define LSM6DSR_FSM_LC_TIMEOUT_L             0x17AU
+#define LSM6DSR_FSM_LC_TIMEOUT_H             0x17BU
+#define LSM6DSR_FSM_PROGRAMS                 0x17CU
+#define LSM6DSR_FSM_START_ADD_L              0x17EU
+#define LSM6DSR_FSM_START_ADD_H              0x17FU
+#define LSM6DSR_PEDO_CMD_REG                 0x183U
+typedef struct {
+  uint8_t ad_det_en                : 1;
+  uint8_t not_used_01              : 1;
+  uint8_t fp_rejection_en          : 1;
+  uint8_t carry_count_en           : 1;
+  uint8_t not_used_02              : 4;
+} lsm6dsr_pedo_cmd_reg_t;
+
+#define LSM6DSR_PEDO_DEB_STEPS_CONF          0x184U
+#define LSM6DSR_PEDO_SC_DELTAT_L             0x1D0U
+#define LSM6DSR_PEDO_SC_DELTAT_H             0x1D1U
+#define LSM6DSR_SENSOR_HUB_1                 0x02U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_1_t;
+
+#define LSM6DSR_SENSOR_HUB_2                 0x03U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_2_t;
+
+#define LSM6DSR_SENSOR_HUB_3                 0x04U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_3_t;
+
+#define LSM6DSR_SENSOR_HUB_4                 0x05U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_4_t;
+
+#define LSM6DSR_SENSOR_HUB_5                 0x06U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_5_t;
+
+#define LSM6DSR_SENSOR_HUB_6                 0x07U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_6_t;
+
+#define LSM6DSR_SENSOR_HUB_7                 0x08U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_7_t;
+
+#define LSM6DSR_SENSOR_HUB_8                 0x09U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_8_t;
+
+#define LSM6DSR_SENSOR_HUB_9                 0x0AU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_9_t;
+
+#define LSM6DSR_SENSOR_HUB_10                0x0BU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_10_t;
+
+#define LSM6DSR_SENSOR_HUB_11                0x0CU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_11_t;
+
+#define LSM6DSR_SENSOR_HUB_12                0x0DU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_12_t;
+
+#define LSM6DSR_SENSOR_HUB_13                0x0EU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_13_t;
+
+#define LSM6DSR_SENSOR_HUB_14                0x0FU
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_14_t;
+
+#define LSM6DSR_SENSOR_HUB_15                0x10U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_15_t;
+
+#define LSM6DSR_SENSOR_HUB_16                0x11U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_16_t;
+
+#define LSM6DSR_SENSOR_HUB_17                0x12U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_17_t;
+
+#define LSM6DSR_SENSOR_HUB_18                0x13U
+typedef struct {
+   uint8_t bit0                    : 1;
+   uint8_t bit1                    : 1;
+   uint8_t bit2                    : 1;
+   uint8_t bit3                    : 1;
+   uint8_t bit4                    : 1;
+   uint8_t bit5                    : 1;
+   uint8_t bit6                    : 1;
+   uint8_t bit7                    : 1;
+} lsm6dsr_sensor_hub_18_t;
+
+#define LSM6DSR_MASTER_CONFIG                0x14U
+typedef struct {
+  uint8_t aux_sens_on              : 2;
+  uint8_t master_on                : 1;
+  uint8_t shub_pu_en               : 1;
+  uint8_t pass_through_mode        : 1;
+  uint8_t start_config             : 1;
+  uint8_t write_once               : 1;
+  uint8_t rst_master_regs          : 1;
+} lsm6dsr_master_config_t;
+
+#define LSM6DSR_SLV0_ADD                     0x15U
+typedef struct {
+  uint8_t rw_0                     : 1;
+  uint8_t slave0                   : 7;
+} lsm6dsr_slv0_add_t;
+
+#define LSM6DSR_SLV0_SUBADD                  0x16U
+typedef struct {
+  uint8_t slave0_reg               : 8;
+} lsm6dsr_slv0_subadd_t;
+
+#define LSM6DSR_SLV0_CONFIG                  0x17U
+typedef struct {
+  uint8_t slave0_numop             : 3;
+  uint8_t batch_ext_sens_0_en      : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t shub_odr                 : 2;
+} lsm6dsr_slv0_config_t;
+
+#define LSM6DSR_SLV1_ADD                     0x18U
+typedef struct {
+  uint8_t r_1                      : 1;
+  uint8_t slave1_add               : 7;
+} lsm6dsr_slv1_add_t;
+
+#define LSM6DSR_SLV1_SUBADD                  0x19U
+typedef struct {
+  uint8_t slave1_reg               : 8;
+} lsm6dsr_slv1_subadd_t;
+
+#define LSM6DSR_SLV1_CONFIG                  0x1AU
+typedef struct {
+  uint8_t slave1_numop             : 3;
+  uint8_t batch_ext_sens_1_en      : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dsr_slv1_config_t;
+
+#define LSM6DSR_SLV2_ADD                     0x1BU
+typedef struct {
+  uint8_t r_2                      : 1;
+  uint8_t slave2_add               : 7;
+} lsm6dsr_slv2_add_t;
+
+#define LSM6DSR_SLV2_SUBADD                  0x1CU
+typedef struct {
+  uint8_t slave2_reg               : 8;
+} lsm6dsr_slv2_subadd_t;
+
+#define LSM6DSR_SLV2_CONFIG                  0x1DU
+typedef struct {
+  uint8_t slave2_numop             : 3;
+  uint8_t batch_ext_sens_2_en      : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dsr_slv2_config_t;
+
+#define LSM6DSR_SLV3_ADD                     0x1EU
+typedef struct {
+  uint8_t r_3                      : 1;
+  uint8_t slave3_add               : 7;
+} lsm6dsr_slv3_add_t;
+
+#define LSM6DSR_SLV3_SUBADD                  0x1FU
+typedef struct {
+  uint8_t slave3_reg               : 8;
+} lsm6dsr_slv3_subadd_t;
+
+#define LSM6DSR_SLV3_CONFIG                  0x20U
+typedef struct {
+  uint8_t slave3_numop             : 3;
+  uint8_t batch_ext_sens_3_en      : 1;
+  uint8_t not_used_01              : 4;
+} lsm6dsr_slv3_config_t;
+
+#define LSM6DSR_DATAWRITE_SLV0  0x21U
+typedef struct {
+  uint8_t slave0_dataw             : 8;
+} lsm6dsr_datawrite_slv0_t;
+
+#define LSM6DSR_STATUS_MASTER                0x22U
+typedef struct {
+  uint8_t sens_hub_endop           : 1;
+  uint8_t not_used_01              : 2;
+  uint8_t slave0_nack              : 1;
+  uint8_t slave1_nack              : 1;
+  uint8_t slave2_nack              : 1;
+  uint8_t slave3_nack              : 1;
+  uint8_t wr_once_done             : 1;
+} lsm6dsr_status_master_t;
+
+/**
+  * @defgroup LSM6DSR_Register_Union
+  * @brief    This union group all the registers that has a bit-field
+  *           description.
+  *           This union is useful but not need by the driver.
+  *
+  *           REMOVING this union you are compliant with:
+  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
+  *
+  * @{
+  *
+  */
+typedef union{
+  lsm6dsr_func_cfg_access_t               func_cfg_access;
+  lsm6dsr_pin_ctrl_t                      pin_ctrl;
+  lsm6dsr_s4s_tph_l_t                     s4s_tph_l;
+  lsm6dsr_s4s_tph_h_t                     s4s_tph_h;
+  lsm6dsr_s4s_rr_t                        s4s_rr;
+  lsm6dsr_fifo_ctrl1_t                    fifo_ctrl1;
+  lsm6dsr_fifo_ctrl2_t                    fifo_ctrl2;
+  lsm6dsr_fifo_ctrl3_t                    fifo_ctrl3;
+  lsm6dsr_fifo_ctrl4_t                    fifo_ctrl4;
+  lsm6dsr_counter_bdr_reg1_t              counter_bdr_reg1;
+  lsm6dsr_counter_bdr_reg2_t              counter_bdr_reg2;
+  lsm6dsr_int1_ctrl_t                     int1_ctrl;
+  lsm6dsr_int2_ctrl_t                     int2_ctrl;
+  lsm6dsr_ctrl1_xl_t                      ctrl1_xl;
+  lsm6dsr_ctrl2_g_t                       ctrl2_g;
+  lsm6dsr_ctrl3_c_t                       ctrl3_c;
+  lsm6dsr_ctrl4_c_t                       ctrl4_c;
+  lsm6dsr_ctrl5_c_t                       ctrl5_c;
+  lsm6dsr_ctrl6_c_t                       ctrl6_c;
+  lsm6dsr_ctrl7_g_t                       ctrl7_g;
+  lsm6dsr_ctrl8_xl_t                      ctrl8_xl;
+  lsm6dsr_ctrl9_xl_t                      ctrl9_xl;
+  lsm6dsr_ctrl10_c_t                      ctrl10_c;
+  lsm6dsr_all_int_src_t                   all_int_src;
+  lsm6dsr_wake_up_src_t                   wake_up_src;
+  lsm6dsr_tap_src_t                       tap_src;
+  lsm6dsr_d6d_src_t                       d6d_src;
+  lsm6dsr_status_reg_t                    status_reg;
+  lsm6dsr_status_spiaux_t                 status_spiaux;
+  lsm6dsr_fifo_status1_t                  fifo_status1;
+  lsm6dsr_fifo_status2_t                  fifo_status2;
+  lsm6dsr_tap_cfg0_t                      tap_cfg0;
+  lsm6dsr_tap_cfg1_t                      tap_cfg1;
+  lsm6dsr_tap_cfg2_t                      tap_cfg2;
+  lsm6dsr_tap_ths_6d_t                    tap_ths_6d;
+  lsm6dsr_int_dur2_t                      int_dur2;
+  lsm6dsr_wake_up_ths_t                   wake_up_ths;
+  lsm6dsr_wake_up_dur_t                   wake_up_dur;
+  lsm6dsr_free_fall_t                     free_fall;
+  lsm6dsr_md1_cfg_t                       md1_cfg;
+  lsm6dsr_md2_cfg_t                       md2_cfg;
+  lsm6dsr_s4s_st_cmd_code_t               s4s_st_cmd_code;
+  lsm6dsr_s4s_dt_reg_t                    s4s_dt_reg;
+  lsm6dsr_i3c_bus_avb_t                   i3c_bus_avb;
+  lsm6dsr_internal_freq_fine_t            internal_freq_fine;
+  lsm6dsr_int_ois_t                       int_ois;
+  lsm6dsr_ctrl1_ois_t                     ctrl1_ois;
+  lsm6dsr_ctrl2_ois_t                     ctrl2_ois;
+  lsm6dsr_ctrl3_ois_t                     ctrl3_ois;
+  lsm6dsr_fifo_data_out_tag_t             fifo_data_out_tag;
+  lsm6dsr_page_sel_t                      page_sel;
+  lsm6dsr_emb_func_en_a_t                 emb_func_en_a;
+  lsm6dsr_emb_func_en_b_t                 emb_func_en_b;
+  lsm6dsr_page_address_t                  page_address;
+  lsm6dsr_page_value_t                    page_value;
+  lsm6dsr_emb_func_int1_t                 emb_func_int1;
+  lsm6dsr_fsm_int1_a_t                    fsm_int1_a;
+  lsm6dsr_fsm_int1_b_t                    fsm_int1_b;
+  lsm6dsr_emb_func_int2_t                 emb_func_int2;
+  lsm6dsr_fsm_int2_a_t                    fsm_int2_a;
+  lsm6dsr_fsm_int2_b_t                    fsm_int2_b;
+  lsm6dsr_emb_func_status_t               emb_func_status;
+  lsm6dsr_fsm_status_a_t                  fsm_status_a;
+  lsm6dsr_fsm_status_b_t                  fsm_status_b;
+  lsm6dsr_page_rw_t                       page_rw;
+  lsm6dsr_emb_func_fifo_cfg_t	            emb_func_fifo_cfg;
+  lsm6dsr_fsm_enable_a_t                  fsm_enable_a;
+  lsm6dsr_fsm_enable_b_t                  fsm_enable_b;
+  lsm6dsr_fsm_long_counter_clear_t        fsm_long_counter_clear;
+  lsm6dsr_fsm_outs1_t                     fsm_outs1;
+  lsm6dsr_fsm_outs2_t                     fsm_outs2;
+  lsm6dsr_fsm_outs3_t                     fsm_outs3;
+  lsm6dsr_fsm_outs4_t                     fsm_outs4;
+  lsm6dsr_fsm_outs5_t                     fsm_outs5;
+  lsm6dsr_fsm_outs6_t                     fsm_outs6;
+  lsm6dsr_fsm_outs7_t                     fsm_outs7;
+  lsm6dsr_fsm_outs8_t                     fsm_outs8;
+  lsm6dsr_fsm_outs9_t                     fsm_outs9;
+  lsm6dsr_fsm_outs10_t                    fsm_outs10;
+  lsm6dsr_fsm_outs11_t                    fsm_outs11;
+  lsm6dsr_fsm_outs12_t                    fsm_outs12;
+  lsm6dsr_fsm_outs13_t                    fsm_outs13;
+  lsm6dsr_fsm_outs14_t                    fsm_outs14;
+  lsm6dsr_fsm_outs15_t                    fsm_outs15;
+  lsm6dsr_fsm_outs16_t                    fsm_outs16;
+  lsm6dsr_emb_func_odr_cfg_b_t            emb_func_odr_cfg_b;
+  lsm6dsr_emb_func_src_t                  emb_func_src;
+  lsm6dsr_emb_func_init_a_t               emb_func_init_a;
+  lsm6dsr_emb_func_init_b_t               emb_func_init_b;
+  lsm6dsr_mag_cfg_a_t                     mag_cfg_a;
+  lsm6dsr_mag_cfg_b_t                     mag_cfg_b;
+  lsm6dsr_pedo_cmd_reg_t                  pedo_cmd_reg;
+  lsm6dsr_sensor_hub_1_t                  sensor_hub_1;
+  lsm6dsr_sensor_hub_2_t                  sensor_hub_2;
+  lsm6dsr_sensor_hub_3_t                  sensor_hub_3;
+  lsm6dsr_sensor_hub_4_t                  sensor_hub_4;
+  lsm6dsr_sensor_hub_5_t                  sensor_hub_5;
+  lsm6dsr_sensor_hub_6_t                  sensor_hub_6;
+  lsm6dsr_sensor_hub_7_t                  sensor_hub_7;
+  lsm6dsr_sensor_hub_8_t                  sensor_hub_8;
+  lsm6dsr_sensor_hub_9_t                  sensor_hub_9;
+  lsm6dsr_sensor_hub_10_t                 sensor_hub_10;
+  lsm6dsr_sensor_hub_11_t                 sensor_hub_11;
+  lsm6dsr_sensor_hub_12_t                 sensor_hub_12;
+  lsm6dsr_sensor_hub_13_t                 sensor_hub_13;
+  lsm6dsr_sensor_hub_14_t                 sensor_hub_14;
+  lsm6dsr_sensor_hub_15_t                 sensor_hub_15;
+  lsm6dsr_sensor_hub_16_t                 sensor_hub_16;
+  lsm6dsr_sensor_hub_17_t                 sensor_hub_17;
+  lsm6dsr_sensor_hub_18_t                 sensor_hub_18;
+  lsm6dsr_master_config_t                 master_config;
+  lsm6dsr_slv0_add_t                      slv0_add;
+  lsm6dsr_slv0_subadd_t                   slv0_subadd;
+  lsm6dsr_slv0_config_t                   slv0_config;
+  lsm6dsr_slv1_add_t                      slv1_add;
+  lsm6dsr_slv1_subadd_t                   slv1_subadd;
+  lsm6dsr_slv1_config_t                   slv1_config;
+  lsm6dsr_slv2_add_t                      slv2_add;
+  lsm6dsr_slv2_subadd_t                   slv2_subadd;
+  lsm6dsr_slv2_config_t                   slv2_config;
+  lsm6dsr_slv3_add_t                      slv3_add;
+  lsm6dsr_slv3_subadd_t                   slv3_subadd;
+  lsm6dsr_slv3_config_t                   slv3_config;
+  lsm6dsr_datawrite_slv0_t                datawrite_slv0;
+  lsm6dsr_status_master_t                 status_master;
+  bitwise_t                               bitwise;
+  uint8_t                                 byte;
+} lsm6dsr_reg_t;
+
+/**
+  * @}
+  *
+  */
+
+int32_t lsm6dsr_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                         uint16_t len);
+int32_t lsm6dsr_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
+                          uint16_t len);
+
+extern float_t lsm6dsr_from_fs2g_to_mg(int16_t lsb);
+extern float_t lsm6dsr_from_fs4g_to_mg(int16_t lsb);
+extern float_t lsm6dsr_from_fs8g_to_mg(int16_t lsb);
+extern float_t lsm6dsr_from_fs16g_to_mg(int16_t lsb);
+extern float_t lsm6dsr_from_fs125dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsr_from_fs250dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsr_from_fs500dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsr_from_fs1000dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsr_from_fs2000dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsr_from_fs4000dps_to_mdps(int16_t lsb);
+extern float_t lsm6dsr_from_lsb_to_celsius(int16_t lsb);
+extern float_t lsm6dsr_from_lsb_to_nsec(int32_t lsb);
+
+typedef enum {
+  LSM6DSR_2g   = 0,
+  LSM6DSR_16g  = 1, /* if XL_FS_MODE = '1' -> LSM6DSR_2g */
+  LSM6DSR_4g   = 2,
+  LSM6DSR_8g   = 3,
+} lsm6dsr_fs_xl_t;
+int32_t lsm6dsr_xl_full_scale_set(stmdev_ctx_t *ctx, lsm6dsr_fs_xl_t val);
+int32_t lsm6dsr_xl_full_scale_get(stmdev_ctx_t *ctx, lsm6dsr_fs_xl_t *val);
+
+typedef enum {
+  LSM6DSR_XL_ODR_OFF    = 0,
+  LSM6DSR_XL_ODR_12Hz5  = 1,
+  LSM6DSR_XL_ODR_26Hz   = 2,
+  LSM6DSR_XL_ODR_52Hz   = 3,
+  LSM6DSR_XL_ODR_104Hz  = 4,
+  LSM6DSR_XL_ODR_208Hz  = 5,
+  LSM6DSR_XL_ODR_417Hz  = 6,
+  LSM6DSR_XL_ODR_833Hz  = 7,
+  LSM6DSR_XL_ODR_1667Hz = 8,
+  LSM6DSR_XL_ODR_3333Hz = 9,
+  LSM6DSR_XL_ODR_6667Hz = 10,
+  LSM6DSR_XL_ODR_6Hz5   = 11, /* (low power only) */
+} lsm6dsr_odr_xl_t;
+int32_t lsm6dsr_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dsr_odr_xl_t val);
+int32_t lsm6dsr_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dsr_odr_xl_t *val);
+
+typedef enum {
+  LSM6DSR_125dps = 2,
+  LSM6DSR_250dps = 0,
+  LSM6DSR_500dps = 4,
+  LSM6DSR_1000dps = 8,
+  LSM6DSR_2000dps = 12,
+  LSM6DSR_4000dps = 1,
+} lsm6dsr_fs_g_t;
+int32_t lsm6dsr_gy_full_scale_set(stmdev_ctx_t *ctx, lsm6dsr_fs_g_t val);
+int32_t lsm6dsr_gy_full_scale_get(stmdev_ctx_t *ctx, lsm6dsr_fs_g_t *val);
+
+typedef enum {
+  LSM6DSR_GY_ODR_OFF    = 0,
+  LSM6DSR_GY_ODR_12Hz5  = 1,
+  LSM6DSR_GY_ODR_26Hz   = 2,
+  LSM6DSR_GY_ODR_52Hz   = 3,
+  LSM6DSR_GY_ODR_104Hz  = 4,
+  LSM6DSR_GY_ODR_208Hz  = 5,
+  LSM6DSR_GY_ODR_417Hz  = 6,
+  LSM6DSR_GY_ODR_833Hz  = 7,
+  LSM6DSR_GY_ODR_1667Hz = 8,
+  LSM6DSR_GY_ODR_3333Hz = 9,
+  LSM6DSR_GY_ODR_6667Hz = 10,
+} lsm6dsr_odr_g_t;
+int32_t lsm6dsr_gy_data_rate_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_odr_g_t val);
+int32_t lsm6dsr_gy_data_rate_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_odr_g_t *val);
+
+int32_t lsm6dsr_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_LSb_1mg  = 0,
+  LSM6DSR_LSb_16mg = 1,
+} lsm6dsr_usr_off_w_t;
+int32_t lsm6dsr_xl_offset_weight_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_usr_off_w_t val);
+int32_t lsm6dsr_xl_offset_weight_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_usr_off_w_t *val);
+
+typedef enum {
+  LSM6DSR_HIGH_PERFORMANCE_MD  = 0,
+  LSM6DSR_LOW_NORMAL_POWER_MD  = 1,
+} lsm6dsr_xl_hm_mode_t;
+int32_t lsm6dsr_xl_power_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_xl_hm_mode_t val);
+int32_t lsm6dsr_xl_power_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_xl_hm_mode_t *val);
+
+typedef enum {
+  LSM6DSR_GY_HIGH_PERFORMANCE  = 0,
+  LSM6DSR_GY_NORMAL            = 1,
+} lsm6dsr_g_hm_mode_t;
+int32_t lsm6dsr_gy_power_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_g_hm_mode_t val);
+int32_t lsm6dsr_gy_power_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_g_hm_mode_t *val);
+
+typedef struct {
+  lsm6dsr_all_int_src_t       all_int_src;
+  lsm6dsr_wake_up_src_t       wake_up_src;
+  lsm6dsr_tap_src_t           tap_src;
+  lsm6dsr_d6d_src_t           d6d_src;
+  lsm6dsr_status_reg_t        status_reg;
+  lsm6dsr_emb_func_status_t   emb_func_status;
+  lsm6dsr_fsm_status_a_t      fsm_status_a;
+  lsm6dsr_fsm_status_b_t      fsm_status_b;
+  } lsm6dsr_all_sources_t;
+int32_t lsm6dsr_all_sources_get(stmdev_ctx_t *ctx,
+                                lsm6dsr_all_sources_t *val);
+
+int32_t lsm6dsr_status_reg_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_status_reg_t *val);
+
+int32_t lsm6dsr_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_xl_usr_offset_y_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_xl_usr_offset_y_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_xl_usr_offset_z_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_xl_usr_offset_z_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_xl_usr_offset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_xl_usr_offset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_timestamp_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSR_NO_ROUND      = 0,
+  LSM6DSR_ROUND_XL      = 1,
+  LSM6DSR_ROUND_GY      = 2,
+  LSM6DSR_ROUND_GY_XL   = 3,
+} lsm6dsr_rounding_t;
+int32_t lsm6dsr_rounding_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_rounding_t val);
+int32_t lsm6dsr_rounding_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_rounding_t *val);
+
+int32_t lsm6dsr_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_fifo_out_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_odr_cal_reg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_odr_cal_reg_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_number_of_steps_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_steps_reset(stmdev_ctx_t *ctx);
+
+typedef enum {
+  LSM6DSR_USER_BANK           = 0,
+  LSM6DSR_SENSOR_HUB_BANK     = 1,
+  LSM6DSR_EMBEDDED_FUNC_BANK  = 2,
+} lsm6dsr_reg_access_t;
+int32_t lsm6dsr_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsr_reg_access_t val);
+int32_t lsm6dsr_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsr_reg_access_t *val);
+
+int32_t lsm6dsr_ln_pg_write_byte(stmdev_ctx_t *ctx, uint16_t address,
+                                 uint8_t *val);
+int32_t lsm6dsr_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
+                            uint8_t *buf, uint8_t len);
+int32_t lsm6dsr_ln_pg_read_byte(stmdev_ctx_t *ctx, uint16_t add,
+                                uint8_t *val);
+int32_t lsm6dsr_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_DRDY_LATCHED = 0,
+  LSM6DSR_DRDY_PULSED  = 1,
+} lsm6dsr_dataready_pulsed_t;
+int32_t lsm6dsr_data_ready_mode_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_dataready_pulsed_t val);
+int32_t lsm6dsr_data_ready_mode_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_dataready_pulsed_t *val);
+
+int32_t lsm6dsr_device_id_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_boot_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_boot_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_XL_ST_DISABLE  = 0,
+  LSM6DSR_XL_ST_POSITIVE = 1,
+  LSM6DSR_XL_ST_NEGATIVE = 2,
+} lsm6dsr_st_xl_t;
+int32_t lsm6dsr_xl_self_test_set(stmdev_ctx_t *ctx, lsm6dsr_st_xl_t val);
+int32_t lsm6dsr_xl_self_test_get(stmdev_ctx_t *ctx, lsm6dsr_st_xl_t *val);
+
+typedef enum {
+  LSM6DSR_GY_ST_DISABLE  = 0,
+  LSM6DSR_GY_ST_POSITIVE = 1,
+  LSM6DSR_GY_ST_NEGATIVE = 3,
+} lsm6dsr_st_g_t;
+int32_t lsm6dsr_gy_self_test_set(stmdev_ctx_t *ctx, lsm6dsr_st_g_t val);
+int32_t lsm6dsr_gy_self_test_get(stmdev_ctx_t *ctx, lsm6dsr_st_g_t *val);
+
+int32_t lsm6dsr_xl_filter_lp2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_xl_filter_lp2_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_gy_filter_lp1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_gy_filter_lp1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_ULTRA_LIGHT  = 0,
+  LSM6DSR_VERY_LIGHT   = 1,
+  LSM6DSR_LIGHT        = 2,
+  LSM6DSR_MEDIUM       = 3,
+  LSM6DSR_STRONG       = 4,
+  LSM6DSR_VERY_STRONG  = 5,
+  LSM6DSR_AGGRESSIVE   = 6,
+  LSM6DSR_XTREME       = 7,
+} lsm6dsr_ftype_t;
+int32_t lsm6dsr_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx, lsm6dsr_ftype_t val);
+int32_t lsm6dsr_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx, lsm6dsr_ftype_t *val);
+
+int32_t lsm6dsr_xl_lp2_on_6d_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_xl_lp2_on_6d_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_HP_PATH_DISABLE_ON_OUT    = 0x00,
+  LSM6DSR_SLOPE_ODR_DIV_4           = 0x10,
+  LSM6DSR_HP_ODR_DIV_10             = 0x11,
+  LSM6DSR_HP_ODR_DIV_20             = 0x12,
+  LSM6DSR_HP_ODR_DIV_45             = 0x13,
+  LSM6DSR_HP_ODR_DIV_100            = 0x14,
+  LSM6DSR_HP_ODR_DIV_200            = 0x15,
+  LSM6DSR_HP_ODR_DIV_400            = 0x16,
+  LSM6DSR_HP_ODR_DIV_800            = 0x17,
+  LSM6DSR_HP_REF_MD_ODR_DIV_10      = 0x31,
+  LSM6DSR_HP_REF_MD_ODR_DIV_20      = 0x32,
+  LSM6DSR_HP_REF_MD_ODR_DIV_45      = 0x33,
+  LSM6DSR_HP_REF_MD_ODR_DIV_100     = 0x34,
+  LSM6DSR_HP_REF_MD_ODR_DIV_200     = 0x35,
+  LSM6DSR_HP_REF_MD_ODR_DIV_400     = 0x36,
+  LSM6DSR_HP_REF_MD_ODR_DIV_800     = 0x37,
+  LSM6DSR_LP_ODR_DIV_10             = 0x01,
+  LSM6DSR_LP_ODR_DIV_20             = 0x02,
+  LSM6DSR_LP_ODR_DIV_45             = 0x03,
+  LSM6DSR_LP_ODR_DIV_100            = 0x04,
+  LSM6DSR_LP_ODR_DIV_200            = 0x05,
+  LSM6DSR_LP_ODR_DIV_400            = 0x06,
+  LSM6DSR_LP_ODR_DIV_800            = 0x07,
+} lsm6dsr_hp_slope_xl_en_t;
+int32_t lsm6dsr_xl_hp_path_on_out_set(stmdev_ctx_t *ctx,
+                                      lsm6dsr_hp_slope_xl_en_t val);
+int32_t lsm6dsr_xl_hp_path_on_out_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_hp_slope_xl_en_t *val);
+
+int32_t lsm6dsr_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_USE_SLOPE = 0,
+  LSM6DSR_USE_HPF   = 1,
+} lsm6dsr_slope_fds_t;
+int32_t lsm6dsr_xl_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                        lsm6dsr_slope_fds_t val);
+int32_t lsm6dsr_xl_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                        lsm6dsr_slope_fds_t *val);
+
+typedef enum {
+  LSM6DSR_HP_FILTER_NONE     = 0x00,
+  LSM6DSR_HP_FILTER_16mHz    = 0x80,
+  LSM6DSR_HP_FILTER_65mHz    = 0x81,
+  LSM6DSR_HP_FILTER_260mHz   = 0x82,
+  LSM6DSR_HP_FILTER_1Hz04    = 0x83,
+} lsm6dsr_hpm_g_t;
+int32_t lsm6dsr_gy_hp_path_internal_set(stmdev_ctx_t *ctx,
+                                        lsm6dsr_hpm_g_t val);
+int32_t lsm6dsr_gy_hp_path_internal_get(stmdev_ctx_t *ctx,
+                                        lsm6dsr_hpm_g_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_PULL_UP_DISC       = 0,
+  LSM6DSR_AUX_PULL_UP_CONNECT    = 1,
+} lsm6dsr_ois_pu_dis_t;
+int32_t lsm6dsr_aux_sdo_ocs_mode_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_ois_pu_dis_t val);
+int32_t lsm6dsr_aux_sdo_ocs_mode_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_ois_pu_dis_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_ON                    = 1,
+  LSM6DSR_AUX_ON_BY_AUX_INTERFACE   = 0,
+} lsm6dsr_ois_on_t;
+int32_t lsm6dsr_aux_pw_on_ctrl_set(stmdev_ctx_t *ctx, lsm6dsr_ois_on_t val);
+int32_t lsm6dsr_aux_pw_on_ctrl_get(stmdev_ctx_t *ctx, lsm6dsr_ois_on_t *val);
+
+int32_t lsm6dsr_aux_status_reg_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_status_spiaux_t *val);
+
+int32_t lsm6dsr_aux_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_aux_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_aux_gy_flag_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_XL_DISABLE = 0,
+  LSM6DSR_AUX_XL_POS     = 1,
+  LSM6DSR_AUX_XL_NEG     = 2,
+} lsm6dsr_st_xl_ois_t;
+int32_t lsm6dsr_aux_xl_self_test_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_st_xl_ois_t val);
+int32_t lsm6dsr_aux_xl_self_test_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_st_xl_ois_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_DEN_ACTIVE_LOW     = 0,
+  LSM6DSR_AUX_DEN_ACTIVE_HIGH    = 1,
+} lsm6dsr_den_lh_ois_t;
+int32_t lsm6dsr_aux_den_polarity_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_den_lh_ois_t val);
+int32_t lsm6dsr_aux_den_polarity_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_den_lh_ois_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_DEN_DISABLE         = 0,
+  LSM6DSR_AUX_DEN_LEVEL_LATCH     = 3,
+  LSM6DSR_AUX_DEN_LEVEL_TRIG      = 2,
+} lsm6dsr_lvl2_ois_t;
+int32_t lsm6dsr_aux_den_mode_set(stmdev_ctx_t *ctx, lsm6dsr_lvl2_ois_t val);
+int32_t lsm6dsr_aux_den_mode_get(stmdev_ctx_t *ctx, lsm6dsr_lvl2_ois_t *val);
+
+int32_t lsm6dsr_aux_drdy_on_int2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_aux_drdy_on_int2_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_DISABLE  = 0,
+  LSM6DSR_MODE_3_GY    = 1,
+  LSM6DSR_MODE_4_GY_XL = 3,
+} lsm6dsr_ois_en_spi2_t;
+int32_t lsm6dsr_aux_mode_set(stmdev_ctx_t *ctx, lsm6dsr_ois_en_spi2_t val);
+int32_t lsm6dsr_aux_mode_get(stmdev_ctx_t *ctx, lsm6dsr_ois_en_spi2_t *val);
+
+typedef enum {
+  LSM6DSR_125dps_AUX  =  0x04,
+  LSM6DSR_250dps_AUX  =  0x00,
+  LSM6DSR_500dps_AUX  =  0x01,
+  LSM6DSR_1000dps_AUX =  0x02,
+  LSM6DSR_2000dps_AUX =  0x03,
+} lsm6dsr_fs_g_ois_t;
+int32_t lsm6dsr_aux_gy_full_scale_set(stmdev_ctx_t *ctx,
+                                      lsm6dsr_fs_g_ois_t val);
+int32_t lsm6dsr_aux_gy_full_scale_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_fs_g_ois_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_SPI_4_WIRE = 0,
+  LSM6DSR_AUX_SPI_3_WIRE = 1,
+} lsm6dsr_sim_ois_t;
+int32_t lsm6dsr_aux_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsr_sim_ois_t val);
+int32_t lsm6dsr_aux_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsr_sim_ois_t *val);
+
+typedef enum {
+  LSM6DSR_351Hz39 = 0,
+  LSM6DSR_236Hz63 = 1,
+  LSM6DSR_172Hz70 = 2,
+  LSM6DSR_937Hz91 = 3,
+} lsm6dsr_ftype_ois_t;
+int32_t lsm6dsr_aux_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+                                         lsm6dsr_ftype_ois_t val);
+int32_t lsm6dsr_aux_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+                                         lsm6dsr_ftype_ois_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_HP_DISABLE = 0x00,
+  LSM6DSR_AUX_HP_Hz016   = 0x10,
+  LSM6DSR_AUX_HP_Hz065   = 0x11,
+  LSM6DSR_AUX_HP_Hz260   = 0x12,
+  LSM6DSR_AUX_HP_1Hz040  = 0x13,
+} lsm6dsr_hpm_ois_t;
+int32_t lsm6dsr_aux_gy_hp_bandwidth_set(stmdev_ctx_t *ctx,
+                                        lsm6dsr_hpm_ois_t val);
+int32_t lsm6dsr_aux_gy_hp_bandwidth_get(stmdev_ctx_t *ctx,
+                                        lsm6dsr_hpm_ois_t *val);
+
+typedef enum {
+  LSM6DSR_ENABLE_CLAMP  = 0,
+  LSM6DSR_DISABLE_CLAMP = 1,
+} lsm6dsr_st_ois_clampdis_t;
+int32_t lsm6dsr_aux_gy_clamp_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_st_ois_clampdis_t val);
+int32_t lsm6dsr_aux_gy_clamp_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_st_ois_clampdis_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_GY_DISABLE = 0,
+  LSM6DSR_AUX_GY_POS     = 1,
+  LSM6DSR_AUX_GY_NEG     = 3,
+} lsm6dsr_st_ois_t;
+int32_t lsm6dsr_aux_gy_self_test_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_st_ois_t val);
+int32_t lsm6dsr_aux_gy_self_test_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_st_ois_t *val);
+
+typedef enum {
+  LSM6DSR_631Hz = 0,
+  LSM6DSR_295Hz = 1,
+  LSM6DSR_140Hz = 2,
+  LSM6DSR_68Hz2 = 3,
+  LSM6DSR_33Hz6 = 4,
+  LSM6DSR_16Hz7 = 5,
+  LSM6DSR_8Hz3  = 6,
+  LSM6DSR_4Hz11 = 7,
+} lsm6dsr_filter_xl_conf_ois_t;
+int32_t lsm6dsr_aux_xl_bandwidth_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_filter_xl_conf_ois_t val);
+int32_t lsm6dsr_aux_xl_bandwidth_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_filter_xl_conf_ois_t *val);
+
+typedef enum {
+  LSM6DSR_AUX_2g  = 0,
+  LSM6DSR_AUX_16g = 1,
+  LSM6DSR_AUX_4g  = 2,
+  LSM6DSR_AUX_8g  = 3,
+} lsm6dsr_fs_xl_ois_t;
+int32_t lsm6dsr_aux_xl_full_scale_set(stmdev_ctx_t *ctx,
+                                      lsm6dsr_fs_xl_ois_t val);
+int32_t lsm6dsr_aux_xl_full_scale_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_fs_xl_ois_t *val);
+
+typedef enum {
+  LSM6DSR_PULL_UP_DISC       = 0,
+  LSM6DSR_PULL_UP_CONNECT    = 1,
+} lsm6dsr_sdo_pu_en_t;
+int32_t lsm6dsr_sdo_sa0_mode_set(stmdev_ctx_t *ctx, lsm6dsr_sdo_pu_en_t val);
+int32_t lsm6dsr_sdo_sa0_mode_get(stmdev_ctx_t *ctx, lsm6dsr_sdo_pu_en_t *val);
+
+typedef enum {
+  LSM6DSR_SPI_4_WIRE = 0,
+  LSM6DSR_SPI_3_WIRE = 1,
+} lsm6dsr_sim_t;
+int32_t lsm6dsr_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsr_sim_t val);
+int32_t lsm6dsr_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsr_sim_t *val);
+
+typedef enum {
+  LSM6DSR_I2C_ENABLE  = 0,
+  LSM6DSR_I2C_DISABLE = 1,
+} lsm6dsr_i2c_disable_t;
+int32_t lsm6dsr_i2c_interface_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_i2c_disable_t val);
+int32_t lsm6dsr_i2c_interface_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_i2c_disable_t *val);
+
+typedef enum {
+  LSM6DSR_I3C_DISABLE         = 0x80,
+  LSM6DSR_I3C_ENABLE_T_50us   = 0x00,
+  LSM6DSR_I3C_ENABLE_T_2us    = 0x01,
+  LSM6DSR_I3C_ENABLE_T_1ms    = 0x02,
+  LSM6DSR_I3C_ENABLE_T_25ms   = 0x03,
+} lsm6dsr_i3c_disable_t;
+int32_t lsm6dsr_i3c_disable_set(stmdev_ctx_t *ctx,
+                                lsm6dsr_i3c_disable_t val);
+int32_t lsm6dsr_i3c_disable_get(stmdev_ctx_t *ctx,
+                                lsm6dsr_i3c_disable_t *val);
+
+typedef struct {
+    lsm6dsr_int1_ctrl_t          int1_ctrl;
+    lsm6dsr_md1_cfg_t            md1_cfg;
+    lsm6dsr_emb_func_int1_t      emb_func_int1;
+    lsm6dsr_fsm_int1_a_t         fsm_int1_a;
+    lsm6dsr_fsm_int1_b_t         fsm_int1_b;
+} lsm6dsr_pin_int1_route_t;
+int32_t lsm6dsr_pin_int1_route_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_pin_int1_route_t *val);
+int32_t lsm6dsr_pin_int1_route_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_pin_int1_route_t *val);
+
+typedef struct {
+  lsm6dsr_int2_ctrl_t          int2_ctrl;
+  lsm6dsr_md2_cfg_t            md2_cfg;
+  lsm6dsr_emb_func_int2_t      emb_func_int2;
+  lsm6dsr_fsm_int2_a_t         fsm_int2_a;
+  lsm6dsr_fsm_int2_b_t         fsm_int2_b;
+} lsm6dsr_pin_int2_route_t;
+int32_t lsm6dsr_pin_int2_route_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_pin_int2_route_t *val);
+int32_t lsm6dsr_pin_int2_route_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_pin_int2_route_t *val);
+
+typedef enum {
+  LSM6DSR_PUSH_PULL   = 0,
+  LSM6DSR_OPEN_DRAIN  = 1,
+} lsm6dsr_pp_od_t;
+int32_t lsm6dsr_pin_mode_set(stmdev_ctx_t *ctx, lsm6dsr_pp_od_t val);
+int32_t lsm6dsr_pin_mode_get(stmdev_ctx_t *ctx, lsm6dsr_pp_od_t *val);
+
+typedef enum {
+  LSM6DSR_ACTIVE_HIGH = 0,
+  LSM6DSR_ACTIVE_LOW  = 1,
+} lsm6dsr_h_lactive_t;
+int32_t lsm6dsr_pin_polarity_set(stmdev_ctx_t *ctx, lsm6dsr_h_lactive_t val);
+int32_t lsm6dsr_pin_polarity_get(stmdev_ctx_t *ctx, lsm6dsr_h_lactive_t *val);
+
+int32_t lsm6dsr_all_on_int1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_all_on_int1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_ALL_INT_PULSED            = 0,
+  LSM6DSR_BASE_LATCHED_EMB_PULSED   = 1,
+  LSM6DSR_BASE_PULSED_EMB_LATCHED   = 2,
+  LSM6DSR_ALL_INT_LATCHED           = 3,
+} lsm6dsr_lir_t;
+int32_t lsm6dsr_int_notification_set(stmdev_ctx_t *ctx, lsm6dsr_lir_t val);
+int32_t lsm6dsr_int_notification_get(stmdev_ctx_t *ctx, lsm6dsr_lir_t *val);
+
+typedef enum {
+  LSM6DSR_LSb_FS_DIV_64       = 0,
+  LSM6DSR_LSb_FS_DIV_256      = 1,
+} lsm6dsr_wake_ths_w_t;
+int32_t lsm6dsr_wkup_ths_weight_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_wake_ths_w_t val);
+int32_t lsm6dsr_wkup_ths_weight_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_wake_ths_w_t *val);
+
+int32_t lsm6dsr_wkup_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_wkup_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_xl_usr_offset_on_wkup_set(stmdev_ctx_t *ctx,
+                                          uint8_t val);
+int32_t lsm6dsr_xl_usr_offset_on_wkup_get(stmdev_ctx_t *ctx,
+                                          uint8_t *val);
+
+int32_t lsm6dsr_wkup_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_wkup_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_gy_sleep_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_gy_sleep_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_DRIVE_SLEEP_CHG_EVENT = 0,
+  LSM6DSR_DRIVE_SLEEP_STATUS    = 1,
+} lsm6dsr_sleep_status_on_int_t;
+int32_t lsm6dsr_act_pin_notification_set(stmdev_ctx_t *ctx,
+                                         lsm6dsr_sleep_status_on_int_t val);
+int32_t lsm6dsr_act_pin_notification_get(stmdev_ctx_t *ctx,
+                                         lsm6dsr_sleep_status_on_int_t *val);
+
+typedef enum {
+  LSM6DSR_XL_AND_GY_NOT_AFFECTED      = 0,
+  LSM6DSR_XL_12Hz5_GY_NOT_AFFECTED    = 1,
+  LSM6DSR_XL_12Hz5_GY_SLEEP           = 2,
+  LSM6DSR_XL_12Hz5_GY_PD              = 3,
+} lsm6dsr_inact_en_t;
+int32_t lsm6dsr_act_mode_set(stmdev_ctx_t *ctx,
+                             lsm6dsr_inact_en_t val);
+int32_t lsm6dsr_act_mode_get(stmdev_ctx_t *ctx,
+                             lsm6dsr_inact_en_t *val);
+
+int32_t lsm6dsr_act_sleep_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_act_sleep_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tap_detection_on_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_detection_on_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tap_detection_on_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_detection_on_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tap_detection_on_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_detection_on_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tap_threshold_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_threshold_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_XYZ = 0,
+  LSM6DSR_YXZ = 1,
+  LSM6DSR_XZY = 2,
+  LSM6DSR_ZYX = 3,
+  LSM6DSR_YZX = 5,
+  LSM6DSR_ZXY = 6,
+} lsm6dsr_tap_priority_t;
+int32_t lsm6dsr_tap_axis_priority_set(stmdev_ctx_t *ctx,
+                                      lsm6dsr_tap_priority_t val);
+int32_t lsm6dsr_tap_axis_priority_get(stmdev_ctx_t *ctx,
+                                      lsm6dsr_tap_priority_t *val);
+
+int32_t lsm6dsr_tap_threshold_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_threshold_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tap_threshold_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_threshold_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tap_shock_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_shock_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tap_quiet_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_quiet_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tap_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tap_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_ONLY_SINGLE        = 0,
+  LSM6DSR_BOTH_SINGLE_DOUBLE = 1,
+} lsm6dsr_single_double_tap_t;
+int32_t lsm6dsr_tap_mode_set(stmdev_ctx_t *ctx,
+                             lsm6dsr_single_double_tap_t val);
+int32_t lsm6dsr_tap_mode_get(stmdev_ctx_t *ctx,
+                             lsm6dsr_single_double_tap_t *val);
+
+typedef enum {
+  LSM6DSR_DEG_80  = 0,
+  LSM6DSR_DEG_70  = 1,
+  LSM6DSR_DEG_60  = 2,
+  LSM6DSR_DEG_50  = 3,
+} lsm6dsr_sixd_ths_t;
+int32_t lsm6dsr_6d_threshold_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_sixd_ths_t val);
+int32_t lsm6dsr_6d_threshold_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_sixd_ths_t *val);
+
+int32_t lsm6dsr_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_FF_TSH_156mg = 0,
+  LSM6DSR_FF_TSH_219mg = 1,
+  LSM6DSR_FF_TSH_250mg = 2,
+  LSM6DSR_FF_TSH_312mg = 3,
+  LSM6DSR_FF_TSH_344mg = 4,
+  LSM6DSR_FF_TSH_406mg = 5,
+  LSM6DSR_FF_TSH_469mg = 6,
+  LSM6DSR_FF_TSH_500mg = 7,
+} lsm6dsr_ff_ths_t;
+int32_t lsm6dsr_ff_threshold_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_ff_ths_t val);
+int32_t lsm6dsr_ff_threshold_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_ff_ths_t *val);
+
+int32_t lsm6dsr_ff_dur_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_ff_dur_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_fifo_watermark_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsr_fifo_watermark_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsr_compression_algo_init_set(stmdev_ctx_t *ctx,
+                                          uint8_t val);
+int32_t lsm6dsr_compression_algo_init_get(stmdev_ctx_t *ctx,
+                                          uint8_t *val);
+
+typedef enum {
+  LSM6DSR_CMP_DISABLE  = 0x00,
+  LSM6DSR_CMP_ALWAYS   = 0x04,
+  LSM6DSR_CMP_8_TO_1   = 0x05,
+  LSM6DSR_CMP_16_TO_1  = 0x06,
+  LSM6DSR_CMP_32_TO_1  = 0x07,
+} lsm6dsr_uncoptr_rate_t;
+int32_t lsm6dsr_compression_algo_set(stmdev_ctx_t *ctx,
+                                     lsm6dsr_uncoptr_rate_t val);
+int32_t lsm6dsr_compression_algo_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_uncoptr_rate_t *val);
+
+int32_t lsm6dsr_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
+                                              uint8_t val);
+int32_t lsm6dsr_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
+                                              uint8_t *val);
+
+int32_t lsm6dsr_compression_algo_real_time_set(stmdev_ctx_t *ctx,
+                                               uint8_t val);
+int32_t lsm6dsr_compression_algo_real_time_get(stmdev_ctx_t *ctx,
+                                               uint8_t *val);
+
+int32_t lsm6dsr_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_XL_NOT_BATCHED     	=  0,
+  LSM6DSR_XL_BATCHED_AT_12Hz5   =  1,
+  LSM6DSR_XL_BATCHED_AT_26Hz    =  2,
+  LSM6DSR_XL_BATCHED_AT_52Hz    =  3,
+  LSM6DSR_XL_BATCHED_AT_104Hz   =  4,
+  LSM6DSR_XL_BATCHED_AT_208Hz   =  5,
+  LSM6DSR_XL_BATCHED_AT_417Hz   =  6,
+  LSM6DSR_XL_BATCHED_AT_833Hz   =  7,
+  LSM6DSR_XL_BATCHED_AT_1667Hz  =  8,
+  LSM6DSR_XL_BATCHED_AT_3333Hz  =  9,
+  LSM6DSR_XL_BATCHED_AT_6667Hz  = 10,
+  LSM6DSR_XL_BATCHED_AT_6Hz5    = 11,
+} lsm6dsr_bdr_xl_t;
+int32_t lsm6dsr_fifo_xl_batch_set(stmdev_ctx_t *ctx, lsm6dsr_bdr_xl_t val);
+int32_t lsm6dsr_fifo_xl_batch_get(stmdev_ctx_t *ctx, lsm6dsr_bdr_xl_t *val);
+
+typedef enum {
+  LSM6DSR_GY_NOT_BATCHED         = 0,
+  LSM6DSR_GY_BATCHED_AT_12Hz5    = 1,
+  LSM6DSR_GY_BATCHED_AT_26Hz     = 2,
+  LSM6DSR_GY_BATCHED_AT_52Hz     = 3,
+  LSM6DSR_GY_BATCHED_AT_104Hz    = 4,
+  LSM6DSR_GY_BATCHED_AT_208Hz    = 5,
+  LSM6DSR_GY_BATCHED_AT_417Hz    = 6,
+  LSM6DSR_GY_BATCHED_AT_833Hz    = 7,
+  LSM6DSR_GY_BATCHED_AT_1667Hz   = 8,
+  LSM6DSR_GY_BATCHED_AT_3333Hz   = 9,
+  LSM6DSR_GY_BATCHED_AT_6667Hz   = 10,
+  LSM6DSR_GY_BATCHED_6Hz5        = 11,
+} lsm6dsr_bdr_gy_t;
+int32_t lsm6dsr_fifo_gy_batch_set(stmdev_ctx_t *ctx, lsm6dsr_bdr_gy_t val);
+int32_t lsm6dsr_fifo_gy_batch_get(stmdev_ctx_t *ctx, lsm6dsr_bdr_gy_t *val);
+
+typedef enum {
+  LSM6DSR_BYPASS_MODE             = 0,
+  LSM6DSR_FIFO_MODE               = 1,
+  LSM6DSR_STREAM_TO_FIFO_MODE     = 3,
+  LSM6DSR_BYPASS_TO_STREAM_MODE   = 4,
+  LSM6DSR_STREAM_MODE             = 6,
+  LSM6DSR_BYPASS_TO_FIFO_MODE     = 7,
+} lsm6dsr_fifo_mode_t;
+int32_t lsm6dsr_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsr_fifo_mode_t val);
+int32_t lsm6dsr_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsr_fifo_mode_t *val);
+
+typedef enum {
+  LSM6DSR_TEMP_NOT_BATCHED        = 0,
+  LSM6DSR_TEMP_BATCHED_AT_52Hz    = 1,
+  LSM6DSR_TEMP_BATCHED_AT_12Hz5   = 2,
+  LSM6DSR_TEMP_BATCHED_AT_1Hz6    = 3,
+} lsm6dsr_odr_t_batch_t;
+int32_t lsm6dsr_fifo_temp_batch_set(stmdev_ctx_t *ctx,
+                                    lsm6dsr_odr_t_batch_t val);
+int32_t lsm6dsr_fifo_temp_batch_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_odr_t_batch_t *val);
+
+typedef enum {
+  LSM6DSR_NO_DECIMATION = 0,
+  LSM6DSR_DEC_1         = 1,
+  LSM6DSR_DEC_8         = 2,
+  LSM6DSR_DEC_32        = 3,
+} lsm6dsr_odr_ts_batch_t;
+int32_t lsm6dsr_fifo_timestamp_decimation_set(stmdev_ctx_t *ctx,
+                                              lsm6dsr_odr_ts_batch_t val);
+int32_t lsm6dsr_fifo_timestamp_decimation_get(stmdev_ctx_t *ctx,
+                                              lsm6dsr_odr_ts_batch_t *val);
+
+typedef enum {
+  LSM6DSR_XL_BATCH_EVENT   = 0,
+  LSM6DSR_GYRO_BATCH_EVENT = 1,
+} lsm6dsr_trig_counter_bdr_t;
+int32_t lsm6dsr_fifo_cnt_event_batch_set(stmdev_ctx_t *ctx,
+                                         lsm6dsr_trig_counter_bdr_t val);
+int32_t lsm6dsr_fifo_cnt_event_batch_get(stmdev_ctx_t *ctx,
+                                         lsm6dsr_trig_counter_bdr_t *val);
+
+int32_t lsm6dsr_rst_batch_counter_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_rst_batch_counter_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_batch_counter_threshold_set(stmdev_ctx_t *ctx,
+                                            uint16_t val);
+int32_t lsm6dsr_batch_counter_threshold_get(stmdev_ctx_t *ctx,
+                                            uint16_t *val);
+
+int32_t lsm6dsr_fifo_data_level_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+int32_t lsm6dsr_fifo_status_get(stmdev_ctx_t *ctx,
+                                lsm6dsr_fifo_status2_t *val);
+
+int32_t lsm6dsr_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_GYRO_NC_TAG    = 1,
+  LSM6DSR_XL_NC_TAG,
+  LSM6DSR_TEMPERATURE_TAG,
+  LSM6DSR_TIMESTAMP_TAG,
+  LSM6DSR_CFG_CHANGE_TAG,
+  LSM6DSR_XL_NC_T_2_TAG,
+  LSM6DSR_XL_NC_T_1_TAG,
+  LSM6DSR_XL_2XC_TAG,
+  LSM6DSR_XL_3XC_TAG,
+  LSM6DSR_GYRO_NC_T_2_TAG,
+  LSM6DSR_GYRO_NC_T_1_TAG,
+  LSM6DSR_GYRO_2XC_TAG,
+  LSM6DSR_GYRO_3XC_TAG,
+  LSM6DSR_SENSORHUB_SLAVE0_TAG,
+  LSM6DSR_SENSORHUB_SLAVE1_TAG,
+  LSM6DSR_SENSORHUB_SLAVE2_TAG,
+  LSM6DSR_SENSORHUB_SLAVE3_TAG,
+  LSM6DSR_STEP_CPUNTER_TAG,
+  LSM6DSR_GAME_ROTATION_TAG,
+  LSM6DSR_GEOMAG_ROTATION_TAG,
+  LSM6DSR_ROTATION_TAG,
+  LSM6DSR_SENSORHUB_NACK_TAG  = 0x19,
+} lsm6dsr_fifo_tag_t;
+int32_t lsm6dsr_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
+                                    lsm6dsr_fifo_tag_t *val);
+
+int32_t lsm6dsr_fifo_pedo_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_fifo_pedo_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_sh_batch_slave_0_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_sh_batch_slave_0_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_sh_batch_slave_1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_sh_batch_slave_1_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_sh_batch_slave_2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_sh_batch_slave_2_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_sh_batch_slave_3_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_sh_batch_slave_3_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_DEN_DISABLE    = 0,
+  LSM6DSR_LEVEL_FIFO     = 6,
+  LSM6DSR_LEVEL_LETCHED  = 3,
+  LSM6DSR_LEVEL_TRIGGER  = 2,
+  LSM6DSR_EDGE_TRIGGER   = 4,
+} lsm6dsr_den_mode_t;
+int32_t lsm6dsr_den_mode_set(stmdev_ctx_t *ctx,
+                             lsm6dsr_den_mode_t val);
+int32_t lsm6dsr_den_mode_get(stmdev_ctx_t *ctx,
+                             lsm6dsr_den_mode_t *val);
+
+typedef enum {
+  LSM6DSR_DEN_ACT_LOW  = 0,
+  LSM6DSR_DEN_ACT_HIGH = 1,
+} lsm6dsr_den_lh_t;
+int32_t lsm6dsr_den_polarity_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_den_lh_t val);
+int32_t lsm6dsr_den_polarity_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_den_lh_t *val);
+
+typedef enum {
+  LSM6DSR_STAMP_IN_GY_DATA     = 0,
+  LSM6DSR_STAMP_IN_XL_DATA     = 1,
+  LSM6DSR_STAMP_IN_GY_XL_DATA  = 2,
+} lsm6dsr_den_xl_g_t;
+int32_t lsm6dsr_den_enable_set(stmdev_ctx_t *ctx,
+                               lsm6dsr_den_xl_g_t val);
+int32_t lsm6dsr_den_enable_get(stmdev_ctx_t *ctx,
+                               lsm6dsr_den_xl_g_t *val);
+
+int32_t lsm6dsr_den_mark_axis_x_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_den_mark_axis_x_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_den_mark_axis_y_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_den_mark_axis_y_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_den_mark_axis_z_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_den_mark_axis_z_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_pedo_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_pedo_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_PEDO_BASE                = 0x00,
+  LSM6DSR_PEDO_BASE_FALSE_STEP_REJ = 0x01,
+  LSM6DSR_PEDO_ADV_FALSE_STEP_REJ  = 0x03,
+} lsm6dsr_pedo_mode_t;
+int32_t lsm6dsr_pedo_mode_set(stmdev_ctx_t *ctx, lsm6dsr_pedo_mode_t val);
+int32_t lsm6dsr_pedo_mode_get(stmdev_ctx_t *ctx, lsm6dsr_pedo_mode_t *val);
+
+int32_t lsm6dsr_pedo_step_detect_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_pedo_debounce_steps_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_pedo_debounce_steps_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_pedo_steps_period_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_pedo_steps_period_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_pedo_adv_detection_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_pedo_adv_detection_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_pedo_false_step_rejection_set(stmdev_ctx_t *ctx,
+                                              uint8_t val);
+int32_t lsm6dsr_pedo_false_step_rejection_get(stmdev_ctx_t *ctx,
+                                              uint8_t *val);
+
+typedef enum {
+  LSM6DSR_EVERY_STEP     = 0,
+  LSM6DSR_COUNT_OVERFLOW = 1,
+} lsm6dsr_carry_count_en_t;
+int32_t lsm6dsr_pedo_int_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_carry_count_en_t val);
+int32_t lsm6dsr_pedo_int_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_carry_count_en_t *val);
+
+int32_t lsm6dsr_motion_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_motion_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_motion_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                           uint8_t *val);
+
+int32_t lsm6dsr_tilt_sens_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_tilt_sens_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_tilt_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_mag_sensitivity_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_mag_sensitivity_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_mag_soft_iron_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_mag_soft_iron_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSR_Z_EQ_Y     = 0,
+  LSM6DSR_Z_EQ_MIN_Y = 1,
+  LSM6DSR_Z_EQ_X     = 2,
+  LSM6DSR_Z_EQ_MIN_X = 3,
+  LSM6DSR_Z_EQ_MIN_Z = 4,
+  LSM6DSR_Z_EQ_Z     = 5,
+} lsm6dsr_mag_z_axis_t;
+int32_t lsm6dsr_mag_z_orient_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_mag_z_axis_t val);
+int32_t lsm6dsr_mag_z_orient_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_mag_z_axis_t *val);
+
+typedef enum {
+  LSM6DSR_Y_EQ_Y     = 0,
+  LSM6DSR_Y_EQ_MIN_Y = 1,
+  LSM6DSR_Y_EQ_X     = 2,
+  LSM6DSR_Y_EQ_MIN_X = 3,
+  LSM6DSR_Y_EQ_MIN_Z = 4,
+  LSM6DSR_Y_EQ_Z     = 5,
+} lsm6dsr_mag_y_axis_t;
+int32_t lsm6dsr_mag_y_orient_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_mag_y_axis_t val);
+int32_t lsm6dsr_mag_y_orient_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_mag_y_axis_t *val);
+
+typedef enum {
+  LSM6DSR_X_EQ_Y     = 0,
+  LSM6DSR_X_EQ_MIN_Y = 1,
+  LSM6DSR_X_EQ_X     = 2,
+  LSM6DSR_X_EQ_MIN_X = 3,
+  LSM6DSR_X_EQ_MIN_Z = 4,
+  LSM6DSR_X_EQ_Z     = 5,
+} lsm6dsr_mag_x_axis_t;
+int32_t lsm6dsr_mag_x_orient_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_mag_x_axis_t val);
+int32_t lsm6dsr_mag_x_orient_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_mag_x_axis_t *val);
+
+int32_t lsm6dsr_long_cnt_flag_data_ready_get(stmdev_ctx_t *ctx,
+                                             uint8_t *val);
+
+int32_t lsm6dsr_emb_fsm_en_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_emb_fsm_en_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct {
+    lsm6dsr_fsm_enable_a_t          fsm_enable_a;
+    lsm6dsr_fsm_enable_b_t          fsm_enable_b;
+} lsm6dsr_emb_fsm_enable_t;
+int32_t lsm6dsr_fsm_enable_set(stmdev_ctx_t *ctx,
+                               lsm6dsr_emb_fsm_enable_t *val);
+int32_t lsm6dsr_fsm_enable_get(stmdev_ctx_t *ctx,
+                               lsm6dsr_emb_fsm_enable_t *val);
+
+int32_t lsm6dsr_long_cnt_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_long_cnt_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef enum {
+  LSM6DSR_LC_NORMAL     = 0,
+  LSM6DSR_LC_CLEAR      = 1,
+  LSM6DSR_LC_CLEAR_DONE = 2,
+} lsm6dsr_fsm_lc_clr_t;
+int32_t lsm6dsr_long_clr_set(stmdev_ctx_t *ctx,
+                             lsm6dsr_fsm_lc_clr_t val);
+int32_t lsm6dsr_long_clr_get(stmdev_ctx_t *ctx,
+                             lsm6dsr_fsm_lc_clr_t *val);
+
+typedef struct {
+    lsm6dsr_fsm_outs1_t    fsm_outs1;
+    lsm6dsr_fsm_outs2_t    fsm_outs2;
+    lsm6dsr_fsm_outs3_t    fsm_outs3;
+    lsm6dsr_fsm_outs4_t    fsm_outs4;
+    lsm6dsr_fsm_outs5_t    fsm_outs5;
+    lsm6dsr_fsm_outs6_t    fsm_outs6;
+    lsm6dsr_fsm_outs7_t    fsm_outs7;
+    lsm6dsr_fsm_outs8_t    fsm_outs8;
+    lsm6dsr_fsm_outs9_t    fsm_outs9;
+    lsm6dsr_fsm_outs10_t    fsm_outs10;
+    lsm6dsr_fsm_outs11_t    fsm_outs11;
+    lsm6dsr_fsm_outs12_t    fsm_outs12;
+    lsm6dsr_fsm_outs13_t    fsm_outs13;
+    lsm6dsr_fsm_outs14_t    fsm_outs14;
+    lsm6dsr_fsm_outs15_t    fsm_outs15;
+    lsm6dsr_fsm_outs16_t    fsm_outs16;
+} lsm6dsr_fsm_out_t;
+int32_t lsm6dsr_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsr_fsm_out_t *val);
+
+typedef enum {
+  LSM6DSR_ODR_FSM_12Hz5 = 0,
+  LSM6DSR_ODR_FSM_26Hz  = 1,
+  LSM6DSR_ODR_FSM_52Hz  = 2,
+  LSM6DSR_ODR_FSM_104Hz = 3,
+} lsm6dsr_fsm_odr_t;
+int32_t lsm6dsr_fsm_data_rate_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_fsm_odr_t val);
+int32_t lsm6dsr_fsm_data_rate_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_fsm_odr_t *val);
+
+int32_t lsm6dsr_fsm_init_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_fsm_init_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_long_cnt_int_value_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_long_cnt_int_value_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+int32_t lsm6dsr_fsm_number_of_programs_set(stmdev_ctx_t *ctx,
+                                           uint8_t *buff);
+int32_t lsm6dsr_fsm_number_of_programs_get(stmdev_ctx_t *ctx,
+                                           uint8_t *buff);
+
+int32_t lsm6dsr_fsm_start_address_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm6dsr_fsm_start_address_get(stmdev_ctx_t *ctx, uint8_t *buff);
+
+typedef struct {
+    lsm6dsr_sensor_hub_1_t   sh_byte_1;
+    lsm6dsr_sensor_hub_2_t   sh_byte_2;
+    lsm6dsr_sensor_hub_3_t   sh_byte_3;
+    lsm6dsr_sensor_hub_4_t   sh_byte_4;
+    lsm6dsr_sensor_hub_5_t   sh_byte_5;
+    lsm6dsr_sensor_hub_6_t   sh_byte_6;
+    lsm6dsr_sensor_hub_7_t   sh_byte_7;
+    lsm6dsr_sensor_hub_8_t   sh_byte_8;
+    lsm6dsr_sensor_hub_9_t   sh_byte_9;
+    lsm6dsr_sensor_hub_10_t  sh_byte_10;
+    lsm6dsr_sensor_hub_11_t  sh_byte_11;
+    lsm6dsr_sensor_hub_12_t  sh_byte_12;
+    lsm6dsr_sensor_hub_13_t  sh_byte_13;
+    lsm6dsr_sensor_hub_14_t  sh_byte_14;
+    lsm6dsr_sensor_hub_15_t  sh_byte_15;
+    lsm6dsr_sensor_hub_16_t  sh_byte_16;
+    lsm6dsr_sensor_hub_17_t  sh_byte_17;
+    lsm6dsr_sensor_hub_18_t  sh_byte_18;
+} lsm6dsr_emb_sh_read_t;
+int32_t lsm6dsr_sh_read_data_raw_get(stmdev_ctx_t *ctx,
+                                     lsm6dsr_emb_sh_read_t *val);
+
+typedef enum {
+  LSM6DSR_SLV_0       = 0,
+  LSM6DSR_SLV_0_1     = 1,
+  LSM6DSR_SLV_0_1_2   = 2,
+  LSM6DSR_SLV_0_1_2_3 = 3,
+} lsm6dsr_aux_sens_on_t;
+int32_t lsm6dsr_sh_slave_connected_set(stmdev_ctx_t *ctx,
+                                       lsm6dsr_aux_sens_on_t val);
+int32_t lsm6dsr_sh_slave_connected_get(stmdev_ctx_t *ctx,
+                                       lsm6dsr_aux_sens_on_t *val);
+
+int32_t lsm6dsr_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_EXT_PULL_UP      = 0,
+  LSM6DSR_INTERNAL_PULL_UP = 1,
+} lsm6dsr_shub_pu_en_t;
+int32_t lsm6dsr_sh_pin_mode_set(stmdev_ctx_t *ctx,
+                                lsm6dsr_shub_pu_en_t val);
+int32_t lsm6dsr_sh_pin_mode_get(stmdev_ctx_t *ctx,
+                                lsm6dsr_shub_pu_en_t *val);
+
+int32_t lsm6dsr_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_EXT_ON_INT2_PIN = 0,
+  LSM6DSR_XL_GY_DRDY      = 1,
+} lsm6dsr_start_config_t;
+int32_t lsm6dsr_sh_syncro_mode_set(stmdev_ctx_t *ctx,
+                                   lsm6dsr_start_config_t val);
+int32_t lsm6dsr_sh_syncro_mode_get(stmdev_ctx_t *ctx,
+                                   lsm6dsr_start_config_t *val);
+
+typedef enum {
+  LSM6DSR_EACH_SH_CYCLE    = 0,
+  LSM6DSR_ONLY_FIRST_CYCLE = 1,
+} lsm6dsr_write_once_t;
+int32_t lsm6dsr_sh_write_mode_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_write_once_t val);
+int32_t lsm6dsr_sh_write_mode_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_write_once_t *val);
+
+int32_t lsm6dsr_sh_reset_set(stmdev_ctx_t *ctx);
+int32_t lsm6dsr_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef enum {
+  LSM6DSR_SH_ODR_104Hz = 0,
+  LSM6DSR_SH_ODR_52Hz  = 1,
+  LSM6DSR_SH_ODR_26Hz  = 2,
+  LSM6DSR_SH_ODR_13Hz  = 3,
+} lsm6dsr_shub_odr_t;
+int32_t lsm6dsr_sh_data_rate_set(stmdev_ctx_t *ctx,
+                                 lsm6dsr_shub_odr_t val);
+int32_t lsm6dsr_sh_data_rate_get(stmdev_ctx_t *ctx,
+                                 lsm6dsr_shub_odr_t *val);
+
+typedef struct{
+  uint8_t   slv0_add;
+  uint8_t   slv0_subadd;
+  uint8_t   slv0_data;
+} lsm6dsr_sh_cfg_write_t;
+int32_t lsm6dsr_sh_cfg_write(stmdev_ctx_t *ctx,
+                             lsm6dsr_sh_cfg_write_t *val);
+
+typedef struct{
+  uint8_t   slv_add;
+  uint8_t   slv_subadd;
+  uint8_t   slv_len;
+} lsm6dsr_sh_cfg_read_t;
+int32_t lsm6dsr_sh_slv0_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6dsr_sh_cfg_read_t *val);
+int32_t lsm6dsr_sh_slv1_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6dsr_sh_cfg_read_t *val);
+int32_t lsm6dsr_sh_slv2_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6dsr_sh_cfg_read_t *val);
+int32_t lsm6dsr_sh_slv3_cfg_read(stmdev_ctx_t *ctx,
+                                 lsm6dsr_sh_cfg_read_t *val);
+
+int32_t lsm6dsr_sh_status_get(stmdev_ctx_t *ctx,
+                              lsm6dsr_status_master_t *val);
+
+typedef enum {
+  LSM6DSR_S4S_TPH_7bit   = 0,
+  LSM6DSR_S4S_TPH_15bit  = 1,
+} lsm6dsr_s4s_tph_res_t;
+int32_t lsm6dsr_s4s_tph_res_set(stmdev_ctx_t *ctx,
+                                lsm6dsr_s4s_tph_res_t val);
+int32_t lsm6dsr_s4s_tph_res_get(stmdev_ctx_t *ctx,
+                                lsm6dsr_s4s_tph_res_t *val);
+
+int32_t lsm6dsr_s4s_tph_val_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsr_s4s_tph_val_get(stmdev_ctx_t *ctx, uint16_t *val);
+
+typedef enum {
+  LSM6DSR_S4S_DT_RES_11 = 0,
+  LSM6DSR_S4S_DT_RES_12 = 1,
+  LSM6DSR_S4S_DT_RES_13 = 2,
+  LSM6DSR_S4S_DT_RES_14 = 3,
+} lsm6dsr_s4s_res_ratio_t;
+int32_t lsm6dsr_s4s_res_ratio_set(stmdev_ctx_t *ctx,
+                                  lsm6dsr_s4s_res_ratio_t val);
+int32_t lsm6dsr_s4s_res_ratio_get(stmdev_ctx_t *ctx,
+                                  lsm6dsr_s4s_res_ratio_t *val);
+
+int32_t lsm6dsr_s4s_command_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_s4s_command_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+int32_t lsm6dsr_s4s_dt_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsr_s4s_dt_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+/**
+  *@}
+  *
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LSM6DSR_REGS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/sensor/stmemsc/lsm9ds1_STdC/driver/lsm9ds1_reg.c
+++ b/sensor/stmemsc/lsm9ds1_STdC/driver/lsm9ds1_reg.c
@@ -6,33 +6,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 #include "lsm9ds1_reg.h"
 
 /**
@@ -62,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm9ds1_read_reg(lsm9ds1_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm9ds1_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                          uint16_t len)
 {
   int32_t ret;
@@ -80,7 +64,7 @@ int32_t lsm9ds1_read_reg(lsm9ds1_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm9ds1_write_reg(lsm9ds1_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t lsm9ds1_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -181,7 +165,7 @@ float_t lsm9ds1_from_lsb_to_celsius(int16_t lsb)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t val)
+int32_t lsm9ds1_gy_full_scale_set(stmdev_ctx_t *ctx, lsm9ds1_gy_fs_t val)
 {
   lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
   int32_t ret;
@@ -203,7 +187,7 @@ int32_t lsm9ds1_gy_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t *val)
+int32_t lsm9ds1_gy_full_scale_get(stmdev_ctx_t *ctx, lsm9ds1_gy_fs_t *val)
 {
   lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
   int32_t ret;
@@ -235,7 +219,7 @@ int32_t lsm9ds1_gy_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_imu_data_rate_set(lsm9ds1_ctx_t *ctx, lsm9ds1_imu_odr_t val)
+int32_t lsm9ds1_imu_data_rate_set(stmdev_ctx_t *ctx, lsm9ds1_imu_odr_t val)
 {
   lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
   lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
@@ -279,7 +263,7 @@ int32_t lsm9ds1_imu_data_rate_set(lsm9ds1_ctx_t *ctx, lsm9ds1_imu_odr_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_imu_data_rate_get(lsm9ds1_ctx_t *ctx, lsm9ds1_imu_odr_t *val)
+int32_t lsm9ds1_imu_data_rate_get(stmdev_ctx_t *ctx, lsm9ds1_imu_odr_t *val)
 {
   lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
   lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
@@ -388,7 +372,7 @@ int32_t lsm9ds1_imu_data_rate_get(lsm9ds1_ctx_t *ctx, lsm9ds1_imu_odr_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_orient_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t val)
+int32_t lsm9ds1_gy_orient_set(stmdev_ctx_t *ctx, lsm9ds1_gy_orient_t val)
 {
   lsm9ds1_orient_cfg_g_t orient_cfg_g;
   int32_t ret;
@@ -413,7 +397,7 @@ int32_t lsm9ds1_gy_orient_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_orient_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t *val)
+int32_t lsm9ds1_gy_orient_get(stmdev_ctx_t *ctx, lsm9ds1_gy_orient_t *val)
 {
   lsm9ds1_orient_cfg_g_t orient_cfg_g;
   int32_t ret;
@@ -436,7 +420,7 @@ int32_t lsm9ds1_gy_orient_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_status_reg_t status_reg;
   int32_t ret;
@@ -455,7 +439,7 @@ int32_t lsm9ds1_xl_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_status_reg_t status_reg;
   int32_t ret;
@@ -474,7 +458,7 @@ int32_t lsm9ds1_gy_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_temp_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_status_reg_t status_reg;
   int32_t ret;
@@ -493,7 +477,7 @@ int32_t lsm9ds1_temp_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t val)
+int32_t lsm9ds1_gy_axis_set(stmdev_ctx_t *ctx, lsm9ds1_gy_axis_t val)
 {
   lsm9ds1_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -516,7 +500,7 @@ int32_t lsm9ds1_gy_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t *val)
+int32_t lsm9ds1_gy_axis_get(stmdev_ctx_t *ctx, lsm9ds1_gy_axis_t *val)
 {
   lsm9ds1_ctrl_reg4_t ctrl_reg4;
   int32_t ret;
@@ -537,7 +521,7 @@ int32_t lsm9ds1_gy_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t val)
+int32_t lsm9ds1_xl_axis_set(stmdev_ctx_t *ctx, lsm9ds1_xl_axis_t val)
 {
   lsm9ds1_ctrl_reg5_xl_t ctrl_reg5_xl;
   int32_t ret;
@@ -561,7 +545,7 @@ int32_t lsm9ds1_xl_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t *val)
+int32_t lsm9ds1_xl_axis_get(stmdev_ctx_t *ctx, lsm9ds1_xl_axis_t *val)
 {
   lsm9ds1_ctrl_reg5_xl_t ctrl_reg5_xl;
   int32_t ret;
@@ -583,7 +567,7 @@ int32_t lsm9ds1_xl_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_decimation_set(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t val)
+int32_t lsm9ds1_xl_decimation_set(stmdev_ctx_t *ctx, lsm9ds1_dec_t val)
 {
   lsm9ds1_ctrl_reg5_xl_t ctrl_reg5_xl;
   int32_t ret;
@@ -606,7 +590,7 @@ int32_t lsm9ds1_xl_decimation_set(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_decimation_get(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t *val)
+int32_t lsm9ds1_xl_decimation_get(stmdev_ctx_t *ctx, lsm9ds1_dec_t *val)
 {
   lsm9ds1_ctrl_reg5_xl_t ctrl_reg5_xl;
   int32_t ret;
@@ -641,7 +625,7 @@ int32_t lsm9ds1_xl_decimation_get(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t val)
+int32_t lsm9ds1_xl_full_scale_set(stmdev_ctx_t *ctx, lsm9ds1_xl_fs_t val)
 {
   lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
   int32_t ret;
@@ -664,7 +648,7 @@ int32_t lsm9ds1_xl_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t *val)
+int32_t lsm9ds1_xl_full_scale_get(stmdev_ctx_t *ctx, lsm9ds1_xl_fs_t *val)
 {
   lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
   int32_t ret;
@@ -700,8 +684,8 @@ int32_t lsm9ds1_xl_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t *val)
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_block_data_update_set(lsm9ds1_ctx_t *ctx_mag,
-                                      lsm9ds1_ctx_t *ctx_imu, uint8_t val)
+int32_t lsm9ds1_block_data_update_set(stmdev_ctx_t *ctx_mag,
+                                      stmdev_ctx_t *ctx_imu, uint8_t val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
   lsm9ds1_ctrl_reg5_m_t ctrl_reg5_m;
@@ -735,8 +719,8 @@ int32_t lsm9ds1_block_data_update_set(lsm9ds1_ctx_t *ctx_mag,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_block_data_update_get(lsm9ds1_ctx_t *ctx_mag,
-                                      lsm9ds1_ctx_t *ctx_imu, uint8_t *val)
+int32_t lsm9ds1_block_data_update_get(stmdev_ctx_t *ctx_mag,
+                                      stmdev_ctx_t *ctx_imu, uint8_t *val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
   lsm9ds1_ctrl_reg5_m_t ctrl_reg5_m;
@@ -760,7 +744,7 @@ int32_t lsm9ds1_block_data_update_get(lsm9ds1_ctx_t *ctx_mag,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_offset_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_write_reg(ctx, LSM9DS1_OFFSET_X_REG_L_M, buff, 6);
@@ -777,7 +761,7 @@ int32_t lsm9ds1_mag_offset_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_offset_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_OFFSET_X_REG_L_M, buff, 6);
@@ -792,7 +776,7 @@ int32_t lsm9ds1_mag_offset_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_data_rate_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_data_rate_set(stmdev_ctx_t *ctx,
                                   lsm9ds1_mag_data_rate_t val)
 {
   lsm9ds1_ctrl_reg1_m_t ctrl_reg1_m;
@@ -837,7 +821,7 @@ int32_t lsm9ds1_mag_data_rate_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_data_rate_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_data_rate_get(stmdev_ctx_t *ctx,
                                   lsm9ds1_mag_data_rate_t *val)
 {
   lsm9ds1_ctrl_reg1_m_t ctrl_reg1_m;
@@ -979,7 +963,7 @@ int32_t lsm9ds1_mag_data_rate_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_mag_fs_t val)
+int32_t lsm9ds1_mag_full_scale_set(stmdev_ctx_t *ctx, lsm9ds1_mag_fs_t val)
 {
   lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
   int32_t ret;
@@ -1001,7 +985,7 @@ int32_t lsm9ds1_mag_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_mag_fs_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_mag_fs_t *val)
+int32_t lsm9ds1_mag_full_scale_get(stmdev_ctx_t *ctx, lsm9ds1_mag_fs_t *val)
 {
   lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
   int32_t ret;
@@ -1035,7 +1019,7 @@ int32_t lsm9ds1_mag_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_mag_fs_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_mag_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_status_reg_m_t status_reg_m;
   int32_t ret;
@@ -1068,7 +1052,7 @@ int32_t lsm9ds1_mag_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_temperature_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_OUT_TEMP_L, buff, 2);
@@ -1084,7 +1068,7 @@ int32_t lsm9ds1_temperature_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_angular_rate_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_OUT_X_L_G, buff, 6);
@@ -1100,7 +1084,7 @@ int32_t lsm9ds1_angular_rate_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_acceleration_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_OUT_X_L_XL, buff, 6);
@@ -1116,7 +1100,7 @@ int32_t lsm9ds1_acceleration_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_magnetic_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_OUT_X_L_M, buff, 6);
@@ -1131,7 +1115,7 @@ int32_t lsm9ds1_magnetic_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_magnetic_overflow_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_magnetic_overflow_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_int_src_m_t int_src_m;
   int32_t ret;
@@ -1163,7 +1147,7 @@ int32_t lsm9ds1_magnetic_overflow_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_dev_id_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_id_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                            lsm9ds1_id_t *buff)
 {
   int32_t ret;
@@ -1185,7 +1169,7 @@ int32_t lsm9ds1_dev_id_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_dev_status_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_status_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                                lsm9ds1_status_t *val)
 {
   int32_t ret;
@@ -1209,7 +1193,7 @@ int32_t lsm9ds1_dev_status_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_dev_reset_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_reset_set(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                               uint8_t val)
 {
   lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
@@ -1244,7 +1228,7 @@ int32_t lsm9ds1_dev_reset_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_dev_reset_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_reset_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                               uint8_t *val)
 {
   lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
@@ -1269,8 +1253,8 @@ int32_t lsm9ds1_dev_reset_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_dev_data_format_set(lsm9ds1_ctx_t *ctx_mag,
-                                    lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_data_format_set(stmdev_ctx_t *ctx_mag,
+                                    stmdev_ctx_t *ctx_imu,
                                     lsm9ds1_ble_t val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
@@ -1305,8 +1289,8 @@ int32_t lsm9ds1_dev_data_format_set(lsm9ds1_ctx_t *ctx_mag,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_dev_data_format_get(lsm9ds1_ctx_t *ctx_mag,
-                                    lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_data_format_get(stmdev_ctx_t *ctx_mag,
+                                    stmdev_ctx_t *ctx_imu,
                                     lsm9ds1_ble_t *val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
@@ -1341,7 +1325,7 @@ int32_t lsm9ds1_dev_data_format_get(lsm9ds1_ctx_t *ctx_mag,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_dev_boot_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_boot_set(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                              uint8_t val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
@@ -1376,7 +1360,7 @@ int32_t lsm9ds1_dev_boot_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_dev_boot_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_boot_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                              uint8_t *val)
 {
   lsm9ds1_ctrl_reg2_m_t ctrl_reg2_m;
@@ -1413,7 +1397,7 @@ int32_t lsm9ds1_dev_boot_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_reference_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_gy_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_write_reg(ctx, LSM9DS1_REFERENCE_G, buff, 1);
@@ -1428,7 +1412,7 @@ int32_t lsm9ds1_gy_filter_reference_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_reference_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_gy_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_REFERENCE_G, buff, 1);
@@ -1443,7 +1427,7 @@ int32_t lsm9ds1_gy_filter_reference_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                            lsm9ds1_gy_lp_bw_t val)
 {
   lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
@@ -1466,7 +1450,7 @@ int32_t lsm9ds1_gy_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                            lsm9ds1_gy_lp_bw_t *val)
 {
   lsm9ds1_ctrl_reg1_g_t ctrl_reg1_g;
@@ -1501,7 +1485,7 @@ int32_t lsm9ds1_gy_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_out_path_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_out_path_set(stmdev_ctx_t *ctx,
                                        lsm9ds1_gy_out_path_t val)
 {
   lsm9ds1_ctrl_reg2_g_t ctrl_reg2_g;
@@ -1536,7 +1520,7 @@ int32_t lsm9ds1_gy_filter_out_path_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_out_path_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_out_path_get(stmdev_ctx_t *ctx,
                                        lsm9ds1_gy_out_path_t *val)
 {
   lsm9ds1_ctrl_reg2_g_t ctrl_reg2_g;
@@ -1578,7 +1562,7 @@ int32_t lsm9ds1_gy_filter_out_path_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_int_path_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_int_path_set(stmdev_ctx_t *ctx,
                                        lsm9ds1_gy_int_path_t val)
 {
   lsm9ds1_ctrl_reg2_g_t ctrl_reg2_g;
@@ -1612,7 +1596,7 @@ int32_t lsm9ds1_gy_filter_int_path_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_int_path_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_int_path_get(stmdev_ctx_t *ctx,
                                        lsm9ds1_gy_int_path_t *val)
 {
   lsm9ds1_ctrl_reg2_g_t ctrl_reg2_g;
@@ -1653,7 +1637,7 @@ int32_t lsm9ds1_gy_filter_int_path_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                            lsm9ds1_gy_hp_bw_t val)
 {
   lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
@@ -1676,7 +1660,7 @@ int32_t lsm9ds1_gy_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                            lsm9ds1_gy_hp_bw_t *val)
 {
   lsm9ds1_ctrl_reg3_g_t ctrl_reg3_g;
@@ -1730,7 +1714,7 @@ int32_t lsm9ds1_gy_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_aalias_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_aalias_bandwidth_set(stmdev_ctx_t *ctx,
                                                lsm9ds1_xl_aa_bw_t val)
 {
   lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
@@ -1755,7 +1739,7 @@ int32_t lsm9ds1_xl_filter_aalias_bandwidth_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_aalias_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_aalias_bandwidth_get(stmdev_ctx_t *ctx,
                                                lsm9ds1_xl_aa_bw_t *val)
 {
   lsm9ds1_ctrl_reg6_xl_t ctrl_reg6_xl;
@@ -1794,7 +1778,7 @@ int32_t lsm9ds1_xl_filter_aalias_bandwidth_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_int_path_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_int_path_set(stmdev_ctx_t *ctx,
                                        lsm9ds1_xl_hp_path_t val)
 {
   lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
@@ -1818,7 +1802,7 @@ int32_t lsm9ds1_xl_filter_int_path_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_int_path_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_int_path_get(stmdev_ctx_t *ctx,
                                        lsm9ds1_xl_hp_path_t *val)
 {
   lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
@@ -1848,7 +1832,7 @@ int32_t lsm9ds1_xl_filter_int_path_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_out_path_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_out_path_set(stmdev_ctx_t *ctx,
                                        lsm9ds1_xl_out_path_t val)
 {
   lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
@@ -1872,7 +1856,7 @@ int32_t lsm9ds1_xl_filter_out_path_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_out_path_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_out_path_get(stmdev_ctx_t *ctx,
                                        lsm9ds1_xl_out_path_t *val)
 {
   lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
@@ -1903,7 +1887,7 @@ int32_t lsm9ds1_xl_filter_out_path_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                            lsm9ds1_xl_lp_bw_t val)
 {
   lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
@@ -1912,8 +1896,8 @@ int32_t lsm9ds1_xl_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
                          (uint8_t*)&ctrl_reg7_xl, 1);
   if(ret == 0){
-    ctrl_reg7_xl.dcf = ((uint8_t)val & 0x10U) >> 4;
-    ctrl_reg7_xl.hr = ((uint8_t)val & 0x03U);
+    ctrl_reg7_xl.hr = ((uint8_t)val & 0x10U) >> 4;
+    ctrl_reg7_xl.dcf = ((uint8_t)val & 0x03U);
     ret = lsm9ds1_write_reg(ctx, LSM9DS1_CTRL_REG7_XL,
                             (uint8_t*)&ctrl_reg7_xl, 1);
   }
@@ -1929,7 +1913,7 @@ int32_t lsm9ds1_xl_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                            lsm9ds1_xl_lp_bw_t *val)
 {
   lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
@@ -1937,7 +1921,7 @@ int32_t lsm9ds1_xl_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
 
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_CTRL_REG7_XL,
                          (uint8_t*)&ctrl_reg7_xl, 1);
-  switch ((ctrl_reg7_xl.dcf << 4) + ctrl_reg7_xl.hr){
+  switch ((ctrl_reg7_xl.hr << 4) + ctrl_reg7_xl.dcf){
     case LSM9DS1_LP_DISABLE:
       *val = LSM9DS1_LP_DISABLE;
       break;
@@ -1969,7 +1953,7 @@ int32_t lsm9ds1_xl_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                            lsm9ds1_xl_hp_bw_t val)
 {
   lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
@@ -1994,7 +1978,7 @@ int32_t lsm9ds1_xl_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                            lsm9ds1_xl_hp_bw_t *val)
 {
   lsm9ds1_ctrl_reg7_xl_t ctrl_reg7_xl;
@@ -2031,7 +2015,7 @@ int32_t lsm9ds1_xl_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_filter_settling_mask_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
   int32_t ret;
@@ -2052,7 +2036,7 @@ int32_t lsm9ds1_filter_settling_mask_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_filter_settling_mask_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
   int32_t ret;
@@ -2085,7 +2069,7 @@ int32_t lsm9ds1_filter_settling_mask_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_auto_increment_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
   int32_t ret;
@@ -2107,7 +2091,7 @@ int32_t lsm9ds1_auto_increment_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_auto_increment_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
   int32_t ret;
@@ -2126,7 +2110,7 @@ int32_t lsm9ds1_auto_increment_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_spi_mode_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_spi_mode_set(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                              lsm9ds1_sim_t val)
 {
   lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
@@ -2159,7 +2143,7 @@ int32_t lsm9ds1_spi_mode_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_spi_mode_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_spi_mode_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                              lsm9ds1_sim_t *val)
 {
   lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
@@ -2194,8 +2178,8 @@ int32_t lsm9ds1_spi_mode_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_i2c_interface_set(lsm9ds1_ctx_t *ctx_mag,
-                                  lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_i2c_interface_set(stmdev_ctx_t *ctx_mag,
+                                  stmdev_ctx_t *ctx_imu,
                                   lsm9ds1_i2c_dis_t val)
 {
   lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
@@ -2229,8 +2213,8 @@ int32_t lsm9ds1_i2c_interface_set(lsm9ds1_ctx_t *ctx_mag,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_i2c_interface_get(lsm9ds1_ctx_t *ctx_mag,
-                                  lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_i2c_interface_get(stmdev_ctx_t *ctx_mag,
+                                  stmdev_ctx_t *ctx_imu,
                                   lsm9ds1_i2c_dis_t *val)
 {
   lsm9ds1_ctrl_reg3_m_t ctrl_reg3_m;
@@ -2277,7 +2261,7 @@ int32_t lsm9ds1_i2c_interface_get(lsm9ds1_ctx_t *ctx_mag,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_logic_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t val)
+int32_t lsm9ds1_pin_logic_set(stmdev_ctx_t *ctx, lsm9ds1_pin_logic_t val)
 {
   lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
   lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
@@ -2311,7 +2295,7 @@ int32_t lsm9ds1_pin_logic_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_logic_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t *val)
+int32_t lsm9ds1_pin_logic_get(stmdev_ctx_t *ctx, lsm9ds1_pin_logic_t *val)
 {
   lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
   lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
@@ -2345,7 +2329,7 @@ int32_t lsm9ds1_pin_logic_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_int1_route_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_pin_int1_route_t val)
 {
   lsm9ds1_int1_ctrl_t int1_ctrl;
@@ -2374,7 +2358,7 @@ int32_t lsm9ds1_pin_int1_route_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_int1_route_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_pin_int1_route_t *val)
 {
   lsm9ds1_int1_ctrl_t int1_ctrl;
@@ -2402,7 +2386,7 @@ int32_t lsm9ds1_pin_int1_route_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_int2_route_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_pin_int2_route_t val)
 {
   lsm9ds1_int2_ctrl_t int2_ctrl;
@@ -2430,7 +2414,7 @@ int32_t lsm9ds1_pin_int2_route_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_int2_route_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int2_route_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_pin_int2_route_t *val)
 {
   lsm9ds1_int2_ctrl_t int2_ctrl;
@@ -2457,8 +2441,8 @@ int32_t lsm9ds1_pin_int2_route_get(lsm9ds1_ctx_t *ctx,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_notification_set(lsm9ds1_ctx_t *ctx_mag,
-                                     lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_pin_notification_set(stmdev_ctx_t *ctx_mag,
+                                     stmdev_ctx_t *ctx_imu,
                                      lsm9ds1_lir_t val)
 {
   lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
@@ -2504,8 +2488,8 @@ int32_t lsm9ds1_pin_notification_set(lsm9ds1_ctx_t *ctx_mag,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_notification_get(lsm9ds1_ctx_t *ctx_mag,
-                                     lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_pin_notification_get(stmdev_ctx_t *ctx_mag,
+                                     stmdev_ctx_t *ctx_imu,
                                      lsm9ds1_lir_t *val)
 {
   lsm9ds1_int_cfg_m_t int_cfg_m;
@@ -2545,7 +2529,7 @@ int32_t lsm9ds1_pin_notification_get(lsm9ds1_ctx_t *ctx_mag,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t val)
+int32_t lsm9ds1_pin_mode_set(stmdev_ctx_t *ctx, lsm9ds1_pp_od_t val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
   int32_t ret;
@@ -2566,7 +2550,7 @@ int32_t lsm9ds1_pin_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t *val)
+int32_t lsm9ds1_pin_mode_get(stmdev_ctx_t *ctx, lsm9ds1_pp_od_t *val)
 {
   lsm9ds1_ctrl_reg8_t ctrl_reg8;
   int32_t ret;
@@ -2594,7 +2578,7 @@ int32_t lsm9ds1_pin_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_int_m_route_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int_m_route_set(stmdev_ctx_t *ctx,
                                     lsm9ds1_pin_m_route_t val)
 {
   lsm9ds1_int_cfg_m_t int_cfg_m;
@@ -2616,7 +2600,7 @@ int32_t lsm9ds1_pin_int_m_route_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_int_m_route_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int_m_route_get(stmdev_ctx_t *ctx,
                                     lsm9ds1_pin_m_route_t *val)
 {
   lsm9ds1_int_cfg_m_t int_cfg_m;
@@ -2637,8 +2621,8 @@ int32_t lsm9ds1_pin_int_m_route_get(lsm9ds1_ctx_t *ctx,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_polarity_set(lsm9ds1_ctx_t *ctx_mag,
-                                 lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_pin_polarity_set(stmdev_ctx_t *ctx_mag,
+                                 stmdev_ctx_t *ctx_imu,
                                  lsm9ds1_polarity_t val)
 {
   lsm9ds1_int_cfg_m_t int_cfg_m;
@@ -2674,8 +2658,8 @@ int32_t lsm9ds1_pin_polarity_set(lsm9ds1_ctx_t *ctx_mag,
   * @retval           Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_pin_polarity_get(lsm9ds1_ctx_t *ctx_mag,
-                                 lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_pin_polarity_get(stmdev_ctx_t *ctx_mag,
+                                 stmdev_ctx_t *ctx_imu,
                                  lsm9ds1_polarity_t *val)
 {
   lsm9ds1_int_cfg_m_t int_cfg_m;
@@ -2723,7 +2707,7 @@ int32_t lsm9ds1_pin_polarity_get(lsm9ds1_ctx_t *ctx_mag,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_trshld_axis_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_xl_trshld_en_t val)
 {
   lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
@@ -2753,7 +2737,7 @@ int32_t lsm9ds1_xl_trshld_axis_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_trshld_axis_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_xl_trshld_en_t *val)
 {
   lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
@@ -2779,7 +2763,7 @@ int32_t lsm9ds1_xl_trshld_axis_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_trshld_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_xl_trshld_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_X_XL, buff, 3);
@@ -2794,7 +2778,7 @@ int32_t lsm9ds1_xl_trshld_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_xl_trshld_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_X_XL, buff, 3);
@@ -2809,7 +2793,7 @@ int32_t lsm9ds1_xl_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_xl_trshld_min_sample_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_int_gen_dur_xl_t int_gen_dur_xl;
   int32_t ret;
@@ -2838,7 +2822,7 @@ int32_t lsm9ds1_xl_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_xl_trshld_min_sample_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_int_gen_dur_xl_t int_gen_dur_xl;
   int32_t ret;
@@ -2858,7 +2842,7 @@ int32_t lsm9ds1_xl_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_src_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_trshld_src_get(stmdev_ctx_t *ctx,
                                   lsm9ds1_gy_trshld_src_t *val)
 {
   lsm9ds1_int_gen_src_g_t int_gen_src_g;
@@ -2885,7 +2869,7 @@ int32_t lsm9ds1_gy_trshld_src_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_trshld_src_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_trshld_src_get(stmdev_ctx_t *ctx,
                                   lsm9ds1_xl_trshld_src_t *val)
 {
   lsm9ds1_int_gen_src_xl_t int_gen_src_xl;
@@ -2913,7 +2897,7 @@ int32_t lsm9ds1_xl_trshld_src_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_trshld_axis_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_gy_trshld_en_t val)
 {
   lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
@@ -2943,7 +2927,7 @@ int32_t lsm9ds1_gy_trshld_axis_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_trshld_axis_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_gy_trshld_en_t *val)
 {
   lsm9ds1_int_gen_cfg_g_t int_gen_cfg_g;
@@ -2968,7 +2952,7 @@ int32_t lsm9ds1_gy_trshld_axis_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_dcrm_g_t val)
+int32_t lsm9ds1_gy_trshld_mode_set(stmdev_ctx_t *ctx, lsm9ds1_dcrm_g_t val)
 {
   lsm9ds1_int_gen_ths_xh_g_t int_gen_ths_xh_g;
   int32_t ret;
@@ -2991,7 +2975,7 @@ int32_t lsm9ds1_gy_trshld_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_dcrm_g_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_dcrm_g_t *val)
+int32_t lsm9ds1_gy_trshld_mode_get(stmdev_ctx_t *ctx, lsm9ds1_dcrm_g_t *val)
 {
   lsm9ds1_int_gen_ths_xh_g_t int_gen_ths_xh_g;
   int32_t ret;
@@ -3020,7 +3004,7 @@ int32_t lsm9ds1_gy_trshld_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_dcrm_g_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_x_set(lsm9ds1_ctx_t *ctx, uint16_t val)
+int32_t lsm9ds1_gy_trshld_x_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   lsm9ds1_int_gen_ths_xh_g_t int_gen_ths_xh_g;
   lsm9ds1_int_gen_ths_xl_g_t int_gen_ths_xl_g;
@@ -3054,7 +3038,7 @@ int32_t lsm9ds1_gy_trshld_x_set(lsm9ds1_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_x_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
+int32_t lsm9ds1_gy_trshld_x_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm9ds1_int_gen_ths_xh_g_t int_gen_ths_xh_g;
   lsm9ds1_int_gen_ths_xl_g_t int_gen_ths_xl_g;
@@ -3081,7 +3065,7 @@ int32_t lsm9ds1_gy_trshld_x_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_y_set(lsm9ds1_ctx_t *ctx, uint16_t val)
+int32_t lsm9ds1_gy_trshld_y_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   lsm9ds1_int_gen_ths_yh_g_t int_gen_ths_yh_g;
   lsm9ds1_int_gen_ths_yl_g_t int_gen_ths_yl_g;
@@ -3115,7 +3099,7 @@ int32_t lsm9ds1_gy_trshld_y_set(lsm9ds1_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_y_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
+int32_t lsm9ds1_gy_trshld_y_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm9ds1_int_gen_ths_yh_g_t int_gen_ths_yh_g;
   lsm9ds1_int_gen_ths_yl_g_t int_gen_ths_yl_g;
@@ -3141,7 +3125,7 @@ int32_t lsm9ds1_gy_trshld_y_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_z_set(lsm9ds1_ctx_t *ctx, uint16_t val)
+int32_t lsm9ds1_gy_trshld_z_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   lsm9ds1_int_gen_ths_zh_g_t int_gen_ths_zh_g;
   lsm9ds1_int_gen_ths_zl_g_t int_gen_ths_zl_g;
@@ -3175,7 +3159,7 @@ int32_t lsm9ds1_gy_trshld_z_set(lsm9ds1_ctx_t *ctx, uint16_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_z_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
+int32_t lsm9ds1_gy_trshld_z_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   lsm9ds1_int_gen_ths_zh_g_t int_gen_ths_zh_g;
   lsm9ds1_int_gen_ths_zl_g_t int_gen_ths_zl_g;
@@ -3202,7 +3186,7 @@ int32_t lsm9ds1_gy_trshld_z_get(lsm9ds1_ctx_t *ctx, uint16_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_gy_trshld_min_sample_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_int_gen_dur_g_t int_gen_dur_g;
   int32_t ret;
@@ -3231,7 +3215,7 @@ int32_t lsm9ds1_gy_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_gy_trshld_min_sample_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_int_gen_dur_g_t int_gen_dur_g;
   int32_t ret;
@@ -3251,7 +3235,7 @@ int32_t lsm9ds1_gy_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_trshld_axis_set(stmdev_ctx_t *ctx,
                                     lsm9ds1_mag_trshld_axis_t val)
 {
   lsm9ds1_int_cfg_m_t int_cfg_m;
@@ -3276,7 +3260,7 @@ int32_t lsm9ds1_mag_trshld_axis_set(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_trshld_axis_get(stmdev_ctx_t *ctx,
                                     lsm9ds1_mag_trshld_axis_t *val)
 {
   lsm9ds1_int_cfg_m_t int_cfg_m;
@@ -3298,7 +3282,7 @@ int32_t lsm9ds1_mag_trshld_axis_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_trshld_src_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_trshld_src_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_mag_trshld_src_t *val)
 {
   lsm9ds1_int_src_m_t int_src_m;
@@ -3324,7 +3308,7 @@ int32_t lsm9ds1_mag_trshld_src_get(lsm9ds1_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_mag_trshld_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_int_ths_l_m_t int_ths_l_m;
   lsm9ds1_int_ths_h_m_t int_ths_h_m;
@@ -3365,7 +3349,7 @@ int32_t lsm9ds1_mag_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_act_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_act_ths_t act_ths;
   int32_t ret;
@@ -3386,7 +3370,7 @@ int32_t lsm9ds1_act_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_act_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_act_ths_t act_ths;
   int32_t ret;
@@ -3405,7 +3389,7 @@ int32_t lsm9ds1_act_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_act_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t val)
+int32_t lsm9ds1_act_mode_set(stmdev_ctx_t *ctx, lsm9ds1_act_mode_t val)
 {
   lsm9ds1_act_ths_t act_ths;
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
@@ -3435,7 +3419,7 @@ int32_t lsm9ds1_act_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_act_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t *val)
+int32_t lsm9ds1_act_mode_get(stmdev_ctx_t *ctx, lsm9ds1_act_mode_t *val)
 {
   lsm9ds1_act_ths_t act_ths;
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
@@ -3468,7 +3452,7 @@ int32_t lsm9ds1_act_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_act_duration_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_act_duration_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_write_reg(ctx, LSM9DS1_ACT_DUR, buff, 1);
@@ -3483,7 +3467,7 @@ int32_t lsm9ds1_act_duration_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_act_duration_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_act_duration_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_ACT_DUR, buff, 1);
@@ -3498,7 +3482,7 @@ int32_t lsm9ds1_act_duration_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_act_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_inact_t *val)
+int32_t lsm9ds1_act_src_get(stmdev_ctx_t *ctx, lsm9ds1_inact_t *val)
 {
   lsm9ds1_status_reg_t status_reg;
   int32_t ret;
@@ -3539,7 +3523,7 @@ int32_t lsm9ds1_act_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_inact_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_6d_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t val)
+int32_t lsm9ds1_6d_mode_set(stmdev_ctx_t *ctx, lsm9ds1_6d_mode_t val)
 {
   lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
   lsm9ds1_ctrl_reg4_t ctrl_reg4;
@@ -3573,7 +3557,7 @@ int32_t lsm9ds1_6d_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_6d_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t *val)
+int32_t lsm9ds1_6d_mode_get(stmdev_ctx_t *ctx, lsm9ds1_6d_mode_t *val)
 {
   lsm9ds1_int_gen_cfg_xl_t int_gen_cfg_xl;
   lsm9ds1_ctrl_reg4_t ctrl_reg4;
@@ -3617,7 +3601,7 @@ int32_t lsm9ds1_6d_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_6d_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_write_reg(ctx, LSM9DS1_INT_GEN_THS_X_XL, buff, 3);
@@ -3632,7 +3616,7 @@ int32_t lsm9ds1_6d_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_6d_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
+int32_t lsm9ds1_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff)
 {
   int32_t ret;
   ret = lsm9ds1_read_reg(ctx, LSM9DS1_INT_GEN_THS_X_XL, buff, 3);
@@ -3647,7 +3631,7 @@ int32_t lsm9ds1_6d_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *buff)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_6d_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_src_t *val)
+int32_t lsm9ds1_6d_src_get(stmdev_ctx_t *ctx, lsm9ds1_6d_src_t *val)
 {
   lsm9ds1_int_gen_src_xl_t int_gen_src_xl;
   int32_t ret;
@@ -3687,7 +3671,7 @@ int32_t lsm9ds1_6d_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_src_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_stop_on_wtm_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
   int32_t ret;
@@ -3709,7 +3693,7 @@ int32_t lsm9ds1_fifo_stop_on_wtm_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_stop_on_wtm_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
   int32_t ret;
@@ -3728,7 +3712,7 @@ int32_t lsm9ds1_fifo_stop_on_wtm_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t val)
+int32_t lsm9ds1_fifo_mode_set(stmdev_ctx_t *ctx, lsm9ds1_fifo_md_t val)
 {
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
   lsm9ds1_fifo_ctrl_t fifo_ctrl;
@@ -3757,7 +3741,7 @@ int32_t lsm9ds1_fifo_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t *val)
+int32_t lsm9ds1_fifo_mode_get(stmdev_ctx_t *ctx, lsm9ds1_fifo_md_t *val)
 {
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
   lsm9ds1_fifo_ctrl_t fifo_ctrl;
@@ -3802,7 +3786,7 @@ int32_t lsm9ds1_fifo_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_temp_batch_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
   int32_t ret;
@@ -3823,7 +3807,7 @@ int32_t lsm9ds1_fifo_temp_batch_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_temp_batch_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_ctrl_reg9_t ctrl_reg9;
   int32_t ret;
@@ -3842,7 +3826,7 @@ int32_t lsm9ds1_fifo_temp_batch_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_watermark_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -3863,7 +3847,7 @@ int32_t lsm9ds1_fifo_watermark_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_watermark_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_fifo_ctrl_t fifo_ctrl;
   int32_t ret;
@@ -3882,7 +3866,7 @@ int32_t lsm9ds1_fifo_watermark_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_full_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_fifo_src_t fifo_src;
   int32_t ret;
@@ -3901,7 +3885,7 @@ int32_t lsm9ds1_fifo_full_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_data_level_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_fifo_src_t fifo_src;
   int32_t ret;
@@ -3920,7 +3904,7 @@ int32_t lsm9ds1_fifo_data_level_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_ovr_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_fifo_src_t fifo_src;
   int32_t ret;
@@ -3939,7 +3923,7 @@ int32_t lsm9ds1_fifo_ovr_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_fifo_wtm_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_fifo_src_t fifo_src;
   int32_t ret;
@@ -3971,7 +3955,7 @@ int32_t lsm9ds1_fifo_wtm_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_xl_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_ctrl_reg10_t ctrl_reg10;
   int32_t ret;
@@ -3992,7 +3976,7 @@ int32_t lsm9ds1_xl_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_xl_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_xl_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_ctrl_reg10_t ctrl_reg10;
   int32_t ret;
@@ -4011,7 +3995,7 @@ int32_t lsm9ds1_xl_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_gy_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_ctrl_reg10_t ctrl_reg10;
   int32_t ret;
@@ -4032,7 +4016,7 @@ int32_t lsm9ds1_gy_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_gy_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_gy_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_ctrl_reg10_t ctrl_reg10;
   int32_t ret;
@@ -4051,7 +4035,7 @@ int32_t lsm9ds1_gy_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
+int32_t lsm9ds1_mag_self_test_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm9ds1_ctrl_reg1_m_t ctrl_reg1_m;
   int32_t ret;
@@ -4073,7 +4057,7 @@ int32_t lsm9ds1_mag_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val)
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm9ds1_mag_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val)
+int32_t lsm9ds1_mag_self_test_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm9ds1_ctrl_reg1_m_t ctrl_reg1_m;
   int32_t ret;

--- a/sensor/stmemsc/lsm9ds1_STdC/driver/lsm9ds1_reg.h
+++ b/sensor/stmemsc/lsm9ds1_STdC/driver/lsm9ds1_reg.h
@@ -7,33 +7,17 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
+
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef LSM9DS1_REGS_H
 #define LSM9DS1_REGS_H
@@ -51,50 +35,13 @@
   *
   */
 
-/** @defgroup LSM9DS1_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -110,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-  /** @addtogroup  LSM9DS1_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -125,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*lsm9ds1_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*lsm9ds1_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  lsm9ds1_write_ptr  write_reg;
-  lsm9ds1_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} lsm9ds1_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -597,9 +570,9 @@ typedef union{
   *
   */
 
-int32_t lsm9ds1_read_reg(lsm9ds1_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm9ds1_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                          uint16_t len);
-int32_t lsm9ds1_write_reg(lsm9ds1_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t lsm9ds1_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
 
 extern float_t lsm9ds1_from_fs2g_to_mg(int16_t lsb);
@@ -623,8 +596,8 @@ typedef enum {
   LSM9DS1_500dps = 1,
   LSM9DS1_2000dps = 3,
 } lsm9ds1_gy_fs_t;
-int32_t lsm9ds1_gy_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t val);
-int32_t lsm9ds1_gy_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_fs_t *val);
+int32_t lsm9ds1_gy_full_scale_set(stmdev_ctx_t *ctx, lsm9ds1_gy_fs_t val);
+int32_t lsm9ds1_gy_full_scale_get(stmdev_ctx_t *ctx, lsm9ds1_gy_fs_t *val);
 
 typedef enum {
   LSM9DS1_IMU_OFF              = 0x00,
@@ -653,9 +626,9 @@ typedef enum {
   LSM9DS1_IMU_59Hz5_LP         = 0xA2,
   LSM9DS1_IMU_119Hz_LP         = 0xB3,
 } lsm9ds1_imu_odr_t;
-int32_t lsm9ds1_imu_data_rate_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_imu_data_rate_set(stmdev_ctx_t *ctx,
                                   lsm9ds1_imu_odr_t val);
-int32_t lsm9ds1_imu_data_rate_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_imu_data_rate_get(stmdev_ctx_t *ctx,
                                   lsm9ds1_imu_odr_t *val);
 
 typedef struct {
@@ -664,30 +637,30 @@ typedef struct {
   uint8_t signy_g             : 1; /*(0: positive; 1: negative)*/
   uint8_t signx_g             : 1; /*(0: positive; 1: negative)*/
 } lsm9ds1_gy_orient_t;
-int32_t lsm9ds1_gy_orient_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t val);
-int32_t lsm9ds1_gy_orient_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_orient_t *val);
+int32_t lsm9ds1_gy_orient_set(stmdev_ctx_t *ctx, lsm9ds1_gy_orient_t val);
+int32_t lsm9ds1_gy_orient_get(stmdev_ctx_t *ctx, lsm9ds1_gy_orient_t *val);
 
-int32_t lsm9ds1_xl_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_xl_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_gy_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_gy_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_temp_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_temp_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t xen_g             : 1;
   uint8_t yen_g             : 1;
   uint8_t zen_g             : 1;
 } lsm9ds1_gy_axis_t;
-int32_t lsm9ds1_gy_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t val);
-int32_t lsm9ds1_gy_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_gy_axis_t *val);
+int32_t lsm9ds1_gy_axis_set(stmdev_ctx_t *ctx, lsm9ds1_gy_axis_t val);
+int32_t lsm9ds1_gy_axis_get(stmdev_ctx_t *ctx, lsm9ds1_gy_axis_t *val);
 
 typedef struct {
   uint8_t xen_xl             : 1;
   uint8_t yen_xl             : 1;
   uint8_t zen_xl             : 1;
 } lsm9ds1_xl_axis_t;
-int32_t lsm9ds1_xl_axis_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t val);
-int32_t lsm9ds1_xl_axis_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_axis_t *val);
+int32_t lsm9ds1_xl_axis_set(stmdev_ctx_t *ctx, lsm9ds1_xl_axis_t val);
+int32_t lsm9ds1_xl_axis_get(stmdev_ctx_t *ctx, lsm9ds1_xl_axis_t *val);
 
 typedef enum {
   LSM9DS1_NO_DECIMATION     = 0,
@@ -695,8 +668,8 @@ typedef enum {
   LSM9DS1_EVERY_4_SAMPLES   = 2,
   LSM9DS1_EVERY_8_SAMPLES   = 3,
 } lsm9ds1_dec_t;
-int32_t lsm9ds1_xl_decimation_set(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t val);
-int32_t lsm9ds1_xl_decimation_get(lsm9ds1_ctx_t *ctx, lsm9ds1_dec_t *val);
+int32_t lsm9ds1_xl_decimation_set(stmdev_ctx_t *ctx, lsm9ds1_dec_t val);
+int32_t lsm9ds1_xl_decimation_get(stmdev_ctx_t *ctx, lsm9ds1_dec_t *val);
 
 typedef enum {
   LSM9DS1_2g     = 0,
@@ -704,16 +677,16 @@ typedef enum {
   LSM9DS1_4g     = 2,
   LSM9DS1_8g     = 3,
 } lsm9ds1_xl_fs_t;
-int32_t lsm9ds1_xl_full_scale_set(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t val);
-int32_t lsm9ds1_xl_full_scale_get(lsm9ds1_ctx_t *ctx, lsm9ds1_xl_fs_t *val);
+int32_t lsm9ds1_xl_full_scale_set(stmdev_ctx_t *ctx, lsm9ds1_xl_fs_t val);
+int32_t lsm9ds1_xl_full_scale_get(stmdev_ctx_t *ctx, lsm9ds1_xl_fs_t *val);
 
-int32_t lsm9ds1_block_data_update_set(lsm9ds1_ctx_t *ctx_mag,
-                                      lsm9ds1_ctx_t *ctx_imu, uint8_t val);
-int32_t lsm9ds1_block_data_update_get(lsm9ds1_ctx_t *ctx_mag,
-                                      lsm9ds1_ctx_t *ctx_imu, uint8_t *val);
+int32_t lsm9ds1_block_data_update_set(stmdev_ctx_t *ctx_mag,
+                                      stmdev_ctx_t *ctx_imu, uint8_t val);
+int32_t lsm9ds1_block_data_update_get(stmdev_ctx_t *ctx_mag,
+                                      stmdev_ctx_t *ctx_imu, uint8_t *val);
 
-int32_t lsm9ds1_mag_offset_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
-int32_t lsm9ds1_mag_offset_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_mag_offset_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_mag_offset_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM9DS1_MAG_POWER_DOWN    = 0xC0,
@@ -755,9 +728,9 @@ typedef enum {
   LSM9DS1_MAG_LP_1000Hz     = 0x08,
   LSM9DS1_MAG_ONE_SHOT      = 0x70,
 } lsm9ds1_mag_data_rate_t;
-int32_t lsm9ds1_mag_data_rate_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_data_rate_set(stmdev_ctx_t *ctx,
                                   lsm9ds1_mag_data_rate_t val);
-int32_t lsm9ds1_mag_data_rate_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_data_rate_get(stmdev_ctx_t *ctx,
                                   lsm9ds1_mag_data_rate_t *val);
 
 typedef enum {
@@ -766,60 +739,60 @@ typedef enum {
   LSM9DS1_12Ga   = 2,
   LSM9DS1_16Ga   = 3,
 } lsm9ds1_mag_fs_t;
-int32_t lsm9ds1_mag_full_scale_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_full_scale_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_mag_fs_t val);
-int32_t lsm9ds1_mag_full_scale_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_full_scale_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_mag_fs_t *val);
 
-int32_t lsm9ds1_mag_flag_data_ready_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_mag_flag_data_ready_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_temperature_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_temperature_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm9ds1_angular_rate_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_angular_rate_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm9ds1_acceleration_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_acceleration_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm9ds1_magnetic_raw_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_magnetic_raw_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm9ds1_magnetic_overflow_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_magnetic_overflow_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t imu;
   uint8_t mag;
 } lsm9ds1_id_t;
-int32_t lsm9ds1_dev_id_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_id_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                            lsm9ds1_id_t *buff);
 
 typedef struct {
   lsm9ds1_status_reg_m_t status_mag;
   lsm9ds1_status_reg_t   status_imu;
 } lsm9ds1_status_t;
-int32_t lsm9ds1_dev_status_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_status_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                                lsm9ds1_status_t *val);
 
-int32_t lsm9ds1_dev_reset_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_reset_set(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                               uint8_t val);
-int32_t lsm9ds1_dev_reset_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_reset_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                               uint8_t *val);
 
 typedef enum {
   LSM9DS1_LSB_LOW_ADDRESS = 0,
   LSM9DS1_MSB_LOW_ADDRESS = 1,
 } lsm9ds1_ble_t;
-int32_t lsm9ds1_dev_data_format_set(lsm9ds1_ctx_t *ctx_mag,
-                                    lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_data_format_set(stmdev_ctx_t *ctx_mag,
+                                    stmdev_ctx_t *ctx_imu,
                                     lsm9ds1_ble_t val);
-int32_t lsm9ds1_dev_data_format_get(lsm9ds1_ctx_t *ctx_mag,
-                                    lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_data_format_get(stmdev_ctx_t *ctx_mag,
+                                    stmdev_ctx_t *ctx_imu,
                                     lsm9ds1_ble_t *val);
 
-int32_t lsm9ds1_dev_boot_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_boot_set(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                              uint8_t val);
-int32_t lsm9ds1_dev_boot_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_dev_boot_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                              uint8_t *val);
 
-int32_t lsm9ds1_gy_filter_reference_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
-int32_t lsm9ds1_gy_filter_reference_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_gy_filter_reference_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_gy_filter_reference_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM9DS1_LP_STRONG        = 0,
@@ -827,9 +800,9 @@ typedef enum {
   LSM9DS1_LP_LIGHT         = 2,
   LSM9DS1_LP_ULTRA_LIGHT   = 3,
 } lsm9ds1_gy_lp_bw_t;
-int32_t lsm9ds1_gy_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                            lsm9ds1_gy_lp_bw_t val);
-int32_t lsm9ds1_gy_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                            lsm9ds1_gy_lp_bw_t *val);
 
 typedef enum {
@@ -838,9 +811,9 @@ typedef enum {
   LSM9DS1_LPF1_LPF2_OUT         = 0x02,
   LSM9DS1_LPF1_HPF_LPF2_OUT     = 0x12,
 } lsm9ds1_gy_out_path_t;
-int32_t lsm9ds1_gy_filter_out_path_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_out_path_set(stmdev_ctx_t *ctx,
                                        lsm9ds1_gy_out_path_t val);
-int32_t lsm9ds1_gy_filter_out_path_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_out_path_get(stmdev_ctx_t *ctx,
                                        lsm9ds1_gy_out_path_t *val);
 
 typedef enum {
@@ -849,9 +822,9 @@ typedef enum {
   LSM9DS1_LPF1_LPF2_INT         = 0x02,
   LSM9DS1_LPF1_HPF_LPF2_INT     = 0x12,
 } lsm9ds1_gy_int_path_t;
-int32_t lsm9ds1_gy_filter_int_path_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_int_path_set(stmdev_ctx_t *ctx,
                                        lsm9ds1_gy_int_path_t val);
-int32_t lsm9ds1_gy_filter_int_path_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_int_path_get(stmdev_ctx_t *ctx,
                                        lsm9ds1_gy_int_path_t *val);
 
 typedef enum {
@@ -866,9 +839,9 @@ typedef enum {
   LSM9DS1_HP_LIGHT         = 8,
   LSM9DS1_HP_ULTRA_LIGHT   = 9,
 } lsm9ds1_gy_hp_bw_t;
-int32_t lsm9ds1_gy_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                            lsm9ds1_gy_hp_bw_t val);
-int32_t lsm9ds1_gy_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                            lsm9ds1_gy_hp_bw_t *val);
 
 typedef enum {
@@ -878,26 +851,26 @@ typedef enum {
   LSM9DS1_105Hz     = 0x12,
   LSM9DS1_50Hz      = 0x13,
 } lsm9ds1_xl_aa_bw_t;
-int32_t lsm9ds1_xl_filter_aalias_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_aalias_bandwidth_set(stmdev_ctx_t *ctx,
                                                lsm9ds1_xl_aa_bw_t val);
-int32_t lsm9ds1_xl_filter_aalias_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_aalias_bandwidth_get(stmdev_ctx_t *ctx,
                                                lsm9ds1_xl_aa_bw_t *val);
 typedef enum {
   LSM9DS1_HP_DIS  = 0,
   LSM9DS1_HP_EN   = 1,
 } lsm9ds1_xl_hp_path_t;
-int32_t lsm9ds1_xl_filter_int_path_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_int_path_set(stmdev_ctx_t *ctx,
                                        lsm9ds1_xl_hp_path_t val);
-int32_t lsm9ds1_xl_filter_int_path_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_int_path_get(stmdev_ctx_t *ctx,
                                        lsm9ds1_xl_hp_path_t *val);
 
 typedef enum {
   LSM9DS1_LP_OUT     = 0,
   LSM9DS1_HP_OUT     = 1,
 } lsm9ds1_xl_out_path_t;
-int32_t lsm9ds1_xl_filter_out_path_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_out_path_set(stmdev_ctx_t *ctx,
                                        lsm9ds1_xl_out_path_t val);
-int32_t lsm9ds1_xl_filter_out_path_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_out_path_get(stmdev_ctx_t *ctx,
                                        lsm9ds1_xl_out_path_t *val);
 
 typedef enum {
@@ -907,9 +880,9 @@ typedef enum {
   LSM9DS1_LP_ODR_DIV_9      = 0x12,
   LSM9DS1_LP_ODR_DIV_400    = 0x13,
 } lsm9ds1_xl_lp_bw_t;
-int32_t lsm9ds1_xl_filter_lp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                            lsm9ds1_xl_lp_bw_t val);
-int32_t lsm9ds1_xl_filter_lp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                            lsm9ds1_xl_lp_bw_t *val);
 
 typedef enum {
@@ -918,43 +891,43 @@ typedef enum {
   LSM9DS1_HP_ODR_DIV_9    = 2,
   LSM9DS1_HP_ODR_DIV_400  = 3,
 } lsm9ds1_xl_hp_bw_t;
-int32_t lsm9ds1_xl_filter_hp_bandwidth_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_hp_bandwidth_set(stmdev_ctx_t *ctx,
                                            lsm9ds1_xl_hp_bw_t val);
-int32_t lsm9ds1_xl_filter_hp_bandwidth_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_filter_hp_bandwidth_get(stmdev_ctx_t *ctx,
                                            lsm9ds1_xl_hp_bw_t *val);
 
-int32_t lsm9ds1_filter_settling_mask_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_filter_settling_mask_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_filter_settling_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_filter_settling_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_auto_increment_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_auto_increment_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM9DS1_SPI_4_WIRE = 0,
   LSM9DS1_SPI_3_WIRE = 1,
 } lsm9ds1_sim_t;
-int32_t lsm9ds1_spi_mode_set(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_spi_mode_set(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                              lsm9ds1_sim_t val);
-int32_t lsm9ds1_spi_mode_get(lsm9ds1_ctx_t *ctx_mag, lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_spi_mode_get(stmdev_ctx_t *ctx_mag, stmdev_ctx_t *ctx_imu,
                              lsm9ds1_sim_t *val);
 
 typedef enum {
   LSM9DS1_I2C_ENABLE = 0,
   LSM9DS1_I2C_DISABLE = 1,
 } lsm9ds1_i2c_dis_t;
-int32_t lsm9ds1_i2c_interface_set(lsm9ds1_ctx_t *ctx_mag,
-                                  lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_i2c_interface_set(stmdev_ctx_t *ctx_mag,
+                                  stmdev_ctx_t *ctx_imu,
                                   lsm9ds1_i2c_dis_t val);
-int32_t lsm9ds1_i2c_interface_get(lsm9ds1_ctx_t *ctx_mag,
-                                  lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_i2c_interface_get(stmdev_ctx_t *ctx_mag,
+                                  stmdev_ctx_t *ctx_imu,
                                   lsm9ds1_i2c_dis_t *val);
 
 typedef enum {
   LSM9DS1_LOGIC_OR    = 0,
   LSM9DS1_LOGIC_AND   = 1,
 } lsm9ds1_pin_logic_t;
-int32_t lsm9ds1_pin_logic_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t val);
-int32_t lsm9ds1_pin_logic_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pin_logic_t *val);
+int32_t lsm9ds1_pin_logic_set(stmdev_ctx_t *ctx, lsm9ds1_pin_logic_t val);
+int32_t lsm9ds1_pin_logic_get(stmdev_ctx_t *ctx, lsm9ds1_pin_logic_t *val);
 
 typedef struct {
   uint8_t int1_drdy_xl      : 1;
@@ -966,9 +939,9 @@ typedef struct {
   uint8_t int1_ig_xl        : 1;
   uint8_t int1_ig_g         : 1;
 } lsm9ds1_pin_int1_route_t;
-int32_t lsm9ds1_pin_int1_route_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int1_route_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_pin_int1_route_t val);
-int32_t lsm9ds1_pin_int1_route_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int1_route_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_pin_int1_route_t *val);
 typedef struct {
   uint8_t int2_drdy_xl       : 1;
@@ -979,45 +952,45 @@ typedef struct {
   uint8_t int2_fss5          : 1;
   uint8_t int2_inact         : 1;
 } lsm9ds1_pin_int2_route_t;
-int32_t lsm9ds1_pin_int2_route_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int2_route_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_pin_int2_route_t val);
-int32_t lsm9ds1_pin_int2_route_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int2_route_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_pin_int2_route_t *val);
 
 typedef enum {
   LSM9DS1_INT_PULSED  = 0,
   LSM9DS1_INT_LATCHED = 1,
 } lsm9ds1_lir_t;
-int32_t lsm9ds1_pin_notification_set(lsm9ds1_ctx_t *ctx_mag,
-                                     lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_pin_notification_set(stmdev_ctx_t *ctx_mag,
+                                     stmdev_ctx_t *ctx_imu,
                                      lsm9ds1_lir_t val);
-int32_t lsm9ds1_pin_notification_get(lsm9ds1_ctx_t *ctx_mag,
-                                     lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_pin_notification_get(stmdev_ctx_t *ctx_mag,
+                                     stmdev_ctx_t *ctx_imu,
                                      lsm9ds1_lir_t *val);
 
 typedef enum {
   LSM9DS1_PUSH_PULL   = 0,
   LSM9DS1_OPEN_DRAIN  = 1,
 } lsm9ds1_pp_od_t;
-int32_t lsm9ds1_pin_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t val);
-int32_t lsm9ds1_pin_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_pp_od_t *val);
+int32_t lsm9ds1_pin_mode_set(stmdev_ctx_t *ctx, lsm9ds1_pp_od_t val);
+int32_t lsm9ds1_pin_mode_get(stmdev_ctx_t *ctx, lsm9ds1_pp_od_t *val);
 
 typedef struct {
   uint8_t ien             : 1;
 } lsm9ds1_pin_m_route_t;
-int32_t lsm9ds1_pin_int_m_route_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int_m_route_set(stmdev_ctx_t *ctx,
                                     lsm9ds1_pin_m_route_t val);
-int32_t lsm9ds1_pin_int_m_route_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_pin_int_m_route_get(stmdev_ctx_t *ctx,
                                     lsm9ds1_pin_m_route_t *val);
 typedef enum {
   LSM9DS1_ACTIVE_LOW    = 0,
   LSM9DS1_ACTIVE_HIGH   = 1,
 } lsm9ds1_polarity_t;
-int32_t lsm9ds1_pin_polarity_set(lsm9ds1_ctx_t *ctx_mag,
-                                 lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_pin_polarity_set(stmdev_ctx_t *ctx_mag,
+                                 stmdev_ctx_t *ctx_imu,
                                  lsm9ds1_polarity_t val);
-int32_t lsm9ds1_pin_polarity_get(lsm9ds1_ctx_t *ctx_mag,
-                                 lsm9ds1_ctx_t *ctx_imu,
+int32_t lsm9ds1_pin_polarity_get(stmdev_ctx_t *ctx_mag,
+                                 stmdev_ctx_t *ctx_imu,
                                  lsm9ds1_polarity_t *val);
 
 typedef struct {
@@ -1028,16 +1001,16 @@ typedef struct {
   uint8_t zlie_xl             : 1;
   uint8_t zhie_xl             : 1;
 } lsm9ds1_xl_trshld_en_t;
-int32_t lsm9ds1_xl_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_trshld_axis_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_xl_trshld_en_t val);
-int32_t lsm9ds1_xl_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_trshld_axis_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_xl_trshld_en_t *val);
 
-int32_t lsm9ds1_xl_trshld_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
-int32_t lsm9ds1_xl_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_xl_trshld_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_xl_trshld_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
-int32_t lsm9ds1_xl_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_xl_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_xl_trshld_min_sample_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_xl_trshld_min_sample_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t xl_g             : 1;
@@ -1048,7 +1021,7 @@ typedef struct {
   uint8_t zh_g             : 1;
   uint8_t ia_g             : 1;
 } lsm9ds1_gy_trshld_src_t;
-int32_t lsm9ds1_gy_trshld_src_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_trshld_src_get(stmdev_ctx_t *ctx,
                                   lsm9ds1_gy_trshld_src_t *val);
 
 typedef struct {
@@ -1060,7 +1033,7 @@ typedef struct {
   uint8_t zh_xl             : 1;
   uint8_t ia_xl             : 1;
 } lsm9ds1_xl_trshld_src_t;
-int32_t lsm9ds1_xl_trshld_src_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_xl_trshld_src_get(stmdev_ctx_t *ctx,
                                          lsm9ds1_xl_trshld_src_t *val);
 
 typedef struct {
@@ -1071,40 +1044,40 @@ typedef struct {
   uint8_t zlie_g             : 1;
   uint8_t zhie_g             : 1;
 } lsm9ds1_gy_trshld_en_t;
-int32_t lsm9ds1_gy_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_trshld_axis_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_gy_trshld_en_t val);
-int32_t lsm9ds1_gy_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_trshld_axis_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_gy_trshld_en_t *val);
 
 typedef enum {
   LSM9DS1_RESET_MODE = 0,
   LSM9DS1_DECREMENT_MODE = 1,
 } lsm9ds1_dcrm_g_t;
-int32_t lsm9ds1_gy_trshld_mode_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_trshld_mode_set(stmdev_ctx_t *ctx,
                                    lsm9ds1_dcrm_g_t val);
-int32_t lsm9ds1_gy_trshld_mode_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_gy_trshld_mode_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_dcrm_g_t *val);
 
-int32_t lsm9ds1_gy_trshld_x_set(lsm9ds1_ctx_t *ctx, uint16_t val);
-int32_t lsm9ds1_gy_trshld_x_get(lsm9ds1_ctx_t *ctx, uint16_t *val);
+int32_t lsm9ds1_gy_trshld_x_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm9ds1_gy_trshld_x_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm9ds1_gy_trshld_y_set(lsm9ds1_ctx_t *ctx, uint16_t val);
-int32_t lsm9ds1_gy_trshld_y_get(lsm9ds1_ctx_t *ctx, uint16_t *val);
+int32_t lsm9ds1_gy_trshld_y_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm9ds1_gy_trshld_y_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm9ds1_gy_trshld_z_set(lsm9ds1_ctx_t *ctx, uint16_t val);
-int32_t lsm9ds1_gy_trshld_z_get(lsm9ds1_ctx_t *ctx, uint16_t *val);
+int32_t lsm9ds1_gy_trshld_z_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm9ds1_gy_trshld_z_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm9ds1_gy_trshld_min_sample_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_gy_trshld_min_sample_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_gy_trshld_min_sample_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_gy_trshld_min_sample_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t zien             : 1;
   uint8_t yien             : 1;
   uint8_t xien             : 1;
 } lsm9ds1_mag_trshld_axis_t;
-int32_t lsm9ds1_mag_trshld_axis_set(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_trshld_axis_set(stmdev_ctx_t *ctx,
                                     lsm9ds1_mag_trshld_axis_t val);
-int32_t lsm9ds1_mag_trshld_axis_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_trshld_axis_get(stmdev_ctx_t *ctx,
                                     lsm9ds1_mag_trshld_axis_t *val);
 typedef struct {
   uint8_t _int              : 1;
@@ -1115,30 +1088,30 @@ typedef struct {
   uint8_t pth_y             : 1;
   uint8_t pth_x             : 1;
 } lsm9ds1_mag_trshld_src_t;
-int32_t lsm9ds1_mag_trshld_src_get(lsm9ds1_ctx_t *ctx,
+int32_t lsm9ds1_mag_trshld_src_get(stmdev_ctx_t *ctx,
                                    lsm9ds1_mag_trshld_src_t *val);
 
-int32_t lsm9ds1_mag_trshld_set(lsm9ds1_ctx_t *ctx, uint8_t *val);
-int32_t lsm9ds1_mag_trshld_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_mag_trshld_set(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_mag_trshld_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_act_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_act_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_act_threshold_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_act_threshold_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM9DS1_GYRO_POWER_DOWN = 0,
   LSM9DS1_GYRO_SLEEP = 1,
 } lsm9ds1_act_mode_t;
-int32_t lsm9ds1_act_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t val);
-int32_t lsm9ds1_act_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_act_mode_t *val);
+int32_t lsm9ds1_act_mode_set(stmdev_ctx_t *ctx, lsm9ds1_act_mode_t val);
+int32_t lsm9ds1_act_mode_get(stmdev_ctx_t *ctx, lsm9ds1_act_mode_t *val);
 
-int32_t lsm9ds1_act_duration_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
-int32_t lsm9ds1_act_duration_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_act_duration_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_act_duration_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef enum {
   LSM9DS1_ACTIVITY    = 0,
   LSM9DS1_INACTIVITY  = 1,
 } lsm9ds1_inact_t;
-int32_t lsm9ds1_act_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_inact_t *val);
+int32_t lsm9ds1_act_src_get(stmdev_ctx_t *ctx, lsm9ds1_inact_t *val);
 
 typedef enum {
   LSM9DS1_POS_MOVE_RECO_DISABLE   = 0x00,
@@ -1147,11 +1120,11 @@ typedef enum {
   LSM9DS1_6D_POS_RECO             = 0x03,
   LSM9DS1_4D_POS_RECO             = 0x07,
 } lsm9ds1_6d_mode_t;
-int32_t lsm9ds1_6d_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t val);
-int32_t lsm9ds1_6d_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_mode_t *val);
+int32_t lsm9ds1_6d_mode_set(stmdev_ctx_t *ctx, lsm9ds1_6d_mode_t val);
+int32_t lsm9ds1_6d_mode_get(stmdev_ctx_t *ctx, lsm9ds1_6d_mode_t *val);
 
-int32_t lsm9ds1_6d_threshold_set(lsm9ds1_ctx_t *ctx, uint8_t *buff);
-int32_t lsm9ds1_6d_threshold_get(lsm9ds1_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_6d_threshold_set(stmdev_ctx_t *ctx, uint8_t *buff);
+int32_t lsm9ds1_6d_threshold_get(stmdev_ctx_t *ctx, uint8_t *buff);
 
 typedef struct {
   uint8_t xl_xl             : 1;
@@ -1162,10 +1135,10 @@ typedef struct {
   uint8_t zh_xl             : 1;
   uint8_t ia_xl             : 1;
 } lsm9ds1_6d_src_t;
-int32_t lsm9ds1_6d_src_get(lsm9ds1_ctx_t *ctx, lsm9ds1_6d_src_t *val);
+int32_t lsm9ds1_6d_src_get(stmdev_ctx_t *ctx, lsm9ds1_6d_src_t *val);
 
-int32_t lsm9ds1_fifo_stop_on_wtm_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_fifo_stop_on_wtm_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM9DS1_FIFO_OFF                = 0x00,
@@ -1175,31 +1148,31 @@ typedef enum {
   LSM9DS1_BYPASS_TO_STREAM_MODE   = 0x14,
   LSM9DS1_STREAM_MODE             = 0x16,
 } lsm9ds1_fifo_md_t;
-int32_t lsm9ds1_fifo_mode_set(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t val);
-int32_t lsm9ds1_fifo_mode_get(lsm9ds1_ctx_t *ctx, lsm9ds1_fifo_md_t *val);
+int32_t lsm9ds1_fifo_mode_set(stmdev_ctx_t *ctx, lsm9ds1_fifo_md_t val);
+int32_t lsm9ds1_fifo_mode_get(stmdev_ctx_t *ctx, lsm9ds1_fifo_md_t *val);
 
-int32_t lsm9ds1_fifo_temp_batch_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_fifo_temp_batch_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_fifo_temp_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_fifo_temp_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_fifo_watermark_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_fifo_watermark_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_fifo_full_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_fifo_full_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_fifo_data_level_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_fifo_data_level_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_fifo_ovr_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_fifo_ovr_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_fifo_wtm_flag_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_fifo_wtm_flag_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_xl_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_xl_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_xl_self_test_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_xl_self_test_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_gy_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_gy_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_gy_self_test_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_gy_self_test_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm9ds1_mag_self_test_set(lsm9ds1_ctx_t *ctx, uint8_t val);
-int32_t lsm9ds1_mag_self_test_get(lsm9ds1_ctx_t *ctx, uint8_t *val);
+int32_t lsm9ds1_mag_self_test_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm9ds1_mag_self_test_get(stmdev_ctx_t *ctx, uint8_t *val);
 /**
   *@}
   *

--- a/sensor/stmemsc/stts751_STdC/driver/stts751_reg.c
+++ b/sensor/stmemsc/stts751_STdC/driver/stts751_reg.c
@@ -6,33 +6,16 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
-*/
+ ******************************************************************************
+ */
 
 #include "stts751_reg.h"
 
@@ -63,7 +46,7 @@
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_read_reg(stts751_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t stts751_read_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                           uint16_t len)
 {
   int32_t ret;
@@ -81,7 +64,7 @@ int32_t stts751_read_reg(stts751_ctx_t* ctx, uint8_t reg, uint8_t* data,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_write_reg(stts751_ctx_t* ctx, uint8_t reg, uint8_t* data,
+int32_t stts751_write_reg(stmdev_ctx_t* ctx, uint8_t reg, uint8_t* data,
                            uint16_t len)
 {
   int32_t ret;
@@ -150,7 +133,7 @@ int16_t stts751_from_celsius_to_lsb(float celsius)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_temp_data_rate_set(stts751_ctx_t *ctx, stts751_odr_t val)
+int32_t stts751_temp_data_rate_set(stmdev_ctx_t *ctx, stts751_odr_t val)
 {
   stts751_configuration_t configuration;
   stts751_conversion_rate_t conversion_rate;
@@ -187,7 +170,7 @@ int32_t stts751_temp_data_rate_set(stts751_ctx_t *ctx, stts751_odr_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_temp_data_rate_get(stts751_ctx_t *ctx, stts751_odr_t *val)
+int32_t stts751_temp_data_rate_get(stmdev_ctx_t *ctx, stts751_odr_t *val)
 {
   stts751_conversion_rate_t conversion_rate;
   stts751_configuration_t configuration;
@@ -251,7 +234,7 @@ int32_t stts751_temp_data_rate_get(stts751_ctx_t *ctx, stts751_odr_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_resolution_set(stts751_ctx_t *ctx, stts751_tres_t val)
+int32_t stts751_resolution_set(stmdev_ctx_t *ctx, stts751_tres_t val)
 {
   stts751_configuration_t reg;
   int32_t ret;
@@ -272,7 +255,7 @@ int32_t stts751_resolution_set(stts751_ctx_t *ctx, stts751_tres_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_resolution_get(stts751_ctx_t *ctx, stts751_tres_t *val)
+int32_t stts751_resolution_get(stmdev_ctx_t *ctx, stts751_tres_t *val)
 {
   stts751_configuration_t reg;
   int32_t ret;
@@ -307,7 +290,7 @@ int32_t stts751_resolution_get(stts751_ctx_t *ctx, stts751_tres_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_status_reg_get(stts751_ctx_t *ctx, stts751_status_t *val)
+int32_t stts751_status_reg_get(stmdev_ctx_t *ctx, stts751_status_t *val)
 {
   int32_t ret;
   ret = stts751_read_reg(ctx, STTS751_STATUS, (uint8_t*) val, 1);
@@ -322,7 +305,7 @@ int32_t stts751_status_reg_get(stts751_ctx_t *ctx, stts751_status_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_flag_busy_get(stts751_ctx_t *ctx, uint8_t *val)
+int32_t stts751_flag_busy_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   stts751_status_t reg;
   int32_t ret;
@@ -354,7 +337,7 @@ int32_t stts751_flag_busy_get(stts751_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_temperature_raw_get(stts751_ctx_t *ctx, int16_t *buff)
+int32_t stts751_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *buff)
 {
   uint16_t temperature;
   uint8_t temperature_low;
@@ -392,7 +375,7 @@ int32_t stts751_temperature_raw_get(stts751_ctx_t *ctx, int16_t *buff)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_pin_event_route_set(stts751_ctx_t *ctx, uint8_t val)
+int32_t stts751_pin_event_route_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   stts751_configuration_t reg;
   int32_t ret;
@@ -413,7 +396,7 @@ int32_t stts751_pin_event_route_set(stts751_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_pin_event_route_get(stts751_ctx_t *ctx, uint8_t *val)
+int32_t stts751_pin_event_route_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   stts751_configuration_t reg;
   int32_t ret;
@@ -443,7 +426,7 @@ int32_t stts751_pin_event_route_get(stts751_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_high_temperature_threshold_set(stts751_ctx_t *ctx,
+int32_t stts751_high_temperature_threshold_set(stmdev_ctx_t *ctx,
                                                int16_t buff)
 {
   uint8_t *temperature_ptr;
@@ -470,7 +453,7 @@ int32_t stts751_high_temperature_threshold_set(stts751_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_high_temperature_threshold_get(stts751_ctx_t *ctx,
+int32_t stts751_high_temperature_threshold_get(stmdev_ctx_t *ctx,
                                                int16_t *buff)
 {
   uint16_t temperature;
@@ -497,7 +480,7 @@ int32_t stts751_high_temperature_threshold_get(stts751_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_low_temperature_threshold_set(stts751_ctx_t *ctx,
+int32_t stts751_low_temperature_threshold_set(stmdev_ctx_t *ctx,
                                               int16_t buff)
 {
 
@@ -525,7 +508,7 @@ int32_t stts751_low_temperature_threshold_set(stts751_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_low_temperature_threshold_get(stts751_ctx_t *ctx,
+int32_t stts751_low_temperature_threshold_get(stmdev_ctx_t *ctx,
                                               int16_t *buff)
 {
   uint16_t temperature;
@@ -567,7 +550,7 @@ int32_t stts751_low_temperature_threshold_get(stts751_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_ota_thermal_limit_set(stts751_ctx_t *ctx, int8_t val)
+int32_t stts751_ota_thermal_limit_set(stmdev_ctx_t *ctx, int8_t val)
 {
   int32_t ret;
   ret = stts751_write_reg(ctx, STTS751_THERM_LIMIT, (uint8_t*)&val, 1);
@@ -582,7 +565,7 @@ int32_t stts751_ota_thermal_limit_set(stts751_ctx_t *ctx, int8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_ota_thermal_limit_get(stts751_ctx_t *ctx, int8_t *val)
+int32_t stts751_ota_thermal_limit_get(stmdev_ctx_t *ctx, int8_t *val)
 {
   int32_t ret;
 
@@ -599,7 +582,7 @@ int32_t stts751_ota_thermal_limit_get(stts751_ctx_t *ctx, int8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_ota_thermal_hyst_set(stts751_ctx_t *ctx, int8_t val)
+int32_t stts751_ota_thermal_hyst_set(stmdev_ctx_t *ctx, int8_t val)
 {
   int32_t ret;
 
@@ -616,7 +599,7 @@ int32_t stts751_ota_thermal_hyst_set(stts751_ctx_t *ctx, int8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_ota_thermal_hyst_get(stts751_ctx_t *ctx, int8_t *val)
+int32_t stts751_ota_thermal_hyst_get(stmdev_ctx_t *ctx, int8_t *val)
 {
   int32_t ret;
 
@@ -645,7 +628,7 @@ int32_t stts751_ota_thermal_hyst_get(stts751_ctx_t *ctx, int8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_smbus_timeout_set(stts751_ctx_t *ctx, uint8_t val)
+int32_t stts751_smbus_timeout_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   stts751_smbus_timeout_t reg;
   int32_t ret;
@@ -667,7 +650,7 @@ int32_t stts751_smbus_timeout_set(stts751_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_smbus_timeout_get(stts751_ctx_t *ctx, uint8_t *val)
+int32_t stts751_smbus_timeout_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   stts751_smbus_timeout_t reg;
   int32_t ret;
@@ -684,7 +667,7 @@ int32_t stts751_smbus_timeout_get(stts751_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t stts751_device_id_get(stts751_ctx_t *ctx, stts751_id_t *buff)
+int32_t stts751_device_id_get(stmdev_ctx_t *ctx, stts751_id_t *buff)
 {
   int32_t ret;
   ret = stts751_read_reg(ctx, STTS751_PRODUCT_ID,

--- a/sensor/stmemsc/stts751_STdC/driver/stts751_reg.h
+++ b/sensor/stmemsc/stts751_STdC/driver/stts751_reg.h
@@ -7,32 +7,15 @@
  ******************************************************************************
  * @attention
  *
- * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright
- *      notice, this list of conditions and the following disclaimer in the
- *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
+ ******************************************************************************
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -52,50 +35,13 @@
   *
   */
 
-/** @defgroup STTS751_sensors_common_types
+/** @defgroup STMicroelectronics sensors common types
   * @{
   *
   */
 
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
-
-/**
-  * @defgroup axisXbitXX_t
-  * @brief    These unions are useful to represent different sensors data type.
-  *           These unions are not need by the driver.
-  *
-  *           REMOVING the unions you are compliant with:
-  *           MISRA-C 2012 [Rule 19.2] -> " Union are not allowed "
-  *
-  * @{
-  *
-  */
-
-typedef union{
-  int16_t i16bit[3];
-  uint8_t u8bit[6];
-} axis3bit16_t;
-
-typedef union{
-  int16_t i16bit;
-  uint8_t u8bit[2];
-} axis1bit16_t;
-
-typedef union{
-  int32_t i32bit[3];
-  uint8_t u8bit[12];
-} axis3bit32_t;
-
-typedef union{
-  int32_t i32bit;
-  uint8_t u8bit[4];
-} axis1bit32_t;
-
-/**
-  * @}
-  *
-  */
 
 typedef struct{
   uint8_t bit0       : 1;
@@ -111,14 +57,7 @@ typedef struct{
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
-#endif /* MEMS_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  STTS751_Interfaces_Functions
+/** @addtogroup  Interfaces_Functions
   * @brief       This section provide a set of functions used to read and
   *              write a generic register of the device.
   *              MANDATORY: return 0 -> no Error.
@@ -126,16 +65,49 @@ typedef struct{
   *
   */
 
-typedef int32_t (*stts751_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
-typedef int32_t (*stts751_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, uint8_t*, uint16_t);
+typedef int32_t (*stmdev_read_ptr) (void *, uint8_t, uint8_t*, uint16_t);
 
 typedef struct {
   /** Component mandatory fields **/
-  stts751_write_ptr  write_reg;
-  stts751_read_ptr   read_reg;
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
   /** Customizable optional pointer **/
   void *handle;
-} stts751_ctx_t;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_SHARED_TYPES */
+
+#ifndef MEMS_UCF_SHARED_TYPES
+#define MEMS_UCF_SHARED_TYPES
+
+/** @defgroup    Generic address-data structure definition
+  * @brief       This structure is useful to load a predefined configuration
+  *              of a sensor.
+	*              You can create a sensor configuration by your own or using 
+	*              Unico / Unicleo tools available on STMicroelectronics
+	*              web site.
+  *
+  * @{
+  *
+  */
+
+typedef struct {
+  uint8_t address;
+  uint8_t data;
+} ucf_line_t;
+
+/**
+  * @}
+  *
+  */
+
+#endif /* MEMS_UCF_SHARED_TYPES */
 
 /**
   * @}
@@ -241,9 +213,9 @@ typedef union{
   *
   */
 
-int32_t stts751_read_reg(stts751_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t stts751_read_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                           uint16_t len);
-int32_t stts751_write_reg(stts751_ctx_t *ctx, uint8_t reg, uint8_t* data,
+int32_t stts751_write_reg(stmdev_ctx_t *ctx, uint8_t reg, uint8_t* data,
                            uint16_t len);
 
 extern float stts751_from_lsb_to_celsius(int16_t lsb);
@@ -263,8 +235,8 @@ typedef enum {
   STTS751_TEMP_ODR_16Hz       = 0x08, /* 9, 10, or 11-bit resolutions only */
   STTS751_TEMP_ODR_32Hz       = 0x09, /* 9 or 10-bit resolutions only */
 } stts751_odr_t;
-int32_t stts751_temp_data_rate_set(stts751_ctx_t *ctx, stts751_odr_t val);
-int32_t stts751_temp_data_rate_get(stts751_ctx_t *ctx, stts751_odr_t *val);
+int32_t stts751_temp_data_rate_set(stmdev_ctx_t *ctx, stts751_odr_t val);
+int32_t stts751_temp_data_rate_get(stmdev_ctx_t *ctx, stts751_odr_t *val);
 
 typedef enum {
   STTS751_9bit      = 2,
@@ -272,44 +244,44 @@ typedef enum {
   STTS751_11bit     = 1,
   STTS751_12bit     = 3,
 } stts751_tres_t;
-int32_t stts751_resolution_set(stts751_ctx_t *ctx, stts751_tres_t val);
-int32_t stts751_resolution_get(stts751_ctx_t *ctx, stts751_tres_t *val);
+int32_t stts751_resolution_set(stmdev_ctx_t *ctx, stts751_tres_t val);
+int32_t stts751_resolution_get(stmdev_ctx_t *ctx, stts751_tres_t *val);
 
-int32_t stts751_status_reg_get(stts751_ctx_t *ctx, stts751_status_t *val);
+int32_t stts751_status_reg_get(stmdev_ctx_t *ctx, stts751_status_t *val);
 
-int32_t stts751_flag_busy_get(stts751_ctx_t *ctx, uint8_t *val);
+int32_t stts751_flag_busy_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t stts751_temperature_raw_get(stts751_ctx_t *ctx, int16_t *buff);
+int32_t stts751_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *buff);
 
-int32_t stts751_pin_event_route_set(stts751_ctx_t *ctx, uint8_t val);
-int32_t stts751_pin_event_route_get(stts751_ctx_t *ctx, uint8_t *val);
+int32_t stts751_pin_event_route_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t stts751_pin_event_route_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 
-int32_t stts751_high_temperature_threshold_set(stts751_ctx_t *ctx,
+int32_t stts751_high_temperature_threshold_set(stmdev_ctx_t *ctx,
                                                int16_t buff);
-int32_t stts751_high_temperature_threshold_get(stts751_ctx_t *ctx,
+int32_t stts751_high_temperature_threshold_get(stmdev_ctx_t *ctx,
                                                int16_t *buff);
 
-int32_t stts751_low_temperature_threshold_set(stts751_ctx_t *ctx,
+int32_t stts751_low_temperature_threshold_set(stmdev_ctx_t *ctx,
                                               int16_t buff);
-int32_t stts751_low_temperature_threshold_get(stts751_ctx_t *ctx,
+int32_t stts751_low_temperature_threshold_get(stmdev_ctx_t *ctx,
                                               int16_t *buff);
 
-int32_t stts751_ota_thermal_limit_set(stts751_ctx_t *ctx, int8_t val);
-int32_t stts751_ota_thermal_limit_get(stts751_ctx_t *ctx, int8_t *val);
+int32_t stts751_ota_thermal_limit_set(stmdev_ctx_t *ctx, int8_t val);
+int32_t stts751_ota_thermal_limit_get(stmdev_ctx_t *ctx, int8_t *val);
 
-int32_t stts751_ota_thermal_hyst_set(stts751_ctx_t *ctx, int8_t val);
-int32_t stts751_ota_thermal_hyst_get(stts751_ctx_t *ctx, int8_t *val);
+int32_t stts751_ota_thermal_hyst_set(stmdev_ctx_t *ctx, int8_t val);
+int32_t stts751_ota_thermal_hyst_get(stmdev_ctx_t *ctx, int8_t *val);
 
-int32_t stts751_smbus_timeout_set(stts751_ctx_t *ctx, uint8_t val);
-int32_t stts751_smbus_timeout_get(stts751_ctx_t *ctx, uint8_t *val);
+int32_t stts751_smbus_timeout_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t stts751_smbus_timeout_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t product_id;
   uint8_t manufacturer_id;
   uint8_t revision_id;
 } stts751_id_t;
-int32_t stts751_device_id_get(stts751_ctx_t *ctx, stts751_id_t *buff);
+int32_t stts751_device_id_get(stmdev_ctx_t *ctx, stts751_id_t *buff);
 
 /**
   * @}


### PR DESCRIPTION
Align stmemsc HAL i/f from v1.00 to v1.02.

Signed-off-by: Armando Visconti <armando.visconti@st.com>


EDIT::
This module is used/tested by https://github.com/zephyrproject-rtos/zephyr/pull/19430