### PR TITLE
hal_st: Make it a zephyr_library()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,17 +5,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_HAS_STLIB)
+
+  zephyr_library()
+
   if(CONFIG_VL53L0X)
     zephyr_include_directories(
 	sensor/vl53l0x/api/core/inc
 	${PROJECT_SOURCE_DIR}/drivers/sensor/vl53l0x
     )
 
-    zephyr_sources(sensor/vl53l0x/api/core/src/vl53l0x_api.c)
-    zephyr_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_ranging.c)
-    zephyr_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_calibration.c)
-    zephyr_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_core.c)
-    zephyr_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_strings.c)
+    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api.c)
+    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_ranging.c)
+    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_calibration.c)
+    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_core.c)
+    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_strings.c)
   endif()
   if(CONFIG_VL53L1X)
     zephyr_include_directories(
@@ -23,18 +26,18 @@ if(CONFIG_HAS_STLIB)
             ${PROJECT_SOURCE_DIR}/drivers/sensor/vl53l1x
     )
 
-    zephyr_sources(sensor/vl53l1x/api/core/src/vl53l1_api.c)
-    zephyr_sources(sensor/vl53l1x/api/core/src/vl53l1_api_calibration.c)
-    zephyr_sources(sensor/vl53l1x/api/core/src/vl53l1_wait.c)
-    zephyr_sources(sensor/vl53l1x/api/core/src/vl53l1_core.c)
-    zephyr_sources(sensor/vl53l1x/api/core/src/vl53l1_api_core.c)
-    zephyr_sources(sensor/vl53l1x/api/core/src/vl53l1_api_preset_modes.c)
-    zephyr_sources(sensor/vl53l1x/api/core/src/vl53l1_core_support.c)
-    zephyr_sources(sensor/vl53l1x/api/core/src/vl53l1_register_funcs.c)
+    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api.c)
+    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_calibration.c)
+    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_wait.c)
+    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_core.c)
+    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_core.c)
+    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_preset_modes.c)
+    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_core_support.c)
+    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_register_funcs.c)
   endif()
   if(CONFIG_AUDIO_MPXXDTYY)
     zephyr_include_directories(audio/microphone)
-    zephyr_sources(audio/microphone/OpenPDMFilter.c)
+    zephyr_library_sources(audio/microphone/OpenPDMFilter.c)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,39 +6,36 @@
 
 if(CONFIG_HAS_STLIB)
 
-  zephyr_library()
+zephyr_library()
 
-  if(CONFIG_VL53L0X)
-    zephyr_include_directories(
-	sensor/vl53l0x/api/core/inc
-	${PROJECT_SOURCE_DIR}/drivers/sensor/vl53l0x
-    )
+if(CONFIG_VL53L0X)
+zephyr_include_directories(sensor/vl53l0x/api/core/inc
+			   ${PROJECT_SOURCE_DIR}/drivers/sensor/vl53l0x)
+zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api.c)
+zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_ranging.c)
+zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_calibration.c)
+zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_core.c)
+zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_strings.c)
+endif()
 
-    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api.c)
-    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_ranging.c)
-    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_calibration.c)
-    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_core.c)
-    zephyr_library_sources(sensor/vl53l0x/api/core/src/vl53l0x_api_strings.c)
-  endif()
-  if(CONFIG_VL53L1X)
-    zephyr_include_directories(
-            sensor/vl53l1x/api/core/inc
-            ${PROJECT_SOURCE_DIR}/drivers/sensor/vl53l1x
-    )
+if(CONFIG_VL53L1X)
+zephyr_include_directories(sensor/vl53l1x/api/core/inc
+			   ${PROJECT_SOURCE_DIR}/drivers/sensor/vl53l1x)
+zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api.c)
+zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_calibration.c)
+zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_wait.c)
+zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_core.c)
+zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_core.c)
+zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_preset_modes.c)
+zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_core_support.c)
+zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_register_funcs.c)
+endif()
 
-    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api.c)
-    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_calibration.c)
-    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_wait.c)
-    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_core.c)
-    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_core.c)
-    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_api_preset_modes.c)
-    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_core_support.c)
-    zephyr_library_sources(sensor/vl53l1x/api/core/src/vl53l1_register_funcs.c)
-  endif()
-  if(CONFIG_AUDIO_MPXXDTYY)
-    zephyr_include_directories(audio/microphone)
-    zephyr_library_sources(audio/microphone/OpenPDMFilter.c)
-  endif()
+if(CONFIG_AUDIO_MPXXDTYY)
+zephyr_include_directories(audio/microphone)
+zephyr_library_sources(audio/microphone/OpenPDMFilter.c)
+endif()
+
 endif()
 
 # STMEMSC - Hardware Abstraction Layer for ST sensor

--- a/sensor/stmemsc/CMakeLists.txt
+++ b/sensor/stmemsc/CMakeLists.txt
@@ -61,7 +61,7 @@ foreach(stmems_pid ${stmems_pids})
     zephyr_include_directories(
         ${stmems_pid}_STdC/driver/
         )
-    zephyr_sources(
+    zephyr_library_sources(
         ${stmems_pid}_STdC/driver/${stmems_pid}_reg.c
         )
   endif()


### PR DESCRIPTION
Stops leaking very long source paths in build directories;
makes them deterministic.

This is identical to what was already merged in
zephyrproject-rtos/hal_stm32/pull/23

see previous code reviews there.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/19614

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>