### PR TITLE
sensor: lsm6dso: Disable -Wmaybe-uninitialized for lsm6dso_mode_set

### DIFF
--- a/sensor/stmemsc/README
+++ b/sensor/stmemsc/README
@@ -56,3 +56,7 @@ License:
 
 License Link:
    https://opensource.org/licenses/BSD-3-Clause
+
+Patch List:
+   * sensor: lsm6dso: Disable -Wmaybe-uninitialized for lsm6dso_mode_set
+     - Modified sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c

--- a/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c
+++ b/sensor/stmemsc/lsm6dso_STdC/driver/lsm6dso_reg.c
@@ -11768,6 +11768,16 @@ int32_t lsm6dso_all_sources_get(stmdev_ctx_t *ctx,
   return ret;
 }
 
+/*
+ * `-Wmaybe-uninitialized` warning is disabled for the `lsm6dso_mode_set`
+ * function because GCC 12 and above may report a false positive warning
+ * claiming that the `ctrl2_ois` variable may be used uninitialized.
+ */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 /**
   * @brief  Sensor conversion parameters selection.[set]
   *
@@ -12225,6 +12235,10 @@ int32_t lsm6dso_mode_set(stmdev_ctx_t *ctx, stmdev_ctx_t *aux_ctx,
 
   return ret;
 }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /**
   * @brief  Sensor conversion parameters selection.[get]


### PR DESCRIPTION
This commit disables the potentially uninitialized variable warning
(`-Wmaybe-uninitialized`) for the `lsm6dso_mode_set` function because
GCC 12 and above may report a false positive warning claiming that the
`ctrl2_ois` variable may be used uninitialized.

Note that the `ctrl2_ois` variable is always set when `aux_ctx != NULL`
and is accessed if and only if `aux_ctx != NULL`, therefore it may
never be used uninitialized as the warning claims.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: This is required for the upcoming Zephyr SDK 0.15.0 release.