### PR TITLE
vl53l0x: Cast unsigned abs param to signed type to fix clang warning

### DIFF
--- a/sensor/vl53l0x/README
+++ b/sensor/vl53l0x/README
@@ -49,5 +49,10 @@ License:
 License Link:
    http://www.st.com/en/embedded-software/stsw-img005.html
 
+Patch List:
 
-
+   *Cast unsigned abs param to signed type
+     This will prevent a compiler warning when using clang
+     without -ffreestanding
+     Impacted files:
+      api/core/src/vl53l0x_api_core.c

--- a/sensor/vl53l0x/api/core/src/vl53l0x_api_core.c
+++ b/sensor/vl53l0x/api/core/src/vl53l0x_api_core.c
@@ -1872,7 +1872,7 @@ VL53L0X_Error VL53L0X_calc_sigma_estimate(VL53L0X_DEV Dev,
 		diff1_mcps <<= 8;
 
 		/* FixPoint0824/FixPoint1616 = FixPoint2408 */
-		xTalkCorrection	 = abs(diff1_mcps/diff2_mcps);
+		xTalkCorrection	 = abs((int32_t) (diff1_mcps/diff2_mcps));
 
 		/* FixPoint2408 << 8 = FixPoint1616 */
 		xTalkCorrection <<= 8;


### PR DESCRIPTION
FixPoint1616_t is typedef'd to uint32_t. The result of dividing two variables of that type is also unsigned. Passing an unsigned value to abs doesn't make sense.

Cast the value to int32_t in case the computaton of diff1_mcps generates a negative result so that xTalkCorrection doesn't end up with a huge value.