### PR TITLE
fix open_pdfm_filter_init double promotion

### DIFF
--- a/README
+++ b/README
@@ -6,3 +6,8 @@ Available libs:
       allows to drive the vl53l0x sensor
       full information can be found here : http://www.st.com/en/embedded-software/stsw-img005.html
   *...
+
+Patch List:
+
+   *Fix double-promotion warnings
+    -audio/microphone/OpenPDMFilter.c modified

--- a/audio/microphone/OpenPDMFilter.c
+++ b/audio/microphone/OpenPDMFilter.c
@@ -177,8 +177,8 @@ void Open_PDM_Filter_Init(TPDMFilter_InitStruct *Param)
   }
 
   Param->OldOut = Param->OldIn = Param->OldZ = 0;
-  Param->LP_ALFA = (Param->LP_HZ != 0 ? (uint16_t) (Param->LP_HZ * 256 / (Param->LP_HZ + Param->Fs / (2 * 3.14159))) : 0);
-  Param->HP_ALFA = (Param->HP_HZ != 0 ? (uint16_t) (Param->Fs * 256 / (2 * 3.14159 * Param->HP_HZ + Param->Fs)) : 0);
+  Param->LP_ALFA = (Param->LP_HZ != 0 ? (uint16_t) (Param->LP_HZ * 256 / (Param->LP_HZ + Param->Fs / (2 * 3.14159f))) : 0);
+  Param->HP_ALFA = (Param->HP_HZ != 0 ? (uint16_t) (Param->Fs * 256 / (2 * 3.14159f * Param->HP_HZ + Param->Fs)) : 0);
 
   Param->FilterLen = decimation * SINCN;       
   sinc[0] = 0;


### PR DESCRIPTION
floating point constants were defined as doubles. change them to single-precision point to prevent double promotion of the whole thing.